### PR TITLE
Upgrades

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -166,12 +166,12 @@ object QueueAreaTitle {
           implicit val eq = PotEq.seqexecQueueEq
           queueConnect(QueueTableLoading.apply)
         },
-        p.user().map { u =>
+        p.user().fold(<.div()) { _ =>
           <.div(
             ^.cls := "right menu",
             statusAndSearchResultsConnect(SequenceSearch.apply)
-          ): ReactNode
-        }.getOrElse[ReactNode](<.div())
+          )
+        }
       )
     ).build.withKey("key.area.title")
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -247,8 +247,8 @@ object QueueArea {
               ^.cls := "stretched row",
               <.div(
                 ^.classSet(
-                  "ten wide computer tablet one wide mobile column"     -> (p.searchArea() == SectionOpen),
-                  "sixteen wide column"                                 -> (p.searchArea() == SectionClosed)
+                  "ten wide computer two wide tablet one wide mobile column" -> (p.searchArea() == SectionOpen),
+                  "sixteen wide column"                                      -> (p.searchArea() == SectionClosed)
                 ),
                 // If there was an error on the process display a message
                 queueConnect(LoadingErrorMsg(_)),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TextMenuSegment.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TextMenuSegment.scala
@@ -14,13 +14,15 @@ case class TextMenuSegment(p: TextMenuSegment.Props, children: Seq[ReactNode], k
     .renderPC((_, p, c) =>
       <.div(
         ^.cls := "ui top attached text menu segment",
+        ^.key := s"$key.text",
         <.div(
           ^.cls := "ui header item",
+          ^.key := s"$key.item",
           p.header
         ),
         c
       )
-    ).build.withKey(key).apply(p, children)
+    ).build.withKey(key).apply(p, children: _*)
 }
 
 object TextMenuSegment {
@@ -31,3 +33,4 @@ object TextMenuSegment {
 
   def apply(header: String, key: String, children: ReactNode*): TextMenuSegment = TextMenuSegment(Props(header), children, key)
 }
+

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -28,9 +28,9 @@ object Settings {
     val scala        = "2.11.8"
 
     // ScalaJS libraries
-    val scalaDom     = "0.9.0"
-    val scalajsReact = "0.11.1"
-    val scalaCSS     = "0.4.1"
+    val scalaDom     = "0.9.1"
+    val scalajsReact = "0.11.2"
+    val scalaCSS     = "0.5.0"
     val uPickle      = "0.4.0"
     val booPickle    = "1.2.4"
     val diode        = "1.0.0"
@@ -43,23 +43,23 @@ object Settings {
     val scalaZStream = "0.8a"
 
     // Scala libraries
-    val http4s       = "0.14.1a"
+    val http4s       = "0.14.7a"
     val squants      = "0.6.2"
     val argonaut     = "6.2-M1"
     val commonsHttp  = "2.0"
     val unboundId    = "3.1.1"
-    val jwt          = "0.7.1"
+    val jwt          = "0.8.1"
     val slf4j        = "1.7.21"
     val knobs        = "3.8.1a"
 
     // test libraries
-    val scalaTest    = "3.0.0-RC1"
+    val scalaTest    = "3.0.0"
     val scalaCheck   = "1.13.1"
 
     // Pure JS libraries
-    val reactJS        = "15.0.1"
+    val reactJS        = "15.3.2"
     val jQuery         = "3.0.0"
-    val semanticUI     = "2.2"
+    val semanticUI     = "2.2.2"
     val jQueryTerminal = "0.11.2"
     val ocsVersion     = "2016102.1.1"
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Gives support for Scala.js compilation
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.10")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")
 
 // sbt revolver lets launching applications from the sbt console
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")


### PR DESCRIPTION
This PR updates several libraries used in the seqexec-web plus some minor ui fixes:

scalaJS 0.6.10 -> 0.6.12
scalaDOM 0.9.0 -> 0.9.1
scalaJS-React 0.11.1 -> 0.11.2
scalaCSS 0.4.0 -> 0.5.0
http4s 0.14.1a -> 0.14.7a
jwt 0.7.1 -> 0.8.1
scalatest 0.3.0-RC1 -> 0.3.0

and on the js side
react 15.0.1 -> 15.3.2
semantic ui 2.2 -> 2.2.2

Very minor code changes are required. The most interesting update is scalajs that should let improve testing. The scalacss update also helps to reduce the js output in about 40k

This was tested on Chrome, Safari and Firefox 38 ESR in OSX and Safari in iOS