### PR TITLE
Reconnecting WebSocket

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
@@ -39,7 +39,7 @@ object SeqexecApp extends JSApp {
     SeqexecStyles.addToDocument()
 
     // Initiate the WebSocket connection
-    SeqexecCircuit.dispatch(WSConnect)
+    SeqexecCircuit.dispatch(WSConnect(0))
 
     // Render the UI using React
     ReactDOM.render(SeqexecUI(), document.getElementById("content"))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
@@ -28,7 +28,7 @@ object SeqexecApp extends JSApp {
   def main(): Unit = {
     // Using the root logger setup the handlers
     val rootLogger = Logger.getLogger("edu")
-    rootLogger.addHandler(new ConsoleHandler)
+    rootLogger.addHandler(new ConsoleHandler(Level.INFO))
     rootLogger.addHandler(new AjaxHandler(Level.INFO))
 
     val log = Logger.getLogger("edu.gemini.seqexec.web.client.SeqexecApp")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
@@ -37,6 +37,9 @@ object SeqexecApp extends JSApp {
     // Register CSS styles
     SeqexecStyles.addToDocument()
 
+    // Initiate the WebSocket connection
+    SeqexecCircuit.dispatch(WSConnect)
+
     // Render the UI using React
     ReactDOM.render(SeqexecUI(), document.getElementById("content"))
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
@@ -12,6 +12,7 @@ import scalacss.ScalaCssReact._
 import org.scalajs.dom.document
 import java.util.logging.{Level, Logger}
 
+import edu.gemini.seqexec.web.client.model.{SeqexecCircuit, WSConnect}
 import edu.gemini.seqexec.web.client.services.log.{AjaxHandler, ConsoleHandler}
 
 /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -38,7 +38,7 @@ object LoginBox {
       $.modState(_.copy(username = v))
     }
 
-    def loggedInEvent(u: UserDetails):Callback = Callback {SeqexecCircuit.dispatch(LoggedIn(u))} >> updateProgressMsg("")
+    def loggedInEvent(u: UserDetails):Callback = Callback { SeqexecCircuit.dispatch(LoggedIn(u)) } >> updateProgressMsg("")
     def updateProgressMsg(m: String):Callback = $.modState(_.copy(progressMsg = Some(m), errorMsg = None))
     def updateErrorMsg(m: String):Callback = $.modState(_.copy(errorMsg = Some(m), progressMsg = None))
     def closeBox:Callback = $.modState(_ => empty) >> Callback {SeqexecCircuit.dispatch(CloseLoginBox)}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -192,10 +192,8 @@ class WebSocketHandler[M](modelRW: ModelRW[M, Option[WebSocket]]) extends Action
 
     val host = document.location.host
 
-    def onOpen(e: Event): Unit = {
-      println("Open")
+    def onOpen(e: Event): Unit =
       SeqexecCircuit.dispatch(Connected)
-    }
 
     def onMessage(e: MessageEvent): Unit = {
       \/.fromTryCatchNonFatal(read[SeqexecEvent](e.data.toString)) match {
@@ -204,14 +202,12 @@ class WebSocketHandler[M](modelRW: ModelRW[M, Option[WebSocket]]) extends Action
       }
     }
 
-    def onError(e: ErrorEvent): Unit = {
-      println("Error " + e)
-      //SeqexecCircuit.dispatch(ConnectionError(e.message))
-    }
+    def onError(e: ErrorEvent): Unit =
+      SeqexecCircuit.dispatch(ConnectionError(e.message))
 
     def onClose(e: CloseEvent): Unit = {
       println("Close ")
-      //SeqexecCircuit.dispatch(ConnectionClosed)
+      SeqexecCircuit.dispatch(ConnectionClosed)
     }
 
     val ws = new WebSocket(s"ws://$host/api/seqexec/events")
@@ -229,6 +225,10 @@ class WebSocketHandler[M](modelRW: ModelRW[M, Option[WebSocket]]) extends Action
       updated(Some(ws))
     case Connected =>
       effectOnly(Effect.action(AppendToLog("Connected")))
+    case ConnectionError(e) =>
+      effectOnly(Effect.action(AppendToLog(e)))
+    case ConnectionClosed =>
+      updated(None)
   }
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -1,5 +1,7 @@
 package edu.gemini.seqexec.web.client.model
 
+import java.util.logging.Logger
+
 import diode.data._
 import diode.react.ReactConnector
 import diode.util.RunAfterJS
@@ -278,6 +280,8 @@ object PotEq {
 object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[SeqexecAppRootModel] {
   type SearchResults = List[Sequence]
 
+  val logger = Logger.getLogger(SeqexecCircuit.getClass.getSimpleName)
+
   def appendToLogE(s: String) =
     Effect(Future(AppendToLog(s)))
 
@@ -318,4 +322,10 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
     sequenceDisplayHandler,
     globalLogHandler,
     sequenceExecHandler)
+
+  override def handleFatal(action: Any, e: Throwable): Unit = {
+    logger.severe(s"Action not handled $action")
+    super.handleFatal(action, e)
+  }
+
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -2,10 +2,11 @@ package edu.gemini.seqexec.web.client.model
 
 import java.time.LocalTime
 
-import diode.{ActionType, Action, RootModelR}
+import diode.{Action, ActionType, RootModelR}
 import diode.data.{Empty, Pot, PotAction, RefTo}
 import edu.gemini.seqexec.model.{SeqexecEvent, UserDetails}
 import edu.gemini.seqexec.web.common.{Instrument, SeqexecQueue, Sequence}
+import org.scalajs.dom.WebSocket
 
 import scalaz._
 import Scalaz._
@@ -46,12 +47,6 @@ case class RemoveFromSearch(s: Sequence) extends Action
 // Action to select a sequence for display
 case class SelectToDisplay(s: Sequence) extends Action
 
-// Actions related to web sockets
-case object ConnectionOpened extends Action
-case object ConnectionClosed extends Action
-case class NewSeqexecEvent(e: SeqexecEvent) extends Action
-case class ConnectionError(s: String) extends Action
-
 // Actions related to executing sequences
 case class RequestRun(s: Sequence) extends Action
 case class RequestStop(s: Sequence) extends Action
@@ -64,6 +59,14 @@ case class ShowStep(s: Sequence, i: Int) extends Action
 case class UnShowStep(s: Sequence) extends Action
 
 case class AppendToLog(s: String) extends Action
+
+// Actions related to web sockets
+case object WSConnect extends Action
+case class Connecting(ws: WebSocket) extends Action
+case object Connected extends Action
+case class NewSeqexecEvent(e: SeqexecEvent) extends Action
+case class ConnectionError(s: String) extends Action
+
 
 // End Actions
 
@@ -121,7 +124,8 @@ object SequencesOnDisplay {
 /**
   * Root of the UI Model of the application
   */
-case class SeqexecAppRootModel(user: Option[UserDetails],
+case class SeqexecAppRootModel(ws: Option[WebSocket],
+                               user: Option[UserDetails],
                                queue: Pot[SeqexecQueue],
                                searchAreaState: SectionVisibilityState,
                                devConsoleState: SectionVisibilityState,
@@ -132,5 +136,5 @@ case class SeqexecAppRootModel(user: Option[UserDetails],
                                sequencesOnDisplay: SequencesOnDisplay)
 
 object SeqexecAppRootModel {
-  val initial = SeqexecAppRootModel(None, Empty, SectionClosed, SectionClosed, SectionClosed, WebSocketsLog(Nil), GlobalLog(Nil), Empty, SequencesOnDisplay.empty)
+  val initial = SeqexecAppRootModel(None, None, Empty, SectionClosed, SectionClosed, SectionClosed, WebSocketsLog(Nil), GlobalLog(Nil), Empty, SequencesOnDisplay.empty)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -2,7 +2,7 @@ package edu.gemini.seqexec.web.client.model
 
 import java.time.LocalTime
 
-import diode.{Action, ActionType, RootModelR}
+import diode.{Action, RootModelR}
 import diode.data.{Empty, Pot, PotAction, RefTo}
 import edu.gemini.seqexec.model.{SeqexecEvent, UserDetails}
 import edu.gemini.seqexec.web.common.{Instrument, SeqexecQueue, Sequence}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -64,6 +64,7 @@ case class AppendToLog(s: String) extends Action
 case object WSConnect extends Action
 case class Connecting(ws: WebSocket) extends Action
 case object Connected extends Action
+case object ConnectionClosed extends Action
 case class NewSeqexecEvent(e: SeqexecEvent) extends Action
 case class ConnectionError(s: String) extends Action
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -64,7 +64,7 @@ case class AppendToLog(s: String) extends Action
 case class WSConnect(delay: Int) extends Action
 case class Connecting(ws: WebSocket) extends Action
 case object Connected extends Action
-case object ConnectionClosed extends Action
+case class ConnectionClosed(delay: Int) extends Action
 case class NewSeqexecEvent(e: SeqexecEvent) extends Action
 case class ConnectionError(s: String) extends Action
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -61,7 +61,7 @@ case class UnShowStep(s: Sequence) extends Action
 case class AppendToLog(s: String) extends Action
 
 // Actions related to web sockets
-case object WSConnect extends Action
+case class WSConnect(delay: Int) extends Action
 case class Connecting(ws: WebSocket) extends Action
 case object Connected extends Action
 case object ConnectionClosed extends Action

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/log.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/log.scala
@@ -4,8 +4,9 @@ import java.util.logging.{Handler, Level, LogRecord, SimpleFormatter}
 
 object log {
   // Override Console Handler to use the default js console
-  class ConsoleHandler extends Handler {
+  class ConsoleHandler(level: Level) extends Handler {
     setFormatter(new SimpleFormatter)
+    setLevel(level)
 
     override def publish(record: LogRecord): Unit = {
       if (record.getLevel == Level.SEVERE) {


### PR DESCRIPTION
This PR brings an implementation of WebSocket reconnections. The application tries to open the connection at startup and if it fails, or the connection breaks at a later point, it will try to reconnect after some delay. This is implemented as a state machine using diode to handle state transitions

The delay is growing doubling every time a reconnect is attempted, up to a max of 1 min.

Note that this PR doesn't contain UI, that will come later

Another missing bit is re-syncing the data. Once we reconnect we need to query the current state of the server to update the UI