### PR TITLE
Version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_script:
   - sudo apt-get install -y rpm
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test:compile test
-  - sbt ++$TRAVIS_SCALA_VERSION seqexec_server/universal:packageZipTarball
-  - sbt ++$TRAVIS_SCALA_VERSION seqexec_server_test_l64/rpm:packageBin
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sbt ++$TRAVIS_SCALA_VERSION seqexec_server/universal:packageZipTarball; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sbt ++$TRAVIS_SCALA_VERSION seqexec_server_test_l64/rpm:packageBin; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,15 @@ scala:
   - 2.11.8
 jdk:
   - oraclejdk8
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
 install:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,6 @@ organization in Global := "edu.gemini.ocs"
 // Gemini repository
 resolvers in ThisBuild += "Gemini Repository" at "https://github.com/gemini-hlsw/maven-repo/raw/master/releases"
 
-// Bintray for knobs
-resolvers in ThisBuild += Resolver.bintrayRepo("oncue", "releases")
-
 // This key is used to find the JRE dir. It could/should be overriden on a user basis
 // Add e.g. a `jres.sbt` file with your particular configuration
 ocsJreDir in ThisBuild := Path.userHome / ".jres8"

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -46,11 +46,11 @@ object QueueTableBody {
 
   def load(p: Props):Callback =
     // Request to load the queue if not present
-    Callback.when(p.queue.value.isEmpty)(p.queue.dispatch(UpdatedQueue(Empty)))
+    Callback.when(p.queue.value.isEmpty)(p.queue.dispatchCB(UpdatedQueue(Empty)))
 
   def showSequence(p: Props,s: Sequence):Callback =
     // Request to display the selected sequence
-    p.queue.dispatch(SelectToDisplay(s))
+    p.queue.dispatchCB(SelectToDisplay(s))
 
   val component = ReactComponentB[Props]("QueueTableBody")
     .render_P( p =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SequenceSearch.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SequenceSearch.scala
@@ -44,9 +44,9 @@ object SequenceSearchResultsBody {
     def status = model()._1
   }
 
-  def addToQueue[A](p: ModelProxy[A], u: Sequence):Callback = p.dispatch(AddToQueue(u))
+  def addToQueue[A](p: ModelProxy[A], u: Sequence):Callback = p.dispatchCB(AddToQueue(u))
 
-  def removeFromResults[A](p: ModelProxy[A], u: Sequence):Callback = p.dispatch(RemoveFromSearch(u))
+  def removeFromResults[A](p: ModelProxy[A], u: Sequence):Callback = p.dispatchCB(RemoveFromSearch(u))
 
   def onAdding[A](p: ModelProxy[A], u: Sequence):Callback = addToQueue(p, u) >> removeFromResults(p, u)
 
@@ -134,10 +134,10 @@ object SequenceSearch {
       }
 
     def openResultsArea: Callback =
-      $.props >>= { _.model.dispatch(OpenSearchArea) }
+      $.props >>= { _.model.dispatchCB(OpenSearchArea) }
 
     def startSearch: Callback =
-      $.props.zip($.state) >>= { case (p, s) => p.model.dispatch(SearchSequence(s.searchText)) }
+      $.props.zip($.state) >>= { case (p, s) => p.model.dispatchCB(SearchSequence(s.searchText)) }
 
     def search: Callback =
       openResultsArea >> startSearch

--- a/project/SeqexecEngineModules.scala
+++ b/project/SeqexecEngineModules.scala
@@ -29,10 +29,6 @@ trait SeqexecEngineModules {
     .settings(
       libraryDependencies ++= Seq(BooPickle.value) ++ TestLibs.value
     )
-    .jsSettings(
-      scalaJSUseRhino := false,
-      jsEnv := NodeJSEnv().value
-    )
 
   lazy val edu_gemini_seqexec_model_JVM:Project = edu_gemini_seqexec_model.jvm
 

--- a/project/SeqexecWebModules.scala
+++ b/project/SeqexecWebModules.scala
@@ -28,8 +28,6 @@ trait SeqexecWebModules extends SeqexecEngineModules {
     .jvmSettings(
     )
     .jsSettings(
-      scalaJSUseRhino := false,
-      jsEnv := NodeJSEnv().value,
       libraryDependencies += JavaLogJS.value
     )
 
@@ -94,8 +92,6 @@ trait SeqexecWebModules extends SeqexecEngineModules {
     .enablePlugins(BuildInfoPlugin)
     .settings(commonSettings: _*)
     .settings(
-      // Run tests is JsDom
-      jsEnv := JSDOMNodeJSEnv().value,
       // This is a not very nice trick to remove js files that exist on the scala tools
       // library and that conflict with the requested on jsDependencies, in particular
       // with jquery.js
@@ -109,6 +105,8 @@ trait SeqexecWebModules extends SeqexecEngineModules {
       // Write the generated js to the filename seqexec.js
       artifactPath in (Compile, fastOptJS) := (resourceManaged in Compile).value / "seqexec.js",
       artifactPath in (Compile, fullOptJS) := (resourceManaged in Compile).value / "seqexec-opt.js",
+      // Requires the DOM
+      jsDependencies += RuntimeDOM,
       // JS dependencies from webjars
       jsDependencies ++= Seq(
         "org.webjars.bower" % "react"       % LibraryVersions.reactJS     / "react-with-addons.js" minified "react-with-addons.min.js" commonJSName "React",
@@ -142,10 +140,11 @@ trait SeqexecWebModules extends SeqexecEngineModules {
     .enablePlugins(BuildInfoPlugin)
     .settings(commonSettings: _*)
     .settings(
-      jsEnv := JSDOMNodeJSEnv().value,
       // Write the generated js to the filename seqexec-cli.js
       artifactPath in (Compile, fastOptJS) := (resourceManaged in Compile).value / "seqexec-cli.js",
       artifactPath in (Compile, fullOptJS) := (resourceManaged in Compile).value / "seqexec-cli-opt.js",
+      // Requires the DOM
+      jsDependencies += RuntimeDOM,
       // JS dependencies from webjars
       jsDependencies ++= Seq(
         "org.webjars" % "jquery"          % LibraryVersions.jQuery         / "jquery.js"            minified "jquery.min.js",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -29,14 +29,14 @@ object Settings {
 
     // ScalaJS libraries
     val scalaDom     = "0.9.1"
-    val scalajsReact = "0.11.2"
+    val scalajsReact = "0.11.3"
     val scalaCSS     = "0.5.0"
     val uPickle      = "0.4.0"
-    val booPickle    = "1.2.4"
+    val booPickle    = "1.2.5"
     val diode        = "1.0.0"
-    val javaTimeJS   = "0.1.0"
+    val javaTimeJS   = "0.2.0"
     val javaLogJS    = "0.1.0"
-    val scalaJQuery  = "1.0-RC6"
+    val scalaJQuery  = "1.0"
 
     // Java libraries
     val scalaZ       = "7.2.2"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -50,7 +50,7 @@ object Settings {
     val unboundId    = "3.1.1"
     val jwt          = "0.8.1"
     val slf4j        = "1.7.21"
-    val knobs        = "3.8.1a"
+    val knobs        = "3.12.27a"
 
     // test libraries
     val scalaTest    = "3.0.0"
@@ -81,7 +81,7 @@ object Settings {
     val UnboundId   = "com.unboundid"      %  "unboundid-ldapsdk-minimal-edition" % LibraryVersions.unboundId
     val JwtCore     = "com.pauldijou"      %% "jwt-core"                          % LibraryVersions.jwt
     val Slf4jJuli   = "org.slf4j"          %  "slf4j-jdk14"                       % LibraryVersions.slf4j
-    val Knobs       = "oncue.knobs"        %% "core"                              % LibraryVersions.knobs
+    val Knobs       = "io.verizon.knobs"   %% "core"                              % LibraryVersions.knobs
 
     val Squants     = Def.setting("com.squants"  %%% "squants"              % LibraryVersions.squants)
     val UPickle     = Def.setting("com.lihaoyi"  %%% "upickle"              % LibraryVersions.uPickle)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
     val scalaCSS     = "0.5.0"
     val uPickle      = "0.4.0"
     val booPickle    = "1.2.5"
-    val diode        = "1.0.0"
+    val diode        = "1.1.0"
     val javaTimeJS   = "0.2.0"
     val javaLogJS    = "0.1.0"
     val scalaJQuery  = "1.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Gives support for Scala.js compilation
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 
 // sbt revolver lets launching applications from the sbt console
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")


### PR DESCRIPTION
This PR updates the version of several of our libraries. In particular, scala.js 0.6.13 is going to be important moving forward

Another small update is a change on travis to only build the distribution packages for non-PR builds

The changes reduce time from app 13m to app 8m