### PR TITLE
SEQNG-52: Implementation of engine startup options

### DIFF
--- a/modules/edu.gemini.seqexec.server/build.sbt
+++ b/modules/edu.gemini.seqexec.server/build.sbt
@@ -14,5 +14,6 @@ libraryDependencies ++= Seq(
   SpModelCore,
   SeqexecOdb,
   POT,
-  EpicsACM
+  EpicsACM,
+  Knobs
 ) ++ TestLibs.value

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -99,11 +99,7 @@ object DhsClient {
 /**
   * Implementation of DhsClient that interfaces with the real DHS over the http interface
   */
-object DhsClientHttp extends DhsClient {
-
-  private var baseURI = "http://cpodhsxx:9090/axis2/services/dhs/images"
-
-  def setBaseURI(s: String): Unit = { baseURI = s }
+class DhsClientHttp(val baseURI: String) extends DhsClient {
 
   sealed case class ErrorType(str: String)
   object BadRequest extends ErrorType("BAD_REQUEST")
@@ -182,6 +178,10 @@ object DhsClientHttp extends DhsClient {
     sendRequest[Unit](new PutMethod(baseURI + "/" + id + "/keywords"),
       Json.jSingleObject("setKeywords", ("final" := finalFlag) ->: ("keywords" := keywords.keywords) ->: Json.jEmptyObject ),
       "Unable to write keywords for image " + id)
+}
+
+object DhsClientHttp {
+  def apply(uri: String) = new DhsClientHttp(uri)
 }
 
 /**

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -101,7 +101,9 @@ object DhsClient {
   */
 object DhsClientHttp extends DhsClient {
 
-  val baseURI = "http://cpodhsxx:9090/axis2/services/dhs/images"
+  private var baseURI = "http://cpodhsxx:9090/axis2/services/dhs/images"
+
+  def setBaseURI(s: String): Unit = { baseURI = s }
 
   sealed case class ErrorType(str: String)
   object BadRequest extends ErrorType("BAD_REQUEST")

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ODBProxy.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ODBProxy.scala
@@ -10,12 +10,10 @@ import scalaz.\/
 /**
   * Created by jluhrs on 9/6/16.
   */
-object ODBProxy {
-  private var loc = new Peer("localhost", 8443, null)
+class ODBProxy(val loc: Peer) {
 
   def host(): Peer = loc
-  def host(l: Peer): Unit = { loc = l }
   def read(oid: SPObservationID): SeqexecFailure \/ ConfigSequence =
-    SeqExecService.client(ODBProxy.host()).sequence(oid).leftMap(SeqexecFailure.ODBSeqError)
+    SeqExecService.client(loc).sequence(oid).leftMap(SeqexecFailure.ODBSeqError)
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -17,50 +17,49 @@ import scalaz.concurrent.Task
   */
 object SeqTranslate {
 
-  case class Settings(dhsSim: Boolean,
-                    tcsSim: Boolean,
-                    instSim: Boolean,
-                    gcalSim: Boolean)
+  case class Systems(
+                    dhs: DhsClient,
+                    tcs: TcsController,
+                    flamingos2: Flamingos2Controller
+                    )
 
-  private var settings = Settings(false, false, false, false)
   private val dhsSimulator = DhsClientSim(LocalDate.now)
-  def setConfig(c: Settings): Unit = { settings = c }
 
   implicit def toAction[A](x: SeqAction[A]): Action = x.run map {
     case -\/(e) => Result.Error(e)
     case \/-(r) => Result.OK(r)
   }
 
-  def step(dhsClient: DhsClient)(i: Int, config: Config): SeqexecFailure \/ Step[Action] = {
+  private def step(systems: Systems)(i: Int, config: Config): SeqexecFailure \/ Step[Action] = {
 
     val instName = config.getItemValue(new ItemKey(INSTRUMENT_KEY, INSTRUMENT_NAME_PROP))
     val instrument = instName match {
-      case GmosSouth.name => Some(GmosSouth)
-      case Flamingos2.name => Some(Flamingos2(if(settings.instSim) Flamingos2ControllerSim else Flamingos2ControllerEpics))
+      case Flamingos2.name => Some(Flamingos2(systems.flamingos2))
       case _ => None
     }
 
     instrument.map { a =>
-      val systems = List(Tcs(if(settings.tcsSim) TcsControllerSim else TcsControllerEpics), a)
+      val sys = List(Tcs(systems.tcs), a)
       // TODO Find a proper way to inject the subsystems
       Step[Action](
         i,
         List(
           // TODO: implicit function doesn't work here, why?
-          systems.map(x => toAction(x.configure(config))),
-          List((a.observe(config)(dhsClient)))
+          sys.map(x => toAction(x.configure(config))),
+          List((a.observe(config)(systems.dhs)))
         )
       ).right
     }.getOrElse(UnrecognizedInstrument(instName.toString).left[Step[Action]])
   }
 
-  def sequence(obsId: String, sequenceConfig: ConfigSequence): SeqexecFailure \/ Sequence[Action] = {
+  def sequence(systems: Systems)(obsId: String, sequenceConfig: ConfigSequence): SeqexecFailure \/ Sequence[Action] = {
     val configs = sequenceConfig.getAllSteps.toList
 
     val steps = configs.zipWithIndex.traverseU {
-      case (c, i) => step(if(settings.dhsSim) dhsSimulator else DhsClientHttp)(i, c)
+      case (c, i) => step(systems)(i, c)
     }
 
     steps.map(Sequence[Action](obsId, _))
   }
+
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -23,6 +23,7 @@ object SeqTranslate {
                     flamingos2: Flamingos2Controller
                     )
 
+  // TODO: Take care of this side effect.
   private val dhsSimulator = DhsClientSim(LocalDate.now)
 
   implicit def toAction[A](x: SeqAction[A]): Action = x.run map {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -31,4 +31,9 @@ web-server {
 seqexec-engine {
     # host for the odb
     odb = "localhost"
+    dhsServer = "http://cpodhsxx:9090/axis2/services/dhs/images"
+    dhsSim = true
+    tcsSim = true
+    instSim = true
+    gcalim = true
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -99,14 +99,14 @@ object WebServerLauncher extends ServerApp with LogInitialization {
     */
   override def server(args: List[String]): Task[Server] =
     for {
-      _  <- configLog
-      ac <- authConf
-      wc <- serverConf
-      c <- config
-      seqc  <- SeqexecEngine.seqexecConfiguration.run(c)
-      as <- authService.run(ac)
+      _    <- configLog
+      ac   <- authConf
+      wc   <- serverConf
+      c    <- config
+      seqc <- SeqexecEngine.seqexecConfiguration.run(c)
+      as   <- authService.run(ac)
       // Put the queue in WebServerConfiguration?
-      q = async.boundedQueue[Event.Event](10)
-      ws <- webServer(as, q, SeqexecEngine(seqc)).run(wc)
+      q    = async.boundedQueue[Event.Event](10)
+      ws   <- webServer(as, q, SeqexecEngine(seqc)).run(wc)
     } yield ws
 }


### PR DESCRIPTION
Read engine startup settings from configuration file app.cfg. The settings are then applied to the Seqexec engine. The implementation of the settings themselves is a bit dirty (uses mutability), but I think it is OK, has they are not supposed to change in run-time.
I also moved the code that configures the Seqexec engine inside ```SeqexecEngine```
   