### PR TITLE
SEQNG-79 Introduce `Executing` and `Next` system events #resolve

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -24,6 +24,8 @@ sealed trait SystemEvent
 case class Completed[R](id: Sequence.Id, i: Int, r: R) extends SystemEvent
 case class Failed[E](id: Sequence.Id, i: Int, e: E) extends SystemEvent
 case class Executed(id: Sequence.Id) extends SystemEvent
+case class Executing(id: Sequence.Id) extends SystemEvent
+case class Next(id: Sequence.Id) extends SystemEvent
 case class Finished(id: Sequence.Id) extends SystemEvent
 
 object Event {
@@ -34,9 +36,11 @@ object Event {
   val exit: Event = EventUser(Exit)
   def load(id: Sequence.Id, sequence: Sequence[Action]): Event = EventUser(Load(id, sequence))
 
-  def completed[R](id: Sequence.Id, i: Int, r: R): Event = EventSystem(Completed(id, i, r))
   def failed[E](id: Sequence.Id, i: Int, e: E): Event = EventSystem(Failed(id, i, e))
+  def completed[R](id: Sequence.Id, i: Int, r: R): Event = EventSystem(Completed(id, i, r))
   def executed(id: Sequence.Id): Event = EventSystem(Executed(id))
+  def executing(id: Sequence.Id): Event = EventSystem(Executing(id))
+  def next(id: Sequence.Id): Event = EventSystem(Next(id))
   def finished(id: Sequence.Id): Event = EventSystem(Finished(id))
 
 }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -88,17 +88,17 @@ class packageSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs = (
       q.enqueueOne(start(seqId)) *>
-        // 6 Actions + 4 Executions + 1 start + 1 finished => take(12)
-        processE(q).take(12).runLast.eval(qs1)).unsafePerformSync.get._2
+        // 6 Actions + 4 Nexts + 4 Executing + 4 Executions + 1 start + 1 finished => take(20)
+        processE(q).take(20).runLast.eval(qs1)).unsafePerformSync.get._2
     assert(qs(seqId).pending.isEmpty)
   }
 
-  it should "be 1 Sequence done after execution" in {
+  it should "be 2 Steps done after execution" in {
     val q = async.boundedQueue[Event](10)
     val qs = (
       q.enqueueOne(start(seqId)) *>
-        // 6 Actions + 4 Executions + 1 start + 1 finished => take(12)
-        processE(q).take(12).runLast.eval(qs1)).unsafePerformSync.get._2
+        // 6 Actions + 4 Nexts + 4 Executing + 4 Executions + 1 start + 1 finished => take(20)
+        processE(q).take(20).runLast.eval(qs1)).unsafePerformSync.get._2
     assert(qs(seqId).done.length == 2)
   }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -81,6 +81,8 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.Completed(_, _, _) => NewLogMessage("Action completed")
       case engine.Failed(_, _, _)    => NewLogMessage("Action failed")
       case engine.Executed(_)        => StepExecuted(svs)
+      case engine.Executing(_)       => NewLogMessage("Executing")
+      case engine.Next(_)            => NewLogMessage("Moving to next Execution")
       case engine.Finished(_)        => SequenceCompleted(svs)
     }
   }


### PR DESCRIPTION
In addition to having more granular transition states, this also ensures that a
separate `Task` is launched when the state is updated solving the issue of having delays in between in some state transitions.

When manually testing, the first `Step` is still not shown as `Running` but that's a separate issue that I'll fix in another PR. For this concrete bugfix, please, check that that the `Start` event shows up right after clicking *Start*.