### PR TITLE
Play Websockets

### DIFF
--- a/modules/edu.gemini.seqexec.web/build.sbt
+++ b/modules/edu.gemini.seqexec.web/build.sbt
@@ -104,10 +104,10 @@ def includeInTrigger(f: java.io.File): Boolean =
 lazy val edu_gemini_seqexec_web_server = project.in(file("edu.gemini.seqexec.web.server"))
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(ScalaZCore.value, UnboundId, JwtCore) ++ Http4s ++ Play,
+    libraryDependencies ++= Seq(ScalaZCore.value, UnboundId, JwtCore, StreamZ) ++ Http4s ++ Play,
 
     // Settings to optimize the use of sbt-revolver
-    
+
     // Allows to read the generated JS on client
     resources in Compile += (fastOptJS in (edu_gemini_seqexec_web_client, Compile)).value.data,
     // Lets the backend to read the .map file for js

--- a/modules/edu.gemini.seqexec.web/build.sbt
+++ b/modules/edu.gemini.seqexec.web/build.sbt
@@ -115,8 +115,8 @@ lazy val edu_gemini_seqexec_web_server = project.in(file("edu.gemini.seqexec.web
     // Lets the server read the jsdeps file
     (managedResources in Compile) += (artifactPath in(edu_gemini_seqexec_web_client, Compile, packageJSDependencies)).value,
     // Support stopping the running server
-    //mainClass in reStart := Some("edu.gemini.seqexec.web.server.play.WebServerLauncher"),
-    mainClass in reStart := Some("edu.gemini.seqexec.web.server.http4s.WebServerLauncher"),
+    mainClass in reStart := Some("edu.gemini.seqexec.web.server.play.WebServerLauncher"),
+    // mainClass in reStart := Some("edu.gemini.seqexec.web.server.http4s.WebServerLauncher"),
     // do a fastOptJS on reStart
     reStart <<= reStart dependsOn (fastOptJS in (edu_gemini_seqexec_web_client, Compile)),
     // This settings makes reStart to rebuild if a scala.js file changes on the client

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -1,6 +1,8 @@
 package edu.gemini.seqexec.web.server.play
 
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Source, _}
+import akka.util.ByteString
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
 import edu.gemini.seqexec.web.common.{Sequence, SequenceState, UserLoginRequest}
@@ -10,19 +12,33 @@ import play.api.routing.Router._
 import play.api.routing.sird._
 import upickle.default._
 import edu.gemini.seqexec.web.server.model.Conversions._
+import play.api.http.websocket.{Message, PingMessage, TextMessage}
 import play.api.mvc.WebSocket.MessageFlowTransformer
 import edu.gemini.seqexec.web.server.security.AuthenticationService._
 import edu.gemini.seqexec.web.server.security.AuthenticationConfig
 
 import scalaz.{-\/, \/-}
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import streamz.akka.stream._
 
 /**
   * Routes for calls from the web ui
   */
 object SeqexecUIApiRoutes {
-  implicit val messageFlowTransformer = MessageFlowTransformer.stringMessageFlowTransformer
+  /**
+    * Creates a process that sends a ping every second to keep the connection alive
+    */
+  def pingProcess = {
+    import scalaz.stream.DefaultScheduler
+    import scalaz.stream.time.awakeEvery
+    import scalaz.concurrent.Strategy
+    import scala.concurrent.duration._
+
+    awakeEvery(1.seconds)(Strategy.DefaultStrategy, DefaultScheduler).map{ d => PingMessage(ByteString.empty) }
+  }
+
+  implicit val system = ActorSystem("seqexec")
+
+  implicit val messageFlowTransformer = MessageFlowTransformer.identityMessageFlowTransformer
 
   val routes: Routes = {
     case GET(p"/api/seqexec/sequence/$id<.*-[0-9]+>") => Action {
@@ -35,8 +51,18 @@ object SeqexecUIApiRoutes {
     case GET(p"/api/seqexec/current/queue") => Action {
       Results.Ok(write(CannedModel.currentQueue))
     }
-    case GET(p"/api/seqexec/events") => WebSocket.accept[String, String] { h =>
-      val source = Source.tick(initialDelay = 0.second, interval = 1.second, tick = "tick")
+    case GET(p"/api/seqexec/events") => WebSocket.accept[Message, Message] { h =>
+      // Merge the ping and events from ExecutorImpl
+      val events = pingProcess merge ExecutorImpl.sequenceEvents.map(v => TextMessage(write(v)))
+
+      // Make an akka publisher out of the scalaz stream
+      val (p2, publisher) = events.publisher()
+      val source = Source.fromPublisher(publisher)
+
+      // We don't really need to listen for completion, so ignore the callback
+      p2.run.unsafePerformAsync(x => ())
+
+      // Return a flow ignoring the input stream
       Flow.fromSinkAndSource(Sink.ignore, source)
     }
     case POST(p"/api/seqexec/logout") => UserAction { a =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -7,7 +7,7 @@ import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
 import edu.gemini.seqexec.web.common.{Sequence, SequenceState, UserLoginRequest}
 import edu.gemini.seqexec.web.server.model.CannedModel
-import play.api.mvc.{Action, Results, WebSocket}
+import play.api.mvc._
 import play.api.routing.Router._
 import play.api.routing.sird._
 import upickle.default._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -1,23 +1,28 @@
 package edu.gemini.seqexec.web.server.play
 
+import akka.stream.scaladsl.{Source, _}
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
 import edu.gemini.seqexec.web.common.{Sequence, SequenceState, UserLoginRequest}
 import edu.gemini.seqexec.web.server.model.CannedModel
-import play.api.mvc._
+import play.api.mvc.{Action, Results, WebSocket}
 import play.api.routing.Router._
 import play.api.routing.sird._
 import upickle.default._
 import edu.gemini.seqexec.web.server.model.Conversions._
+import play.api.mvc.WebSocket.MessageFlowTransformer
 import edu.gemini.seqexec.web.server.security.AuthenticationService._
 import edu.gemini.seqexec.web.server.security.AuthenticationConfig
 
 import scalaz.{-\/, \/-}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 /**
   * Routes for calls from the web ui
   */
 object SeqexecUIApiRoutes {
+  implicit val messageFlowTransformer = MessageFlowTransformer.stringMessageFlowTransformer
 
   val routes: Routes = {
     case GET(p"/api/seqexec/sequence/$id<.*-[0-9]+>") => Action {
@@ -30,10 +35,13 @@ object SeqexecUIApiRoutes {
     case GET(p"/api/seqexec/current/queue") => Action {
       Results.Ok(write(CannedModel.currentQueue))
     }
+    case GET(p"/api/seqexec/events") => WebSocket.accept[String, String] { h =>
+      val source = Source.tick(initialDelay = 0.second, interval = 1.second, tick = "tick")
+      Flow.fromSinkAndSource(Sink.ignore, source)
+    }
     case POST(p"/api/seqexec/logout") => UserAction { a =>
       // This is not necessary, it is just code to verify token decoding
       println("Logged out " + a.user)
-
       Results.Ok("").discardingCookies(DiscardingCookie(AuthenticationConfig.cookieName))
     }
     case POST(p"/api/seqexec/login") => Action(BodyParsers.parse.text) { s =>

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -38,7 +38,7 @@ object Settings {
     // Java libraries
     val scalaZ       = "7.2.2"
     val scalaZStream = "0.8a"
-    val streamZ      = "0.4-SNAPSHOT"
+    val streamZ      = "0.3.2"
 
     val http4s       = "0.13.2a"
     val play         = "2.5.3"
@@ -83,11 +83,10 @@ object Settings {
     val JavaTimeJS  = Def.setting("org.scala-js" %%% "scalajs-java-time" % LibraryVersions.javaTimeJS)
 
     // ScalaZ
-    val ScalaZCore       = Def.setting("org.scalaz" %%% "scalaz-core"       % LibraryVersions.scalaZ)
-    
-    val ScalaZConcurrent = "org.scalaz"          %% "scalaz-concurrent"   % LibraryVersions.scalaZ
-    val ScalaZStream     = "org.scalaz.stream"   %% "scalaz-stream"       % LibraryVersions.scalaZStream
-    val StreamZ          = "com.github.krasserm" %% "streamz-akka-stream" % LibraryVersions.streamZ
+    val ScalaZCore       = Def.setting("org.scalaz" %%% "scalaz-core"     % LibraryVersions.scalaZ)
+    val ScalaZConcurrent = "org.scalaz"             %%  "scalaz-concurrent"   % LibraryVersions.scalaZ
+    val ScalaZStream     = "org.scalaz.stream"      %%  "scalaz-stream"       % LibraryVersions.scalaZStream
+    val StreamZ          = "com.github.krasserm"    %%  "streamz-akka-stream" % LibraryVersions.streamZ
 
     // Server side libraries
     val Http4s  = Seq(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -38,9 +38,10 @@ object Settings {
     // Java libraries
     val scalaZ       = "7.2.2"
     val scalaZStream = "0.8a"
+    val streamZ      = "0.4-SNAPSHOT"
 
     val http4s       = "0.13.2a"
-    val play         = "2.5.1"
+    val play         = "2.5.3"
     val scalaJQuery  = "1.0-RC2"
     val squants      = "0.6.1-GEM" // GEM Denotes our gemini built package
     val argonaut     = "6.2-M1"
@@ -84,8 +85,9 @@ object Settings {
     // ScalaZ
     val ScalaZCore       = Def.setting("org.scalaz" %%% "scalaz-core"       % LibraryVersions.scalaZ)
     
-    val ScalaZConcurrent = "org.scalaz"        %% "scalaz-concurrent" % LibraryVersions.scalaZ
-    val ScalaZStream     = "org.scalaz.stream" %% "scalaz-stream"     % LibraryVersions.scalaZStream
+    val ScalaZConcurrent = "org.scalaz"          %% "scalaz-concurrent"   % LibraryVersions.scalaZ
+    val ScalaZStream     = "org.scalaz.stream"   %% "scalaz-stream"       % LibraryVersions.scalaZStream
+    val StreamZ          = "com.github.krasserm" %% "streamz-akka-stream" % LibraryVersions.streamZ
 
     // Server side libraries
     val Http4s  = Seq(


### PR DESCRIPTION
The Websocket channel was made using `scalaz-stream`. The http4s backend was able to use the stream directly, but the play backend was left pending as it is not compatible with `scalaz-stream` preferring `akka-streams` instead.

This PR uses the `streamz` library to convert from one type of stream to the other, letting the play backend use the same data source

Fixes #55