### PR TITLE
Authentication part I

### DIFF
--- a/modules/edu.gemini.seqexec.web/build.sbt
+++ b/modules/edu.gemini.seqexec.web/build.sbt
@@ -104,7 +104,7 @@ def includeInTrigger(f: java.io.File): Boolean =
 lazy val edu_gemini_seqexec_web_server = project.in(file("edu.gemini.seqexec.web.server"))
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= ScalaZCore.value +: (Http4s ++ Play),
+    libraryDependencies ++= Seq(ScalaZCore.value, UnboundId) ++ Http4s ++ Play,
 
     // Settings to optimize the use of sbt-revolver
     

--- a/modules/edu.gemini.seqexec.web/build.sbt
+++ b/modules/edu.gemini.seqexec.web/build.sbt
@@ -104,7 +104,7 @@ def includeInTrigger(f: java.io.File): Boolean =
 lazy val edu_gemini_seqexec_web_server = project.in(file("edu.gemini.seqexec.web.server"))
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(ScalaZCore.value, UnboundId) ++ Http4s ++ Play,
+    libraryDependencies ++= Seq(ScalaZCore.value, UnboundId, JwtCore) ++ Http4s ++ Play,
 
     // Settings to optimize the use of sbt-revolver
     

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -48,19 +48,17 @@ object SeqexecWebClient {
   /**
     * Login request
     */
-  def login(u: String, p: String): Future[UserDetails] = {
+  def login(u: String, p: String): Future[UserDetails] =
     Ajax.post(
       url = s"$baseUrl/login",
       data = default.write(UserLoginRequest(u, p))
     ).map(s => default.read[UserDetails](s.responseText))
-  }
 
   /**
-    * Login request
+    * Logout request
     */
-  def logout(): Future[String] = {
+  def logout(): Future[String] =
     Ajax.post(
       url = s"$baseUrl/logout"
     ).map(_.responseText)
-  }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -1,6 +1,6 @@
 package edu.gemini.seqexec.web.client.services
 
-import edu.gemini.seqexec.web.common.{HttpStatusCodes, RegularCommand, SeqexecQueue, Sequence}
+import edu.gemini.seqexec.web.common._
 import org.scalajs.dom.ext.{Ajax, AjaxException}
 import upickle.default
 
@@ -43,5 +43,24 @@ object SeqexecWebClient {
     Ajax.post(
       url = s"$baseUrl/commands/${s.id}/stop"
     ).map(s => default.read[RegularCommand](s.responseText))
+  }
+
+  /**
+    * Login request
+    */
+  def login(u: String, p: String): Future[UserDetails] = {
+    Ajax.post(
+      url = s"$baseUrl/login",
+      data = default.write(UserLoginRequest(u, p))
+    ).map(s => default.read[UserDetails](s.responseText))
+  }
+
+  /**
+    * Login request
+    */
+  def logout(): Future[String] = {
+    Ajax.post(
+      url = s"$baseUrl/logout"
+    ).map(_.responseText)
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
@@ -22,7 +22,7 @@ class JwtAuthentication extends Authentication {
       for {
         cookies <- req.headers.get(headers.`Cookie`).map(_.values) \/> MissingCookie
         token   <- cookies.findLeft(_.name == AuthenticationConfig.cookieName) \/> MissingCookie
-        auth    <- decodeToken2(token.content)
+        auth    <- decodeToken(token.content)
       } yield auth
     }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
@@ -1,0 +1,35 @@
+package edu.gemini.seqexec.web.server.http4s
+
+import edu.gemini.seqexec.web.common.UserDetails
+import edu.gemini.seqexec.web.server.security.{AuthenticationConfig, MissingCookie}
+import edu.gemini.seqexec.web.server.security.AuthenticationService._
+import org.http4s.{AttributeKey, Challenge, Request, headers}
+import org.http4s.server.middleware.authentication.Authentication
+
+import scalaz._
+import Scalaz._
+import scalaz.concurrent.Task
+
+object JwtAuthentication {
+  val authenticatedUser = AttributeKey[UserDetails]("edu.gemini.seqexec.authenticatedUser")
+}
+
+class JwtAuthentication extends Authentication {
+  override protected def getChallenge(req: Request): Task[\/[Challenge, Request]] = {
+    val challenge = -\/(Challenge("jwt", Realm))
+
+    def checkAuth(req: Request): Task[AuthResult] = Task.now {
+      for {
+        cookies <- req.headers.get(headers.`Cookie`).map(_.values) \/> MissingCookie
+        token   <- cookies.findLeft(_.name == AuthenticationConfig.cookieName) \/> MissingCookie
+        auth    <- decodeToken2(token.content)
+      } yield auth
+    }
+
+    checkAuth(req) >>= {
+      case \/-(u) => Task.now(\/-(req.withAttribute(JwtAuthentication.authenticatedUser, u)))
+      case -\/(e) => Task.now(challenge)
+    }
+  }
+}
+

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -9,18 +9,19 @@ import edu.gemini.seqexec.web.common._
 import edu.gemini.seqexec.web.server.model.CannedModel
 import upickle.default._
 import edu.gemini.seqexec.web.server.model.Conversions._
+import edu.gemini.seqexec.web.server.security.LDAPService
 import org.http4s.server.websocket._
 import org.http4s.websocket.WebsocketBits._
 
 import scalaz._
 import Scalaz._
-
 import scalaz.stream.Exchange
 
 /**
   * Rest Endpoints under the /api route
   */
 object SeqexecUIApiRoutes {
+  val ldapService = new LDAPService("gs-dc6.gemini.edu", 3268)
 
   /**
     * Creates a process that sends a ping every second to keep the connection alive

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -1,6 +1,5 @@
 package edu.gemini.seqexec.web.server.play
 
-
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
 import edu.gemini.seqexec.web.common.{Sequence, SequenceState, UserLoginRequest}
@@ -11,7 +10,7 @@ import play.api.routing.sird._
 import upickle.default._
 import edu.gemini.seqexec.web.server.model.Conversions._
 import edu.gemini.seqexec.web.server.security.AuthenticationService._
-import edu.gemini.seqexec.web.server.security.{AuthenticationConfig, AuthenticationService}
+import edu.gemini.seqexec.web.server.security.AuthenticationConfig
 
 import scalaz.{-\/, \/-}
 
@@ -31,10 +30,14 @@ object SeqexecUIApiRoutes {
     case GET(p"/api/seqexec/current/queue") => Action {
       Results.Ok(write(CannedModel.currentQueue))
     }
-    case POST(p"/api/seqexec/login") => Action { r =>
-      r.cookies.get(AuthenticationConfig.cookieName).foreach { c =>
-        println(c.value)
-      }
+    case POST(p"/api/seqexec/logout") => Action { r =>
+      // This is not necessary, it is just code to verify token decoding
+      val u = for {
+        token   <- r.cookies.get(AuthenticationConfig.cookieName)
+        user    <- decodeToken(token.value).toOption
+      } yield user
+      println("Logged out " + u)
+
       Results.Ok("").discardingCookies(DiscardingCookie(AuthenticationConfig.cookieName))
     }
     case POST(p"/api/seqexec/login") => Action(BodyParsers.parse.text) { s =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -42,12 +42,15 @@ object SeqexecUIApiRoutes {
     }
     case POST(p"/api/seqexec/login") => Action(BodyParsers.parse.text) { s =>
       val u = read[UserLoginRequest](s.body)
+      // Try to authenticate
       AuthenticationConfig.authServices.authenticateUser(u.username, u.password) match {
         case \/-(user) =>
+          // if successful set a cookie
           val cookieVal = buildToken(user)
           val cookie = Cookie(AuthenticationConfig.cookieName, cookieVal, maxAge = Option(AuthenticationConfig.sessionTimeout), secure = AuthenticationConfig.onSSL, httpOnly = true)
           Results.Ok(write(user)).withCookies(cookie)
-        case -\/(_)    => Results.Unauthorized("")
+        case -\/(_)    =>
+          Results.Unauthorized("")
       }
     }
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -30,13 +30,9 @@ object SeqexecUIApiRoutes {
     case GET(p"/api/seqexec/current/queue") => Action {
       Results.Ok(write(CannedModel.currentQueue))
     }
-    case POST(p"/api/seqexec/logout") => Action { r =>
+    case POST(p"/api/seqexec/logout") => UserAction { a =>
       // This is not necessary, it is just code to verify token decoding
-      val u = for {
-        token   <- r.cookies.get(AuthenticationConfig.cookieName)
-        user    <- decodeToken(token.value).toOption
-      } yield user
-      println("Logged out " + u)
+      println("Logged out " + a.user)
 
       Results.Ok("").discardingCookies(DiscardingCookie(AuthenticationConfig.cookieName))
     }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -5,7 +5,7 @@ import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
 import edu.gemini.seqexec.web.common.{Sequence, SequenceState, UserLoginRequest}
 import edu.gemini.seqexec.web.server.model.CannedModel
-import play.api.mvc.{Action, BodyParsers, Cookie, Results}
+import play.api.mvc._
 import play.api.routing.Router._
 import play.api.routing.sird._
 import upickle.default._
@@ -31,12 +31,18 @@ object SeqexecUIApiRoutes {
     case GET(p"/api/seqexec/current/queue") => Action {
       Results.Ok(write(CannedModel.currentQueue))
     }
+    case POST(p"/api/seqexec/login") => Action { r =>
+      r.cookies.get(AuthenticationConfig.cookieName).foreach { c =>
+        println(c.value)
+      }
+      Results.Ok("").discardingCookies(DiscardingCookie(AuthenticationConfig.cookieName))
+    }
     case POST(p"/api/seqexec/login") => Action(BodyParsers.parse.text) { s =>
       val u = read[UserLoginRequest](s.body)
       AuthenticationConfig.authServices.authenticateUser(u.username, u.password) match {
         case \/-(user) =>
           val cookieVal = buildToken(user)
-          val cookie = Cookie("token", cookieVal, maxAge = Option(AuthenticationConfig.sessionTimeout), secure = AuthenticationConfig.onSSL, httpOnly = true)
+          val cookie = Cookie(AuthenticationConfig.cookieName, cookieVal, maxAge = Option(AuthenticationConfig.sessionTimeout), secure = AuthenticationConfig.onSSL, httpOnly = true)
           Results.Ok(write(user)).withCookies(cookie)
         case -\/(_)    => Results.Unauthorized("")
       }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/UserAction.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/UserAction.scala
@@ -1,0 +1,30 @@
+package edu.gemini.seqexec.web.server.play
+
+import play.api.mvc._
+import edu.gemini.seqexec.web.common.UserDetails
+import edu.gemini.seqexec.web.server.security.{AuthenticationConfig, MissingCookie}
+import edu.gemini.seqexec.web.server.security.AuthenticationService._
+
+import scala.concurrent.Future
+import scalaz._
+import Scalaz._
+
+case class UserRequest[A](user: Option[UserDetails], request: Request[A]) extends WrappedRequest[A](request)
+
+object UserAction extends
+    ActionBuilder[UserRequest] with ActionTransformer[Request, UserRequest] {
+  override def transform[A](request: Request[A]) = Future.successful {
+
+    def checkAuth(req: Request[A]): AuthResult =
+      for {
+        cookies <- \/-(req.cookies)
+        token   <- cookies.find(_.name == AuthenticationConfig.cookieName) \/> MissingCookie
+        auth    <- decodeToken(token.value)
+      } yield auth
+
+    checkAuth(request) match {
+      case \/-(u) => new UserRequest(u.some, request)
+      case -\/(e) => new UserRequest(none, request)
+    }
+  }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/LDAPAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/LDAPAuthenticationService.scala
@@ -9,13 +9,13 @@ import scalaz._
 import Scalaz._
 
 /**
-  * Handles the connections to the LDAP server
+  * Handles authentication against the AD/LDAP server
   */
-class LDAPService(host: String, port: Int) extends AuthenticationService {
+class LDAPAuthenticationService(host: String, port: Int) extends AuthenticationService {
   val MaxConnections = 20
   val Domain = "@gemini.edu"
   val UidExtractor = s"(\\w*)($Domain)?".r
-  // Shorten the timeout
+  // Shorten the default timeout
   val Timeout = 1000
 
   lazy val connection = new LDAPConnection(new LDAPConnectionOptions() <| {_.setConnectTimeoutMillis(Timeout)}, host, port)
@@ -57,10 +57,8 @@ class LDAPService(host: String, port: Int) extends AuthenticationService {
       case e:LDAPException if e.getResultCode == ResultCode.INVALID_CREDENTIALS =>
         UserNotFound(username).left
       case e:LDAPException =>
-        e.printStackTrace()
         GenericFailure("LDAP Authentication error").left
       case e:Exception =>
-        e.printStackTrace()
         GenericFailure(e.getMessage).left
     } finally {
       pool.releaseConnection(c)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/LDAPService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/LDAPService.scala
@@ -1,6 +1,7 @@
 package edu.gemini.seqexec.web.server.security
 
 import com.unboundid.ldap.sdk._
+import edu.gemini.seqexec.web.common.UserDetails
 import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
 
 import scala.collection.JavaConverters._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/LDAPService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/LDAPService.scala
@@ -1,0 +1,75 @@
+package edu.gemini.seqexec.web.server.security
+
+import com.unboundid.ldap.sdk._
+import com.unboundid.util.Debug
+
+import scala.collection.JavaConverters._
+import scalaz._
+import Scalaz._
+
+sealed trait AuthenticationFailure
+case class UserNotFound(user: String) extends AuthenticationFailure
+case class BadCredentials(user: String) extends AuthenticationFailure
+case class GenericFailure(msg: String) extends AuthenticationFailure
+
+case class UserDetails(username: String, displayName: String)
+
+/**
+  * Handles the connections to the LDAP server
+  */
+class LDAPService(host: String, port: Int) {
+  val MaxConnections = 20
+  val Domain = "@gemini.edu"
+  val UidExtractor = s"(\\w*)($Domain)?".r
+
+  val connection = new LDAPConnection(host, port)
+  val pool = new LDAPConnectionPool(connection, MaxConnections)
+  //Debug.setEnabled(true)
+
+  def authenticateUser(username: String, password: String): AuthenticationFailure \/ UserDetails = {
+    val c = pool.getConnection
+    try {
+      // Let users enter with or without the domain
+      val usernameWithDomain = if (username.endsWith(Domain)) username else s"$username$Domain"
+      // Uid shouldn't have domain
+      val uid = usernameWithDomain match {
+        case UidExtractor(u, _) => u
+        case _                  => username
+      }
+      val bindRequest = new SimpleBindRequest(usernameWithDomain, password)
+      // Authenticate
+      c.bind(bindRequest)
+
+      // Find user details
+      val baseDN = c.getRootDSE.getAttributeValue("namingContexts")
+      val filter = Filter.createANDFilter(
+        Filter.createEqualityFilter("uid", uid),
+        Filter.createEqualityFilter("objectClass", "user")
+      )
+      val search = new SearchRequest(s"cn=users,$baseDN", SearchScope.SUB, filter)
+      val searchResult = c.search(search)
+
+      val displayName = for {
+          s <- searchResult.getSearchEntries.asScala.headOption
+          a <- Option(s.getAttribute("displayName"))
+          d <- Option(a.getValue)
+        } yield d
+
+      UserDetails(username, ~displayName).right
+    } catch {
+      case e:LDAPException if e.getResultCode == ResultCode.NO_SUCH_OBJECT      =>
+        e.printStackTrace()
+        BadCredentials(username).left
+      case e:LDAPException if e.getResultCode == ResultCode.INVALID_CREDENTIALS =>
+        UserNotFound(username).left
+      case e:LDAPException =>
+        e.printStackTrace()
+        GenericFailure("LDAP Authentication error").left
+      case e:Exception =>
+        e.printStackTrace()
+        GenericFailure(e.getMessage).left
+    } finally {
+      pool.releaseConnection(c)
+    }
+  }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/TestAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/TestAuthenticationService.scala
@@ -6,7 +6,8 @@ import scalaz._
 import Scalaz._
 
 /**
-  * Authentication service to avoid the LDAP dependency
+  * Authentication service for testing with a hardcoded list of users
+  * It lets you avoid the LDAP dependency but should not be used in production
   */
 object TestAuthenticationService extends AuthenticationService {
   val cannedUsers = List(UserDetails("telops", "Telops") -> "pwd")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/TestAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/TestAuthenticationService.scala
@@ -1,5 +1,7 @@
 package edu.gemini.seqexec.web.server.security
 
+import edu.gemini.seqexec.web.common.UserDetails
+
 import scalaz._
 import Scalaz._
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/TestAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/TestAuthenticationService.scala
@@ -1,0 +1,17 @@
+package edu.gemini.seqexec.web.server.security
+
+import scalaz._
+import Scalaz._
+
+/**
+  * Authentication service to avoid the LDAP dependency
+  */
+object TestAuthenticationService extends AuthenticationService {
+  val cannedUsers = List(UserDetails("telops", "Telops") -> "pwd")
+
+  override def authenticateUser(username: String, password: String): AuthenticationFailure \/ UserDetails = {
+    cannedUsers.collect {
+      case (ud @ UserDetails(u, _), p) if u == username && p == password => ud
+    }.headOption.fold(BadCredentials(username).left[UserDetails])(_.right)
+  }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -20,12 +20,26 @@ trait AuthenticationService {
   def authenticateUser(username: String, password: String): AuthResult
 }
 
-object AuthenticationService {
-  type AuthResult = AuthenticationFailure \/ UserDetails
-
+object AuthenticationConfig {
   // TODO externalize
   val sessionTimeout = 8 * 3600
   val onSSL = false
+  val key = "secretkey"
+
+  val testMode = true
+  val ldapHost = "gs-dc6.gemini.edu"
+  val ldapPort = 3268
+
+  val ldapService = new LDAPService(ldapHost, ldapPort)
+
+  // TODO Only the LDAP service should be present on production mode
+  val authServices = if (testMode) List(TestAuthenticationService, ldapService)
+  else List(ldapService)
+
+}
+
+object AuthenticationService {
+  type AuthResult = AuthenticationFailure \/ UserDetails
 
   // Allows calling authenticate on a list of authenticator, stopping at the first
   // that succeeds
@@ -47,6 +61,6 @@ object AuthenticationService {
 
   def buildToken(u: UserDetails): String = {
     // Given that only this server will need the key we can just use HMAC. 512-bit is the max key size allowed
-    Jwt.encode(JwtClaim(write(u)).issuedNow.expiresIn(3600), "secretkey", JwtAlgorithm.HmacSHA256)
+    Jwt.encode(JwtClaim(write(u)).issuedNow.expiresIn(3600), AuthenticationConfig.key, JwtAlgorithm.HmacSHA256)
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -79,16 +79,7 @@ object AuthenticationService {
   /**
     * Decodes a token out of JSON Web Token
     */
-  def decodeToken(t: String): Try[UserDetails] =
-    for {
-      claim <- Jwt.decode(t, AuthenticationConfig.key, Seq(JwtAlgorithm.HmacSHA256))
-      token <- Try(read[JwtUserClaim](claim))
-    } yield token.toUserDetails
-
-  /**
-    * Decodes a token out of JSON Web Token
-    */
-  def decodeToken2(t: String): AuthResult =
+  def decodeToken(t: String): AuthResult =
     (for {
       claim <- Jwt.decode(t, AuthenticationConfig.key, Seq(JwtAlgorithm.HmacSHA256)).toDisjunction
       token <- \/.fromTryCatchNonFatal(read[JwtUserClaim](claim))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -1,0 +1,40 @@
+package edu.gemini.seqexec.web.server.security
+
+import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
+
+import scala.annotation.tailrec
+import scalaz.{-\/, \/, \/-}
+
+sealed trait AuthenticationFailure
+case class UserNotFound(user: String) extends AuthenticationFailure
+case class BadCredentials(user: String) extends AuthenticationFailure
+case object NoAuthenticator extends AuthenticationFailure
+case class GenericFailure(msg: String) extends AuthenticationFailure
+
+case class UserDetails(username: String, displayName: String)
+
+trait AuthenticationService {
+  def authenticateUser(username: String, password: String): AuthResult
+}
+
+object AuthenticationService {
+  type AuthResult = AuthenticationFailure \/ UserDetails
+
+  // Allows calling authenticate on a list of authenticator, stopping at the first
+  // that succeeds
+  implicit class ComposedAuth(val s: List[AuthenticationService]) extends AnyVal {
+
+    def authenticateUser(username: String, password: String): AuthResult = {
+      @tailrec
+      def go(l: List[AuthenticationService]): AuthResult = l match {
+        case Nil      => -\/(NoAuthenticator)
+        case x :: Nil => x.authenticateUser(username, password)
+        case x :: xs  => x.authenticateUser(username, password) match {
+            case u @ \/-(_) => u
+            case -\/(e)     => go(xs)
+          }
+      }
+      go(s)
+    }
+  }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -2,6 +2,9 @@ package edu.gemini.seqexec.web.server.security
 
 import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
 
+import upickle.default._
+import pdi.jwt.{Jwt, JwtAlgorithm, JwtHeader, JwtClaim, JwtOptions}
+
 import scala.annotation.tailrec
 import scalaz.{-\/, \/, \/-}
 
@@ -20,6 +23,10 @@ trait AuthenticationService {
 object AuthenticationService {
   type AuthResult = AuthenticationFailure \/ UserDetails
 
+  // TODO externalize
+  val sessionTimeout = 8 * 3600
+  val onSSL = false
+
   // Allows calling authenticate on a list of authenticator, stopping at the first
   // that succeeds
   implicit class ComposedAuth(val s: List[AuthenticationService]) extends AnyVal {
@@ -36,5 +43,10 @@ object AuthenticationService {
       }
       go(s)
     }
+  }
+
+  def buildToken(u: UserDetails): String = {
+    // Given that only this server will need the key we can just use HMAC. 512-bit is the max key size allowed
+    Jwt.encode(JwtClaim(write(u)).issuedNow.expiresIn(3600), "secretkey", JwtAlgorithm.HmacSHA256)
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
@@ -1,0 +1,17 @@
+package edu.gemini.seqexec.web.server.security
+
+import edu.gemini.seqexec.web.common.UserDetails
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Success
+
+class JWTTokensSpec extends FlatSpec with Matchers with PropertyChecks {
+  "JWT Tokens" should "encode/decode" in {
+    forAll { (u: String, p: String) =>
+      val userDetails = UserDetails(u, p)
+      val token = AuthenticationService.buildToken(userDetails)
+      Success(userDetails) shouldEqual AuthenticationService.decodeToken(token)
+    }
+  }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
@@ -5,13 +5,14 @@ import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Success
+import scalaz.\/-
 
 class JWTTokensSpec extends FlatSpec with Matchers with PropertyChecks {
   "JWT Tokens" should "encode/decode" in {
     forAll { (u: String, p: String) =>
       val userDetails = UserDetails(u, p)
       val token = AuthenticationService.buildToken(userDetails)
-      Success(userDetails) shouldEqual AuthenticationService.decodeToken(token)
+      \/-(userDetails) shouldEqual AuthenticationService.decodeToken(token)
     }
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/authentication.scala
@@ -1,3 +1,4 @@
 package edu.gemini.seqexec.web.common
 
 case class UserLoginRequest(username: String, password: String)
+case class UserDetails(username: String, displayName: String)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/authentication.scala
@@ -1,0 +1,3 @@
+package edu.gemini.seqexec.web.common
+
+case class UserLoginRequest(username: String, password: String)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -46,6 +46,7 @@ object Settings {
     val argonaut     = "6.2-M1"
     val commonsHttp  = "2.0"
     val unboundId    = "3.1.1"
+    val jwt          = "0.7.1"
 
     // test libraries
     val scalaTest    = "3.0.0-M15"
@@ -74,6 +75,7 @@ object Settings {
     val Argonaut    = "io.argonaut"        %% "argonaut"                         % LibraryVersions.argonaut
     val CommonsHttp = "commons-httpclient" %  "commons-httpclient"               % LibraryVersions.commonsHttp
     val UnboundId   = "com.unboundid"      % "unboundid-ldapsdk-minimal-edition" % LibraryVersions.unboundId
+    val JwtCore     = "com.pauldijou"      %% "jwt-core"                         % LibraryVersions.jwt
 
     val Squants     = Def.setting("com.squants"  %%% "squants"           % LibraryVersions.squants)
     val UPickle     = Def.setting("com.lihaoyi"  %%% "upickle"           % LibraryVersions.uPickle)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -45,6 +45,7 @@ object Settings {
     val squants      = "0.6.1-GEM" // GEM Denotes our gemini built package
     val argonaut     = "6.2-M1"
     val commonsHttp  = "2.0"
+    val unboundId    = "3.1.1"
 
     // test libraries
     val scalaTest    = "3.0.0-M15"
@@ -70,8 +71,9 @@ object Settings {
       "org.scalacheck" %%% "scalacheck"  % LibraryVersions.scalaCheck % "test"
     ))
 
-    val Argonaut    = "io.argonaut"        %% "argonaut"           % LibraryVersions.argonaut
-    val CommonsHttp = "commons-httpclient" %  "commons-httpclient" % LibraryVersions.commonsHttp
+    val Argonaut    = "io.argonaut"        %% "argonaut"                         % LibraryVersions.argonaut
+    val CommonsHttp = "commons-httpclient" %  "commons-httpclient"               % LibraryVersions.commonsHttp
+    val UnboundId   = "com.unboundid"      % "unboundid-ldapsdk-minimal-edition" % LibraryVersions.unboundId
 
     val Squants     = Def.setting("com.squants"  %%% "squants"           % LibraryVersions.squants)
     val UPickle     = Def.setting("com.lihaoyi"  %%% "upickle"           % LibraryVersions.uPickle)


### PR DESCRIPTION
This PR sets the basis to support authentication on the Seqexec webapp.

It can do authentication against the LDAP/AD server, with support for a test in-memory auth database for testing. This is done with the [UboundId SDK](unboundid.com/products/ldapsdk/) library. Besides authentication we can read the display name

Once auth is established it will construct a [JSON Web Token](https://jwt.io/) and return it to the client as a cookie. See the rationale behind using a [cookie for storing](https://stormpath.com/blog/where-to-store-your-jwts-cookies-vs-html5-web-storage) the token. Tokens are built using the [JWT Scala](https://github.com/pauldijou/jwt-scala) library using HMAC with SHA-512 and a single secret key

Note that this approach is stateless, we don't need to store the cookies as they can be decoded and authenticated

Two routes (login/logout) are added to the backends to let the UI interact with the authentication

There are several steps pending:
* Make the UI to login/logout
* Protect the routes with authentication
* Support authentication on the web socket channel
* Ensure we are XSRF resistant
* Ensure cookies expire properly
* Improve configuration, the secret key cannot be on the clear as in this PR
* Check that the user is allowed to use the seqexec (LDAP Groups?)