### PR TITLE
Fixed typo on setting name

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -35,5 +35,5 @@ seqexec-engine {
     dhsSim = true
     tcsSim = true
     instSim = true
-    gcalim = true
+    gcalSim = true
 }


### PR DESCRIPTION
Trying to start the web application I found a missing configuration item, and traced to the typo on the `app.conf` file