### PR TITLE
SEQNG-66 Broadcast engine output to each connected websocket

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -233,7 +233,7 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
     def onMessage(e: MessageEvent): Unit = {
       val byteBuffer = TypedArrayBuffer.wrap(e.data.asInstanceOf[ArrayBuffer])
       \/.fromTryCatchNonFatal(Unpickle[SeqexecEvent].fromBytes(byteBuffer)) match {
-        case \/-(event) => SeqexecCircuit.dispatch(NewSeqexecEvent(event))
+        case \/-(event) => println(s"Decoding event: $event"); SeqexecCircuit.dispatch(NewSeqexecEvent(event))
         case -\/(t)     => println(s"Error decoding event ${t.getMessage}")
       }
     }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -1,6 +1,5 @@
 package edu.gemini.seqexec.web.server.http4s
 
-import edu.gemini.seqexec.model.SharedModel.SeqexecEvent
 import edu.gemini.seqexec.server.Commands
 import edu.gemini.seqexec.server.SeqexecEngine
 import edu.gemini.seqexec.engine
@@ -10,18 +9,15 @@ import edu.gemini.seqexec.web.server.security.AuthenticationService
 import org.http4s._
 import org.http4s.dsl._
 import org.http4s.server.middleware.GZip
-import scalaz.stream.async.mutable.Topic
 
 /**
   * Rest Endpoints under the /api route
   */
-class SeqexecCommandRoutes(auth: AuthenticationService, events: (engine.EventQueue, Topic[SeqexecEvent]), se: SeqexecEngine) extends BooEncoders {
+class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: engine.EventQueue, se: SeqexecEngine) extends BooEncoders {
 
   val tokenAuthService = JwtAuthentication(auth)
 
   val commands = Commands(se.odbProxy)
-
-  val inputQueue = events._1
 
   val service = tokenAuthService { GZip { HttpService {
     case req @ GET  -> Root  / "host" =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -21,7 +21,7 @@ class SeqexecCommandRoutes(auth: AuthenticationService, events: (engine.EventQue
 
   val commands = Commands(se.odbProxy)
 
-  val inq = events._1
+  val inputQueue = events._1
 
   val service = tokenAuthService { GZip { HttpService {
     case req @ GET  -> Root  / "host" =>
@@ -60,18 +60,18 @@ class SeqexecCommandRoutes(auth: AuthenticationService, events: (engine.EventQue
     case req @ POST -> Root / "start" =>
       // TODO: Get rid of `.toString` How do we want to represent input results
       // now?
-      Ok(se.start(inq).map(_.toString))
+      Ok(se.start(inputQueue).map(_.toString))
 
     // TODO: Add obsId parameter
     case req @ POST -> Root / "pause" =>
       // TODO: Get rid of `.toString` How do we want to represent input results
       // now?
-      Ok(se.requestPause(inq).map(_.toString))
+      Ok(se.requestPause(inputQueue).map(_.toString))
 
     case req @ GET -> Root / "refresh" =>
       // TODO: Get rid of `.toString` How do we want to represent input results
       // now?
-      Ok(se.requestRefresh(inq).map(_.toString))
+      Ok(se.requestRefresh(inputQueue).map(_.toString))
 
   }}}
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -5,10 +5,9 @@ import java.util.logging.Logger
 
 import edu.gemini.seqexec.engine
 import edu.gemini.seqexec.model.SharedModel.SeqexecEvent
-import edu.gemini.seqexec.server.{ODBProxy, SeqexecEngine}
+import edu.gemini.seqexec.server.SeqexecEngine
 import edu.gemini.seqexec.web.server.common.LogInitialization
 import edu.gemini.seqexec.web.server.security.{AuthenticationConfig, AuthenticationService, LDAPConfig}
-import edu.gemini.spModel.core.Peer
 import knobs._
 import org.http4s.server.{Server, ServerApp}
 import org.http4s.server.blaze.BlazeBuilder

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -89,7 +89,7 @@ object WebServerLauncher extends ServerApp with LogInitialization {
     BlazeBuilder.bindHttp(conf.port, conf.host)
       .withWebSockets(true)
       .mountService(new StaticRoutes(conf.devMode).service, "/")
-      .mountService(new SeqexecCommandRoutes(as, events, se).service, "/api/seqexec/commands")
+      .mountService(new SeqexecCommandRoutes(as, events._1, se).service, "/api/seqexec/commands")
       .mountService(new SeqexecUIApiRoutes(as, events, se).service, "/api")
       .start
   }


### PR DESCRIPTION
Now the engine is launchedonly once when starting the server and uses `scalaz-streams` *topic*s to broadcast the output to every client. I implemented this similar to how was in a previous version of the executor.

I tested it with Firefox and Chrome at the same time.