### PR TITLE
SEGNG-34 Attach the event with each generated Engine state output

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -15,13 +15,11 @@ object Event {
   case object Start extends UserEvent
   case object Pause extends UserEvent
   case object Poll extends UserEvent
-  case class AddExecution(pend: Execution[Action]) extends UserEvent
   case object Exit extends UserEvent
 
   val start: Event = EventUser(Start)
   val pause: Event = EventUser(Pause)
   val poll: Event = EventUser(Poll)
-  def addExecution(pend: Execution[Action]): Event = EventUser(AddExecution(pend))
   val exit: Event = EventUser(Exit)
 
   /**

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Handler.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Handler.scala
@@ -17,8 +17,6 @@ object Handler {
         log("Output: Started") *> switch(q)(Status.Running)
       case Pause              =>
         log("Output: Paused") *> switch(q)(Status.Waiting)
-      case AddExecution(pend) =>
-        log("Output: Adding Pending Execution") // TODO: Implement handler
       case Poll               =>
         log("Output: Polling current state")
       case Exit               =>

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -135,7 +135,7 @@ package object engine {
     */
   def receive(queue: EventQueue): Process[Engine, Event] = hoistEngine(queue.dequeue)
 
-  private def pure[A](a: A): Engine[A] = Applicative[Engine].pure(a)
+  def pure[A](a: A): Engine[A] = Applicative[Engine].pure(a)
 
   private val unit: Engine[Unit] = pure(Unit)
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -1,6 +1,8 @@
 package edu.gemini.seqexec.server
 
 import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.engine
+import edu.gemini.seqexec.engine.Event
 
 import scalaz.\/
 import scalaz.concurrent.Task
@@ -18,12 +20,8 @@ object SeqexecEngine {
   def requestRefresh(): Unit = ???
   def eventProcess(): Process[Task, SeqexecEvent] = ???
 
-
   sealed trait SeqexecEvent
   object SeqexecEvent {
-
-    import edu.gemini.seqexec.engine
-    import edu.gemini.seqexec.engine.Event
 
     case class SequenceStart(view: List[SequenceView]) extends SeqexecEvent
     case class StepExecuted(view: List[SequenceView]) extends SeqexecEvent
@@ -40,14 +38,14 @@ object SeqexecEngine {
         case Event.Start => SequenceStart(svs)
         case Event.Pause => SequencePauseRequested(svs)
         case Event.Poll  => NewLogMessage("Immediate State requested")
-        case Event.Exit => NewLogMessage("Exit requested by user")
+        case Event.Exit  => NewLogMessage("Exit requested by user")
       }
       case Event.EventSystem(se) => se match {
         // TODO: Sequence completed event not emited by engine.
         case Event.Completed(_, _) => NewLogMessage("Action completed")
-        case Event.Failed(_, _) => NewLogMessage("Action failed")
-        case Event.Executed => StepExecuted(svs)
-        case Event.Finished => NewLogMessage("Execution finished")
+        case Event.Failed(_, _)    => NewLogMessage("Action failed")
+        case Event.Executed        => StepExecuted(svs)
+        case Event.Finished        => NewLogMessage("Execution finished")
       }
     }
 
@@ -112,8 +110,6 @@ object SeqexecEngine {
 
   object SequenceView {
 
-    import edu.gemini.seqexec.engine
-
     // TODO: Better name and move it to `engine`
     type QueueAR = engine.Queue[engine.Action \/ engine.Result]
     type SequenceAR = engine.Sequence[engine.Action \/ engine.Result]
@@ -154,10 +150,7 @@ object SeqexecEngine {
         )
 
       seq.steps.map(viewStep)
-
     }
-
-
   }
 
   // Log message types
@@ -172,5 +165,4 @@ object SeqexecEngine {
   }
 
   case class LogMsg(t: LogType, timestamp: Time, msg: String)
-
 }


### PR DESCRIPTION
With these changes there is now a Process of `SeqexecEvent`s that in theory could be used directly by the client to display the state of execution.