### PR TITLE
SEQNG-85 Enable Stop from Web UI

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Step.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Step.scala
@@ -20,7 +20,8 @@ object Step {
 
     // At least an Action in this Step errored.
     // TODO: These errors for empty cases should be enforced at the type level
-    if (step.executions.isEmpty || step.executions.all(_.isEmpty)
+    if (step.executions.isEmpty
+          || step.executions.all(_.isEmpty)
           || step.any(Execution.errored)
     ) StepState.Error("An action errored")
     // All actions in this Step are pending.

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -124,9 +124,9 @@ class packageSpec extends FlatSpec {
           q.enqueueOne(start(seqId)),
           Task(Thread.sleep(2000)),
           q.enqueueOne(pause(seqId)),
-          Task(Thread.sleep(2000)),
+          Task(Thread.sleep(1000)),
           q.enqueueOne(start(seqId)),
-          Task(Thread.sleep(3000)),
+          Task(Thread.sleep(5000)),
           q.enqueueOne(exit)
         ).sequence_,
        processE(q).run.eval(qs1)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -50,7 +50,7 @@ object Model {
     case object Skipped extends StepState
     case class Error(msg: String) extends StepState
     case object Running extends StepState
-    case object Paused extends StepState
+    case object Stopped extends StepState
 
     implicit val equal: Equal[StepState] = Equal.equalA[StepState]
   }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -50,6 +50,7 @@ object Model {
     case object Skipped extends StepState
     case class Error(msg: String) extends StepState
     case object Running extends StepState
+    case object Paused extends StepState
 
     implicit val equal: Equal[StepState] = Equal.equalA[StepState]
   }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -27,10 +27,10 @@ trait ModelBooPicklers {
   implicit val stepStatePickler = compositePickler[StepState]
     .addConcreteType[StepState.Pending.type]
     .addConcreteType[StepState.Completed.type]
-    .addConcreteType[StepState.Paused.type]
     .addConcreteType[StepState.Skipped.type]
     .addConcreteType[StepState.Error]
     .addConcreteType[StepState.Running.type]
+    .addConcreteType[StepState.Stopped.type]
 
   implicit val stepPickler = compositePickler[Step]
     .addConcreteType[StandardStep]

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -27,6 +27,7 @@ trait ModelBooPicklers {
   implicit val stepStatePickler = compositePickler[StepState]
     .addConcreteType[StepState.Pending.type]
     .addConcreteType[StepState.Completed.type]
+    .addConcreteType[StepState.Paused.type]
     .addConcreteType[StepState.Skipped.type]
     .addConcreteType[StepState.Error]
     .addConcreteType[StepState.Running.type]

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -111,11 +111,16 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
         def splitWhere[A](l: List[A])(p: (A => Boolean)): (List[A], List[A]) =
           l.splitAt(l.indexWhere(p))
 
+        // TODO: Calculate the whole status here and remove `Engine.Step.status`
+        // This will be easier once the exact status labels in the UI are fixed.
         seq.steps.map(viewStep) match {
           // Find first Pending Step when no Step is Running and mark it as Running
           case steps if st === SequenceState.Running && steps.all(_.status =/= StepState.Running) =>
             val (xs, (y :: ys)) = splitWhere(steps)(_.status === StepState.Pending)
             xs ++ (y.copy(status = StepState.Running) :: ys)
+          case steps if st === SequenceState.Idle =>
+            val (xs, (y :: ys)) = splitWhere(steps)(_.status === StepState.Running)
+            xs ++ (y.copy(status = StepState.Paused) :: ys)
           case x => x
         }
       }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -120,7 +120,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
             xs ++ (y.copy(status = StepState.Running) :: ys)
           case steps if st === SequenceState.Idle =>
             val (xs, (y :: ys)) = splitWhere(steps)(_.status === StepState.Running)
-            xs ++ (y.copy(status = StepState.Paused) :: ys)
+            xs ++ (y.copy(status = StepState.Stopped) :: ys)
           case x => x
         }
       }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -33,13 +33,15 @@ object SequenceStepsTableContainer {
 
   class Backend($: BackendScope[Props, State]) {
 
-    def requestRun(s: SequenceView): Callback = $.modState(_.copy(runRequested = true)) >> Callback {
-      SeqexecCircuit.dispatch(RequestRun(s))
-    }
+    def requestRun(s: SequenceView): Callback =
+      $.modState(_.copy(runRequested = true, stopRequested = false)) >> Callback {
+        SeqexecCircuit.dispatch(RequestRun(s))
+      }
 
-    def requestStop(s: SequenceView): Callback = $.modState(_.copy(stopRequested = true)) >> Callback {
-      SeqexecCircuit.dispatch(RequestStop(s))
-    }
+    def requestStop(s: SequenceView): Callback =
+      $.modState(_.copy(stopRequested = true, runRequested = false)) >> Callback {
+        SeqexecCircuit.dispatch(RequestStop(s))
+      }
 
     def render(p: Props, s: State) = {
       <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -27,7 +27,7 @@ import org.scalajs.dom.document
   * Container for a table with the steps
   */
 object SequenceStepsTableContainer {
-  case class State(runRequested: Boolean, nextScrollPos: Double, autoScrolled: Boolean)
+  case class State(runRequested: Boolean, stopRequested: Boolean, nextScrollPos: Double, autoScrolled: Boolean)
 
   case class Props(s: SequenceView, status: ClientStatus, stepConfigDisplayed: Option[Int])
 
@@ -35,6 +35,10 @@ object SequenceStepsTableContainer {
 
     def requestRun(s: SequenceView): Callback = $.modState(_.copy(runRequested = true)) >> Callback {
       SeqexecCircuit.dispatch(RequestRun(s))
+    }
+
+    def requestStop(s: SequenceView): Callback = $.modState(_.copy(stopRequested = true)) >> Callback {
+      SeqexecCircuit.dispatch(RequestStop(s))
     }
 
     def render(p: Props, s: State) = {
@@ -56,7 +60,7 @@ object SequenceStepsTableContainer {
             p.status.isLogged && p.s.status === SequenceState.Idle ?=
               Button(Button.Props(icon = Some(IconPlay), labeled = true, onClick = requestRun(p.s), disabled = !p.status.isConnected || s.runRequested), "Run"),
             p.status.isLogged && p.s.status === SequenceState.Running ?=
-              Button(Button.Props(icon = Some(IconStop), labeled = true, onClick = requestStop(p.s), disabled = !p.status.isConnected), "Stop")
+              Button(Button.Props(icon = Some(IconStop), labeled = true, onClick = requestStop(p.s), disabled = !p.status.isConnected || s.stopRequested), "Stop")
           )
         } { i =>
           <.div(
@@ -189,7 +193,7 @@ object SequenceStepsTableContainer {
   val scrollRef = Ref[HTMLElement]("scrollRef")
 
   val component = ReactComponentB[Props]("HeadersSideBar")
-    .initialState(State(runRequested = false, 0, autoScrolled = false))
+    .initialState(State(runRequested = false, stopRequested = false, 0, autoScrolled = false))
     .renderBackend[Backend]
     .componentWillReceiveProps { f =>
       // Update state of run requested depending on the run state

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -142,9 +142,11 @@ object SequenceStepsTableContainer {
                 p.s.steps.zipWithIndex.map {
                   case (step, i) =>
                     <.tr(
+                      // Available row states: http://semantic-ui.com/collections/table.html#positive--negative
                       ^.classSet(
                         "positive" -> (step.status === StepState.Completed),
                         "warning"  -> (step.status === StepState.Running),
+                        "active"   -> (step.status === StepState.Stopped),
                         // TODO Show error case
                         //"negative" -> (step.status == StepState.Error),
                         "negative" -> (step.status === StepState.Skipped)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -56,8 +56,6 @@ object SequenceStepsTableContainer {
             p.status.isLogged && p.s.status === SequenceState.Idle ?=
               Button(Button.Props(icon = Some(IconPlay), labeled = true, onClick = requestRun(p.s), disabled = !p.status.isConnected || s.runRequested), "Run"),
             p.status.isLogged && p.s.status === SequenceState.Running ?=
-              Button(Button.Props(icon = Some(IconPause), labeled = true, disabled = true, onClick = requestPause(p.s)), "Pause"),
-            p.status.isLogged && p.s.status === SequenceState.Running ?=
               Button(Button.Props(icon = Some(IconStop), labeled = true, onClick = requestStop(p.s), disabled = !p.status.isConnected), "Stop")
           )
         } { i =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
@@ -18,6 +18,7 @@ object ModelOps {
   implicit val steStateShow = Show.shows[StepState] {
     case StepState.Pending    => "Pending"
     case StepState.Completed  => "Done"
+    case StepState.Paused     => "Paused"
     case StepState.Skipped    => "Skipped"
     case StepState.Error(msg) => s"Error $msg"
     case StepState.Running    => "Running"

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
@@ -18,10 +18,10 @@ object ModelOps {
   implicit val steStateShow = Show.shows[StepState] {
     case StepState.Pending    => "Pending"
     case StepState.Completed  => "Done"
-    case StepState.Paused     => "Paused"
     case StepState.Skipped    => "Skipped"
     case StepState.Error(msg) => s"Error $msg"
     case StepState.Running    => "Running"
+    case StepState.Stopped    => "Stopped"
   }
 
   implicit class SequenceViewOps(val s: SequenceView) extends AnyVal {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -61,7 +61,7 @@ object SeqexecWebClient extends ModelBooPicklers {
     */
   def stop(s: SequenceView): Future[RegularCommand] = {
     Ajax.post(
-      url = s"$baseUrl/commands/${s.id}/stop",
+      url = s"$baseUrl/commands/${s.id}/pause",
       responseType = "arraybuffer"
     ).map(unpickle[RegularCommand])
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -61,7 +61,7 @@ object SeqexecWebClient extends ModelBooPicklers {
     */
   def stop(s: SequenceView): Future[RegularCommand] = {
     Ajax.post(
-      url = s"$baseUrl/commands/${s.id}/pause",
+      url = s"$baseUrl/commands/${s.id}/stop",
       responseType = "arraybuffer"
     ).map(unpickle[RegularCommand])
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -31,23 +31,6 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: engine.Event
     case req @ GET  -> Root  / obsId / "count" =>
       Ok(toCommandResult("count", commands.showCount(obsId)))
 
-    /*case req @ GET  -> Root  / obsId / "static" =>
-      Ok(toSequenceConfig("show", commands.showStatic(obsId)))
-
-    case req @ GET  -> Root  / obsId / "static" / system =>
-      Ok(toSequenceConfig("show", commands.showStatic(obsId, system)))
-
-    case req @ GET  -> Root  / obsId / "dynamic" / step =>
-      Ok(toSequenceConfig("show", commands.showDynamic(obsId, step)))
-
-    case req @ GET  -> Root  / obsId / "dynamic" / step / system =>
-      Ok(toSequenceConfig("show", commands.showDynamic(obsId, step, system)))*/
-
-    /*case req @ GET  -> Root  / obsId / "state" =>
-      Ok(toSequenceConfig("state", commands.state(obsId)))*/
-
-    // New SeqexecEngine
-
     // TODO: Add obsId parameter
     case POST -> Root / obsId / "start" =>
       // TODO: Get rid of `.toString` How do we want to represent input results
@@ -61,7 +44,7 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: engine.Event
       } yield resp
 
     // TODO: Add obsId parameter
-    case POST -> Root / obsId / "pause" =>
+    case POST -> Root / obsId / "stop" =>
       // TODO: Get rid of `.toString` How do we want to represent input results
       // now?
       for {


### PR DESCRIPTION
Concretely:

- Wire up UI button with stop route.
- Remove `Pause` button.
- Fix regression where the sequence didn't fully stop after more events were
  introduced.
- Initial attempt of labeling the Step status when in Paused state.

The way the current Step status is displayed in the UI now when paused is strange. This is because there are different cases involving the underlying `Execution`s which are not shown to the client. In the next meeting I can explain with a demo what is going on under the hood and why displaying the Paused status of a Step is trickier than it initially seems.