### PR TITLE
Tests with jsdom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ project/plugins/project/
 .ensime
 .ensime_cache/
 .#*
+
+# Node modules
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ scala:
   - 2.11.8
 jdk:
   - oraclejdk8
+install:
+  - . $HOME/.nvm/nvm.sh
+  - nvm install stable
+  - nvm use stable
+  - npm install jsdom
 before_script:
   - sudo apt-get install -y rpm
 script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OCS3
 
+[![Build Status](https://travis-ci.org/gemini-hlsw/ocs3.svg?branch=develop)](https://travis-ci.org/gemini-hlsw/ocs3)
+
 This project aims to build the next generation Observatory Control System (OCS). At the time of this writing, only the Seqexec has been integrated. This setup has the following goals
 
 - Adhere to the simplest possible sbt structure.
@@ -44,6 +46,10 @@ To tests the javascript side you need to install node and jsdom. In OSX using `b
 brew install node
 npm install jsdom
 ```
+
+`node` should be at least on version `0.6.x`, check it with `node --version` once installed
+
+Don't install jsdom at the global level (with the -g option) as it doesn't work properly with scala.js
 
 ## IDEA
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,12 @@
 # OCS3
 
-This project aims to build the next generation Observatory Control System (OCS). At the time of this writing, only the Seqexec has been integrated. This setup has the following goals 
+This project aims to build the next generation Observatory Control System (OCS). At the time of this writing, only the Seqexec has been integrated. This setup has the following goals
 
 - Adhere to the simplest possible sbt structure.
 - No need for OSGi
 - Use managed dependencies
 - Support of web applications using scala.js
 - Testing supported on both JVM and JS backends
-
-Some build-level tasks are still pending
-
-- [ ] Support deployable artifacts
-- [ ] Include modules cross-compiled to both JVM and JS backends
-- [ ] Enable travis
-- [ ] Unify JVM/JS scalaz versions
 
 ## Structure
 The project contains a single `modules` subtree. Inside that module each of the bundles is located. Web applications are further devided internally to have the server side, client side and shared code compiled to their respective backends
@@ -30,40 +23,41 @@ ocs3/
  |           +-- edu.gemini.seqexec.web.shared/
  |           +-- edu.gemini.seqexec.web.server/
  |           +-- edu.gemini.seqexec.web.client/
- +-- lib/
- +-- project/
+ +-- app/
 ```
-`lib` contains only unmanaged dependencies where `project` includes sbt definitions
+`app` contains build.sbt definitions for deployable applications
 
 ## Settings
 
 Settings and module versions are defined in the file `project/Settings.scala`
 
-## Dependencies
-
-Most dependencies are managed dependencies coming from either maven central or the Gemini repository.
-
-Intra-module dependencies are declared on `project/OcsBuild`. Being at the top level the project declarations can be used on each module's `build.sbt`
-
 ## Testing
 
-`ScalaTest` has been chosen as the test framework since it works in both scala.js and jvm. `ScalaCheck` is also supported running with `ScalaTest`. Sample tests using `scalatest` and `scalacheck` are included in some modules. You can run `test` at the root level or on a module basis.
+`ScalaTest` has been chosen as the test framework since it works in both scala.js and jvm. `ScalaCheck` is also supported running with `ScalaTest`.
+Sample tests using `scalatest` and `scalacheck` are included in some modules. You can run `test` at the root level or on a module basis.
 
 Note that IDEA doesn't support running tests on scala.js. See this [issue](https://github.com/scalatest/scalatest/issues/743)
+
+To tests the javascript side you need to install node and jsdom. In OSX using `brew` you can do:
+
+```
+brew install node
+npm install jsdom
+```
 
 ## IDEA
 
 Before opening the project in IDEA, run a top-level compile at least once to generate code that will be picked up by IDEA
 
-IDEA can open directly the project's sbt. Go to 
+IDEA can open directly the project's sbt. Go to
 
 ```
 File -> Open
 ```
 
-And find the file `ocs/build.sbt`. IDEA should show a dialog box to import the project. You may need to select the appropriate JVM version (1.8) and IDEA will import the project. `sbt` files may have highlight errors due to this [bug](https://youtrack.jetbrains.com/issue/SCL-9599). Otherwise, sbt import seems to work quite well.
+And find the file `ocs/build.sbt`. IDEA should show a dialog box to import the project. You may need to select the appropriate JVM version (1.8) and IDEA will import the project.
+`sbt` files may have highlight errors due to this [bug](https://youtrack.jetbrains.com/issue/SCL-9599). Otherwise, sbt import seems to work quite well.
 
 **Note:** Sbt import in IDEA changes very often. This has been tested on IDEA C 2016.1 and the Scala plugin version 3.0
 
 **Note:** If you need to re-generate the project, delete the `.idea` folder
- 

--- a/project/SeqexecEngineModules.scala
+++ b/project/SeqexecEngineModules.scala
@@ -25,7 +25,8 @@ trait SeqexecEngineModules {
       libraryDependencies ++= Seq(BooPickle.value) ++ TestLibs.value
     )
     .jsSettings(
-      scalaJSUseRhino := false
+      scalaJSUseRhino := false,
+      jsEnv := NodeJSEnv().value
     )
 
   lazy val edu_gemini_seqexec_model_JVM:Project = edu_gemini_seqexec_model.jvm

--- a/project/SeqexecWebModules.scala
+++ b/project/SeqexecWebModules.scala
@@ -1,6 +1,5 @@
 import sbt.Keys._
 import sbt._
-
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport._
 import sbtbuildinfo.BuildInfoPlugin
@@ -30,6 +29,7 @@ trait SeqexecWebModules extends SeqexecEngineModules {
     )
     .jsSettings(
       scalaJSUseRhino := false,
+      jsEnv := NodeJSEnv().value,
       libraryDependencies += JavaLogJS.value
     )
 
@@ -94,8 +94,8 @@ trait SeqexecWebModules extends SeqexecEngineModules {
     .enablePlugins(BuildInfoPlugin)
     .settings(commonSettings: _*)
     .settings(
-      // Skip tests in module, Rhino doesn't play nice with jquery
-      test := {},
+      // Run tests is JsDom
+      jsEnv := JSDOMNodeJSEnv().value,
       // This is a not very nice trick to remove js files that exist on the scala tools
       // library and that conflict with the requested on jsDependencies, in particular
       // with jquery.js
@@ -113,7 +113,7 @@ trait SeqexecWebModules extends SeqexecEngineModules {
       jsDependencies ++= Seq(
         "org.webjars.bower" % "react"       % LibraryVersions.reactJS     / "react-with-addons.js" minified "react-with-addons.min.js" commonJSName "React",
         "org.webjars.bower" % "react"       % LibraryVersions.reactJS     / "react-dom.js"         minified "react-dom.min.js" dependsOn "react-with-addons.js" commonJSName "ReactDOM",
-        "org.webjars"       % "jquery"      % LibraryVersions.jQuery      / "jquery.js"            minified "jquery.min.js",
+        "org.webjars"       % "jquery"      % LibraryVersions.jQuery      / "jquery.js"            minified "jquery.min.js" commonJSName "jQuery",
         "org.webjars"       % "Semantic-UI" % LibraryVersions.semanticUI  / "semantic.js"          minified "semantic.min.js" dependsOn "jquery.js"
       ),
       // Build a js dependencies file
@@ -142,9 +142,8 @@ trait SeqexecWebModules extends SeqexecEngineModules {
     .enablePlugins(BuildInfoPlugin)
     .settings(commonSettings: _*)
     .settings(
-      // Skip tests in module, Rhino doesn't play nice with jquery
-      test := {},
-      // Write the generated js to the filename seqexec.js
+      jsEnv := JSDOMNodeJSEnv().value,
+      // Write the generated js to the filename seqexec-cli.js
       artifactPath in (Compile, fastOptJS) := (resourceManaged in Compile).value / "seqexec-cli.js",
       artifactPath in (Compile, fullOptJS) := (resourceManaged in Compile).value / "seqexec-cli-opt.js",
       // JS dependencies from webjars
@@ -157,6 +156,8 @@ trait SeqexecWebModules extends SeqexecEngineModules {
       emitSourceMaps in fullOptJS := true,
       // Put the jsdeps file on a place reachable for the server
       crossTarget in (Compile, packageJSDependencies) := (resourceManaged in Compile).value,
+      // Compile tests to JS using fast-optimisation
+      scalaJSStage in Test := FastOptStage,
       libraryDependencies ++= Seq(
         JQuery.value
       )


### PR DESCRIPTION
This PR fixes one of the trouble running test that interact with the DOM. There has been no reliable way to run these on any of the Scala.js runtime environments, since rhino is to weak and slow to execute `jQuery` and `node` doesn't have a DOM

On this PR we use [jsdom](https://github.com/tmpvar/jsdom) that runs in `node` but provides a DOM basic environment. Note that this requires you installing node and jsdom but that is going to become the default for scala.js anyway

With this PR we can finally run the client-side tests on travis and we can build more meaningful tests in the future