### PR TITLE
Seqexec execution with a Zipper

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Handler.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Handler.scala
@@ -15,7 +15,7 @@ object Handler {
     def handleUserEvent(ue: UserEvent): Engine[QState] = ue match {
       case Start => log("Output: Started") *> switch(q)(Status.Running)
       case Pause => log("Output: Paused") *> switch(q)(Status.Waiting)
-      case AddExecution(pend) => log("Output: Adding Pending Execution") // *> add(pend)
+      case AddExecution(pend) => log("Output: Adding Pending Execution") // TODO: Implement handler
       case Poll => log("Output: Polling current state")
       case Exit => log("Bye") *> close(q)
     }
@@ -38,5 +38,5 @@ object Handler {
   }
 
   def run(q: EventQueue)(qs: QState): Task[QState] =
-    handler(q).takeWhile(!_.pending.isEmpty).run.exec(qs)
+    handler(q).run.exec(qs)
 }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/HandlerSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/HandlerSpec.scala
@@ -99,10 +99,11 @@ class HandlerSpec extends FlatSpec {
   //   assert(result.queue.pending.length == 2)
   // }
 
-  it should "print qs1 execution" in {
-    intercept[Cause.Terminated](Nondeterminism[Task].both(
-      (queue.enqueueOne(start)), // *> queue.enqueueOne(exit)),
-      (handler(queue).run.exec(qs1))
+  it should "Print qs1 execution" in {
+    intercept[Cause.Terminated](
+      Nondeterminism[Task].both(
+        queue.enqueueOne(start),
+        handler(queue).run.exec(qs1)
       ).unsafePerformSync
     )
   }


### PR DESCRIPTION
With the *Zipper* there is now a deeper data hierarchy with a top level *Queue*, *Sequence*s, *Step*s, *Execution*s and *Action*s. Previously there were only the equivalent of *Execution*s and *Action*s. Also with this structure it comes support for marking `Execution`s as completed instead of remove them.

The executions for each test can be seen printed to the console. The tests themselves only check that the executions finish.

Don't bother too much reviewing this PR since the changes are quite messy. It can be considered as a starting point for the Zipper based execution.