### PR TITLE
SEQNG-65: Upgrade to http4s 0.15.0

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -96,11 +96,14 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
               )
             )
 
-          case POST -> Root / "seqexec" / "logout"              =>
-            // Clean the auth cookie
-            val cookie = Cookie(auth.config.cookieName, "", path = "/".some,
-                                secure = auth.config.useSSL, maxAge = Some(-1), httpOnly = true)
-            Ok("").removeCookie(cookie)
+          case req @ POST -> Root / "seqexec" / "logout"              =>
+            val user = userInRequest(req)
+            user.fold(Unauthorized(Challenge("jwt", "seqexec"))) { _ =>
+              // Clean the auth cookie
+              val cookie = Cookie(auth.config.cookieName, "", path = "/".some,
+                secure = auth.config.useSSL, maxAge = Some(-1), httpOnly = true)
+              Ok("").removeCookie(cookie)
+            }
 
           case req @ GET -> Root / "seqexec" / "sequence" / oid =>
             val user = userInRequest(req)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -57,7 +57,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
           case \/-(user) =>
             // if successful set a cookie
             val cookieVal = auth.buildToken(user)
-            val expiration = Instant.now().plusSeconds(auth.sessionTimeout)
+            val expiration = Instant.now().plusSeconds(auth.sessionTimeout.toSeconds.toLong)
             val cookie = Cookie(auth.config.cookieName, cookieVal,
               path = "/".some, expires = expiration.some, secure = auth.config.useSSL, httpOnly = true)
             Ok(user).addCookie(cookie)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -12,6 +12,7 @@ import edu.gemini.web.server.common.{LogInitialization, StaticRoutes}
 import knobs._
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.{Server, ServerApp}
+import squants.time.Hours
 
 import scalaz.Scalaz._
 import scalaz._
@@ -70,7 +71,7 @@ object WebServerLauncher extends ServerApp with LogInitialization {
       val cookieName = cfg.require[String]("authentication.cookieName")
       val secretKey = cfg.require[String]("authentication.secretKey")
       val useSSL = cfg.require[Boolean]("authentication.useSSL")
-      AuthenticationConfig(devMode.equalsIgnoreCase("dev"), sessionTimeout, cookieName, secretKey, useSSL, ld)
+      AuthenticationConfig(devMode.equalsIgnoreCase("dev"), Hours(sessionTimeout), cookieName, secretKey, useSSL, ld)
     }
 
   /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/FreeLDAPAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/FreeLDAPAuthenticationService.scala
@@ -98,9 +98,14 @@ class FreeLDAPAuthenticationService(hosts: List[(String, Int)]) extends AuthServ
   val Timeout = 1000
   val Domain = "@gemini.edu"
 
+  lazy val ldapOptions: LDAPConnectionOptions = {
+    val opts = new LDAPConnectionOptions()
+    opts.setConnectTimeoutMillis(Timeout)
+    opts
+  }
+
   // Will attempt several servers in case they fail
-  lazy val failoverServerSet = new FailoverServerSet(hosts.map(_._1).toArray, hosts.map(_._2).toArray,
-    new LDAPConnectionOptions() <| {_.setConnectTimeoutMillis(Timeout)})
+  lazy val failoverServerSet = new FailoverServerSet(hosts.map(_._1).toArray, hosts.map(_._2).toArray, ldapOptions)
 
   override def authenticateUser(username: String, password: String): AuthResult = {
     // We should always return the domain

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -6,6 +6,7 @@ import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
 import upickle.default._
 import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim}
 import squants.Time
+import squants.time.Seconds
 
 import scala.annotation.tailrec
 import scalaz._
@@ -63,7 +64,7 @@ case class AuthenticationService(config: AuthenticationConfig) extends AuthServi
     */
   def buildToken(u: UserDetails): String =
     // Given that only this server will need the key we can just use HMAC. 512-bit is the max key size allowed
-    Jwt.encode(JwtClaim(write(u)).issuedNow.expiresIn(3600), config.secretKey, JwtAlgorithm.HmacSHA256)
+    Jwt.encode(JwtClaim(write(u)).issuedNow.expiresIn(sessionTimeout.toSeconds.toLong), config.secretKey, JwtAlgorithm.HmacSHA256)
 
   /**
     * Decodes a token out of JSON Web Token
@@ -74,7 +75,7 @@ case class AuthenticationService(config: AuthenticationConfig) extends AuthServi
       token <- \/.fromTryCatchNonFatal(read[JwtUserClaim](claim))
     } yield token.toUserDetails).leftMap(m => DecodingFailure(m.getMessage))
 
-  val sessionTimeout: Long = config.sessionLifeHrs.toMinutes.toLong
+  val sessionTimeout: Time = config.sessionLifeHrs in Seconds
 
   override def authenticateUser(username: String, password: String): AuthResult =
     authServices.authenticateUser(username, password)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -5,6 +5,7 @@ import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
 import upickle.default._
 import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim}
+import squants.Time
 
 import scala.annotation.tailrec
 import scalaz._
@@ -43,7 +44,7 @@ case class LDAPConfig(ldapHosts: List[String]) {
   * @param useSSL Whether we use SSL setting the cookie to be https only
   * @param ldap Configuration for the ldap client
   */
-case class AuthenticationConfig(devMode: Boolean, sessionLifeHrs: Int, cookieName: String, secretKey: String, useSSL: Boolean, ldap: LDAPConfig)
+case class AuthenticationConfig(devMode: Boolean, sessionLifeHrs: Time, cookieName: String, secretKey: String, useSSL: Boolean, ldap: LDAPConfig)
 
 // Intermediate class to decode the claim stored in the JWT token
 case class JwtUserClaim(exp: Int, iat: Int, username: String, displayName: String) {
@@ -73,7 +74,7 @@ case class AuthenticationService(config: AuthenticationConfig) extends AuthServi
       token <- \/.fromTryCatchNonFatal(read[JwtUserClaim](claim))
     } yield token.toUserDetails).leftMap(m => DecodingFailure(m.getMessage))
 
-  val sessionTimeout: Long = config.sessionLifeHrs * 3600
+  val sessionTimeout: Long = config.sessionLifeHrs.toMinutes.toLong
 
   override def authenticateUser(username: String, password: String): AuthResult =
     authServices.authenticateUser(username, password)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
@@ -1,0 +1,54 @@
+package edu.gemini.seqexec.web.server.http4s
+
+import edu.gemini.seqexec.web.server.security.{AuthenticationConfig, AuthenticationService, LDAPConfig}
+import edu.gemini.seqexec.engine.Event
+import edu.gemini.seqexec.model.Model.SeqexecEvent
+import edu.gemini.seqexec.model.{ModelBooPicklers, UserLoginRequest}
+import edu.gemini.seqexec.server.SeqexecEngine
+import edu.gemini.seqexec.server.SeqexecEngine.Settings
+import org.http4s._
+import scodec.bits.ByteVector
+import squants.time._
+import boopickle.Default._
+
+import scalaz.stream.Process.emit
+import scalaz.stream.async
+import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+
+import org.http4s.util.CaseInsensitiveStringSyntax
+import org.scalatest.{FlatSpec, Matchers}
+
+class SeqexecUIApiRoutesSpec extends FlatSpec with Matchers with UriFunctions with ModelBooPicklers with CaseInsensitiveStringSyntax {
+  val config = AuthenticationConfig(devMode = true, Hours(8), "token", "abc", useSSL = false, LDAPConfig(Nil))
+  val engine = SeqexecEngine(Settings("", LocalDate.now(), "", dhsSim = true, tcsSim = true, instSim = true, gcalSim = true))
+  val authService = AuthenticationService(config)
+  val inq  = async.boundedQueue[Event](10)
+  val out  = async.topic[SeqexecEvent]()
+  val queues = (inq, out)
+
+  val service = new SeqexecUIApiRoutes(authService, queues, engine).service
+
+  "SeqexecUIApiRoutes" should
+    "reject requests without body" in {
+      service.apply(Request(method = Method.POST, uri = uri("/seqexec/login"))).unsafePerformSync.status should equal(Status.BadRequest)
+    }
+    it should "reject GET requests" in {
+      service.apply(Request(uri = uri("/seqexec/login"))).unsafePerformSync.status should equal(Status.NotFound)
+    }
+    it should "reject requests with string body" in {
+      val b = emit(ByteVector.view("hello".getBytes(StandardCharsets.UTF_8)))
+      service.apply(Request(method = Method.POST, uri = uri("/seqexec/login"), body = b)).unsafePerformSync.status should equal(Status.BadRequest)
+    }
+    it should "not authorize requests with unmatching credentials" in {
+      val b = emit(ByteVector.view(Pickle.intoBytes(UserLoginRequest("a", "b"))))
+      service.apply(Request(method = Method.POST, uri = uri("/seqexec/login"), body = b)).unsafePerformSync.status should equal(Status.Unauthorized)
+    }
+    it should "authorize requests with matching credentials and return a Cookie" in {
+      val b = emit(ByteVector.view(Pickle.intoBytes(UserLoginRequest("telops", "pwd"))))
+      val response: Response = service.apply(Request(method = Method.POST, uri = uri("/seqexec/login"), body = b)).unsafePerformSync
+      response.status should equal(Status.Ok)
+      println(response.attributes)
+      response.headers.toList.exists(_.name == "Set-Cookie".ci) should be (true)
+    }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
@@ -3,13 +3,13 @@ package edu.gemini.seqexec.web.server.security
 import edu.gemini.seqexec.model.UserDetails
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
+import squants.time.Hours
 
-import scala.util.Success
 import scalaz.\/-
 
 class JWTTokensSpec extends FlatSpec with Matchers with PropertyChecks {
   val ldapConfig = LDAPConfig(Nil)
-  val config = AuthenticationConfig(devMode = true, 8, "token", "key", useSSL = false, ldapConfig)
+  val config = AuthenticationConfig(devMode = true, Hours(8), "token", "key", useSSL = false, ldapConfig)
   val authService = AuthenticationService(config)
 
   "JWT Tokens" should "encode/decode" in {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -40,10 +40,10 @@ object Settings {
 
     // Java libraries
     val scalaZ       = "7.2.2"
-    val scalaZStream = "0.8a"
+    val scalaZStream = "0.8.6a"
 
     // Scala libraries
-    val http4s       = "0.14.7a"
+    val http4s       = "0.15.1a"
     val squants      = "1.0.0"
     val argonaut     = "6.2-M1"
     val commonsHttp  = "2.0"


### PR DESCRIPTION
This PR started simply as an upgrade to the latest version of http4s but it grew as tests have been added that showed a few bugs

the latest version of http4s changes the way authentication is performed so we should attempt to do it but it showed a harder problem than planned. However the current system still works

This exercise showed some of the limitations of http4s, leading to at least one PR submitted to the project