### PR TITLE
sbt-buildinfo into the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Note that IDEA doesn't support running tests on scala.js. See this [issue](https
 
 ## IDEA
 
+Before opening the project in IDEA, run a top-level compile at least once to generate code that will be picked up by IDEA
+
 IDEA can open directly the project's sbt. Go to 
 
 ```
@@ -62,4 +64,6 @@ File -> Open
 And find the file `ocs/build.sbt`. IDEA should show a dialog box to import the project. You may need to select the appropriate JVM version (1.8) and IDEA will import the project. `sbt` files may have highlight errors due to this [bug](https://youtrack.jetbrains.com/issue/SCL-9599). Otherwise, sbt import seems to work quite well.
 
 **Note:** Sbt import in IDEA changes very often. This has been tested on IDEA C 2016.1 and the Scala plugin version 3.0
-	
+
+**Note:** If you need to re-generate the project, delete the `.idea` folder
+ 

--- a/modules/edu.gemini.seqexec.web/build.sbt
+++ b/modules/edu.gemini.seqexec.web/build.sbt
@@ -34,6 +34,7 @@ lazy val edu_gemini_seqexec_web_shared_JS = edu_gemini_seqexec_web_shared.js
 // Client side project using Scala.js
 lazy val edu_gemini_seqexec_web_client = project.in(file("edu.gemini.seqexec.web.client"))
   .enablePlugins(ScalaJSPlugin)
+  .enablePlugins(BuildInfoPlugin)
   .settings(commonSettings: _*)
   .settings(
     // Skip tests in module, Rhino doesn't play nice with jquery
@@ -57,6 +58,11 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("edu.gemini.seqexec.web
       ScalaCSS.value,
       ScalaJSDom.value
     ) ++ ReactScalaJS.value ++ Diode.value
+  )
+  .settings(
+    buildInfoUsePackageAsPath := true,
+    buildInfoKeys := Seq(name, version),
+    buildInfoPackage := "edu.gemini.seqexec.web.client"
   )
   .dependsOn(edu_gemini_seqexec_web_shared_JS % "compile->compile;test->test")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.8")
 
 // sbt revolver lets launching applications from the sbt console
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
+
+// Extract metadata from sbt and make it available to the code
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")


### PR DESCRIPTION
I'm raising this PR for discussion as I don't need this right away. I want, at some moment, display the version of the software on the UI. I'd think the best way to do this is by bringing the information from sbt avoiding repetition, and that's exactly what the [sbt-buildinfo](https://github.com/sbt/sbt-buildinfo) plugin does.

This PR integrates buildinfo into the build and will generate a managed class with the content as

```scala
package edu.gemini.seqexec.web.client

import scala.Predef._

/** This object was generated by sbt-buildinfo. */
case object BuildInfo {
  /** The value is "edu_gemini_seqexec_web_client". */
  val name: String = "edu_gemini_seqexec_web_client"
  /** The value is "0.1-SNAPSHOT". */
  val version: String = "0.1-SNAPSHOT"
  override val toString: String = {
    "name: %s, version: %s" format (
      name, version
    )
  }
}
```

I found one caveat though. You need to generate the class before opening the project on IDEA. If you open it before it won't compile as the `BuildInfo` class won't be on idea's classpath. It works fine if you do an initial compile and then open it with IDEA. I believe the same happens for any generated code, see [bug](https://youtrack.jetbrains.com/issue/SCL-9301)

What do you think, is this the right approach?