### PR TITLE
Keep engine running after finalizing

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Handler.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Handler.scala
@@ -32,9 +32,8 @@ object Handler {
         log("Output: Action failed") *> fail(q)(i, e)
       case Executed          =>
         log("Output: Execution completed, launching next execution") *> next(q)
-      // TODO: Closing to facilitate testing, in reality it shouldn't close
       case Finished          =>
-        log("Output: Finished") *> switch(q)(Status.Completed) *> close(q)
+        log("Output: Finished") *> switch(q)(Status.Completed)
     }
 
     (ev match {

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/HandlerSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/HandlerSpec.scala
@@ -103,7 +103,11 @@ class HandlerSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     intercept[Cause.Terminated](
       Nondeterminism[Task].both(
-        q.enqueueOne(start),
+        List(
+          q.enqueueOne(start),
+          Task(Thread.sleep(5000)),
+          q.enqueueOne(exit)
+        ).sequence_,
         processE(q).run.eval(qs1)
       ).unsafePerformSync
     )
@@ -118,7 +122,9 @@ class HandlerSpec extends FlatSpec {
           Task(Thread.sleep(2000)),
           q.enqueueOne(pause),
           Task(Thread.sleep(2000)),
-          q.enqueueOne(start)
+          q.enqueueOne(start),
+          Task(Thread.sleep(3000)),
+          q.enqueueOne(exit)
         ).sequence_,
        processE(q).run.eval(qs1)
       ).unsafePerformSync


### PR DESCRIPTION
This was necessary in order to reload extra sequences after a sequence was finished. We want to keep the Engine running along with the web server.

I don't know if it's worth sending a PR for this kind of *microcommits*, I could directly push it to `feature/engine` if you prefer.