### PR TITLE
Track sequence running step

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -12,6 +12,7 @@ import edu.gemini.seqexec.web.common.{SeqexecQueue, Sequence, SequenceState}
 import japgolly.scalajs.react.vdom.prefix_<^._
 import japgolly.scalajs.react._
 
+import scala.scalajs.js
 import scalacss.ScalaCssReact._
 import scalaz.syntax.show._
 
@@ -141,7 +142,7 @@ object QueueTableLoading {
         ^.cls := "ui header item",
         p.queue.renderPending(_ => <.span(IconCircleNotched.copyIcon(loading = true), "Loading..."))
       )
-    ).build
+    ).build.withKey("key.queue.loading")
 
   def apply(p: ModelProxy[Pot[SeqexecQueue]]) = component(Props(p()))
 }
@@ -150,15 +151,15 @@ object QueueTableLoading {
   * Component for the title of the queue area, including the search component
   */
 object QueueAreaTitle {
-  val statusAndSearchResultsConnect = SeqexecCircuit.connect(SeqexecCircuit.statusAndSearchResults)
-  val queueConnect = SeqexecCircuit.connect(_.queue)
+  val statusAndSearchResultsConnect = SeqexecCircuit.connect(SeqexecCircuit.statusAndSearchResults, "key.queue.search": js.Any)
+  val queueConnect = SeqexecCircuit.connect(_.queue, "key.queue.area": js.Any)
 
   case class Props(user: ModelProxy[Option[UserDetails]])
 
   val component = ReactComponentB[Props]("QueueAreaTitle")
     .stateless
     .render_P(p =>
-      TextMenuSegment("Queue",
+      TextMenuSegment("Queue", "key.queue.menu",
         // Show a loading indicator if we are waiting for server data
         {
           // Special equality check to avoid certain UI artifacts
@@ -168,12 +169,11 @@ object QueueAreaTitle {
         p.user().map { u =>
           <.div(
             ^.cls := "right menu",
-            ^.key := "queue.area.title",
             statusAndSearchResultsConnect(SequenceSearch.apply)
           ): ReactNode
-        }.getOrElse[ReactNode](<.div(^.key := "queue.area.empty"))
+        }.getOrElse[ReactNode](<.div())
       )
-    ).build
+    ).build.withKey("key.area.title")
 
   def apply(user: ModelProxy[Option[UserDetails]]) = component(Props(user))
 }
@@ -182,7 +182,7 @@ object QueueAreaTitle {
   * Container for the queue table
   */
 object QueueTableSection {
-  val queueConnect = SeqexecCircuit.connect(_.queue)
+  val queueConnect = SeqexecCircuit.connect(_.queue, "key.queue": js.Any)
 
   case class Props(opened: SectionVisibilityState)
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -51,6 +51,9 @@ object SeqexecStyles extends StyleSheet.Inline {
     maxHeight(24.3.em)
   }
 
+  val stepsListBody = style() // Marker css
+  val stepRunning = style() // Marker css
+
   val observeConfig = style {
     backgroundColor.lightcyan
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SequenceSearch.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SequenceSearch.scala
@@ -168,7 +168,7 @@ object SequenceSearch {
   val component = ReactComponentB[Props]("SequenceSearch")
     .initialState(State(""))
     .renderBackend[Backend]
-    .build
+    .build.withKey("key.sequence.search")
 
   def apply(p: ModelProxy[(ClientStatus, Pot[List[Sequence]])]) = component(Props(p))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TabularMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TabularMenu.scala
@@ -1,8 +1,9 @@
 package edu.gemini.seqexec.web.client.components
 
+import edu.gemini.seqexec.web.client.model.SequencesOnDisplay
 import edu.gemini.seqexec.web.client.semanticui._
 import japgolly.scalajs.react.vdom.prefix_<^._
-import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM, ReactNode}
+import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM}
 
 /**
   * Menu with tabs
@@ -10,6 +11,8 @@ import japgolly.scalajs.react.{Callback, ReactComponentB, ReactDOM, ReactNode}
 object TabularMenu {
   case class TabItem(title: String, isActive: Boolean, dataItem: String)
   case class Props(tabs: List[TabItem])
+
+  def sequencesTabs(d: SequencesOnDisplay) = d.instrumentSequences.map(a => TabItem(a.instrument, isActive = a == d.instrumentSequences.focus, a.instrument))
 
   val component = ReactComponentB[Props]("TabularMenu")
     .stateless
@@ -37,5 +40,5 @@ object TabularMenu {
       }
     ).build
 
-  def apply(tabs: List[TabItem], children: ReactNode*) = component(Props(tabs), children)
+  def apply(p: SequencesOnDisplay) = component(Props(sequencesTabs(p).toStream.toList))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TextMenuSegment.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TextMenuSegment.scala
@@ -1,15 +1,15 @@
 package edu.gemini.seqexec.web.client.components
 
-import japgolly.scalajs.react.{ReactComponentB, ReactNode}
+import japgolly.scalajs.react.{ReactComponentB, ReactElement, ReactNode}
 import japgolly.scalajs.react.vdom.prefix_<^._
 
 /**
   * Bar at the top of the page segtions
   */
-object TextMenuSegment {
-  case class Props(header: String)
+case class TextMenuSegment(p: TextMenuSegment.Props, children: Seq[ReactNode], key: String) {
+  import TextMenuSegment.Props
 
-  val component = ReactComponentB[Props]("TextMenuSegment")
+  def component = ReactComponentB[Props]("TextMenuSegment")
     .stateless
     .renderPC((_, p, c) =>
       <.div(
@@ -20,7 +20,14 @@ object TextMenuSegment {
         ),
         c
       )
-    ).build
+    ).build.withKey(key).apply(p, children)
+}
 
-  def apply(header: String, children: ReactNode*) = component(Props(header), children)
+object TextMenuSegment {
+  case class Props(header: String)
+
+  // Used to call TextMenuSegment directly on a jsx component declaration
+  implicit def icon2TagMod(i: TextMenuSegment):ReactElement = i.component
+
+  def apply(header: String, key: String, children: ReactNode*): TextMenuSegment = TextMenuSegment(Props(header), children, key)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TextMenuSegment.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TextMenuSegment.scala
@@ -27,7 +27,7 @@ object TextMenuSegment {
   case class Props(header: String)
 
   // Used to call TextMenuSegment directly on a jsx component declaration
-  implicit def icon2TagMod(i: TextMenuSegment):ReactElement = i.component
+  implicit def textMenu2TagMod(i: TextMenuSegment):ReactElement = i.component
 
   def apply(header: String, key: String, children: ReactNode*): TextMenuSegment = TextMenuSegment(Props(header), children, key)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/WebSocketsConsole.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/WebSocketsConsole.scala
@@ -14,7 +14,7 @@ object WebSocketsConsole {
       if (p.searchArea == SectionOpen) {
         <.div(
           ^.cls := "ui raised segments container",
-          TextMenuSegment("WebSocket Console"),
+          TextMenuSegment("WebSocket Console", "key.websockets.menu"),
           <.div(
             ^.cls := "ui attached segment",
             <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -350,7 +350,7 @@ object SequenceArea {
     .render( _ =>
       <.div(
         ^.cls := "ui raised segments container",
-        TextMenuSegment("Running Sequences"),
+        TextMenuSegment("Running Sequences", "key.sequences.menu"),
         SequenceTabs()
       )
     ).build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -207,7 +207,14 @@ object SequenceStepsTableContainer {
       def scrollPosition: Option[(Element, Double)] = {
         val node = ReactDOM.findDOMNode(f)
         val tableSelector = s".${SeqexecStyles.stepsListPane.htmlClass}"
-        val rowSelector = s".${SeqexecStyles.stepsListBody.htmlClass} tr.${SeqexecStyles.stepRunning.htmlClass}"
+        val progress = f.props.s.steps.progress
+        // Build a css selector for the relevant row, either the last one when complete
+        // or the currently running one
+        val rowSelector = if (progress._1 == progress._2) {
+            s".${SeqexecStyles.stepsListBody.htmlClass} tr:last-child"
+          } else {
+            s".${SeqexecStyles.stepsListBody.htmlClass} tr.${SeqexecStyles.stepRunning.htmlClass}"
+          }
         Option(node.querySelector(rowSelector)).flatMap { e =>
           import org.querki.jquery.$
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -318,6 +318,7 @@ object PotEq {
 
   val seqexecQueueEq = potStateEq[SeqexecQueue]
   val searchResultsEq = potStateEq[SearchResults]
+  val sequenceEq = potStateEq[Sequence]
 }
 
 /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/model.scala
@@ -47,6 +47,11 @@ case class SequenceSteps(steps: List[Step]) {
   def progress: (Int, Int) = (steps.count(_.state == StepState.Done), steps.length)
 
   /**
+    * Indicates if all the steps are marked as done
+    */
+  def allStepsDone: Boolean = steps.count(_.state == StepState.Done) == steps.length
+
+  /**
     * Mark the next step as aborted
     */
   def stopAtNext: SequenceSteps = {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -61,7 +61,7 @@ object Settings {
     val jQuery         = "3.0.0"
     val semanticUI     = "2.2"
     val jQueryTerminal = "0.9.3"
-    val ocsVersion     = "2016001.1.1"
+    val ocsVersion     = "2016102.1.1"
   }
 
   /**


### PR DESCRIPTION
This PR changes the Ui to always have the running step visible as required on the seqexec specs document. Basically if you have more steps than visible on the steps table, the ui should autoscroll to make the running step always visible

Changing the scroll position on a page can only be done on plain javascript and that collides with React way of handling the DOM. This was solved by creating  a React `Ref` to the scroll pane and hook into React lifecycle events to calculate the new scroll position, store it in the component's state and then make it effective

There are still some open issues with this like

* If the user scrolls manually, should the position be reset?
* Pausing is not supported in this schema
* For fully executed sequences, should we focus on the first or the last row?

I'll expect user feedback to continue polishing this feature

Fixes #50 