### PR TITLE
SEQNG-46 Initial engine unit tests

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/execution.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/execution.scala
@@ -27,7 +27,8 @@ case class Current(execution: Execution[Action \/ Result]) {
     *
     */
   def status: Status =
-    if (execution.isEmpty || execution.all(_.isLeft)) Status.Waiting
+    if (execution.forall(_.isLeft)) Status.Waiting
+    // Empty execution is handled here
     else if (execution.all(_.isRight)) Status.Completed
     else Status.Running
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/execution.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/execution.scala
@@ -36,7 +36,7 @@ case class Current(execution: Execution[Action \/ Result]) {
     *
     */
   val uncurrentify: Option[Execution[Result]] =
-    execution.all(_.isRight).option(results)
+    (execution.nonEmpty && execution.all(_.isRight)).option(results)
 
   /**
     * Set the `Result` for the given `Action` index in `Current`.

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -67,8 +67,10 @@ package object engine {
     */
   def next(q: EventQueue): Engine[Unit] =
     gets(_.next).flatMap {
-      // No more Executions left
+      // Empty state
       case None     => send(q)(finished)
+      // Final State
+      case Some(qs@QStateF(_, _)) => put(qs) *> send(q)(finished)
       // Execution completed, execute next actions
       case Some(qs) => put(qs) *> execute(q)
     }

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -70,7 +70,7 @@ package object engine {
       // Empty state
       case None     => send(q)(finished)
       // Final State
-      case Some(qs@QStateF(_, _)) => put(qs) *> send(q)(finished)
+      case Some(qs: QStateF) => put(qs) *> send(q)(finished)
       // Execution completed, execute next actions
       case Some(qs) => put(qs) *> execute(q)
     }

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/sequence.scala
@@ -64,11 +64,10 @@ case class SequenceZ(
       case None      =>
         pending match {
           case Nil             => None
-          case stepp :: stepps => for {
-            // TODO: Applicative style?
-            curr  <- StepZ.currentify(stepp)
-            stepd <- focus.uncurrentify
-          } yield SequenceZ(id, stepps, curr, stepd :: done)
+          case stepp :: stepps =>
+            (StepZ.currentify(stepp) |@| focus.uncurrentify) (
+              (curr, stepd) => SequenceZ(id, stepps, curr, stepd :: done)
+            )
         }
       // Current step ongoing
       case Some(stz) => Some(SequenceZ(id, pending, stz, done))
@@ -92,8 +91,8 @@ case class SequenceZ(
       id,
       // TODO: Functor composition?
       done.map(_.map(_.right)) ++
-      List(focus.toStep) ++
-      pending.map(_.map(_.left))
+        List(focus.toStep) ++
+        pending.map(_.map(_.left))
     )
 }
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/step.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/step.scala
@@ -56,11 +56,10 @@ case class StepZ(
   val next: Option[StepZ] =
     pending match {
       case Nil           => None
-      case exep :: exeps => for {
-        // TODO: Applicative syntax?
-        curr <- Current.currentify(exep)
-        exed <- focus.uncurrentify
-      } yield StepZ(id, exeps, curr, exed :: done)
+      case exep :: exeps =>
+        (Current.currentify(exep) |@| focus.uncurrentify) (
+          (curr, exed) => StepZ(id, exeps, curr, exed :: done)
+        )
     }
 
   /**
@@ -81,8 +80,9 @@ case class StepZ(
       id,
       // TODO: Functor composition?
       done.map(_.map(_.right)) ++
-      List(focus.execution) ++
-      pending.map(_.map(_.left))
+        List(focus.execution) ++
+        pending.map(_.map(_.left)
+        )
     )
 }
 

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/CurrentSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/CurrentSpec.scala
@@ -1,0 +1,32 @@
+package edu.gemini.seqexec.engine
+
+import scalaz._
+import Scalaz._
+import org.scalatest._
+import scalaz.concurrent.Task
+
+class CurrentSpec extends FlatSpec with Matchers {
+
+  val ok: Result = Result.OK(Unit)
+  val action: Action = Task(ok)
+  val curr : Current = Current(List(ok.right, action.left))
+
+  "currentify" should "be None only when an Execution is empty" in {
+    assert(Current.currentify(List(action, action)).nonEmpty)
+    assert(Current.currentify(Nil).isEmpty)
+  }
+
+  "uncurrentify" should "be None when not all actions are completed" in {
+    assert(Current(Nil).uncurrentify.isEmpty)
+    assert(curr.uncurrentify.isEmpty)
+  }
+
+  "marking an index out of bonds" should "not modify the execution" in {
+    assert(curr.mark(3)(Result.Error(Unit)) === curr)
+  }
+
+  "marking an index inbound" should "modify the execution" in {
+    assert(curr.mark(1)(Result.Error(Unit)) !== curr)
+  }
+
+}

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/CurrentSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/CurrentSpec.scala
@@ -21,7 +21,7 @@ class CurrentSpec extends FlatSpec with Matchers {
     assert(curr.uncurrentify.isEmpty)
   }
 
-  "marking an index out of bonds" should "not modify the execution" in {
+  "marking an index out of bounds" should "not modify the execution" in {
     assert(curr.mark(3)(Result.Error(Unit)) === curr)
   }
 

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -1,6 +1,9 @@
 package edu.gemini.seqexec.engine
 
+import scalaz._
+import Scalaz._
 import org.scalatest.FlatSpec
+import scalaz.concurrent.Task
 
 /**
   * Created by jluhrs on 9/29/16.
@@ -36,6 +39,38 @@ class SequenceSpec extends FlatSpec {
   //For this test, an action in one of the steps in the sequence must return an error.
   ignore should "stop execution and propagate error when an Action ends in error." in {
 
+  }
+
+  // TODO: Share these fixtures with StepSpec
+  val result = Result.OK(Unit)
+  val action: Action = Task(result)
+  val stepz0: StepZ  = StepZ(0, Nil, Current.empty, Nil)
+  val stepza0: StepZ = StepZ(1, List(List(action)), Current.empty, Nil)
+  val stepza1: StepZ = StepZ(1, List(List(action)), Current(List(result.right)), Nil)
+  val stepzr0: StepZ = StepZ(1, Nil, Current.empty, List(List(result)))
+  val stepzr1: StepZ = StepZ(1, Nil, Current(List(result.right, result.right)), Nil)
+  val stepzr2: StepZ = StepZ(1, Nil, Current(List(result.right, result.right)), List(List(result)))
+  val stepzar0: StepZ = StepZ(1, Nil, Current(List(result.right, action.left)), Nil)
+  val stepzar1: StepZ = StepZ(1, List(List(action)), Current(List(result.right, result.right)), List(List(result)))
+
+  val seqz0: SequenceZ = SequenceZ("id", Nil, stepz0, Nil)
+  val seqza0: SequenceZ = SequenceZ("id", Nil, stepza0, Nil)
+  val seqza1: SequenceZ = SequenceZ("id", Nil, stepza1, Nil)
+  val seqzr0: SequenceZ = SequenceZ("id", Nil, stepzr0, Nil)
+  val seqzr1: SequenceZ = SequenceZ("id", Nil, stepzr1, Nil)
+  val seqzr2: SequenceZ = SequenceZ("id", Nil, stepzr2, Nil)
+  val seqzar0: SequenceZ = SequenceZ("id", Nil, stepzar0, Nil)
+  val seqzar1: SequenceZ = SequenceZ("id", Nil, stepzar1, Nil)
+
+  "next" should "be None when there are no more pending executions" in {
+    assert(seqz0.next.isEmpty)
+    assert(seqza0.next.isEmpty)
+    assert(seqza1.next.nonEmpty)
+    assert(seqzr0.next.isEmpty)
+    assert(seqzr1.next.isEmpty)
+    assert(seqzr2.next.isEmpty)
+    assert(seqzar0.next.isEmpty)
+    assert(seqzar1.next.nonEmpty)
   }
 
 }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -1,6 +1,9 @@
 package edu.gemini.seqexec.engine
 
+import scalaz._
+import Scalaz._
 import org.scalatest.FlatSpec
+import scalaz.concurrent.Task
 
 /**
   * Created by jluhrs on 9/29/16.
@@ -39,5 +42,37 @@ class StepSpec extends FlatSpec {
 
   }
 
+  val result = Result.OK(Unit)
+  val action: Action = Task(result)
+  val stepz0: StepZ  = StepZ(0, Nil, Current.empty, Nil)
+  val stepza0: StepZ = StepZ(1, List(List(action)), Current.empty, Nil)
+  val stepza1: StepZ = StepZ(1, List(List(action)), Current(List(result.right)), Nil)
+  val stepzr0: StepZ = StepZ(1, Nil, Current.empty, List(List(result)))
+  val stepzr1: StepZ = StepZ(1, Nil, Current(List(result.right, result.right)), Nil)
+  val stepzr2: StepZ = StepZ(1, Nil, Current(List(result.right, result.right)), List(List(result)))
+  val stepzar0: StepZ = StepZ(1, Nil, Current(List(result.right, action.left)), Nil)
+  val stepzar1: StepZ = StepZ(1, List(List(action)), Current(List(result.right, result.right)), List(List(result)))
+
+  "uncurrentify" should "be None when not all executions are completed" in {
+    assert(stepz0.uncurrentify.isEmpty)
+    assert(stepza0.uncurrentify.isEmpty)
+    assert(stepza1.uncurrentify.isEmpty)
+    assert(stepzr0.uncurrentify.isEmpty)
+    assert(stepzr1.uncurrentify.nonEmpty)
+    assert(stepzr2.uncurrentify.nonEmpty)
+    assert(stepzar0.uncurrentify.isEmpty)
+    assert(stepzar1.uncurrentify.isEmpty)
+  }
+
+  "next" should "be None when there are no more pending executions" in {
+    assert(stepz0.next.isEmpty)
+    assert(stepza0.next.isEmpty)
+    assert(stepza1.next.nonEmpty)
+    assert(stepzr0.next.isEmpty)
+    assert(stepzr1.next.isEmpty)
+    assert(stepzr2.next.isEmpty)
+    assert(stepzar0.next.isEmpty)
+    assert(stepzar1.next.nonEmpty)
+  }
 
 }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepZSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepZSpec.scala
@@ -1,0 +1,20 @@
+package edu.gemini.seqexec.engine
+
+import scalaz._
+import Scalaz._
+import org.scalatest._
+import scalaz.concurrent.Task
+
+class StepZSpec extends FlatSpec with Matchers {
+  val action: Action = Task(Result.OK(Unit))
+  val step0: Step[Action] = Step(1, List(Nil))
+  val step1: Step[Action] = Step(1, List(List(action)))
+  val step2: Step[Action] = Step(2, List(List(action, action), List(action)))
+
+  "currentify" should "be None only when a Step is empty of executions" in {
+    assert(StepZ.currentify(Step(0, Nil)).isEmpty)
+    assert(StepZ.currentify(step0).isEmpty)
+    assert(StepZ.currentify(step1).nonEmpty)
+    assert(StepZ.currentify(step2).nonEmpty)
+  }
+}


### PR DESCRIPTION
These are the initial unit tests intended to catch the bug causing extra executions to be reported. These tests still don't reveal the bug I was chasing, but since it's not critical, I'm moving it back to the backlog and will revisit it later.

Obviously there is plenty of room for improvement of these tests but I'm sending this PR now because I don't want to get bogged down writing tests when there are other tasks with more priority.