### PR TITLE
Add scalastyle configuration file

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,94 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Za-z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][a-z]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+ <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+  <parameters>
+   <parameter name="ignoreOverride">false</parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true" customId="kind.projector.lambda">
+  <parameters>
+   <parameter name="regex">Lambda\[</parameter>
+  </parameters>
+  <customMessage><![CDATA[Use Greek characters in a kind projection (λ[α => ...]).]]></customMessage>
+ </check>
+ <check enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" level="error">
+  <parameters>
+   <parameter name="tokens">PACKAGE, WHILE, CASE, NEW, DO, EQUALS, SUBTYPE, SEALED, TYPE, FINAL, IMPORT, RETURN, VAL, VAR, ELSE, MATCH, TRY, SUPERTYPE, OP, CATCH, THROW, CLASS, DEF, FOR, LARROW, ABSTRACT, IF, OBJECT, COMMA, YIELD, PIPE, IMPLICIT, LAZY, TRAIT, FORSOME, FINALLY, OVERRIDE, ARROW, EXTENDS</parameter>
+  </parameters>
+ </check>
+ <check enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" level="error">
+   <parameters>
+     <parameter name="tokens">OP, PIPE, FORSOME</parameter>
+   </parameters>
+ </check>
+ <check enabled="true" class="org.scalastyle.scalariform.ForBraceChecker" level="error"/>
+ <check enabled="true" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" level="error"/>
+ <check enabled="true" class="org.scalastyle.scalariform.RedundantIfChecker" level="error"/>
+ <check enabled="true" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" level="error"/>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true" customId="type.class.spacing">
+  <parameters>
+   <parameter name="regex"><![CDATA[(?<!@|simulacrum\.)typeclass]]></parameter>
+  </parameters>
+  <customMessage><![CDATA[Use 'type class' instead of typeclass (See #441)]]></customMessage>
+ </check>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true" customId="if.paren.spacing">
+  <parameters>
+   <parameter name="regex"><![CDATA[if\(|if\s\s+\(]]></parameter>
+  </parameters>
+  <customMessage><![CDATA[Put exactly a single space between 'if' and the following parenthesis.]]></customMessage>
+ </check>
+</scalastyle>


### PR DESCRIPTION
This was taken from the `cats` project whose style seems to align better with
the current one than the default configuration from scalastyle.

This could also be used to enforce proper styling by having travis fail if scalastyle throws warnings. However, speaking with @cquiroz and @tpolecat, we think it may not be a good idea to do so until we get used to it first.

From scalastyle website:

> You can enable scalastyle in Intellij by selecting *Settings->Editor->Inspections*, then searching for Scala style inspections.
