### PR TITLE
DhsClient simulator

### DIFF
--- a/modules/edu.gemini.seqexec.server/build.sbt
+++ b/modules/edu.gemini.seqexec.server/build.sbt
@@ -14,4 +14,4 @@ libraryDependencies ++= Seq(
   SpModelCore,
   POT,
   EpicsACM
-)
+) ++ TestLibs.value

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -1,10 +1,8 @@
 package edu.gemini.seqexec.server
 
-import java.util.logging.Logger
-
 import argonaut._
 import Argonaut._
-import org.apache.commons.httpclient.{HttpMethod, HttpClient}
+import org.apache.commons.httpclient.HttpClient
 import org.apache.commons.httpclient.methods.{EntityEnclosingMethod, PutMethod, PostMethod}
 
 import scala.io.Source
@@ -12,9 +10,6 @@ import scala.io.Source
 import scalaz.concurrent.Task
 import scalaz.EitherT
 
-/**
- * Created by jluhrs on 11/5/15.
- */
 object DhsClient {
 
   val baseURI = "http://cpodhsxx:9090/axis2/services/dhs/images"
@@ -38,7 +33,7 @@ object DhsClient {
   }
 
   implicit def errorDecode: DecodeJson[Error] = DecodeJson[Error]( c => for {
-      t <- (c --\ "type").as[ErrorType]
+      t   <- (c --\ "type").as[ErrorType]
       msg <- (c --\ "message").as[String]
     } yield Error(t, msg)
   )

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -10,7 +10,13 @@ import scala.io.Source
 import scalaz.concurrent.Task
 import scalaz.EitherT
 
-object DhsClient {
+trait DhsClient {
+  def createImage(p: DhsClient.ImageParameters): SeqAction[DhsClient.ObsId]
+
+  def setKeywords(id: DhsClient.ObsId, keywords: DhsClient.KeywordBag, finalFlag: Boolean = false): SeqAction[Unit]
+}
+
+object DhsClient extends DhsClient {
 
   val baseURI = "http://cpodhsxx:9090/axis2/services/dhs/images"
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -99,7 +99,7 @@ object DhsClient {
 }
 
 /**
-  * Implementation of DhsClient that interfaces with the real DHS oven the http interface
+  * Implementation of DhsClient that interfaces with the real DHS over the http interface
   */
 object DhsClientHttp extends DhsClient {
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -14,6 +14,9 @@ import scala.io.Source
 import scalaz.concurrent.Task
 import scalaz.EitherT
 
+/**
+  * Defines the interface for dhs client, with methods, e.g. to request image creation
+  */
 trait DhsClient {
   /**
     * Requests the DHS to create an image returning the obs id if applicable
@@ -26,22 +29,78 @@ trait DhsClient {
   def setKeywords(id: DhsClient.ObsId, keywords: DhsClient.KeywordBag, finalFlag: Boolean = false): SeqAction[Unit]
 }
 
-class DhsClientSim(date: LocalDate) extends DhsClient {
-  private val counter = new AtomicInteger(0)
+object DhsClient {
 
-  val format = DateTimeFormatter.ofPattern("yyyyMMdd")
+  // Common data types
+  type ObsId = String
 
-  override def createImage(p: ImageParameters): SeqAction[ObsId] =
-    EitherT(Task.now(TrySeq(f"S${date.format(format)}${counter.incrementAndGet()}%04d")))
+  type Contributor = String
 
-  override def setKeywords(id: ObsId, keywords: KeywordBag, finalFlag: JsonBoolean): SeqAction[Unit] =
-    EitherT(Task.now(TrySeq(())))
+  sealed case class Lifetime(str: String)
+  object Permanent extends Lifetime("PERMANENT")
+  object Temporary extends Lifetime("TEMPORARY")
+  object Transient extends Lifetime("TRANSIENT")
+
+  final case class ImageParameters(lifetime: Lifetime, contributors: List[Contributor])
+
+  // TODO: Implement the unsigned types, if needed.
+  sealed case class KeywordType protected (str: String)
+  object TypeInt8 extends KeywordType("INT8")
+  object TypeInt16 extends KeywordType("INT16")
+  object TypeInt32 extends KeywordType("INT32")
+  object TypeFloat extends KeywordType("FLOAT")
+  object TypeDouble extends KeywordType("DOUBLE")
+  object TypeBoolean extends KeywordType("BOOLEAN")
+  object TypeString extends KeywordType("STRING")
+
+
+  // The developer uses these classes to define all the typed keywords
+  sealed class Keyword[T] protected (val n: String, val t: KeywordType, val v: T)
+  final case class Int8Keyword(name: String, value: Byte) extends Keyword[Byte](name, TypeInt8, value)
+  final case class Int16Keyword(name: String, value: Short) extends Keyword[Short](name, TypeInt16, value)
+  final case class Int32Keyword(name: String, value: Int) extends Keyword[Int](name, TypeInt32, value)
+  final case class FloatKeyword(name: String, value: Float) extends Keyword[Float](name, TypeFloat, value)
+  final case class DoubleKeyword(name: String, value: Double) extends Keyword[Double](name, TypeDouble, value)
+  final case class BooleanKeyword(name: String, value: Boolean) extends Keyword[Boolean](name, TypeBoolean, value)
+  final case class StringKeyword(name: String, value: String) extends Keyword[String](name, TypeString, value)
+
+  // At the end, I want to just pass a list of keywords to be sent to the DHS. I cannot do this with Keyword[T],
+  // because I cannot mix different types in a List. But at the end I only care about the value as a String, so I
+  // use an internal representation, and offer a class to the developer (KeywordBag) to create the list from typed
+  // keywords.
+
+  final case class InternalKeyword(name: String, keywordType: KeywordType, value: String)
+
+  protected implicit def internalKeywordConvert[T](k: Keyword[T]): InternalKeyword = InternalKeyword(k.n, k.t, k.v.toString)
+
+  final case class KeywordBag(keywords: List[InternalKeyword]) {
+    def add[T](k: Keyword[T]): KeywordBag = KeywordBag(internalKeywordConvert(k) :: keywords)
+    def append(other: KeywordBag): KeywordBag =  KeywordBag(keywords ::: other.keywords)
+  }
+
+  //TODO: Add more apply methods if necessary
+  object KeywordBag {
+    def apply: KeywordBag = KeywordBag(List())
+    def apply[A](k1: Keyword[A]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1)))
+    def apply[A, B](k1: Keyword[A], k2: Keyword[B]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2)))
+    def apply[A, B, C](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3)))
+    def apply[A, B, C, D](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4)))
+    def apply[A, B, C, D, E](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4), internalKeywordConvert(k5)))
+    def apply[A, B, C, D, E, F](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E], k6: Keyword[F]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4), internalKeywordConvert(k5), internalKeywordConvert(k6)))
+  }
+
 }
 
-object DhsClientSim {
-  def apply(date: LocalDate) = new DhsClientSim(date)
-}
-
+/**
+  * Implementation of DhsClient that interfaces with the real DHS oven the http interface
+  */
 object DhsClientHttp extends DhsClient {
 
   val baseURI = "http://cpodhsxx:9090/axis2/services/dhs/images"
@@ -125,70 +184,21 @@ object DhsClientHttp extends DhsClient {
       "Unable to write keywords for image " + id)
 }
 
-object DhsClient {
+/**
+  * Implementation of the Dhs client that simulates a dhs without external dependencies
+  */
+class DhsClientSim(date: LocalDate) extends DhsClient {
+  private val counter = new AtomicInteger(0)
 
-  type ObsId = String
+  val format = DateTimeFormatter.ofPattern("yyyyMMdd")
 
-  type Contributor = String
+  override def createImage(p: ImageParameters): SeqAction[ObsId] =
+    EitherT(Task.now(TrySeq(f"S${date.format(format)}${counter.incrementAndGet()}%04d")))
 
-  sealed case class Lifetime(str: String)
-  object Permanent extends Lifetime("PERMANENT")
-  object Temporary extends Lifetime("TEMPORARY")
-  object Transient extends Lifetime("TRANSIENT")
+  override def setKeywords(id: ObsId, keywords: KeywordBag, finalFlag: JsonBoolean): SeqAction[Unit] =
+    EitherT(Task.now(TrySeq(())))
+}
 
-  final case class ImageParameters(lifetime: Lifetime, contributors: List[Contributor])
-
-  // TODO: Implement the unsigned types, if needed.
-  sealed case class KeywordType protected (str: String)
-  object TypeInt8 extends KeywordType("INT8")
-  object TypeInt16 extends KeywordType("INT16")
-  object TypeInt32 extends KeywordType("INT32")
-  object TypeFloat extends KeywordType("FLOAT")
-  object TypeDouble extends KeywordType("DOUBLE")
-  object TypeBoolean extends KeywordType("BOOLEAN")
-  object TypeString extends KeywordType("STRING")
-
-
-  // The developer uses these classes to define all the typed keywords
-  sealed class Keyword[T] protected (val n: String, val t: KeywordType, val v: T)
-  final case class Int8Keyword(name: String, value: Byte) extends Keyword[Byte](name, TypeInt8, value)
-  final case class Int16Keyword(name: String, value: Short) extends Keyword[Short](name, TypeInt16, value)
-  final case class Int32Keyword(name: String, value: Int) extends Keyword[Int](name, TypeInt32, value)
-  final case class FloatKeyword(name: String, value: Float) extends Keyword[Float](name, TypeFloat, value)
-  final case class DoubleKeyword(name: String, value: Double) extends Keyword[Double](name, TypeDouble, value)
-  final case class BooleanKeyword(name: String, value: Boolean) extends Keyword[Boolean](name, TypeBoolean, value)
-  final case class StringKeyword(name: String, value: String) extends Keyword[String](name, TypeString, value)
-
-  // At the end, I want to just pass a list of keywords to be sent to the DHS. I cannot do this with Keyword[T],
-  // because I cannot mix different types in a List. But at the end I only care about the value as a String, so I
-  // use an internal representation, and offer a class to the developer (KeywordBag) to create the list from typed
-  // keywords.
-
-  final case class InternalKeyword(name: String, keywordType: KeywordType, value: String)
-
-  protected implicit def internalKeywordConvert[T](k: Keyword[T]): InternalKeyword = InternalKeyword(k.n, k.t, k.v.toString)
-
-  final case class KeywordBag(keywords: List[InternalKeyword]) {
-    def add[T](k: Keyword[T]): KeywordBag = KeywordBag(internalKeywordConvert(k) :: keywords)
-    def append(other: KeywordBag): KeywordBag =  KeywordBag(keywords ::: other.keywords)
-  }
-
-  //TODO: Add more apply methods if necessary
-  object KeywordBag {
-    def apply: KeywordBag = KeywordBag(List())
-    def apply[A](k1: Keyword[A]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1)))
-    def apply[A, B](k1: Keyword[A], k2: Keyword[B]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2)))
-    def apply[A, B, C](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C]): KeywordBag =
-      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3)))
-    def apply[A, B, C, D](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D]): KeywordBag =
-      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
-        internalKeywordConvert(k4)))
-    def apply[A, B, C, D, E](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E]): KeywordBag =
-      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
-        internalKeywordConvert(k4), internalKeywordConvert(k5)))
-    def apply[A, B, C, D, E, F](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E], k6: Keyword[F]): KeywordBag =
-      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
-        internalKeywordConvert(k4), internalKeywordConvert(k5), internalKeywordConvert(k6)))
-  }
-
+object DhsClientSim {
+  def apply(date: LocalDate) = new DhsClientSim(date)
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Executor.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Executor.scala
@@ -37,7 +37,7 @@ object Step {
     instrument map { a => {
 //        val systems = List(Tcs(TcsControllerEpics), a)
         val systems = List(Tcs(TcsControllerSim), a)
-        (systems.toSet, step(systems.map(_.configure(config)), a.observe(config))).right
+        (systems.toSet, step(systems.map(_.configure(config)), a.observe(config).run(???))).right
       }
     } getOrElse UnrecognizedInstrument(instName.toString).left[(Set[System], Step)]
   }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Executor.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Executor.scala
@@ -1,11 +1,9 @@
 package edu.gemini.seqexec.server
 
 import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
-import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.server.SeqexecFailure._
-import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
+import edu.gemini.spModel.config2.{Config, ItemKey}
 import edu.gemini.spModel.obscomp.InstConstants.INSTRUMENT_NAME_PROP
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 
@@ -14,10 +12,6 @@ import scalaz._
 import Scalaz._
 
 import scalaz.concurrent.Task
-
-/**
- * Created by jluhrs on 4/28/15.
- */
 
 object Step {
   type Step = EitherT[Task, NonEmptyList[SeqexecFailure], StepResult]
@@ -45,7 +39,7 @@ object Step {
         val systems = List(Tcs(TcsControllerSim), a)
         (systems.toSet, step(systems.map(_.configure(config)), a.observe(config))).right
       }
-    } getOrElse(UnrecognizedInstrument(instName.toString).left[(Set[System], Step)])
+    } getOrElse UnrecognizedInstrument(instName.toString).left[(Set[System], Step)]
   }
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2.scala
@@ -20,10 +20,6 @@ import scala.concurrent.duration.Duration
 import scalaz.concurrent.Task
 import scalaz.{EitherT, \/, \/-}
 
-
-/**
- * Created by jluhrs on 11/16/15.
- */
 final case class Flamingos2(f2Controller: Flamingos2Controller) extends Instrument {
 
   import Flamingos2._

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Controller.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Controller.scala
@@ -4,9 +4,6 @@ import edu.gemini.seqexec.server.DhsClient.ObsId
 
 import scala.concurrent.duration.Duration
 
-/**
- * Created by jluhrs on 11/16/15.
- */
 trait Flamingos2Controller {
   import Flamingos2Controller._
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerSim.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerSim.scala
@@ -8,9 +8,6 @@ import edu.gemini.seqexec.server.Flamingos2Controller.Flamingos2Config
 import scalaz.EitherT
 import scalaz.concurrent.Task
 
-/**
- * Created by jluhrs on 11/24/15.
- */
 object Flamingos2ControllerSim extends Flamingos2Controller {
   private val Log = Logger.getLogger(getClass.getName)
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouth.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouth.scala
@@ -9,9 +9,6 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import scalaz.EitherT
 import scalaz.concurrent.Task
 
-/**
- * Created by jluhrs on 4/27/15.
- */
 object GmosSouth extends Instrument {
 
   override val name: String = INSTRUMENT_NAME_PROP

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouth.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouth.scala
@@ -39,7 +39,7 @@ object GmosSouth extends Instrument {
              Log.log(Level.INFO, name + ": observation completed")
              TrySeq(())
            })
-      _ <- DhsClient.setKeywords(id, DhsClient.KeywordBag(
+      _ <- client.setKeywords(id, DhsClient.KeywordBag(
              DhsClient.StringKeyword("instrument", "gmos"),
              DhsClient.Int32Keyword("INPORT", 3),
              DhsClient.DoubleKeyword("WAVELENG", 3.14159),

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouth.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouth.scala
@@ -6,7 +6,7 @@ import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth.INSTRUMENT_NAME_PROP
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 
-import scalaz.EitherT
+import scalaz.{EitherT, Reader}
 import scalaz.concurrent.Task
 
 object GmosSouth extends Instrument {
@@ -30,20 +30,22 @@ object GmosSouth extends Instrument {
     TrySeq(ConfigResult(this))
   })
 
-  override def observe(config: Config): SeqAction[ObserveResult] = for {
-    id <- DhsClient.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List("gmos", "dhs-http")))
-    _ <- EitherT ( Task {
-      Log.log(Level.INFO, name + ": starting observation " + id)
-      Thread.sleep(5000)
-      Log.log(Level.INFO, name + ": observation completed")
-      TrySeq(())
-    } )
-    _ <- DhsClient.setKeywords(id, DhsClient.KeywordBag(
-      DhsClient.StringKeyword("instrument", "gmos"),
-      DhsClient.Int32Keyword("INPORT", 3),
-      DhsClient.DoubleKeyword("WAVELENG", 3.14159),
-      DhsClient.BooleanKeyword("PROP_MD", value = true)
-    ))
-  } yield ObserveResult(id)
+  override def observe(config: Config): Reader[DhsClient, SeqAction[ObserveResult]] = Reader { client =>
+    for {
+      id <- client.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List("gmos", "dhs-http")))
+      _ <- EitherT(Task {
+             Log.log(Level.INFO, name + ": starting observation " + id)
+             Thread.sleep(5000)
+             Log.log(Level.INFO, name + ": observation completed")
+             TrySeq(())
+           })
+      _ <- DhsClient.setKeywords(id, DhsClient.KeywordBag(
+             DhsClient.StringKeyword("instrument", "gmos"),
+             DhsClient.Int32Keyword("INPORT", 3),
+             DhsClient.DoubleKeyword("WAVELENG", 3.14159),
+             DhsClient.BooleanKeyword("PROP_MD", value = true)
+           ))
+    } yield ObserveResult(id)
+  }
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Instrument.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Instrument.scala
@@ -10,9 +10,6 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import scalaz.EitherT
 import scalaz.concurrent.Task
 
-/**
- * Created by jluhrs on 4/22/15.
- */
 trait Instrument extends System {
   // The name used for this instrument in the science fold configuration
   val sfName: String

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Instrument.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Instrument.scala
@@ -7,13 +7,13 @@ import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 
-import scalaz.EitherT
+import scalaz.{EitherT, Reader}
 import scalaz.concurrent.Task
 
 trait Instrument extends System {
   // The name used for this instrument in the science fold configuration
   val sfName: String
-  def observe(config: Config): SeqAction[ObserveResult]
+  def observe(config: Config): Reader[DhsClient, SeqAction[ObserveResult]]
 }
 
 //Placeholder for observe response
@@ -31,8 +31,10 @@ object UnknownInstrument extends Instrument {
     TrySeq(ConfigResult(this))
   } )
 
-  override def observe(config: Config): SeqAction[ObserveResult] = EitherT ( Task {
-    imageCount += 1
-    TrySeq(ObserveResult(f"S20150519S$imageCount%04d"))
-  } )
+  override def observe(config: Config): Reader[DhsClient, SeqAction[ObserveResult]] = Reader { _ =>
+    EitherT(Task {
+      imageCount += 1
+      TrySeq(ObserveResult(f"S20150519S$imageCount%04d"))
+    })
+  }
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
@@ -35,12 +35,5 @@ package object server {
         case \/-(b) => Success(b)
       }
   }
-
-  // This is built into scalaz 7.1
-  implicit class MoreMonadOps[M[+_], A](ma: M[A])(implicit M: Monad[M]) {
-    def whileM_(p: M[Boolean]): M[Unit] =
-      M.ifM(p, M.bind(ma)(_ => whileM_(p)), M.point(()))
-  }
-
 }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
@@ -1,7 +1,6 @@
 package edu.gemini.seqexec
 
-import edu.gemini.seqexec.server.SeqexecFailure.{SeqexecException, Unexpected}
-import edu.gemini.seqexec.server.System
+import edu.gemini.seqexec.server.SeqexecFailure.SeqexecException
 
 import scala.language.higherKinds
 import scalaz._
@@ -9,9 +8,6 @@ import Scalaz._
 
 import scalaz.concurrent.Task
 
-/**
- * Created by jluhrs on 5/18/15.
- */
 package object server {
 
   type TrySeq[A] = SeqexecFailure \/ A
@@ -40,7 +36,7 @@ package object server {
       }
   }
 
-    // This is built into scalaz 7.1
+  // This is built into scalaz 7.1
   implicit class MoreMonadOps[M[+_], A](ma: M[A])(implicit M: Monad[M]) {
     def whileM_(p: M[Boolean]): M[Unit] =
       M.ifM(p, M.bind(ma)(_ => whileM_(p)), M.point(()))

--- a/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/DhsClientSimSpec.scala
+++ b/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/DhsClientSimSpec.scala
@@ -1,0 +1,25 @@
+package edu.gemini.seqexec.server
+
+import java.time.LocalDate
+
+import edu.gemini.seqexec.server.DhsClient.{Int32Keyword, KeywordBag, Permanent}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scalaz.\/-
+
+class DhsClientSimSpec extends FlatSpec with Matchers {
+  "DhsClientSim" should "produce data labels for today" in {
+      DhsClientSim(LocalDate.of(2016, 4, 15)).createImage(DhsClient.ImageParameters(Permanent, Nil)).run.run should matchPattern {
+        case \/-("S201604150001") =>
+      }
+    }
+  it should "accept keywords" in {
+    val client = DhsClientSim(LocalDate.of(2016, 4, 15))
+    client.createImage(DhsClient.ImageParameters(Permanent, Nil)).run.run.fold(
+      _ => fail(),
+      id => client.setKeywords(id, KeywordBag(Int32Keyword("Key", 10)), finalFlag = true).run.run should matchPattern {
+        case \/-(()) =>
+      }
+    )
+  }
+}


### PR DESCRIPTION
This PR gives me an opportunity to dig into the seqexec server and fix a specific problem I'm having. I want to test with a mock dhs client. The current implementation only lets you use the real DHS client making it impossible harder to work without the VPN and it maybe risky to do calls to the real DHS

It is still an open question how'll configure the Seqexec, right now it is set to simulated instruments, simulated tcs and the new mock dhs client but we need to find out a way to properly configure it for different scenarios

This PR fixes #35 