### PR TITLE
SEGNG-58A: Replace Sequence in the client with SequenceView

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -1,8 +1,11 @@
 package edu.gemini.seqexec.engine
 
+import edu.gemini.seqexec.model.SharedModel.SequenceMetadata
+
 import scalaz._
 import Scalaz._
 import org.scalatest.FlatSpec
+
 import scalaz.concurrent.Task
 
 /**
@@ -41,26 +44,28 @@ class SequenceSpec extends FlatSpec {
 
   }
 
+  val metadata = SequenceMetadata("F2")
+
   // TODO: Share these fixtures with StepSpec
   val result = Result.OK(Unit)
   val action: Action = Task(result)
-  val stepz0: Step.Zipper  = Step.Zipper(0, Nil, Execution.empty, Nil)
-  val stepza0: Step.Zipper = Step.Zipper(1, List(List(action)), Execution.empty, Nil)
-  val stepza1: Step.Zipper = Step.Zipper(1, List(List(action)), Execution(List(result.right)), Nil)
-  val stepzr0: Step.Zipper = Step.Zipper(1, Nil, Execution.empty, List(List(result)))
-  val stepzr1: Step.Zipper = Step.Zipper(1, Nil, Execution(List(result.right, result.right)), Nil)
-  val stepzr2: Step.Zipper = Step.Zipper(1, Nil, Execution(List(result.right, result.right)), List(List(result)))
+  val stepz0: Step.Zipper   = Step.Zipper(0, Nil, Execution.empty, Nil)
+  val stepza0: Step.Zipper  = Step.Zipper(1, List(List(action)), Execution.empty, Nil)
+  val stepza1: Step.Zipper  = Step.Zipper(1, List(List(action)), Execution(List(result.right)), Nil)
+  val stepzr0: Step.Zipper  = Step.Zipper(1, Nil, Execution.empty, List(List(result)))
+  val stepzr1: Step.Zipper  = Step.Zipper(1, Nil, Execution(List(result.right, result.right)), Nil)
+  val stepzr2: Step.Zipper  = Step.Zipper(1, Nil, Execution(List(result.right, result.right)), List(List(result)))
   val stepzar0: Step.Zipper = Step.Zipper(1, Nil, Execution(List(result.right, action.left)), Nil)
   val stepzar1: Step.Zipper = Step.Zipper(1, List(List(action)), Execution(List(result.right, result.right)), List(List(result)))
 
-  val seqz0: Sequence.Zipper = Sequence.Zipper("id", Nil, stepz0, Nil)
-  val seqza0: Sequence.Zipper = Sequence.Zipper("id", Nil, stepza0, Nil)
-  val seqza1: Sequence.Zipper = Sequence.Zipper("id", Nil, stepza1, Nil)
-  val seqzr0: Sequence.Zipper = Sequence.Zipper("id", Nil, stepzr0, Nil)
-  val seqzr1: Sequence.Zipper = Sequence.Zipper("id", Nil, stepzr1, Nil)
-  val seqzr2: Sequence.Zipper = Sequence.Zipper("id", Nil, stepzr2, Nil)
-  val seqzar0: Sequence.Zipper = Sequence.Zipper("id", Nil, stepzar0, Nil)
-  val seqzar1: Sequence.Zipper = Sequence.Zipper("id", Nil, stepzar1, Nil)
+  val seqz0: Sequence.Zipper   = Sequence.Zipper("id", metadata, Nil, stepz0, Nil)
+  val seqza0: Sequence.Zipper  = Sequence.Zipper("id", metadata, Nil, stepza0, Nil)
+  val seqza1: Sequence.Zipper  = Sequence.Zipper("id", metadata, Nil, stepza1, Nil)
+  val seqzr0: Sequence.Zipper  = Sequence.Zipper("id", metadata, Nil, stepzr0, Nil)
+  val seqzr1: Sequence.Zipper  = Sequence.Zipper("id", metadata, Nil, stepzr1, Nil)
+  val seqzr2: Sequence.Zipper  = Sequence.Zipper("id", metadata, Nil, stepzr2, Nil)
+  val seqzar0: Sequence.Zipper = Sequence.Zipper("id", metadata, Nil, stepzar0, Nil)
+  val seqzar1: Sequence.Zipper = Sequence.Zipper("id", metadata, Nil, stepzar1, Nil)
 
   "next" should "be None when there are no more pending executions" in {
     assert(seqz0.next.isEmpty)

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -2,7 +2,9 @@ package edu.gemini.seqexec.engine
 
 import Result._
 import Event._
+import edu.gemini.seqexec.model.SharedModel.SequenceMetadata
 import org.scalatest.FlatSpec
+
 import scalaz._
 import Scalaz._
 import scalaz.concurrent.Task
@@ -52,6 +54,7 @@ class packageSpec extends FlatSpec {
       List(
         Sequence(
           "First",
+          SequenceMetadata("F2"),
           List(
             Step(
               1,

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/SharedModel.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/SharedModel.scala
@@ -71,7 +71,14 @@ object SharedModel {
     case object Idle      extends SequenceState
   }
 
+  /**
+    * Metadata about the sequence required on the exit point
+    */
+  // TODO Une a proper instrument class
+  case class SequenceMetadata(instrument: String)
+
   case class SequenceView (
+    metadata: SequenceMetadata,
     status: SequenceState,
     steps: List[Step],
     willStopIn: Option[Int]

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -53,8 +53,8 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
 
   def eventProcess(q: engine.EventQueue): Process[Task, SeqexecEvent] =
     engine.process(q)(qs).map {
-      case (ev, qs) =>
-        toSeqexecEvent(ev)(qs.toQueue.sequences.map(viewSequence))
+      case (ev, qState) =>
+        toSeqexecEvent(ev)(qState.toQueue.sequences.map(viewSequence))
     }
 
   def load(q: engine.EventQueue, seqId: SPObservationID): EitherT[Task, SeqexecFailure, Unit] = {
@@ -92,7 +92,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
 
     def viewSequence(seq: SequenceAR): SequenceView =
       // TODO: Implement willStopIn
-      SequenceView(statusSequence(seq), engineSteps(seq), None)
+      SequenceView(seq.metadata, statusSequence(seq), engineSteps(seq), None)
 
     private def statusSequence(seq: SequenceAR): SequenceState =
       engine.Sequence.status(seq) match {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -57,13 +57,13 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
         toSeqexecEvent(ev)(qs.toQueue.sequences.map(viewSequence))
     }
 
-  def load(q: engine.EventQueue, seqId: SPObservationID): Task[SeqexecFailure \/ Unit] = {
+  def load(q: engine.EventQueue, seqId: SPObservationID): EitherT[Task, SeqexecFailure, Unit] = {
     val t = EitherT( for {
         odbSeq <- Task(odbProxy.read(seqId))
       } yield odbSeq.flatMap(s => SeqTranslate.sequence(systems)(seqId.stringValue(), s))
     )
     val u = t.flatMapF(x => q.enqueueOne(Event.load(x)).map(_.right))
-    u.run
+    u
   }
 
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -7,10 +7,9 @@ import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.engine
 import edu.gemini.seqexec.model._
 import edu.gemini.seqexec.server.SeqexecFailure.Unexpected
-import edu.gemini.seqexec.server.{ODBProxy, SeqexecEngine, SeqexecFailure}
+import edu.gemini.seqexec.server.{SeqexecEngine, SeqexecFailure}
 import edu.gemini.seqexec.web.common._
 import edu.gemini.seqexec.web.server.model.CannedModel
-import edu.gemini.seqexec.web.server.model.Conversions._
 import edu.gemini.seqexec.web.server.security.AuthenticationService
 import edu.gemini.seqexec.web.server.http4s.encoder._
 import org.http4s._
@@ -88,7 +87,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, q: engine.EventQueue, se: 
         WS(Exchange(pingProcess ++ Process.emit(Binary(trimmedArray(SeqexecConnectionOpenEvent(user)))) merge
           se.eventProcess(q).map(v => Binary(newTrimmedArray(v))), scalaz.stream.Process.empty))
 
-      case req @ POST -> Root / "seqexec" / "logout"        =>
+      case POST -> Root / "seqexec" / "logout"        =>
         // Clean the auth cookie
         val cookie = Cookie(auth.config.cookieName, "", path = "/".some,
           secure = auth.config.useSSL, maxAge = Some(-1), httpOnly = true)
@@ -103,8 +102,8 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, q: engine.EventQueue, se: 
           } yield (obsId, s)
 
           r.run >>= {
-            case -\/(e) => NotFound(SeqexecFailure.explain(e))
-            case _      => Ok("")
+            case -\/(e)      => NotFound(SeqexecFailure.explain(e))
+            case \/-((i, _)) => Ok(s"Loaded sequence $i")
           }
         }
     }}


### PR DESCRIPTION
This is the first PR towards SEQNG-58A. It skips the direct response when loading the sequence instead relying on the event through the websocket

It also adds a metadata element to the sequence that should contain extra data in the future

This PR is mostly to get comments about the approach taken to further integrate the new engine into the UI