### PR TITLE
Authentication part II (UI)

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/authentication.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/authentication.scala
@@ -1,4 +1,5 @@
 package edu.gemini.seqexec.model
 
+// Shared classes used for authentication
 case class UserLoginRequest(username: String, password: String)
 case class UserDetails(username: String, displayName: String)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/authentication.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/authentication.scala
@@ -1,4 +1,4 @@
-package edu.gemini.seqexec.web.common
+package edu.gemini.seqexec.model
 
 case class UserLoginRequest(username: String, password: String)
 case class UserDetails(username: String, displayName: String)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/events.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/events.scala
@@ -7,7 +7,7 @@ import edu.gemini.seqexec.model.dhs.ObsId
   */
 sealed trait SeqexecEvent
 case object NullEvent extends SeqexecEvent
-case object SeqexecConnectionOpenEvent extends SeqexecEvent
+case class SeqexecConnectionOpenEvent(u: Option[UserDetails]) extends SeqexecEvent
 case object SeqexecConnectionCloseEvent extends SeqexecEvent
 case class SeqexecConnectionError(e: String) extends SeqexecEvent
 case class SequenceStartEvent(id: String) extends SeqexecEvent

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ExecutorImpl.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ExecutorImpl.scala
@@ -116,7 +116,7 @@ class ExecutorImpl private (cancelRef: TaskRef[Set[SPObservationID]], stateRef: 
   }
 
   // Important, make it a def so each client gets a new one
-  def sequenceEvents: Process[Task, SeqexecEvent] = Process.emit(SeqexecConnectionOpenEvent) ++ eventsQueue.subscribe
+  def sequenceEvents: Process[Task, SeqexecEvent] = eventsQueue.subscribe
 
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -8,7 +8,6 @@ import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
-import edu.gemini.seqexec.web.client.semanticui.elements.input.Input
 import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
 import edu.gemini.seqexec.web.client.services.SeqexecWebClient
 
@@ -24,6 +23,8 @@ object LoginBox {
   case class State(username: String, password: String, progressMsg: Option[String], errorMsg: Option[String])
 
   val empty = State("", "", None, None)
+
+  val formId = "login"
 
   class Backend($: BackendScope[Props, State]) {
     def pwdMod(e: ReactEventI) = {
@@ -65,6 +66,9 @@ object LoginBox {
           ^.cls := "ui content",
           <.form(
             ^.cls :="ui form",
+            ^.id := formId,
+            ^.method := "post",
+            ^.action := "#",
             <.div(
               ^.cls :="required field",
               Label(Label.Props("Username", "username")),
@@ -122,7 +126,7 @@ object LoginBox {
               <.div(
                 ^.cls := "right floated right aligned ten wide column",
                 Button(Button.Props(onClick = closeBox), "Cancel"),
-                Button(Button.Props(onClick = attemptLogin), "Login")
+                Button(Button.Props(onClick = attemptLogin, buttonType = Button.SubmitType, form = Some(formId)), "Login")
               )
             )
           )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -9,11 +9,14 @@ import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.input.Input
-import edu.gemini.seqexec.web.client.semanticui.elements.input.Input.ChangeCallback
+import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
 import edu.gemini.seqexec.web.client.services.SeqexecWebClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
+/**
+  * UI for the login box
+  */
 object LoginBox {
 
   case class Props(open: ModelProxy[SectionVisibilityState])
@@ -21,8 +24,6 @@ object LoginBox {
   case class State(username: String, password: String, progressMsg: Option[String], errorMsg: Option[String])
 
   val empty = State("", "", None, None)
-
-  def pwdInput(callback: ChangeCallback) = Input(Input.Props("password", "password", Input.PasswordInput, "Password", onChange = callback))
 
   class Backend($: BackendScope[Props, State]) {
     def pwdMod(e: ReactEventI) = {
@@ -40,7 +41,6 @@ object LoginBox {
     def loggedInEvent(u: UserDetails):Callback = Callback {SeqexecCircuit.dispatch(LoggedIn(u))} >> updateProgressMsg("")
     def updateProgressMsg(m: String):Callback = $.modState(_.copy(progressMsg = Some(m), errorMsg = None))
     def updateErrorMsg(m: String):Callback = $.modState(_.copy(errorMsg = Some(m), progressMsg = None))
-
     def closeBox = $.modState(_ => empty) >> Callback {SeqexecCircuit.dispatch(CloseLoginBox)}
 
     def attemptLogin = $.state >>= { s =>
@@ -67,10 +67,7 @@ object LoginBox {
             ^.cls :="ui form",
             <.div(
               ^.cls :="required field",
-              <.label(
-                ^.htmlFor := "username",
-                "Username: "
-              ),
+              Label(Label.Props("Username", "username")),
               <.div(
                 ^.cls :="ui icon input",
                 <.input(
@@ -86,10 +83,7 @@ object LoginBox {
             ),
             <.div(
               ^.cls :="required field",
-              <.label(
-                ^.htmlFor := "password",
-                "Password: "
-              ),
+              Label(Label.Props("Password", "password")),
               <.div(
                 ^.cls := "ui icon input",
                 <.input(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -4,8 +4,8 @@ import diode.react.ModelProxy
 import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM}
 import japgolly.scalajs.react.vdom.prefix_<^._
 import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
-import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconUser, IconLock}
-import edu.gemini.seqexec.web.client.model.{SectionOpen, SectionVisibilityState}
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconLock, IconUser}
+import edu.gemini.seqexec.web.client.model._
 
 /**
   * Created by cquiroz on 5/27/16.
@@ -66,11 +66,11 @@ object LoginBox {
         <.div(
           ^.cls := "actions",
             <.div(
-              ^.cls := "ui button",
+              ^.cls := "ui cancel button",
               "Cancel"
             ),
             <.div(
-              ^.cls := "ui button",
+              ^.cls := "ui approve button",
               "Login"
             )
         )
@@ -80,7 +80,18 @@ object LoginBox {
         import org.querki.jquery.$
 
         // Open the modal box
+        if (s.currentProps.open() == SectionClosed) {
+          $(ReactDOM.findDOMNode(s.$)).modal("hide")
+        }
         if (s.currentProps.open() == SectionOpen) {
+          $(ReactDOM.findDOMNode(s.$)).modal(
+            JsModalOptions
+              .autofocus(true)
+              .onDeny { () =>
+                SeqexecCircuit.dispatch(CloseLoginBox)
+              }
+              .onApprove(() => println("Ok"))
+          )
           $(ReactDOM.findDOMNode(s.$)).modal("show")
         }
       }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -1,0 +1,38 @@
+package edu.gemini.seqexec.web.client.components
+
+import diode.react.ModelProxy
+import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM}
+import japgolly.scalajs.react.vdom.prefix_<^._
+import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+import edu.gemini.seqexec.web.client.model.{SectionOpen, SectionVisibilityState}
+
+/**
+  * Created by cquiroz on 5/27/16.
+  */
+object LoginBox {
+
+  case class Props(open: ModelProxy[SectionVisibilityState])
+
+  val component = ReactComponentB[Props]("Login")
+    .stateless
+    .render_P(p => {println("Render" + p.open())
+      <.div(
+        ^.cls := "ui modal",
+        <.div(
+          ^.cls := "header",
+          "Header"
+        )
+      )}
+    ).componentDidUpdate(s =>
+      Callback {
+        import org.querki.jquery.$
+
+        // Open the modal box
+        if (s.currentProps.open() == SectionOpen) {
+          $(ReactDOM.findDOMNode(s.$)).modal("show")
+        }
+      }
+    ).build
+
+  def apply(s: ModelProxy[SectionVisibilityState]) = component(Props(s))
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -4,6 +4,7 @@ import diode.react.ModelProxy
 import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM}
 import japgolly.scalajs.react.vdom.prefix_<^._
 import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconUser, IconLock}
 import edu.gemini.seqexec.web.client.model.{SectionOpen, SectionVisibilityState}
 
 /**
@@ -15,14 +16,65 @@ object LoginBox {
 
   val component = ReactComponentB[Props]("Login")
     .stateless
-    .render_P(p => {println("Render" + p.open())
+    .render_P(p =>
       <.div(
         ^.cls := "ui modal",
         <.div(
           ^.cls := "header",
-          "Header"
+          "Login"
+        ),
+        <.div(
+          ^.cls := "ui content",
+          <.form(
+            ^.cls :="ui form",
+            <.div(
+              ^.cls :="field",
+              <.label(
+                ^.htmlFor := "username",
+                "Username: "
+              ),
+              <.div(
+                ^.cls :="ui icon input",
+                <.input(
+                  ^.`type` := "text",
+                  ^.placeholder := "Username",
+                  ^.name := "username",
+                  ^.id := "username"
+                ),
+                IconUser
+              )
+            ),
+            <.div(
+              ^.cls :="field",
+              <.label(
+                ^.htmlFor := "password",
+                "Password: "
+              ),
+              <.div(
+                ^.cls :="ui icon input",
+                <.input(
+                  ^.`type` :="password",
+                  ^.placeholder := "Password",
+                  ^.name := "password",
+                  ^.id := "password"
+                ),
+                IconLock
+              )
+            )
+          )
+        ),
+        <.div(
+          ^.cls := "actions",
+            <.div(
+              ^.cls := "ui button",
+              "Cancel"
+            ),
+            <.div(
+              ^.cls := "ui button",
+              "Login"
+            )
         )
-      )}
+      )
     ).componentDidUpdate(s =>
       Callback {
         import org.querki.jquery.$

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
@@ -19,10 +19,10 @@ object NavBar {
       <.div(
         SeqexecStyles.mainContainer,
         <.div(
-          ^.cls := "ui header container",
+          ^.cls := "ui container",
           <.div(
             ^.href :="#",
-            ^.cls := "header item",
+            ^.cls := "ui header item",
             <.img(
               ^.cls := "logo",
               ^.src :="images/launcher.png"

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
@@ -35,7 +35,7 @@ object NavBar {
               IconTerminal.copy(p = IconTerminal.p.copy(link = true, circular = true, onClick = Callback {SeqexecCircuit.dispatch(ToggleDevConsole)}))
             )
           ),
-          TopMenu()
+          SeqexecCircuit.connect(_.user)(TopMenu(_))
         )
       )
     )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -168,7 +168,7 @@ object QueueAreaTitle {
             ^.key := "queue.area.title",
             SeqexecCircuit.connect(_.searchResults)(SequenceSearch(_))
           ): ReactNode
-        }.getOrElse[ReactNode](<.div())
+        }.getOrElse[ReactNode](<.div(^.key := "queue.area.empty"))
       )
     ).build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -3,6 +3,7 @@ package edu.gemini.seqexec.web.client.components
 import diode.data.{Empty, Pot}
 import diode.react.ReactPot._
 import diode.react._
+import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconAttention, IconCheckmark, IconCircleNotched}
 import edu.gemini.seqexec.web.client.semanticui.elements.message.CloseableMessage
@@ -149,10 +150,11 @@ object QueueTableLoading {
   * Component for the title of the queue area, including the search component
   */
 object QueueAreaTitle {
+  case class Props(user: ModelProxy[Option[UserDetails]])
 
-  val component = ReactComponentB[Unit]("QueueAreaTitle")
+  val component = ReactComponentB[Props]("QueueAreaTitle")
     .stateless
-    .render(_ =>
+    .render_P(p =>
       TextMenuSegment("Queue",
         // Show a loading indicator if we are waiting for server data
         {
@@ -160,15 +162,17 @@ object QueueAreaTitle {
           implicit val eq = PotEq.seqexecQueueEq
           SeqexecCircuit.connect(_.queue)(QueueTableLoading(_))
         },
-        <.div(
-          ^.cls := "right menu",
-          ^.key := "queue.area.title",
-          SeqexecCircuit.connect(_.searchResults)(SequenceSearch(_))
-        )
+        p.user().map { u =>
+          <.div(
+            ^.cls := "right menu",
+            ^.key := "queue.area.title",
+            SeqexecCircuit.connect(_.searchResults)(SequenceSearch(_))
+          ): ReactNode
+        }.getOrElse[ReactNode](<.div())
       )
     ).build
 
-  def apply() = component()
+  def apply(user: ModelProxy[Option[UserDetails]]) = component(Props(user))
 }
 
 /**
@@ -226,7 +230,7 @@ object QueueArea {
     .render_P(p =>
       <.div(
         ^.cls := "ui raised segments container",
-        QueueAreaTitle(),
+        SeqexecCircuit.connect(_.user)(QueueAreaTitle(_)),
         <.div(
           ^.cls := "ui attached segment",
           <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -96,4 +96,5 @@ object SeqexecStyles extends StyleSheet.Inline {
   val smallTextArea = style(
     fontSize.smaller
   )
+
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -17,10 +17,12 @@ object SeqexecUI {
         NavBar(),
         SeqexecCircuit.connect(m => (m.devConsoleState, m.webSocketLog))(u => WebSocketsConsole(u()._1, u()._2)),
         SeqexecCircuit.connect(_.searchAreaState)(QueueArea(_)),
-        SequenceArea()
+        SequenceArea(),
+        SeqexecCircuit.connect(_.loginBox)(LoginBox(_))
       )
     )
     .build
 
   def apply() = component()
 }
+

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -51,15 +51,32 @@ object TopMenu {
   def openLogin = Callback {SeqexecCircuit.dispatch(OpenLoginBox)}
   def logout = Callback {SeqexecCircuit.dispatch(Logout)}
 
-  val loginButton = Button(Button.Props(size = Size.Small, onClick = openLogin), "Login")
-  val logoutButton = Button(Button.Props(size = Size.Small, onClick = logout, icon = Some(IconSignOut)), "Logout")
+  val loginButton = Button(Button.Props(size = Size.Medium, onClick = openLogin), "Login")
+  val logoutButton = Button(Button.Props(size = Size.Medium, onClick = logout, icon = Some(IconSignOut)), "Logout")
 
   val component = ReactComponentB[Props]("SeqexecTopMenu")
     .stateless
     .render_P( p =>
       <.div(
-        ^.cls := "ui right floated item",
-        p.u.fold(loginButton: ReactElement)(u => logoutButton)
+        ^.cls := "ui secondary right menu",
+        p.u.fold(
+          <.div(
+            ^.cls := "ui item",
+            loginButton
+          )
+        )(u =>
+          <.div(
+            ^.cls := "ui secondary right menu",
+            <.div(
+              ^.cls := "ui header item",
+              u.displayName
+            ),
+            <.div(
+              ^.cls := "ui item",
+              logoutButton
+            )
+          )
+        )
       )
     )
     .build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -2,12 +2,12 @@ package edu.gemini.seqexec.web.client.components
 
 import diode.react.ModelProxy
 import edu.gemini.seqexec.model.UserDetails
-import edu.gemini.seqexec.web.client.model.{OpenLoginBox, SeqexecCircuit}
+import edu.gemini.seqexec.web.client.model.{Logout, OpenLoginBox, SeqexecCircuit}
 import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.divider.Divider
-import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconDropdown
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconDropdown, IconSignOut}
 import edu.gemini.seqexec.web.client.semanticui.elements.menu.Item
 import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM, ReactElement}
 import japgolly.scalajs.react.vdom.prefix_<^._
@@ -49,15 +49,17 @@ object TopMenu {
   case class Props(u: Option[UserDetails])
 
   def openLogin = Callback {SeqexecCircuit.dispatch(OpenLoginBox)}
+  def logout = Callback {SeqexecCircuit.dispatch(Logout)}
 
   val loginButton = Button(Button.Props(size = Size.Small, onClick = openLogin), "Login")
+  val logoutButton = Button(Button.Props(size = Size.Small, onClick = logout, icon = Some(IconSignOut)), "Logout")
 
   val component = ReactComponentB[Props]("SeqexecTopMenu")
     .stateless
     .render_P( p =>
       <.div(
         ^.cls := "ui right floated item",
-        p.u.fold(loginButton: ReactElement)(u => LoggedInMenu(u))
+        p.u.fold(loginButton: ReactElement)(u => logoutButton)
       )
     )
     .build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -2,30 +2,23 @@ package edu.gemini.seqexec.web.client.components
 
 import diode.react.ModelProxy
 import edu.gemini.seqexec.model.UserDetails
+import edu.gemini.seqexec.web.client.model.{OpenLoginBox, SeqexecCircuit}
 import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.divider.Divider
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconDropdown
 import edu.gemini.seqexec.web.client.semanticui.elements.menu.Item
-import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM}
+import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM, ReactElement}
 import japgolly.scalajs.react.vdom.prefix_<^._
 
-/**
-  * Menu at the top bar
-  */
-object TopMenu {
+object LoggedInMenu {
+  case class Props(u: UserDetails)
 
-  case class Props(u: Option[UserDetails])
-
-  val loginButton = Button(Button.Props(emphasis = Button.Secondary), "Login")
-
-  val component = ReactComponentB[Props]("SeqexecTopMenu")
+  val component = ReactComponentB[Props]("SeqexecLoggedInMenu")
     .stateless
     .render_P(p =>
-      <.a(
-        ^.href :="#",
-        ^.cls := "ui right floated dropdown item",
-        p.u.map(i => <.span(i.displayName)).getOrElse(loginButton),
+      <.div(
+        p.u.displayName,
         IconDropdown,
         <.div(
           ^.cls := "menu",
@@ -34,14 +27,37 @@ object TopMenu {
           Item("Settings")
         )
       )
-    )
-    .componentDidMount(s =>
+    ).componentDidMount(s =>
       Callback {
         // Enable menu on Semantic UI
         import org.querki.jquery.$
 
         $(ReactDOM.findDOMNode(s)).dropdown()
       }
+    ).build
+
+  def apply(u: UserDetails) = component(Props(u))
+}
+
+/**
+  * Menu at the top bar
+  */
+object TopMenu {
+
+  case class Props(u: Option[UserDetails])
+
+  def openLogin = Callback {SeqexecCircuit.dispatch(OpenLoginBox)}
+
+  val loginButton = Button(Button.Props(emphasis = Button.Secondary, onClick = openLogin), "Login")
+
+  val component = ReactComponentB[Props]("SeqexecTopMenu")
+    .stateless
+    .render_P( p =>
+      <.a(
+        ^.href :="#",
+        ^.cls := "ui right floated dropdown item",
+        p.u.fold(loginButton: ReactElement)(u => LoggedInMenu(u))
+      )
     )
     .build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -9,8 +9,9 @@ import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.divider.Divider
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconDropdown, IconSignOut}
 import edu.gemini.seqexec.web.client.semanticui.elements.menu.Item
-import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM, ReactElement}
+import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM}
 import japgolly.scalajs.react.vdom.prefix_<^._
+import scalacss.ScalaCssReact._
 
 object LoggedInMenu {
   case class Props(u: UserDetails)
@@ -52,7 +53,8 @@ object TopMenu {
   def logout = Callback {SeqexecCircuit.dispatch(Logout)}
 
   val loginButton = Button(Button.Props(size = Size.Medium, onClick = openLogin), "Login")
-  val logoutButton = Button(Button.Props(size = Size.Medium, onClick = logout, icon = Some(IconSignOut)), "Logout")
+  def logoutButton(text: String) =
+    Button(Button.Props(size = Size.Medium, onClick = logout, icon = Some(IconSignOut)), text)
 
   val component = ReactComponentB[Props]("SeqexecTopMenu")
     .stateless
@@ -69,11 +71,25 @@ object TopMenu {
             ^.cls := "ui secondary right menu",
             <.div(
               ^.cls := "ui header item",
+              SeqexecStyles.notInMobile,
               u.displayName
             ),
             <.div(
+              ^.cls := "ui header item",
+              SeqexecStyles.onlyMobile,
+              // Ideally we'd do this with css but it is not working properly
+              // inside a header item
+              u.displayName.split("\\s").headOption.map(_.substring(0, 10) + "...").getOrElse[String]("")
+            ),
+            <.div(
               ^.cls := "ui item",
-              logoutButton
+              SeqexecStyles.notInMobile,
+              logoutButton("Logout")
+            ),
+            <.div(
+              ^.cls := "ui item",
+              SeqexecStyles.onlyMobile,
+              logoutButton("")
             )
           )
         )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -1,6 +1,9 @@
 package edu.gemini.seqexec.web.client.components
 
+import diode.react.ModelProxy
+import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.divider.Divider
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconDropdown
 import edu.gemini.seqexec.web.client.semanticui.elements.menu.Item
@@ -12,13 +15,17 @@ import japgolly.scalajs.react.vdom.prefix_<^._
   */
 object TopMenu {
 
-  val component = ReactComponentB[Unit]("SeqexecTopMenu")
+  case class Props(u: Option[UserDetails])
+
+  val loginButton = Button(Button.Props(emphasis = Button.Secondary), "Login")
+
+  val component = ReactComponentB[Props]("SeqexecTopMenu")
     .stateless
-    .render(P =>
+    .render_P(p =>
       <.a(
         ^.href :="#",
         ^.cls := "ui right floated dropdown item",
-        "Telops",
+        p.u.map(i => <.span(i.displayName)).getOrElse(loginButton),
         IconDropdown,
         <.div(
           ^.cls := "menu",
@@ -38,5 +45,5 @@ object TopMenu {
     )
     .build
 
-  def apply() = component()
+  def apply(u: ModelProxy[Option[UserDetails]]) = component(Props(u()))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -13,6 +13,8 @@ import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM}
 import japgolly.scalajs.react.vdom.prefix_<^._
 import scalacss.ScalaCssReact._
 
+// Former logged in menu, not in use at the moment but it may eventually
+// be used if we need to add user settings
 object LoggedInMenu {
   case class Props(u: UserDetails)
 
@@ -77,8 +79,8 @@ object TopMenu {
             <.div(
               ^.cls := "ui header item",
               SeqexecStyles.onlyMobile,
-              // Ideally we'd do this with css but it is not working properly
-              // inside a header item
+              // Ideally we'd do this with css text-overflow but it is not
+              // working properly inside a header item, let's abbreviate in code
               u.displayName.split("\\s").headOption.map(_.substring(0, 10) + "...").getOrElse[String]("")
             ),
             <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -4,6 +4,7 @@ import diode.react.ModelProxy
 import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.client.model.{OpenLoginBox, SeqexecCircuit}
 import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.divider.Divider
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconDropdown
@@ -18,6 +19,7 @@ object LoggedInMenu {
     .stateless
     .render_P(p =>
       <.div(
+        ^.cls := "ui dropdown",
         p.u.displayName,
         IconDropdown,
         <.div(
@@ -46,16 +48,15 @@ object TopMenu {
 
   case class Props(u: Option[UserDetails])
 
-  def openLogin = Callback.log("Open") >> Callback {SeqexecCircuit.dispatch(OpenLoginBox)}
+  def openLogin = Callback {SeqexecCircuit.dispatch(OpenLoginBox)}
 
-  val loginButton = Button(Button.Props(emphasis = Button.Secondary, onClick = openLogin), "Login")
+  val loginButton = Button(Button.Props(size = Size.Small, onClick = openLogin), "Login")
 
   val component = ReactComponentB[Props]("SeqexecTopMenu")
     .stateless
     .render_P( p =>
-      <.a(
-        ^.href :="#",
-        ^.cls := "ui right floated dropdown item",
+      <.div(
+        ^.cls := "ui right floated item",
         p.u.fold(loginButton: ReactElement)(u => LoggedInMenu(u))
       )
     )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -46,7 +46,7 @@ object TopMenu {
 
   case class Props(u: Option[UserDetails])
 
-  def openLogin = Callback {SeqexecCircuit.dispatch(OpenLoginBox)}
+  def openLogin = Callback.log("Open") >> Callback {SeqexecCircuit.dispatch(OpenLoginBox)}
 
   val loginButton = Button(Button.Props(emphasis = Button.Secondary, onClick = openLogin), "Login")
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -190,7 +190,9 @@ object SequenceTabContent {
           "active" -> p.isActive
         ),
         dataTab := p.st.instrument,
-        p.st.sequence().render(s => SeqexecCircuit.connect(SeqexecCircuit.sequenceReader(s.id))(u => u().map(t => SequenceStepsTableContainer(t, p.user, p.st.stepConfigDisplayed)).getOrElse(<.div(): ReactElement))),
+        p.st.sequence().render { s =>
+          SeqexecCircuit.connect(SeqexecCircuit.sequenceReader(s.id))(u => u().map(t => SequenceStepsTableContainer(t, p.user, p.st.stepConfigDisplayed)).getOrElse(<.div(): ReactElement))
+        },
         p.st.sequence().renderEmpty(IconMessage(IconMessage.Props(IconInbox, Some("No sequence loaded"), IconMessage.Style.Warning)))
       )
     )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -1,6 +1,7 @@
 package edu.gemini.seqexec.web.client.components.sequence
 
 import diode.react.ReactPot._
+import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.client.components.{SeqexecStyles, TabularMenu, TextMenuSegment}
 import edu.gemini.seqexec.web.client.components.TabularMenu.TabItem
 import edu.gemini.seqexec.web.client.model._
@@ -15,6 +16,7 @@ import edu.gemini.seqexec.web.common.{Sequence, SequenceState, StepState}
 import edu.gemini.seqexec.web.client.services.HtmlConstants.iconEmpty
 import japgolly.scalajs.react.vdom.prefix_<^._
 import japgolly.scalajs.react.{Callback, ReactComponentB, ReactElement}
+
 import scalacss.ScalaCssReact._
 import scalaz.syntax.show._
 
@@ -22,7 +24,7 @@ import scalaz.syntax.show._
   * Container for a table with the steps
   */
 object SequenceStepsTableContainer {
-  case class Props(s: Sequence, stepConfigDisplayed: Option[Int])
+  case class Props(s: Sequence, user: Option[UserDetails], stepConfigDisplayed: Option[Int])
 
   def requestRun(s: Sequence): Callback = Callback {SeqexecCircuit.dispatch(RequestRun(s))}
 
@@ -42,15 +44,22 @@ object SequenceStepsTableContainer {
         p.stepConfigDisplayed.fold {
           <.div(
             ^.cls := "row",
-            p.s.state == SequenceState.Abort ?= <.h3(
-              ^.cls := "ui red header",
-              "Sequence aborted"),
-            p.s.state == SequenceState.Completed ?= <.h3(
-              ^.cls := "ui green header",
-              "Sequence completed"),
-            p.s.state == SequenceState.NotRunning ?= Button(Button.Props(icon = Some(IconPlay), labeled = true, onClick = requestRun(p.s)), "Run"),
-            p.s.state == SequenceState.Running ?= Button(Button.Props(icon = Some(IconPause), labeled = true, disabled = true, onClick = requestPause(p.s)), "Pause"),
-            p.s.state == SequenceState.Running ?= Button(Button.Props(icon = Some(IconStop), labeled = true, onClick = requestStop(p.s)), "Stop")
+            p.user.isDefined && p.s.state == SequenceState.Abort ?=
+              <.h3(
+                ^.cls := "ui red header",
+                "Sequence aborted"
+              ),
+            p.user.isDefined && p.s.state == SequenceState.Completed ?=
+              <.h3(
+                ^.cls := "ui green header",
+                "Sequence completed"
+              ),
+            p.user.isDefined && p.s.state == SequenceState.NotRunning ?=
+              Button(Button.Props(icon = Some(IconPlay), labeled = true, onClick = requestRun(p.s)), "Run"),
+            p.user.isDefined && p.s.state == SequenceState.Running ?=
+              Button(Button.Props(icon = Some(IconPause), labeled = true, disabled = true, onClick = requestPause(p.s)), "Pause"),
+            p.user.isDefined && p.s.state == SequenceState.Running ?=
+              Button(Button.Props(icon = Some(IconStop), labeled = true, onClick = requestStop(p.s)), "Stop")
           )
         } { i =>
           <.div(
@@ -163,14 +172,14 @@ object SequenceStepsTableContainer {
     )
     .build
 
-  def apply(s: Sequence, stepConfigDisplayed: Option[Int]) = component(Props(s, stepConfigDisplayed))
+  def apply(s: Sequence, user: Option[UserDetails], stepConfigDisplayed: Option[Int]) = component(Props(s, user,  stepConfigDisplayed))
 }
 
 /**
   * Content of a single tab with a sequence
   */
 object SequenceTabContent {
-  case class Props(isActive: Boolean, st: SequenceTab)
+  case class Props(isActive: Boolean, user: Option[UserDetails], st: SequenceTab)
 
   val component = ReactComponentB[Props]("SequenceTabContent")
     .stateless
@@ -181,7 +190,7 @@ object SequenceTabContent {
           "active" -> p.isActive
         ),
         dataTab := p.st.instrument,
-        p.st.sequence().render(s => SeqexecCircuit.connect(SeqexecCircuit.sequenceReader(s.id))(u => u().map(t => SequenceStepsTableContainer(t, p.st.stepConfigDisplayed)).getOrElse(<.div(): ReactElement))),
+        p.st.sequence().render(s => SeqexecCircuit.connect(SeqexecCircuit.sequenceReader(s.id))(u => u().map(t => SequenceStepsTableContainer(t, p.user, p.st.stepConfigDisplayed)).getOrElse(<.div(): ReactElement))),
         p.st.sequence().renderEmpty(IconMessage(IconMessage.Props(IconInbox, Some("No sequence loaded"), IconMessage.Style.Warning)))
       )
     )
@@ -194,10 +203,10 @@ object SequenceTabContent {
   * Contains all the tabs for the sequences available in parallel
   */
 object SequenceTabs {
-  case class Props(sequences: SequencesOnDisplay)
+  case class Props(user: Option[UserDetails], sequences: SequencesOnDisplay)
 
   def sequencesTabs(d: SequencesOnDisplay) = d.instrumentSequences.map(a => TabItem(a.instrument, isActive = a == d.instrumentSequences.focus, a.instrument))
-  def tabContents(d: SequencesOnDisplay) = d.instrumentSequences.map(a => SequenceTabContent.Props(isActive = a == d.instrumentSequences.focus, a)).toStream
+  def tabContents(user: Option[UserDetails], d: SequencesOnDisplay) = d.instrumentSequences.map(a => SequenceTabContent.Props(isActive = a == d.instrumentSequences.focus, user, a)).toStream
 
   val component = ReactComponentB[Props]("SequenceTabs")
     .stateless
@@ -216,7 +225,7 @@ object SequenceTabs {
             <.div(
               ^.cls := "twelve wide computer twelve wide tablet sixteen wide mobile column",
               TabularMenu(sequencesTabs(p.sequences).toStream.toList),
-              tabContents(p.sequences).map(SequenceTabContent(_))
+              tabContents(p.user, p.sequences).map(SequenceTabContent(_))
             )
           ),
           <.div(
@@ -231,7 +240,7 @@ object SequenceTabs {
     )
     .build
 
-  def apply(sequences: SequencesOnDisplay) = component(Props(sequences))
+  def apply(user: Option[UserDetails], sequences: SequencesOnDisplay) = component(Props(user, sequences))
 }
 
 object SequenceArea {
@@ -241,7 +250,7 @@ object SequenceArea {
       <.div(
         ^.cls := "ui raised segments container",
         TextMenuSegment("Running Sequences"),
-        SeqexecCircuit.connect(_.sequencesOnDisplay)(p => SequenceTabs(p()))
+        SeqexecCircuit.connect(m => (m.user, m.sequencesOnDisplay))(p => SequenceTabs(p()._1, p()._2))
       )
     ).build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -111,7 +111,7 @@ class DevConsoleHandler[M](modelRW: ModelRW[M, SectionVisibilityState]) extends 
 }
 
 /**
-  * Handles actions related to the development console
+  * Handles actions related to opening/closing the login box
   */
 class LoginBoxHandler[M](modelRW: ModelRW[M, SectionVisibilityState]) extends ActionHandler(modelRW) {
   implicit val runner = new RunAfterJS
@@ -121,6 +121,20 @@ class LoginBoxHandler[M](modelRW: ModelRW[M, SectionVisibilityState]) extends Ac
       updated(SectionOpen)
     case CloseLoginBox if value == SectionOpen  =>
       updated(SectionClosed)
+  }
+}
+
+/**
+  * Handles actions related to opening/closing the login box
+  */
+class UserLoginHandler[M](modelRW: ModelRW[M, Option[UserDetails]]) extends ActionHandler(modelRW) {
+  implicit val runner = new RunAfterJS
+
+  override def handle: PartialFunction[AnyRef, ActionResult[M]] = {
+    case LoggedIn(u) =>
+      // Close the login box
+      val effect = Effect(Future(CloseLoginBox))
+      updated(Some(u), effect)
   }
 }
 
@@ -251,6 +265,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   val searchAreaHandler      = new SearchAreaHandler(zoomRW(_.searchAreaState)((m, v) => m.copy(searchAreaState = v)))
   val devConsoleHandler      = new DevConsoleHandler(zoomRW(_.devConsoleState)((m, v) => m.copy(devConsoleState = v)))
   val loginBoxHandler        = new LoginBoxHandler(zoomRW(_.loginBox)((m, v) => m.copy(loginBox = v)))
+  val userLoginHandler       = new UserLoginHandler(zoomRW(_.user)((m, v) => m.copy(user = v)))
   val wsLogHandler           = new WebSocketEventsHandler(zoomRW(m => (m.queue, m.webSocketLog, m.user))((m, v) => m.copy(queue = v._1, webSocketLog = v._2, user = v._3)))
   val sequenceDisplayHandler = new SequenceDisplayHandler(zoomRW(_.sequencesOnDisplay)((m, v) => m.copy(sequencesOnDisplay = v)))
   val sequenceExecHandler    = new SequenceExecutionHandler(zoomRW(_.queue)((m, v) => m.copy(queue = v)))
@@ -275,6 +290,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
     searchAreaHandler,
     devConsoleHandler,
     loginBoxHandler,
+    userLoginHandler,
     wsLogHandler,
     sequenceDisplayHandler,
     globalLogHandler,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -4,7 +4,7 @@ import diode.data._
 import diode.react.ReactConnector
 import diode.util.RunAfterJS
 import diode._
-import edu.gemini.seqexec.model.{SeqexecEvent, SequenceCompletedEvent, SequenceStartEvent, StepExecutedEvent}
+import edu.gemini.seqexec.model._
 import edu.gemini.seqexec.web.client.model.SeqexecCircuit.SearchResults
 import edu.gemini.seqexec.web.client.services.{Audio, SeqexecWebClient}
 import edu.gemini.seqexec.web.common.{SeqexecQueue, Sequence}
@@ -154,6 +154,9 @@ class WebSocketEventsHandler[M](modelRW: ModelRW[M, (Pot[SeqexecQueue], WebSocke
   implicit val runner = new RunAfterJS
 
   override def handle = {
+    case NewSeqexecEvent(SeqexecConnectionOpenEvent(u)) =>
+      println("User " + u)
+      noChange
     case NewSeqexecEvent(event @ SequenceStartEvent(id)) =>
       val logE = SeqexecCircuit.appendToLogE(s"Sequence $id started")
       updated(value.copy(_1 = value._1.map(_.sequenceRunning(id)), _2 = value._2.append(event)), logE)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -111,6 +111,20 @@ class DevConsoleHandler[M](modelRW: ModelRW[M, SectionVisibilityState]) extends 
 }
 
 /**
+  * Handles actions related to the development console
+  */
+class LoginBoxHandler[M](modelRW: ModelRW[M, SectionVisibilityState]) extends ActionHandler(modelRW) {
+  implicit val runner = new RunAfterJS
+
+  override def handle: PartialFunction[AnyRef, ActionResult[M]] = {
+    case OpenLoginBox if value == SectionOpen   =>
+      updated(SectionClosed)
+    case CloseLoginBox if value == SectionClosed =>
+      updated(SectionOpen)
+  }
+}
+
+/**
   * Handles actions related to the changing the selection of the displayed sequence
   */
 class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesOnDisplay]) extends ActionHandler(modelRW) {
@@ -236,6 +250,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   val searchHandler          = new SearchHandler(zoomRW(_.searchResults)((m, v) => m.copy(searchResults = v)))
   val searchAreaHandler      = new SearchAreaHandler(zoomRW(_.searchAreaState)((m, v) => m.copy(searchAreaState = v)))
   val devConsoleHandler      = new DevConsoleHandler(zoomRW(_.devConsoleState)((m, v) => m.copy(devConsoleState = v)))
+  val loginBoxHandler        = new LoginBoxHandler(zoomRW(_.loginBox)((m, v) => m.copy(loginBox = v)))
   val wsLogHandler           = new WebSocketEventsHandler(zoomRW(m => (m.queue, m.webSocketLog, m.user))((m, v) => m.copy(queue = v._1, webSocketLog = v._2, user = v._3)))
   val sequenceDisplayHandler = new SequenceDisplayHandler(zoomRW(_.sequencesOnDisplay)((m, v) => m.copy(sequencesOnDisplay = v)))
   val sequenceExecHandler    = new SequenceExecutionHandler(zoomRW(_.queue)((m, v) => m.copy(queue = v)))
@@ -259,6 +274,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
     searchHandler,
     searchAreaHandler,
     devConsoleHandler,
+    loginBoxHandler,
     wsLogHandler,
     sequenceDisplayHandler,
     globalLogHandler,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -136,8 +136,9 @@ class UserLoginHandler[M](modelRW: ModelRW[M, Option[UserDetails]]) extends Acti
       val effect = Effect(Future(CloseLoginBox))
       updated(Some(u), effect)
     case Logout =>
-      // Remove the user
-      updated(None)
+      val effect = Effect(SeqexecWebClient.logout())
+      // Remove the user and call logout
+      updated(None, effect)
   }
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -117,10 +117,10 @@ class LoginBoxHandler[M](modelRW: ModelRW[M, SectionVisibilityState]) extends Ac
   implicit val runner = new RunAfterJS
 
   override def handle: PartialFunction[AnyRef, ActionResult[M]] = {
-    case OpenLoginBox if value == SectionOpen   =>
-      updated(SectionClosed)
-    case CloseLoginBox if value == SectionClosed =>
+    case OpenLoginBox if value == SectionClosed =>
       updated(SectionOpen)
+    case CloseLoginBox if value == SectionOpen  =>
+      updated(SectionClosed)
   }
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -135,6 +135,9 @@ class UserLoginHandler[M](modelRW: ModelRW[M, Option[UserDetails]]) extends Acti
       // Close the login box
       val effect = Effect(Future(CloseLoginBox))
       updated(Some(u), effect)
+    case Logout =>
+      // Remove the user
+      updated(None)
   }
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -32,6 +32,10 @@ case object CloseSearchArea
 // Actions to close and/open the dev console area
 case object ToggleDevConsole
 
+// Actions to close and/open the login box
+case object OpenLoginBox
+case object CloseLoginBox
+
 // Action to add a sequence to the queue
 case class AddToQueue(s: Sequence)
 // Action to remove a sequence from the search results
@@ -118,11 +122,12 @@ case class SeqexecAppRootModel(user: Option[UserDetails],
                                queue: Pot[SeqexecQueue],
                                searchAreaState: SectionVisibilityState,
                                devConsoleState: SectionVisibilityState,
+                               loginBox: SectionVisibilityState,
                                webSocketLog: WebSocketsLog,
                                globalLog: GlobalLog,
                                searchResults: Pot[List[Sequence]],
                                sequencesOnDisplay: SequencesOnDisplay)
 
 object SeqexecAppRootModel {
-  val initial = SeqexecAppRootModel(None, Empty, SectionClosed, SectionClosed, WebSocketsLog(Nil), GlobalLog(Nil), Empty, SequencesOnDisplay.empty)
+  val initial = SeqexecAppRootModel(None, Empty, SectionClosed, SectionClosed, SectionClosed, WebSocketsLog(Nil), GlobalLog(Nil), Empty, SequencesOnDisplay.empty)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -36,6 +36,8 @@ case object ToggleDevConsole
 case object OpenLoginBox
 case object CloseLoginBox
 
+case class LoggedIn(u: UserDetails)
+
 // Action to add a sequence to the queue
 case class AddToQueue(s: Sequence)
 // Action to remove a sequence from the search results

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -4,7 +4,7 @@ import java.time.LocalTime
 
 import diode.RootModelR
 import diode.data.{Empty, Pot, PotAction, RefTo}
-import edu.gemini.seqexec.model.SeqexecEvent
+import edu.gemini.seqexec.model.{SeqexecEvent, UserDetails}
 import edu.gemini.seqexec.web.common.{Instrument, SeqexecQueue, Sequence}
 
 import scalaz._
@@ -114,7 +114,8 @@ object SequencesOnDisplay {
 /**
   * Root of the UI Model of the application
   */
-case class SeqexecAppRootModel(queue: Pot[SeqexecQueue],
+case class SeqexecAppRootModel(user: Option[UserDetails],
+                               queue: Pot[SeqexecQueue],
                                searchAreaState: SectionVisibilityState,
                                devConsoleState: SectionVisibilityState,
                                webSocketLog: WebSocketsLog,
@@ -123,5 +124,5 @@ case class SeqexecAppRootModel(queue: Pot[SeqexecQueue],
                                sequencesOnDisplay: SequencesOnDisplay)
 
 object SeqexecAppRootModel {
-  val initial = SeqexecAppRootModel(Empty, SectionClosed, SectionClosed, WebSocketsLog(Nil), GlobalLog(Nil), Empty, SequencesOnDisplay.empty)
+  val initial = SeqexecAppRootModel(None, Empty, SectionClosed, SectionClosed, WebSocketsLog(Nil), GlobalLog(Nil), Empty, SequencesOnDisplay.empty)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -37,6 +37,7 @@ case object OpenLoginBox
 case object CloseLoginBox
 
 case class LoggedIn(u: UserDetails)
+case object Logout
 
 // Action to add a sequence to the queue
 case class AddToQueue(s: Sequence)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
@@ -30,6 +30,8 @@ object SemanticUI {
     def tab(): this.type = js.native
 
     def transition(s: String): this.type = js.native
+
+    def modal(s: String): this.type = js.native
   }
 
   implicit def jq2Semantic(jq: JQuery): SemanticCommands = jq.asInstanceOf[SemanticCommands]

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
@@ -28,6 +28,8 @@ object SemanticUI {
   class JsModalOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsModalOptions, JsModalOptionBuilder](new JsModalOptionBuilder(_)) {
     def autofocus(t: Boolean) = jsOpt("autofocus", t)
     def onDeny[A](t: js.Function0[A]) = jsOpt("onDeny", t)
+    def onHide[A](t: js.Function0[A]) = jsOpt("onHide", t)
+    def onHidden[A](t: js.Function0[A]) = jsOpt("onHidden", t)
     def onApprove[A](t: js.Function0[A]) = jsOpt("onApprove", t)
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
@@ -21,6 +21,17 @@ object SemanticUI {
   }
 
   @js.native
+  trait JsModalOptions extends js.Object
+
+  object JsModalOptions extends JsModalOptionBuilder(noOpts)
+
+  class JsModalOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsModalOptions, JsModalOptionBuilder](new JsModalOptionBuilder(_)) {
+    def autofocus(t: Boolean) = jsOpt("autofocus", t)
+    def onDeny[A](t: js.Function0[A]) = jsOpt("onDeny", t)
+    def onApprove[A](t: js.Function0[A]) = jsOpt("onApprove", t)
+  }
+
+  @js.native
   trait SemanticCommands extends JQuery {
     def visibility(o: JsVisiblityOptions): this.type = js.native
 
@@ -32,6 +43,8 @@ object SemanticUI {
     def transition(s: String): this.type = js.native
 
     def modal(s: String): this.type = js.native
+
+    def modal(o: JsModalOptions): this.type = js.native
   }
 
   implicit def jq2Semantic(jq: JQuery): SemanticCommands = jq.asInstanceOf[SemanticCommands]

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/common.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/common.scala
@@ -1,0 +1,16 @@
+package edu.gemini.seqexec.web.client.semanticui
+
+sealed trait Size
+
+object Size {
+  case object NotSized extends Size
+  case object Tiny extends Size
+  case object Mini extends Size
+  case object Medium extends Size
+  case object Small extends Size
+  case object Large extends Size
+  case object Big extends Size
+  case object Huge extends Size
+  case object Massive extends Size
+}
+

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/button/Button.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/button/Button.scala
@@ -1,5 +1,6 @@
 package edu.gemini.seqexec.web.client.semanticui.elements.button
 
+import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.prefix_<^._
@@ -24,6 +25,7 @@ object Button {
                    emphasis: Emphasis    = NoEmphasis,
                    animated: Animated    = NotAnimated,
                    icon: Option[Icon]    = None,
+                   size: Size            = Size.NotSized,
                    basic: Boolean        = false,
                    inverted: Boolean     = false,
                    circular: Boolean     = false,
@@ -46,7 +48,14 @@ object Button {
       "inverted"  -> p.inverted,
       "circular"  -> p.circular,
       "labeled"   -> p.labeled,
-      "disabled"  -> p.disabled
+      "disabled"  -> p.disabled,
+      "tiny"      -> (p.size == Size.Tiny),
+      "mini"      -> (p.size == Size.Mini),
+      "small"     -> (p.size == Size.Small),
+      "large"     -> (p.size == Size.Large),
+      "big"       -> (p.size == Size.Big),
+      "huge"      -> (p.size == Size.Huge),
+      "massive"   -> (p.size == Size.Massive)
     )
 
   def component = ReactComponentB[Props]("Button")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/button/Button.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/button/Button.scala
@@ -1,6 +1,7 @@
 package edu.gemini.seqexec.web.client.semanticui.elements.button
 
 import edu.gemini.seqexec.web.client.semanticui.Size
+import edu.gemini.seqexec.web.client.semanticui._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.prefix_<^._
@@ -21,11 +22,18 @@ object Button {
   case object Vertical extends Animated
   case object Fade extends Animated
 
+  sealed trait Type
+  case object ButtonType extends Type
+  case object ResetType extends Type
+  case object SubmitType extends Type
+
   case class Props(state: ButtonState    = Inactive,
                    emphasis: Emphasis    = NoEmphasis,
                    animated: Animated    = NotAnimated,
                    icon: Option[Icon]    = None,
                    size: Size            = Size.NotSized,
+                   buttonType: Type      = ButtonType,
+                   form: Option[String]  = None,
                    basic: Boolean        = false,
                    inverted: Boolean     = false,
                    circular: Boolean     = false,
@@ -63,6 +71,12 @@ object Button {
       if (p.animated == NotAnimated)
         <.button(
           ^.cls := "ui button",
+          ^.`type` := (p.buttonType match {
+            case ButtonType => "button"
+            case SubmitType => "submit"
+            case ResetType  => "reset"
+          }),
+          p.form.map(f => formId := f),
           p.color.map(u => ^.cls := u),
           classSet(p),
           ^.onClick --> p.onClick,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/Input.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/Input.scala
@@ -1,0 +1,48 @@
+package edu.gemini.seqexec.web.client.semanticui.elements.input
+
+import japgolly.scalajs.react.{Callback, CallbackTo, ReactComponentB, ReactEventI}
+import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.vdom.prefix_<^._
+
+object Input {
+  type ChangeCallback = String => Callback
+
+  case class Props(name: String,
+                   id: String,
+                   inputType: InputType = TextInput,
+                   placeholder: String = "",
+                   onChange: ChangeCallback = s => Callback.empty) // callback for parents of this component
+
+  sealed trait InputType
+  case object TextInput extends InputType
+  case object PasswordInput extends InputType
+
+  // Use state monad to hold the state of the system
+  val ST = ReactS.Fix[String]
+
+  def onTextChange(c: ChangeCallback)(e: ReactEventI):ReactST[CallbackTo, String, Unit] = {
+    // Capture the value outside setState, react reuses the events
+    val v = e.target.value
+    // First update the internal state, then call the outside listener
+    ST.set(v).liftCB >> ST.retM(c(v))
+  }
+
+  def component = ReactComponentB[Props]("Icon")
+    .initialState("")
+    .renderPS { ($, p, s) =>
+      <.input(
+        ^.`type` := (p.inputType match {
+          case TextInput     => "text"
+          case PasswordInput => "password"
+        }),
+        ^.placeholder := p.placeholder,
+        ^.name := p.name,
+        ^.id := p.id,
+        ^.value := s,
+        ^.onChange ==> $._runState(onTextChange(p.onChange))
+      )
+    }
+    .build
+
+  def apply(p: Props) = component(p)
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
@@ -1,0 +1,20 @@
+package edu.gemini.seqexec.web.client.semanticui.elements.label
+
+import japgolly.scalajs.react.{ReactComponentB, ReactNode}
+import japgolly.scalajs.react.vdom.prefix_<^._
+
+object Label {
+  case class Props(text: String, htmlFor: String)
+
+  val component = ReactComponentB[Props]("Label")
+    .stateless
+    .renderPC((_, p, c) =>
+      <.label(
+        ^.htmlFor := p.htmlFor,
+        p.text,
+        c
+      )
+    ).build
+
+  def apply(p: Props, children: ReactNode*) = component(p, children)
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/menu/Item.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/menu/Item.scala
@@ -19,6 +19,5 @@ object Item {
       )
     ).build
 
-
   def apply(name: String, children: ReactNode*) = component(Props(name), children: _*)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/package.scala
@@ -5,5 +5,6 @@ import japgolly.scalajs.react.vdom.prefix_<^._
 package object semanticui {
   // Custom attributes used by SemanticUI
   val dataTab = "data-tab".reactAttr
+  val formId = "form".reactAttr
 
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/package.scala
@@ -6,17 +6,4 @@ package object semanticui {
   // Custom attributes used by SemanticUI
   val dataTab = "data-tab".reactAttr
 
-  sealed trait Size
-
-  object Size {
-    case object NotSized extends Size
-    case object Tiny extends Size
-    case object Mini extends Size
-    case object Medium extends Size
-    case object Small extends Size
-    case object Large extends Size
-    case object Big extends Size
-    case object Huge extends Size
-    case object Massive extends Size
-  }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -2,6 +2,7 @@ package edu.gemini.seqexec.web.client.services
 
 import java.util.logging.LogRecord
 
+import edu.gemini.seqexec.model.{UserDetails, UserLoginRequest}
 import edu.gemini.seqexec.web.common._
 import edu.gemini.seqexec.web.common.LogMessage._
 import org.scalajs.dom.ext.{Ajax, AjaxException}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
@@ -1,6 +1,6 @@
 package edu.gemini.seqexec.web.server.http4s
 
-import edu.gemini.seqexec.web.common.UserDetails
+import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.server.security.AuthenticationConfig
 import edu.gemini.seqexec.web.server.security.AuthenticationService._
 import org.http4s.AttributeKey

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
@@ -1,35 +1,24 @@
 package edu.gemini.seqexec.web.server.http4s
 
 import edu.gemini.seqexec.web.common.UserDetails
-import edu.gemini.seqexec.web.server.security.{AuthenticationConfig, MissingCookie}
+import edu.gemini.seqexec.web.server.security.AuthenticationConfig
 import edu.gemini.seqexec.web.server.security.AuthenticationService._
-import org.http4s.{AttributeKey, Challenge, Request, headers}
-import org.http4s.server.middleware.authentication.Authentication
+import org.http4s.AttributeKey
 
 import scalaz._
 import Scalaz._
 import scalaz.concurrent.Task
 
 object JwtAuthentication {
-  val authenticatedUser = AttributeKey[UserDetails]("edu.gemini.seqexec.authenticatedUser")
+  val authenticatedUser = AttributeKey[Option[UserDetails]]("edu.gemini.seqexec.authenticatedUser")
 }
 
-class JwtAuthentication extends Authentication {
-  override protected def getChallenge(req: Request): Task[\/[Challenge, Request]] = {
-    val challenge = -\/(Challenge("jwt", Realm))
-
-    def checkAuth(req: Request): Task[AuthResult] = Task.now {
-      for {
-        cookies <- req.headers.get(headers.`Cookie`).map(_.values) \/> MissingCookie
-        token   <- cookies.findLeft(_.name == AuthenticationConfig.cookieName) \/> MissingCookie
-        auth    <- decodeToken(token.content)
-      } yield auth
-    }
-
-    checkAuth(req) >>= {
-      case \/-(u) => Task.now(\/-(req.withAttribute(JwtAuthentication.authenticatedUser, u)))
-      case -\/(e) => Task.now(challenge)
-    }
+class JwtAuthentication extends TokenAuthenticator[UserDetails] with TokenInCookies {
+  override val cookieName = AuthenticationConfig.cookieName
+  override val attributeKey = JwtAuthentication.authenticatedUser
+  override val store = (t: String) => decodeToken(t) match {
+    case \/-(u) => Task.now(Some(u))
+    case -\/(e) => Task.now(None)
   }
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 import java.util.logging.Logger
 
 import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.model.{SeqexecConnectionOpenEvent, UserLoginRequest}
 import edu.gemini.seqexec.server.SeqexecFailure.Unexpected
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
 import edu.gemini.seqexec.web.common._
@@ -21,7 +22,7 @@ import org.http4s.websocket.WebsocketBits._
 
 import scalaz._
 import Scalaz._
-import scalaz.stream.Exchange
+import scalaz.stream.{Exchange, Process}
 
 /**
   * Rest Endpoints under the /api route
@@ -86,6 +87,11 @@ object SeqexecUIApiRoutes {
   }
 
   val protectedServices: HttpService = tokenAuthService { HttpService {
+    case req @ GET -> Root / "seqexec" / "events" =>
+      // Stream seqexec events to clients and a ping
+      val user = req.attributes.get(JwtAuthentication.authenticatedUser).flatten
+      WS(Exchange(pingProcess merge (Process.emit(Text(write(SeqexecConnectionOpenEvent(user)))) ++ ExecutorImpl.sequenceEvents.map(v => Text(write(v)))), scalaz.stream.Process.empty))
+
       case req @ POST -> Root / "seqexec" / "logout" =>
         // This is not necessary, it is just code to verify token decoding
         println("Logged out " + req.attributes.get(JwtAuthentication.authenticatedUser))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -90,7 +90,8 @@ object SeqexecUIApiRoutes {
         // This is not necessary, it is just code to verify token decoding
         println("Logged out " + req.attributes.get(JwtAuthentication.authenticatedUser))
 
-        Ok("").removeCookie(AuthenticationConfig.cookieName)
+        val cookie = Cookie(AuthenticationConfig.cookieName, "", path = "/".some, secure = AuthenticationConfig.onSSL, maxAge = Some(-1), httpOnly = true)
+        Ok("").removeCookie(cookie)
     }
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -92,12 +92,12 @@ object SeqexecUIApiRoutes {
       val user = req.attributes.get(JwtAuthentication.authenticatedUser).flatten
       WS(Exchange(pingProcess merge (Process.emit(Text(write(SeqexecConnectionOpenEvent(user)))) ++ ExecutorImpl.sequenceEvents.map(v => Text(write(v)))), scalaz.stream.Process.empty))
 
-      case req @ POST -> Root / "seqexec" / "logout" =>
-        // This is not necessary, it is just code to verify token decoding
-        println("Logged out " + req.attributes.get(JwtAuthentication.authenticatedUser))
+    case req @ POST -> Root / "seqexec" / "logout" =>
+      // This is not necessary, it is just code to verify token decoding
+      println("Logged out " + req.attributes.get(JwtAuthentication.authenticatedUser))
 
-        val cookie = Cookie(AuthenticationConfig.cookieName, "", path = "/".some, secure = AuthenticationConfig.onSSL, maxAge = Some(-1), httpOnly = true)
-        Ok("").removeCookie(cookie)
+      val cookie = Cookie(AuthenticationConfig.cookieName, "", path = "/".some, secure = AuthenticationConfig.onSSL, maxAge = Some(-1), httpOnly = true)
+      Ok("").removeCookie(cookie)
     }
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/TokenAuthenticator.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/TokenAuthenticator.scala
@@ -33,8 +33,6 @@ trait TokenInCookies {
 /**
  * TokenAuthentication instances are middleware that provide a
  * {@link HttpService} with optional HTTP authentication.
- *
- * @type A user object type
  */
 trait TokenAuthenticator[A] extends HttpMiddleware {
   type TokenAuth = String => Task[Option[A]]
@@ -44,17 +42,7 @@ trait TokenAuthenticator[A] extends HttpMiddleware {
   val attributeKey: AttributeKey[Option[A]]
 
   /**
-   * Check if req contains valid credentials. You may assume that
-   * the returned Task is executed at most once (to allow for side-effects,
-   * e.g. the incrementation of a nonce counter in DigestAuthentication).
-    *
-    * @param req The request received from the client.
-   * @return If req contains valid credentials, a copy of req is returned that
-   *         contains additional attributes pertaining to authentication such
-   *         as the username and realm from the valid credentials.
-   *         If req does not contain valid credentials, a challenge is returned.
-   *         This challenge will be included in the HTTP 401
-   *         Unauthorized response that is returned to the client.
+   * Check if req contains valid credentials. it delegates to TokenExtractor
    *
    */
   protected def getUser(req: Request): Task[Option[A]] =
@@ -67,8 +55,8 @@ trait TokenAuthenticator[A] extends HttpMiddleware {
     getUser(req) flatMap {
       case u @ Some(_) =>
         service(req.withAttribute(attributeKey, u))
-      case None =>
-        service(req)
+      case None        =>
+        service(req) // The request is allowed for an anonymous usel
     }
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/TokenAuthenticator.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/TokenAuthenticator.scala
@@ -1,0 +1,76 @@
+package edu.gemini.seqexec.web.server.http4s
+
+import edu.gemini.seqexec.web.server.http4s.TokenAuthenticator.TokenExtractor
+import org.http4s.{Service, _}
+
+import scalaz.concurrent.Task
+import org.http4s.server._
+
+import scalaz._
+import Scalaz._
+
+object TokenAuthenticator {
+  /**
+   * TokenAuthentication function that extract a token from the request, e.g.
+   * from a Cookie or a header
+   */
+  type TokenExtractor = Request => Task[Option[String]]
+
+}
+
+trait TokenInCookies {
+  // Can be overriden for custom cookie name
+  val cookieName: String = "token"
+
+  val extractor: TokenExtractor = req => Task.now {
+    for {
+      cookies <- req.headers.get(headers.`Cookie`).map(_.values)
+      token   <- cookies.findLeft(_.name == cookieName)
+    } yield token.content
+  }
+}
+
+/**
+ * TokenAuthentication instances are middleware that provide a
+ * {@link HttpService} with optional HTTP authentication.
+ *
+ * @type A user object type
+ */
+trait TokenAuthenticator[A] extends HttpMiddleware {
+  type TokenAuth = String => Task[Option[A]]
+
+  val store: TokenAuth
+  val extractor: TokenExtractor
+  val attributeKey: AttributeKey[Option[A]]
+
+  /**
+   * Check if req contains valid credentials. You may assume that
+   * the returned Task is executed at most once (to allow for side-effects,
+   * e.g. the incrementation of a nonce counter in DigestAuthentication).
+    *
+    * @param req The request received from the client.
+   * @return If req contains valid credentials, a copy of req is returned that
+   *         contains additional attributes pertaining to authentication such
+   *         as the username and realm from the valid credentials.
+   *         If req does not contain valid credentials, a challenge is returned.
+   *         This challenge will be included in the HTTP 401
+   *         Unauthorized response that is returned to the client.
+   *
+   */
+  protected def getUser(req: Request): Task[Option[A]] =
+    extractor(req).flatMap {
+      case Some(t) => store(t)
+      case None    => Task.now(None)
+    }
+
+  def apply(service: HttpService): HttpService = Service.lift { req =>
+    getUser(req) flatMap {
+      case u @ Some(_) =>
+        service(req.withAttribute(attributeKey, u))
+      case None =>
+        service(req)
+    }
+  }
+}
+
+

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -52,11 +52,13 @@ object SeqexecUIApiRoutes {
   implicit val messageFlowTransformer = MessageFlowTransformer.identityMessageFlowTransformer
 
   val routes: Routes = {
-    case GET(p"/api/seqexec/sequence/$id<.*-[0-9]+>") => Action {
-      val obsId = new SPObservationID(id)
-      ExecutorImpl.read(obsId) match {
-        case \/-(s) => Results.Ok(write(List(Sequence(obsId.stringValue(), SequenceState.NotRunning, "F2", s.toSequenceSteps, None))))
-        case -\/(e) => Results.NotFound(SeqexecFailure.explain(e))
+    case GET(p"/api/seqexec/sequence/$id<.*-[0-9]+>") => UserAction { h =>
+      h.user.fold(Results.Unauthorized("")) { _ =>
+        val obsId = new SPObservationID(id)
+        ExecutorImpl.read(obsId) match {
+          case \/-(s) => Results.Ok(write(List(Sequence(obsId.stringValue(), SequenceState.NotRunning, "F2", s.toSequenceSteps, None))))
+          case -\/(e) => Results.NotFound(SeqexecFailure.explain(e))
+        }
       }
     }
     case GET(p"/api/seqexec/current/queue") => Action {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -5,7 +5,7 @@ import java.util.logging.Logger
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.model.{SeqexecConnectionOpenEvent, UserLoginRequest}
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
-import edu.gemini.seqexec.web.common.{LogMessage, Sequence, SequenceState, UserLoginRequest}
+import edu.gemini.seqexec.web.common.{LogMessage, Sequence, SequenceState}
 import edu.gemini.seqexec.web.common.LogMessage._
 import edu.gemini.seqexec.web.server.model.CannedModel
 import edu.gemini.seqexec.web.server.model.Conversions._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/SeqexecUIApiRoutes.scala
@@ -3,6 +3,7 @@ package edu.gemini.seqexec.web.server.play
 import java.util.logging.Logger
 
 import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.model.UserLoginRequest
 import edu.gemini.seqexec.server.{ExecutorImpl, SeqexecFailure}
 import edu.gemini.seqexec.web.common.{LogMessage, Sequence, SequenceState, UserLoginRequest}
 import edu.gemini.seqexec.web.common.LogMessage._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/UserAction.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/UserAction.scala
@@ -14,6 +14,7 @@ case class UserRequest[A](user: Option[UserDetails], request: Request[A]) extend
 object UserAction extends
     ActionBuilder[UserRequest] with ActionTransformer[Request, UserRequest] {
 
+  // Attempts to extract from the request cookies the id of the user
   def checkAuth(req: RequestHeader): AuthResult =
     for {
       cookies <- \/-(req.cookies)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/UserAction.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/UserAction.scala
@@ -1,7 +1,7 @@
 package edu.gemini.seqexec.web.server.play
 
+import edu.gemini.seqexec.model.UserDetails
 import play.api.mvc._
-import edu.gemini.seqexec.web.common.UserDetails
 import edu.gemini.seqexec.web.server.security.{AuthenticationConfig, MissingCookie}
 import edu.gemini.seqexec.web.server.security.AuthenticationService._
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/UserAction.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/play/UserAction.scala
@@ -13,14 +13,15 @@ case class UserRequest[A](user: Option[UserDetails], request: Request[A]) extend
 
 object UserAction extends
     ActionBuilder[UserRequest] with ActionTransformer[Request, UserRequest] {
-  override def transform[A](request: Request[A]) = Future.successful {
 
-    def checkAuth(req: Request[A]): AuthResult =
-      for {
-        cookies <- \/-(req.cookies)
-        token   <- cookies.find(_.name == AuthenticationConfig.cookieName) \/> MissingCookie
-        auth    <- decodeToken(token.value)
-      } yield auth
+  def checkAuth(req: RequestHeader): AuthResult =
+    for {
+      cookies <- \/-(req.cookies)
+      token   <- cookies.find(_.name == AuthenticationConfig.cookieName) \/> MissingCookie
+      auth    <- decodeToken(token.value)
+    } yield auth
+
+  override def transform[A](request: Request[A]) = Future.successful {
 
     checkAuth(request) match {
       case \/-(u) => new UserRequest(u.some, request)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/LDAPAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/LDAPAuthenticationService.scala
@@ -1,7 +1,7 @@
 package edu.gemini.seqexec.web.server.security
 
 import com.unboundid.ldap.sdk._
-import edu.gemini.seqexec.web.common.UserDetails
+import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
 
 import scala.collection.JavaConverters._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/TestAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/TestAuthenticationService.scala
@@ -1,6 +1,6 @@
 package edu.gemini.seqexec.web.server.security
 
-import edu.gemini.seqexec.web.common.UserDetails
+import edu.gemini.seqexec.model.UserDetails
 
 import scalaz._
 import Scalaz._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -1,6 +1,6 @@
 package edu.gemini.seqexec.web.server.security
 
-import edu.gemini.seqexec.web.common.UserDetails
+import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
 import upickle.default._
 import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim, JwtHeader, JwtOptions}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
@@ -1,6 +1,6 @@
 package edu.gemini.seqexec.web.server.security
 
-import edu.gemini.seqexec.web.common.UserDetails
+import edu.gemini.seqexec.model.UserDetails
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -32,7 +32,7 @@ object Settings {
     val scalajsReact = "0.11.1"
     val scalaCSS     = "0.4.1"
     val uPickle      = "0.4.0"
-    val diode        = "0.5.1"
+    val diode        = "0.5.2"
     val javaTimeJS   = "0.1.0"
     val javaLogJS    = "0.1.0"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -29,9 +29,9 @@ object Settings {
 
     // ScalaJS libraries
     val scalaDom     = "0.9.0"
-    val scalajsReact = "0.11.0"
+    val scalajsReact = "0.11.1"
     val scalaCSS     = "0.4.1"
-    val uPickle      = "0.3.9"
+    val uPickle      = "0.4.0"
     val diode        = "0.5.1"
     val javaTimeJS   = "0.1.0"
     val javaLogJS    = "0.1.0"
@@ -43,8 +43,7 @@ object Settings {
 
     val http4s       = "0.13.2a"
     val play         = "2.5.3"
-    val scalaJQuery  = "1.0-RC2"
-    val squants      = "0.6.1-GEM" // GEM Denotes our gemini built package
+    val squants      = "0.6.2"
     val argonaut     = "6.2-M1"
     val commonsHttp  = "2.0"
     val unboundId    = "3.1.1"
@@ -74,10 +73,10 @@ object Settings {
       "org.scalacheck" %%% "scalacheck"  % LibraryVersions.scalaCheck % "test"
     ))
 
-    val Argonaut    = "io.argonaut"        %% "argonaut"                         % LibraryVersions.argonaut
-    val CommonsHttp = "commons-httpclient" %  "commons-httpclient"               % LibraryVersions.commonsHttp
-    val UnboundId   = "com.unboundid"      % "unboundid-ldapsdk-minimal-edition" % LibraryVersions.unboundId
-    val JwtCore     = "com.pauldijou"      %% "jwt-core"                         % LibraryVersions.jwt
+    val Argonaut    = "io.argonaut"        %% "argonaut"                          % LibraryVersions.argonaut
+    val CommonsHttp = "commons-httpclient" %  "commons-httpclient"                % LibraryVersions.commonsHttp
+    val UnboundId   = "com.unboundid"      %  "unboundid-ldapsdk-minimal-edition" % LibraryVersions.unboundId
+    val JwtCore     = "com.pauldijou"      %% "jwt-core"                          % LibraryVersions.jwt
 
     val Squants     = Def.setting("com.squants"  %%% "squants"              % LibraryVersions.squants)
     val UPickle     = Def.setting("com.lihaoyi"  %%% "upickle"              % LibraryVersions.uPickle)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -50,8 +50,8 @@ object Settings {
     val jwt          = "0.7.1"
 
     // test libraries
-    val scalaTest    = "3.0.0-M15"
-    val scalaCheck   = "1.12.5"
+    val scalaTest    = "3.0.0-RC1"
+    val scalaCheck   = "1.13.1"
 
     // Pure JS libraries
     val reactJS        = "15.0.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -35,6 +35,7 @@ object Settings {
     val diode        = "0.5.2"
     val javaTimeJS   = "0.1.0"
     val javaLogJS    = "0.1.0"
+    val scalaJQuery  = "1.0-RC6"
 
     // Java libraries
     val scalaZ       = "7.2.2"


### PR DESCRIPTION
This PR updates the UI to support authentication. It adds:

* Login box to enter username/password
* Logout button
* Checks authentication at startup
* Restrict functions depending if a user is logged in

This is mostly an UI PR but it contains a few changes to the backend, in particular a fix to make http4s support optional authentication, an extractor of user credentials for play and restrictions on certain routes

some screenshots:

Login box
![screenshot 2016-06-02 09 36 52](https://cloud.githubusercontent.com/assets/3615303/15748612/f0810126-28b5-11e6-9a53-b436fe50fd98.png)

Restricted access for anonymous users
![screenshot 2016-06-02 09 41 58](https://cloud.githubusercontent.com/assets/3615303/15748625/fdf165c6-28b5-11e6-93d8-00bbc1288dc4.png)

Run button enabled for logged in users

![screenshot 2016-06-02 09 42 19](https://cloud.githubusercontent.com/assets/3615303/15748653/0ae354ba-28b6-11e6-80a9-d35e7ebfb479.png)

