### PR TITLE
Seqexec Queue load

### DIFF
--- a/modules/edu.gemini.seqexec.web/build.sbt
+++ b/modules/edu.gemini.seqexec.web/build.sbt
@@ -58,7 +58,7 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("edu.gemini.seqexec.web
       ScalaJSDom.value
     ) ++ ReactScalaJS.value ++ Diode.value
   )
-  .dependsOn(edu_gemini_seqexec_web_shared_JS)
+  .dependsOn(edu_gemini_seqexec_web_shared_JS % "compile->compile;test->test")
 
 // This function allows triggered compilation to run only when scala files changes
 // It lets change static files freely

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -33,14 +33,14 @@ object QueueTableBody {
       <.tbody(
         // Render after data arrives
         p.queue().render( q =>
-          q.queue.map(Some.apply).padTo(minRows, None).collect {
-            case Some(s) =>
+          q.queue.map(Some.apply).padTo(minRows, None).zipWithIndex.collect {
+            case (Some(s), i) =>
               <.tr(
                 ^.classSet(
                   "positive" -> (s.state == SequenceState.Running),
                   "negative" -> (s.state == SequenceState.Error)
                 ),
-                ^.key := s"item.queue.${s.id}",
+                ^.key := s"item.queue.$i",
                 <.td(
                   ^.cls := "collapsing",
                   s.id
@@ -52,14 +52,14 @@ object QueueTableBody {
                   s.error.map(_ => <.p(Icon("attention"), " Error")).getOrElse(<.p("-"))
                 )
               )
-            case _ =>
-              emptyRow(s"time.queue." + (1000*math.random).toInt)
+            case (_, i) =>
+              emptyRow(s"item.queue.$i")
           }
         ),
         // Render some rows when pending
-        p.queue().renderPending(_ => (0 until minRows).map(i => emptyRow(s"time.queue.$i"))),
+        p.queue().renderPending(_ => (0 until minRows).map(i => emptyRow(s"item.queue.$i"))),
         // Render some rows even if it failed
-        p.queue().renderFailed(_ => (0 until minRows).map(i => emptyRow(s"time.queue.$i")))
+        p.queue().renderFailed(_ => (0 until minRows).map(i => emptyRow(s"item.queue.$i")))
       )
     )
     .build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -18,8 +18,9 @@ object QueueTableBody {
   // Minimum rows to display, pad with empty rows if needed
   val minRows = 5
 
-  val emptyRow =
+  def emptyRow(k: String) =
     <.tr(
+      ^.key := k, // React requires unique keys
       <.td("\u00a0"),
       <.td("\u00a0"),
       <.td("\u00a0"),
@@ -32,6 +33,7 @@ object QueueTableBody {
     .stateless
     .render_P( p =>
       <.tbody(
+        // Render after data arrives
         p.queue().render( q =>
           q.queue.map(Some.apply).padTo(minRows, None).collect {
             case Some(s) =>
@@ -53,7 +55,7 @@ object QueueTableBody {
                 )
               )
             case _ =>
-              emptyRow
+              emptyRow(s"time.queue." + (1000*math.random).toInt)
           }
         )
       )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -15,87 +15,46 @@ import scalacss.ScalaCssReact._
 case class Props(queue: ModelProxy[Pot[SeqexecQueue]])
 
 object QueueTableBody {
+  // Minimum rows to display, pad with empty rows if needed
+  val minRows = 5
+
+  val emptyRow =
+    <.tr(
+      <.td("\u00a0"),
+      <.td("\u00a0"),
+      <.td("\u00a0"),
+      <.td(
+        SeqexecStyles.notInMobile,
+        "\u00a0")
+    )
+
   val component = ReactComponentB[Props]("QueueTableBody")
     .stateless
     .render_P( p =>
       <.tbody(
         p.queue().render( q =>
-          q.queue.map( s =>
-            <.tr(
-              ^.classSet(
-                "positive" -> (s.state == SequenceState.Running),
-                "negative" -> (s.state == SequenceState.Error)
-              ),
-              ^.key := s"item.queue.${s.id}",
-              <.td(
-                ^.cls := "collapsing",
-                s.id
-              ),
-              <.td(s.state.toString),
-              <.td(s.instrument),
-              <.td(
-                SeqexecStyles.notInMobile,
-                s.error.map(_ => <.p(Icon("attention"), " Error")).getOrElse(<.p("-"))
+          q.queue.map(Some.apply).padTo(minRows, None).collect {
+            case Some(s) =>
+              <.tr(
+                ^.classSet(
+                  "positive" -> (s.state == SequenceState.Running),
+                  "negative" -> (s.state == SequenceState.Error)
+                ),
+                ^.key := s"item.queue.${s.id}",
+                <.td(
+                  ^.cls := "collapsing",
+                  s.id
+                ),
+                <.td(s.state.toString),
+                <.td(s.instrument),
+                <.td(
+                  SeqexecStyles.notInMobile,
+                  s.error.map(_ => <.p(Icon("attention"), " Error")).getOrElse(<.p("-"))
+                )
               )
-            )
-          )
-        ),
-        <.tr(
-          <.td("\u00a0"),
-          <.td(" -- "),
-          <.td(" -- "),
-          <.td(
-            SeqexecStyles.notInMobile,
-            " ")
-        ),
-        <.tr(
-          <.td(
-            ^.cls := "collapsing",
-            "GS-2016A-Q-0-1"
-          ),
-          <.td("Not Started"),
-          <.td("GPI"),
-          <.td(
-            SeqexecStyles.notInMobile,
-            "-"
-          )
-        ),
-        <.tr(
-          ^.cls := "positive",
-          <.td("GS-2016A-Q-5-3"),
-          <.td("Running"),
-          <.td("GMOS-S"),
-          <.td(
-            SeqexecStyles.notInMobile,
-            "-"
-          )
-        ),
-        <.tr(
-          ^.cls := "negative",
-          <.td("GS-2016A-Q-4-1"),
-          <.td("Error"),
-          <.td("Flamingos 2"),
-          <.td(
-            SeqexecStyles.notInMobile,
-            Icon("attention"),
-            " Error"
-          )
-        ),
-        <.tr(
-          <.td("\u00a0"),
-          <.td(" "),
-          <.td(" "),
-          <.td(
-            SeqexecStyles.notInMobile,
-            " ")
-        ),
-        <.tr(
-          <.td("\u00a0"),
-          <.td(" "),
-          <.td(" "),
-          <.td(
-            SeqexecStyles.notInMobile,
-            " ")
+            case _ =>
+              emptyRow
+          }
         )
       )
     )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -1,6 +1,7 @@
 package edu.gemini.seqexec.web.client.components
 
 import diode.react.ModelProxy
+import edu.gemini.seqexec.web.client.model.RefreshQueue
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
 import edu.gemini.seqexec.web.common.SeqexecQueue
 import japgolly.scalajs.react.vdom.prefix_<^._
@@ -16,7 +17,11 @@ object QueueArea {
   case class Props(queue: ModelProxy[Option[SeqexecQueue]])
 
   class Backend($: BackendScope[Props, Unit]) {
-    def render() = {
+    def load(p: Props) =
+      // Request to load the queue if not present
+      Callback.ifTrue(p.queue.value.isEmpty, p.queue.dispatch(RefreshQueue))
+
+    def render(p: Props) = {
       <.div(
         ^.cls := "ui grid container",
         <.div(
@@ -151,6 +156,7 @@ object QueueArea {
   val component = ReactComponentB[Props]("QueueArea")
     .stateless
     .renderBackend[Backend]
+    .componentDidMount($ => $.backend.load($.props))
     .build
 
   def apply(p: ModelProxy[Option[SeqexecQueue]]) = component(Props(p))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -1,20 +1,114 @@
 package edu.gemini.seqexec.web.client.components
 
-import diode.react.ModelProxy
+
+import diode.data.Pot
+import diode.react.ReactPot._
+import diode.react._
 import edu.gemini.seqexec.web.client.model.RefreshQueue
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
-import edu.gemini.seqexec.web.common.SeqexecQueue
+import edu.gemini.seqexec.web.common.{SeqexecQueue, SequenceState}
 import japgolly.scalajs.react.vdom.prefix_<^._
 import japgolly.scalajs.react._
 
 import scalacss.ScalaCssReact._
 
+case class Props(queue: ModelProxy[Pot[SeqexecQueue]])
+
+object QueueTableBody {
+  val component = ReactComponentB[Props]("QueueTableBody")
+    .stateless
+    .render_P( p =>
+      <.tbody(
+        p.queue().render( q =>
+          q.queue.map( s =>
+            <.tr(
+              ^.classSet(
+                "positive" -> (s.state == SequenceState.Running),
+                "negative" -> (s.state == SequenceState.Error)
+              ),
+              ^.key := s"item.queue.${s.id}",
+              <.td(
+                ^.cls := "collapsing",
+                s.id
+              ),
+              <.td(s.state.toString),
+              <.td(s.instrument),
+              <.td(
+                SeqexecStyles.notInMobile,
+                s.error.map(_ => <.p(Icon("attention"), " Error")).getOrElse(<.p("-"))
+              )
+            )
+          )
+        ),
+        <.tr(
+          <.td("\u00a0"),
+          <.td(" -- "),
+          <.td(" -- "),
+          <.td(
+            SeqexecStyles.notInMobile,
+            " ")
+        ),
+        <.tr(
+          <.td(
+            ^.cls := "collapsing",
+            "GS-2016A-Q-0-1"
+          ),
+          <.td("Not Started"),
+          <.td("GPI"),
+          <.td(
+            SeqexecStyles.notInMobile,
+            "-"
+          )
+        ),
+        <.tr(
+          ^.cls := "positive",
+          <.td("GS-2016A-Q-5-3"),
+          <.td("Running"),
+          <.td("GMOS-S"),
+          <.td(
+            SeqexecStyles.notInMobile,
+            "-"
+          )
+        ),
+        <.tr(
+          ^.cls := "negative",
+          <.td("GS-2016A-Q-4-1"),
+          <.td("Error"),
+          <.td("Flamingos 2"),
+          <.td(
+            SeqexecStyles.notInMobile,
+            Icon("attention"),
+            " Error"
+          )
+        ),
+        <.tr(
+          <.td("\u00a0"),
+          <.td(" "),
+          <.td(" "),
+          <.td(
+            SeqexecStyles.notInMobile,
+            " ")
+        ),
+        <.tr(
+          <.td("\u00a0"),
+          <.td(" "),
+          <.td(" "),
+          <.td(
+            SeqexecStyles.notInMobile,
+            " ")
+        )
+      )
+    )
+    .build
+
+  def apply(p: ModelProxy[Pot[SeqexecQueue]]) = component(Props(p))
+
+}
+
 /**
   * Displays the elements on the queue
   */
 object QueueArea {
-
-  case class Props(queue: ModelProxy[Option[SeqexecQueue]])
 
   class Backend($: BackendScope[Props, Unit]) {
     def load(p: Props) =
@@ -68,57 +162,7 @@ object QueueArea {
                     )
                   )
                 ),
-                <.tbody(
-                  <.tr(
-                    <.td(
-                      ^.cls := "collapsing",
-                      "GS-2016A-Q-0-1"
-                    ),
-                    <.td("Not Started"),
-                    <.td("GPI"),
-                    <.td(
-                      SeqexecStyles.notInMobile,
-                      "-"
-                    )
-                  ),
-                  <.tr(
-                    ^.cls := "positive",
-                    <.td("GS-2016A-Q-5-3"),
-                    <.td("Running"),
-                    <.td("GMOS-S"),
-                    <.td(
-                      SeqexecStyles.notInMobile,
-                      "-"
-                    )
-                  ),
-                  <.tr(
-                    ^.cls := "negative",
-                    <.td("GS-2016A-Q-4-1"),
-                    <.td("Error"),
-                    <.td("Flamingos 2"),
-                    <.td(
-                      SeqexecStyles.notInMobile,
-                      Icon("attention"),
-                      " Error"
-                    )
-                  ),
-                  <.tr(
-                    <.td("\u00a0"),
-                    <.td(" "),
-                    <.td(" "),
-                    <.td(
-                      SeqexecStyles.notInMobile,
-                      " ")
-                  ),
-                  <.tr(
-                    <.td("\u00a0"),
-                    <.td(" "),
-                    <.td(" "),
-                    <.td(
-                      SeqexecStyles.notInMobile,
-                      " ")
-                  )
-                ),
+                QueueTableBody(p.queue),
                 <.tfoot(
                   <.tr(
                     <.th(
@@ -159,6 +203,6 @@ object QueueArea {
     .componentDidMount($ => $.backend.load($.props))
     .build
 
-  def apply(p: ModelProxy[Option[SeqexecQueue]]) = component(Props(p))
+  def apply(p: ModelProxy[Pot[SeqexecQueue]]) = component(Props(p))
 
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -74,12 +74,13 @@ object QueueTableBody {
 object QueueArea {
   case class Props(queue: ModelProxy[Pot[SeqexecQueue]])
 
-  class Backend($: BackendScope[Props, Unit]) {
-    def load(p: Props) =
-      // Request to load the queue if not present
-      Callback.ifTrue(p.queue.value.isEmpty, p.queue.dispatch(UpdatedQueue(Empty)))
+  def load(p: Props) =
+    // Request to load the queue if not present
+    Callback.ifTrue(p.queue.value.isEmpty, p.queue.dispatch(UpdatedQueue(Empty)))
 
-    def render(p: Props) = {
+  val component = ReactComponentB[Props]("QueueArea")
+    .stateless
+    .render_P(p =>
       <.div(
         ^.cls := "ui grid container",
         <.div(
@@ -169,13 +170,8 @@ object QueueArea {
           )
         )
       )
-    }
-  }
-
-  val component = ReactComponentB[Props]("QueueArea")
-    .stateless
-    .renderBackend[Backend]
-    .componentDidMount($ => $.backend.load($.props))
+    )
+    .componentDidMount($ => load($.props))
     .build
 
   def apply(p: ModelProxy[Pot[SeqexecQueue]]) = component(Props(p))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -1,8 +1,11 @@
 package edu.gemini.seqexec.web.client.components
 
+import diode.react.ModelProxy
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
+import edu.gemini.seqexec.web.common.SeqexecQueue
 import japgolly.scalajs.react.vdom.prefix_<^._
 import japgolly.scalajs.react._
+
 import scalacss.ScalaCssReact._
 
 /**
@@ -10,7 +13,9 @@ import scalacss.ScalaCssReact._
   */
 object QueueArea {
 
-  class Backend($: BackendScope[Unit, Unit]) {
+  case class Props(queue: ModelProxy[Option[SeqexecQueue]])
+
+  class Backend($: BackendScope[Props, Unit]) {
     def render() = {
       <.div(
         ^.cls := "ui grid container",
@@ -143,11 +148,11 @@ object QueueArea {
     }
   }
 
-  val component = ReactComponentB[Unit]("QueueArea")
+  val component = ReactComponentB[Props]("QueueArea")
     .stateless
     .renderBackend[Backend]
-    .buildU
+    .build
 
-  def apply() = component()
+  def apply(p: ModelProxy[Option[SeqexecQueue]]) = component(Props(p))
 
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -5,6 +5,7 @@ import diode.react.ReactPot._
 import diode.react._
 import edu.gemini.seqexec.web.client.model.UpdatedQueue
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
+import edu.gemini.seqexec.web.client.semanticui.elements.message.CloseableMessage
 import edu.gemini.seqexec.web.common.{SeqexecQueue, SequenceState}
 import japgolly.scalajs.react.vdom.prefix_<^._
 import japgolly.scalajs.react._
@@ -119,14 +120,7 @@ object QueueArea {
                   "Loading")
               )),
               p.queue().renderFailed(_ =>
-                <.div(
-                  ^.cls := "ui negative message",
-                  Icon("close"),
-                  <.div(
-                    ^.cls := "header",
-                    "Sorry, there was an error reading the queue from the server"
-                  )
-                )
+                CloseableMessage(CloseableMessage.Props(Some("Sorry, there was an error reading the queue from the server"), CloseableMessage.Style.Negative))
               ),
               <.table(
                 ^.cls := "ui selectable compact celled table unstackable",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -113,12 +113,14 @@ object QueueArea {
             ),
             <.div(
               ^.cls := "ui secondary segment",
+              // Show a loading indicator if we are waiting for server data
               p.queue().renderPending(_ => <.div(
                 ^.cls := "ui active dimmer",
                 <.div(
                   ^.cls := "ui text loader large",
                   "Loading")
               )),
+              // If there was an error on the process display a message
               p.queue().renderFailed(_ =>
                 CloseableMessage(CloseableMessage.Props(Some("Sorry, there was an error reading the queue from the server"), CloseableMessage.Style.Negative))
               ),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -1,10 +1,10 @@
 package edu.gemini.seqexec.web.client.components
 
 
-import diode.data.Pot
+import diode.data.{Empty, Pot}
 import diode.react.ReactPot._
 import diode.react._
-import edu.gemini.seqexec.web.client.model.RefreshQueue
+import edu.gemini.seqexec.web.client.model.UpdatedQueue
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
 import edu.gemini.seqexec.web.common.{SeqexecQueue, SequenceState}
 import japgolly.scalajs.react.vdom.prefix_<^._
@@ -57,7 +57,9 @@ object QueueTableBody {
             case _ =>
               emptyRow(s"time.queue." + (1000*math.random).toInt)
           }
-        )
+        ),
+        // Render some rows when empty
+        p.queue().renderEmpty((0 until minRows).map(i => emptyRow(s"time.queue.$i")))
       )
     )
     .build
@@ -74,7 +76,7 @@ object QueueArea {
   class Backend($: BackendScope[Props, Unit]) {
     def load(p: Props) =
       // Request to load the queue if not present
-      Callback.ifTrue(p.queue.value.isEmpty, p.queue.dispatch(RefreshQueue))
+      Callback.ifTrue(p.queue.value.isEmpty, p.queue.dispatch(UpdatedQueue(Empty)))
 
     def render(p: Props) = {
       <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -58,8 +58,8 @@ object QueueTableBody {
               emptyRow(s"time.queue." + (1000*math.random).toInt)
           }
         ),
-        // Render some rows when empty
-        p.queue().renderEmpty((0 until minRows).map(i => emptyRow(s"time.queue.$i")))
+        // Render some rows when pending
+        p.queue().renderPending(_ => (0 until minRows).map(i => emptyRow(s"time.queue.$i")))
       )
     )
     .build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -11,8 +11,6 @@ import japgolly.scalajs.react._
 
 import scalacss.ScalaCssReact._
 
-case class Props(queue: ModelProxy[Pot[SeqexecQueue]])
-
 object QueueTableBody {
   // Minimum rows to display, pad with empty rows if needed
   val minRows = 5
@@ -28,7 +26,7 @@ object QueueTableBody {
         "\u00a0")
     )
 
-  val component = ReactComponentB[Props]("QueueTableBody")
+  val component = ReactComponentB[QueueArea.Props]("QueueTableBody")
     .stateless
     .render_P( p =>
       <.tbody(
@@ -58,12 +56,14 @@ object QueueTableBody {
           }
         ),
         // Render some rows when pending
-        p.queue().renderPending(_ => (0 until minRows).map(i => emptyRow(s"time.queue.$i")))
+        p.queue().renderPending(_ => (0 until minRows).map(i => emptyRow(s"time.queue.$i"))),
+        // Render some rows even if it failed
+        p.queue().renderFailed(_ => (0 until minRows).map(i => emptyRow(s"time.queue.$i")))
       )
     )
     .build
 
-  def apply(p: ModelProxy[Pot[SeqexecQueue]]) = component(Props(p))
+  def apply(p: ModelProxy[Pot[SeqexecQueue]]) = component(QueueArea.Props(p))
 
 }
 
@@ -71,6 +71,7 @@ object QueueTableBody {
   * Displays the elements on the queue
   */
 object QueueArea {
+  case class Props(queue: ModelProxy[Pot[SeqexecQueue]])
 
   class Backend($: BackendScope[Props, Unit]) {
     def load(p: Props) =
@@ -117,6 +118,16 @@ object QueueArea {
                   ^.cls := "ui text loader large",
                   "Loading")
               )),
+              p.queue().renderFailed(_ =>
+                <.div(
+                  ^.cls := "ui negative message",
+                  Icon("close"),
+                  <.div(
+                    ^.cls := "header",
+                    "Sorry, there was an error reading the queue from the server"
+                  )
+                )
+              ),
               <.table(
                 ^.cls := "ui selectable compact celled table unstackable",
                 <.thead(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -1,6 +1,5 @@
 package edu.gemini.seqexec.web.client.components
 
-
 import diode.data.{Empty, Pot}
 import diode.react.ReactPot._
 import diode.react._
@@ -112,6 +111,12 @@ object QueueArea {
             ),
             <.div(
               ^.cls := "ui secondary segment",
+              p.queue().renderPending(_ => <.div(
+                ^.cls := "ui active dimmer",
+                <.div(
+                  ^.cls := "ui text loader large",
+                  "Loading")
+              )),
               <.table(
                 ^.cls := "ui selectable compact celled table unstackable",
                 <.thead(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -1,5 +1,6 @@
 package edu.gemini.seqexec.web.client.components
 
+import edu.gemini.seqexec.web.client.model.SeqexecCircuit
 import edu.gemini.seqexec.web.client.services.SeqexecWebClient
 import edu.gemini.seqexec.web.common.Sequence
 import japgolly.scalajs.react.{BackendScope, Callback, ReactComponentB}
@@ -42,7 +43,7 @@ object SeqexecUI {
     def render(s:State) = {
       <.div(
         NavBar(),
-        QueueArea()
+        SeqexecCircuit.connect(_.queue.toOption)(proxy => QueueArea(proxy))
       )
     }
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -43,7 +43,7 @@ object SeqexecUI {
     def render(s:State) = {
       <.div(
         NavBar(),
-        SeqexecCircuit.connect(_.queue)(proxy => QueueArea(proxy))
+        SeqexecCircuit.connect(_.queue)(QueueArea(_))
       )
     }
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -43,7 +43,7 @@ object SeqexecUI {
     def render(s:State) = {
       <.div(
         NavBar(),
-        SeqexecCircuit.connect(_.queue.toOption)(proxy => QueueArea(proxy))
+        SeqexecCircuit.connect(_.queue)(proxy => QueueArea(proxy))
       )
     }
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -1,9 +1,8 @@
 package edu.gemini.seqexec.web.client.model
 
-import diode.data.PotState._
-import diode.data.{Empty, Pot, PotAction, PotState}
+import diode.data.{Empty, Pot, PotAction}
 import diode.react.ReactConnector
-import diode.util.{RunAfter, RunAfterJS}
+import diode.util.RunAfterJS
 import diode._
 import edu.gemini.seqexec.web.client.services.SeqexecWebClient
 import edu.gemini.seqexec.web.common.SeqexecQueue

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -1,0 +1,36 @@
+package edu.gemini.seqexec.web.client.model
+
+import diode.data.{Empty, Pot}
+import diode.react.ReactConnector
+import diode.{ActionHandler, Circuit, ModelRW}
+import edu.gemini.seqexec.web.common.SeqexecQueue
+
+case class UpdateQueue(queue: Pot[SeqexecQueue])
+
+/**
+  * Handles actions related to todos
+  *
+  * @param modelRW Reader/Writer to access the model
+  */
+class QueueHandler[M](modelRW: ModelRW[M, Pot[SeqexecQueue]]) extends ActionHandler(modelRW) {
+  override def handle = {
+    case UpdateQueue(queue) => updated(queue)
+  }
+}
+
+/**
+  * Root of the UI Model of the application
+  */
+case class SeqexecAppRootModel(queue: Pot[SeqexecQueue])
+
+/**
+  * Contains the model for Diode
+  */
+object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[SeqexecAppRootModel] {
+
+  val queueHandler = new QueueHandler(zoomRW(_.queue)((m, v) => m.copy(queue = v)))
+
+  override protected def initialModel = SeqexecAppRootModel(Empty)
+
+  override protected def actionHandler = combineHandlers(queueHandler)
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -21,15 +21,14 @@ case class UpdatedQueue(potResult: Pot[SeqexecQueue]) extends PotAction[SeqexecQ
 }
 
 /**
-  * Handles actions related to todos
-  *
-  * @param modelRW Reader/Writer to access the model
+  * Handles actions related to the queue like loading and adding new elements
   */
 class QueueHandler[M](modelRW: ModelRW[M, Pot[SeqexecQueue]]) extends ActionHandler(modelRW) {
   implicit val runner = new RunAfterJS
 
   override def handle = {
     case action: UpdatedQueue =>
+      // Request loading the queue with ajax
       val loadEffect = action.effect(SeqexecWebClient.readQueue())(identity)
       action.handleWith(this, loadEffect)(PotAction.handler(250.milli))
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -31,7 +31,7 @@ class QueueHandler[M](modelRW: ModelRW[M, Pot[SeqexecQueue]]) extends ActionHand
   override def handle = {
     case action: UpdatedQueue =>
       val loadEffect = action.effect(SeqexecWebClient.readQueue())(identity)
-      action.handleWith(this, loadEffect)(PotAction.handler(100.milli))
+      action.handleWith(this, loadEffect)(PotAction.handler(250.milli))
   }
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -1,11 +1,18 @@
 package edu.gemini.seqexec.web.client.model
 
-import diode.data.{Empty, Pot}
+import diode.data.{Empty, Pot, Ready}
 import diode.react.ReactConnector
-import diode.{ActionHandler, Circuit, ModelRW}
+import diode.{ActionHandler, Circuit, Effect, ModelRW}
+import edu.gemini.seqexec.web.client.services.SeqexecWebClient
 import edu.gemini.seqexec.web.common.SeqexecQueue
 
-case class UpdateQueue(queue: Pot[SeqexecQueue])
+import scala.concurrent.ExecutionContext.Implicits.global
+
+// Actions
+
+// Request loading the queue
+case object RefreshQueue
+case class UpdatedQueue(queue: SeqexecQueue)
 
 /**
   * Handles actions related to todos
@@ -14,7 +21,11 @@ case class UpdateQueue(queue: Pot[SeqexecQueue])
   */
 class QueueHandler[M](modelRW: ModelRW[M, Pot[SeqexecQueue]]) extends ActionHandler(modelRW) {
   override def handle = {
-    case UpdateQueue(queue) => updated(queue)
+    case RefreshQueue        =>
+      // Call the backend requesting the queue
+      effectOnly(Effect(SeqexecWebClient.readQueue().map(UpdatedQueue)))
+    case UpdatedQueue(queue) =>
+      updated(Ready(queue))
   }
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
@@ -26,6 +26,8 @@ object SemanticUI {
     def dropdown(): this.type = js.native
 
     def tab(): this.type = js.native
+
+    def transition(s: String): this.type = js.native
   }
 
   implicit def jq2Semantic(jq: JQuery): SemanticCommands = jq.asInstanceOf[SemanticCommands]

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/message/CloseableMessage.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/message/CloseableMessage.scala
@@ -1,0 +1,63 @@
+package edu.gemini.seqexec.web.client.semanticui.elements.message
+
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
+import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM, ReactNode}
+import japgolly.scalajs.react.vdom.prefix_<^._
+
+/**
+  * ReactComponent for a closeable message
+  */
+object CloseableMessage {
+  sealed trait Style
+
+  object Style {
+    case object NotDefined extends Style
+    case object Warning extends Style
+    case object Info extends Style
+    case object Positive extends Style
+    case object Success extends Style
+    case object Negative extends Style
+    case object Error extends Style
+  }
+
+  case class Props(header: Option[String] = None, style: Style = Style.NotDefined)
+
+  def component = ReactComponentB[Props]("Message")
+    .stateless
+    .renderPC((_, p, c) =>
+      <.div(
+        ^.cls := "ui message",
+        ^.classSet(
+          "warning"  -> (p.style == Style.Warning),
+          "info"     -> (p.style == Style.Info),
+          "positive" -> (p.style == Style.Positive),
+          "success"  -> (p.style == Style.Success),
+          "negative" -> (p.style == Style.Negative),
+          "error"    -> (p.style == Style.Error)
+        ),
+        Icon("close"),
+        p.header.map(h =>
+          <.div(
+            ^.cls := "header",
+            h
+          )
+        ),
+        c
+      )
+    )
+    .componentDidMount(s =>
+      Callback {
+        // Need to go into jQuery and semantic to enable the close button
+        import org.querki.jquery.$
+        import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+        import org.scalajs.dom.Element
+
+        $(ReactDOM.findDOMNode(s)).on("click", (e: Element, ev: Any) =>
+          $(e).closest(".message").transition("fade")
+        )
+      }
+    )
+    .build
+
+  def apply(p: Props, children: ReactNode*) = component(p, children: _*)
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -1,6 +1,6 @@
 package edu.gemini.seqexec.web.client.services
 
-import edu.gemini.seqexec.web.common.{Sequence, SequenceSteps}
+import edu.gemini.seqexec.web.common.{SeqexecQueue, Sequence, SequenceSteps}
 import org.scalajs.dom.ext.Ajax
 import upickle.default
 
@@ -11,11 +11,17 @@ import scala.concurrent.ExecutionContext.Implicits.global
   * Encapsulates remote calls to the Seqexec Web API
   */
 object SeqexecWebClient {
-  val baseUrl = "/api"
+  val baseUrl = "/api/seqexec"
 
   def read(id: String): Future[Sequence] = {
     Ajax.get(
       url = s"$baseUrl/sequence/$id"
     ).map(s => default.read[Sequence](s.responseText))
+  }
+
+  def readQueue(): Future[SeqexecQueue] = {
+    Ajax.get(
+      url = s"$baseUrl/current/queue"
+    ).map(s => default.read[SeqexecQueue](s.responseText))
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuitSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuitSpec.scala
@@ -12,7 +12,7 @@ class SeqexecCircuitSpec extends FlatSpec with Matchers with PropertyChecks with
 
   "SeqexecCircuit" should "support queue updates" in {
     forAll { (sequences: List[SequenceInQueue]) =>
-      val result = build.handle(UpdateQueue(Ready(SeqexecQueue(sequences))))
+      val result = build.handle(UpdatedQueue(Ready(SeqexecQueue(sequences))))
       result should matchPattern {
         case ModelUpdate(Ready(SeqexecQueue(q))) if q == sequences =>
       }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuitSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuitSpec.scala
@@ -1,0 +1,21 @@
+package edu.gemini.seqexec.web.client.model
+
+import diode.ActionResult.ModelUpdate
+import diode.RootModelRW
+import diode.data.{Empty, Ready}
+import edu.gemini.seqexec.web.common.{Arbitraries, SeqexecQueue, SequenceInQueue}
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class SeqexecCircuitSpec extends FlatSpec with Matchers with PropertyChecks with Arbitraries {
+  def build = new QueueHandler(new RootModelRW(Empty))
+
+  "SeqexecCircuit" should "support queue updates" in {
+    forAll { (sequences: List[SequenceInQueue]) =>
+      val result = build.handle(UpdateQueue(Ready(SeqexecQueue(sequences))))
+      result should matchPattern {
+        case ModelUpdate(Ready(SeqexecQueue(q))) if q == sequences =>
+      }
+    }
+  }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuitSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuitSpec.scala
@@ -1,8 +1,8 @@
 package edu.gemini.seqexec.web.client.model
 
-import diode.ActionResult.ModelUpdate
+import diode.ActionResult.{ModelUpdate, ModelUpdateEffect}
 import diode.RootModelRW
-import diode.data.{Empty, Ready}
+import diode.data.{Empty, Failed, Pot, Ready}
 import edu.gemini.seqexec.web.common.{Arbitraries, SeqexecQueue, SequenceInQueue}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
@@ -10,12 +10,25 @@ import org.scalatest.{FlatSpec, Matchers}
 class SeqexecCircuitSpec extends FlatSpec with Matchers with PropertyChecks with Arbitraries {
   def build = new QueueHandler(new RootModelRW(Empty))
 
-  "SeqexecCircuit" should "support queue updates" in {
+  "SeqexecCircuit" should
+    "support queue updates" in {
     forAll { (sequences: List[SequenceInQueue]) =>
       val result = build.handle(UpdatedQueue(Ready(SeqexecQueue(sequences))))
       result should matchPattern {
         case ModelUpdate(Ready(SeqexecQueue(q))) if q == sequences =>
       }
+    }
+  }
+  it should "support pending state" in {
+    val result = build.handle(UpdatedQueue(Empty))
+    result should matchPattern {
+      case ModelUpdateEffect(newValue: Pot[_], effects) if newValue.isPending && effects.size == 2 =>
+    }
+  }
+  it should "support error case" in {
+    val result = build.handle(UpdatedQueue(Failed(new RuntimeException("error"))))
+    result should matchPattern {
+      case ModelUpdate(newValue: Pot[_]) if newValue.isFailed =>
     }
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/seqexec-semantic.html
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/seqexec-semantic.html
@@ -57,6 +57,9 @@
               </div>
             </div>
             <div class="ui secondary segment">
+              <div class="ui dimmer">
+                <div class="ui text loader large">Loading</div>
+              </div>
               <table class="ui selectable compact celled table unstackable">
                 <thead>
                   <tr>
@@ -287,8 +290,8 @@
 
     </div>
 
-    <script src="edu-gemini-seqexec-web-client-jsdeps.js"></script>
-    <script src="seqexec-opt.js"></script>
+    <script src="edu_gemini_seqexec_web_client-jsdeps.js"></script>
+    <script src="seqexec.js"></script>
     <script type="text/javascript">
       $(document)
       .ready(function() {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/seqexec-semantic.html
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/seqexec-semantic.html
@@ -60,6 +60,12 @@
               <div class="ui dimmer">
                 <div class="ui text loader large">Loading</div>
               </div>
+              <div class="ui negative message">
+                <i class="close icon"></i>
+                <div class="header">
+                  Sorry, there was an error reading the queue from the server
+                </div>
+              </div>
               <table class="ui selectable compact celled table unstackable">
                 <thead>
                   <tr>
@@ -301,7 +307,15 @@
         $(".main.menu .ui.dropdown").dropdown();
         $(".tabular.menu .item").tab();
         $(".ui.dropdown").dropdown();
-        });
+        $('.message .close')
+          .on('click', function() {
+            $(this)
+              .closest('.message')
+              .transition('fade')
+            ;
+          })
+        ;
+      });
     </script>
   </body>
 </html>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/RestRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/RestRoutes.scala
@@ -6,9 +6,12 @@ import upickle.default._
 import edu.gemini.seqexec.web.common._
 import edu.gemini.seqexec.web.server.model.CannedModel
 
+/**
+  * Rest Endpoints under the /api route
+  */
 object RestRoutes {
   val service = HttpService {
-    case req @ GET -> Root / "api" / "seqexec" / "current" / "queue" =>
+    case req @ GET -> Root  / "seqexec" / "current" / "queue" =>
       Ok(write(CannedModel.currentQueue))
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/WebServerLauncher.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/WebServerLauncher.scala
@@ -3,6 +3,7 @@ package edu.gemini.seqexec.web.server.play
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
 import edu.gemini.seqexec.web.common._
+import edu.gemini.seqexec.web.server.model.CannedModel
 import play.api.routing.Router
 import play.api.{BuiltInComponents, Mode}
 import play.core.server.{NettyServerComponents, ServerConfig}
@@ -29,6 +30,9 @@ object WebServerLauncher extends App {
         case GET(p"/") =>
           // Index
           CustomAssets.at("./src/main/resources", "index.html", "/")
+        case GET(p"/api/seqexec/current/queue") => Action {
+          Results.Ok(write(CannedModel.currentQueue))
+        }
         case GET(p"/api/sequence/$id<.*-[0-9]+>") => Action {
           val obsId = new SPObservationID(id)
           ExecutorImpl.read(obsId) match {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/test/scala/edu/gemini/seqexec/web/common/Arbitraries.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/test/scala/edu/gemini/seqexec/web/common/Arbitraries.scala
@@ -24,4 +24,14 @@ trait Arbitraries {
   implicit val arbSequenceState: Arbitrary[SequenceState] =
     Arbitrary(Gen.oneOf[SequenceState](SequenceState.Completed, SequenceState.Error, SequenceState.NotRunning, SequenceState.Running))
 
+  implicit val arbSequenceInQueue: Arbitrary[SequenceInQueue] =
+    Arbitrary {
+      for {
+        i  <- arbitrary[String]
+        s  <- arbitrary[SequenceState]
+        in <- arbitrary[String]
+        e  <- arbitrary[Option[String]]
+      } yield SequenceInQueue(i, s, in, e)
+    }
+
 }


### PR DESCRIPTION
This PR builds on the Web UI by loading the contents of the Seqexec Queue (Canned data ATM), Implements #8. At startup it will request the current queue using an ajax request and display the contents of the queue on the queue table. Some notes:

* Both backends can be used to serve the application
* This PR starts using [Diode](http://ochrons.github.io/diode/index.html), which is the scala.js version of the [Flux Architecture](http://facebook.github.io/flux/) for React applications
* The code contains logic to display an indicator while loading and to display proper error in case of a failure

Below there is a small video (á la @tpolecat) with the happy path and an error case. In both cases the server has an artificial 3 seconds delay, otherwise you cannot see the loading process while serving locally

[HappyCase](https://www.dropbox.com/sc/oydtgm5be9tf9f1/AAAk2LStHPPjCyifyjS9aGMPa)
[ErrorCase](https://www.dropbox.com/sc/iywl4mo4tfnnt8x/AABvI8HNBbKPVSfUmKKaMmL9a)