### PR TITLE
SEQNG-88 Fix showing first Step as Done

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -119,8 +119,8 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
             val (xs, (y :: ys)) = splitWhere(steps)(_.status === StepState.Pending)
             xs ++ (y.copy(status = StepState.Running) :: ys)
           case steps if st === SequenceState.Idle =>
-            val (xs, (y :: ys)) = splitWhere(steps)(_.status === StepState.Running)
-            xs ++ (y.copy(status = StepState.Paused) :: ys)
+            val (xs, ys0@(y :: ys)) = splitWhere(steps)(_.status === StepState.Running)
+            if (xs.isEmpty) ys0 else xs ++ (y.copy(status = StepState.Paused) :: ys)
           case x => x
         }
       }


### PR DESCRIPTION
I thought this would be harder but it was actually a trivial fix.

Notice that if you pause during an observation it will mark that `Step` as `Done` and there won't be any other `Paused` Step in the `Sequence`. As we discussed, it's still open for discussion how we are going to represent that case, so you may consider the current behavior provisional.