### PR TITLE
Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: scala
+scala:
+  - 2.11.8
+jdk:
+  - oraclejdk8
+script: sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -8,5 +8,5 @@ scalacOptions in ThisBuild ++= Settings.Definitions.scalacOptions
 organization in Global := "edu.gemini.ocs"
 
 // Gemini repository
-resolvers in ThisBuild += "Gemini Repository" at "http://sbfswgosxdev-mp1.cl.gemini.edu:8081/artifactory/libs-release-local"
+resolvers in ThisBuild += "Gemini Repository" at "https://github.com/gemini-hlsw/maven-repo/raw/master/releases"
 


### PR DESCRIPTION
This PR brings travis support to ocs3. It uses the GitHub repo to host the ocs bundles.
I changed the config so that you cannot merge PRs unless the build passes