### PR TITLE
AD Server name changes

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/FreeLDAPAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/FreeLDAPAuthenticationService.scala
@@ -93,12 +93,14 @@ class FreeLDAPAuthenticationService(hosts: List[(String, Int)]) extends Authenti
 
   val Log = Logger.getLogger(FreeLDAPAuthenticationService.getClass.getSimpleName)
 
-  // Will attempt several servers in case they fail
-  val failoverServerSet = new FailoverServerSet(hosts.map(_._1).toArray, hosts.map(_._2).toArray)
   val MaxConnections = 20
   // Shorten the default timeout
   val Timeout = 1000
   val Domain = "@gemini.edu"
+
+  // Will attempt several servers in case they fail
+  val failoverServerSet = new FailoverServerSet(hosts.map(_._1).toArray, hosts.map(_._2).toArray,
+    new LDAPConnectionOptions() <| {_.setConnectTimeoutMillis(Timeout)})
 
   override def authenticateUser(username: String, password: String): AuthResult = {
     // We should always return the domain

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -3,10 +3,9 @@ package edu.gemini.seqexec.web.server.security
 import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
 import upickle.default._
-import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim, JwtHeader, JwtOptions}
+import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim}
 
 import scala.annotation.tailrec
-import scala.util.Try
 import scalaz._
 import Scalaz._
 
@@ -30,7 +29,7 @@ object AuthenticationConfig {
   val cookieName = "SeqexecToken"
 
   val testMode = true
-  val ldapHosts = List(("cpodc-wv1.gemini.edu", 3268), ("sbfdc-wv1.gemini.edu", 3286))
+  val ldapHosts = List(("cpodc-wv1.gemini.edu", 3268), ("sbfdc-wv1.gemini.edu", 3268))
 
   val ldapService = new FreeLDAPAuthenticationService(ldapHosts)
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -30,10 +30,9 @@ object AuthenticationConfig {
   val cookieName = "SeqexecToken"
 
   val testMode = true
-  val ldapHost = "gs-dc6.gemini.edu"
-  val ldapPort = 3268
+  val ldapHosts = List(("cpodc-wv1.gemini.edu", 3268), ("sbfdc-wv1.gemini.edu", 3286))
 
-  val ldapService = new FreeLDAPAuthenticationService(ldapHost, ldapPort)
+  val ldapService = new FreeLDAPAuthenticationService(ldapHosts)
 
   // TODO Only the LDAP service should be present on production mode
   val authServices =
@@ -65,7 +64,12 @@ object AuthenticationService {
             case -\/(e)     => go(xs)
           }
       }
-      go(s)
+      // Discard empty values right away
+      if (username.isEmpty || password.isEmpty) {
+        \/.left(BadCredentials(username))
+      } else {
+        go(s)
+      }
     }
   }
 


### PR DESCRIPTION
The AD server names were changing rendering the logging functionality of ocs3 inoperable
This PR fixes the server names and adds support for failover. The server will attempt first cpo and if it fails it will attempt sbf before giving up