### PR TITLE
Move DhsClientHttp inner classes to the DhsClientHttp object

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -100,22 +100,7 @@ object DhsClient {
   * Implementation of DhsClient that interfaces with the real DHS over the http interface
   */
 class DhsClientHttp(val baseURI: String) extends DhsClient {
-
-  sealed case class ErrorType(str: String)
-  object BadRequest extends ErrorType("BAD_REQUEST")
-  object DhsError extends ErrorType("DHS_ERROR")
-  object InternalServerError extends ErrorType("INTERNAL_SERVER_ERROR")
-
-  implicit def errorTypeDecode: DecodeJson[ErrorType] = DecodeJson[ErrorType]( c =>  c.as[String].map {
-      case BadRequest.str          => BadRequest
-      case DhsError.str            => DhsError
-      case InternalServerError.str => InternalServerError
-    }
-  )
-
-  final case class Error(t: ErrorType, msg: String) {
-    override def toString = s"(${t.str}) $msg"
-  }
+  import DhsClientHttp._
 
   implicit def errorDecode: DecodeJson[Error] = DecodeJson[Error]( c => for {
       t   <- (c --\ "type").as[ErrorType]
@@ -181,6 +166,23 @@ class DhsClientHttp(val baseURI: String) extends DhsClient {
 }
 
 object DhsClientHttp {
+
+  sealed case class ErrorType(str: String)
+  object BadRequest extends ErrorType("BAD_REQUEST")
+  object DhsError extends ErrorType("DHS_ERROR")
+  object InternalServerError extends ErrorType("INTERNAL_SERVER_ERROR")
+
+  implicit def errorTypeDecode: DecodeJson[ErrorType] = DecodeJson[ErrorType]( c =>  c.as[String].map {
+      case BadRequest.str          => BadRequest
+      case DhsError.str            => DhsError
+      case InternalServerError.str => InternalServerError
+    }
+  )
+
+  final case class Error(t: ErrorType, msg: String) {
+    override def toString = s"(${t.str}) $msg"
+  }
+
   def apply(uri: String) = new DhsClientHttp(uri)
 }
 


### PR DESCRIPTION
This is a small suggestion for a change. It seems strange to have inner classes defined inside another class. Normally you'd put them in the companion object.

I got a compiler warning due to the original code:

```
[warn] /Users/cquiroz/Projects/ocs3/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala:116: The outer reference in this type test cannot be checked at run time.
[warn]   final case class Error(t: ErrorType, msg: String) {
[warn]                    ^
[warn] one warning found
```

What do you think?