### PR TITLE
SEQNG-93: UI elements for exposure control

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -119,22 +119,6 @@ object LoadingErrorMsg {
   def apply(p: ModelProxy[SeqexecAppRootModel.LoadedSequences]) = component(Props(p))
 }
 
-object QueueTableLoading {
-  case class Props(queue: SeqexecAppRootModel.LoadedSequences)
-
-  val component = ReactComponentB[Props]("QueueTableLoading")
-    .stateless
-    .render_P(p =>
-      <.div(
-        ^.cls := "ui header item",
-          "Loading"
-        //p.queue.renderPending(_ => <.span(IconCircleNotched.copyIcon(loading = true), "Loading..."))
-      )
-    ).build.withKey("key.queue.loading")
-
-  def apply(p: ModelProxy[SeqexecAppRootModel.LoadedSequences]) = component(Props(p()))
-}
-
 /**
   * Component for the title of the queue area, including the search component
   */
@@ -147,13 +131,7 @@ object QueueAreaTitle {
   val component = ReactComponentB[Props]("QueueAreaTitle")
     .stateless
     .render_P(p =>
-      TextMenuSegment("Queue", "key.queue.menu",
-        // Show a loading indicator if we are waiting for server data
-        {
-          // Special equality check to avoid certain UI artifacts
-          implicit val eq = PotEq.seqexecQueueEq
-          queueConnect(QueueTableLoading.apply)
-        },
+      TextMenuSegment("Night Queue", "key.queue.menu",
         p.user().fold(<.div()) { _ =>
           <.div(
             ^.cls := "right menu",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -83,32 +83,27 @@ object SeqexecStyles extends StyleSheet.Inline {
     marginBottom(0.px)
   )
 
-  val warningSegment = style("ui.segment.warning")(
-    backgroundColor(c"#FFFAF3").important,
-    color(c"#573A08")
-  )
-
-  val segmentLittlePadding = style("ui.segment.running")(
+  // Common properties for a segment displayed when running
+  val segmentRunningMixin = mixin(
+    backgroundColor(rgba(0, 0, 0, 0.0)).important,
+    color.inherit,
     padding(0.em),
     margin(0.px),
-    borderLeft.none.important,
-    alignSelf.center,
     (boxShadow := ("none")).important
   )
 
-  val segmentsLittlePadding = style("ui.segments.running")(
-    padding(0.px),
-    margin(0.px),
-    border.none,
-    borderRadius(0.px),
-    (boxShadow := ("none")).important,
-    backgroundColor(c"#FFFAF3").important,
-    color(c"#573A08")
+  // CSS for a segment where a step is running
+  val segmentRunning = style("ui.segment.running")(
+    segmentRunningMixin,
+    borderLeft.none.important,
+    alignSelf.center
   )
 
-  val rowNoPadding = style(
-    paddingBottom(0.px).important,
-    paddingTop(0.px).important
+  // CSS for a segments where a step is running
+  val segmentsRunning = style("ui.segments.running")(
+    segmentRunningMixin,
+    border.none,
+    borderRadius(0.px)
   )
 
   // Media queries to hide/display items for mobile

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -79,17 +79,31 @@ object SeqexecStyles extends StyleSheet.Inline {
     padding(0.px).important
   )
 
+  val progressVCentered = style("ui.progress.vcentered")(
+    marginBottom(0.px)
+  )
+
+  val warningSegment = style("ui.segment.warning")(
+    backgroundColor(c"#FFFAF3").important,
+    color(c"#573A08")
+  )
+
   val segmentLittlePadding = style("ui.segment.running")(
-    padding(0.2.em),
+    padding(0.em),
     margin(0.px),
-    borderLeft.none.important
+    borderLeft.none.important,
+    alignSelf.center,
+    (boxShadow := ("none")).important
   )
 
   val segmentsLittlePadding = style("ui.segments.running")(
     padding(0.px),
     margin(0.px),
     border.none,
-    borderRadius(0.px)
+    borderRadius(0.px),
+    (boxShadow := ("none")).important,
+    backgroundColor(c"#FFFAF3").important,
+    color(c"#573A08")
   )
 
   val rowNoPadding = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -75,6 +75,23 @@ object SeqexecStyles extends StyleSheet.Inline {
     display.none
   )
 
+  val tdNoPadding = style(
+    padding(0.px).important
+  )
+
+  val segmentLittlePadding = style("ui.segment.running")(
+    padding(0.2.em),
+    margin(0.px),
+    borderLeft.none.important
+  )
+
+  val segmentsLittlePadding = style("ui.segments.running")(
+    padding(0.px),
+    margin(0.px),
+    border.none,
+    borderRadius(0.px)
+  )
+
   val rowNoPadding = style(
     paddingBottom(0.px).important,
     paddingTop(0.px).important

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -124,6 +124,67 @@ object SequenceStepsTableContainer {
         )
       )
 
+
+    /*def stepDisplay(step: Step): ReactNode = {
+      println(step.status)
+      step.status match {
+        case StepState.Running => <.div(<.div(step.status.shows))
+        case  _ => <.table(
+          ^.cls := "ui fixed table"
+          <.tr(
+            <.td(step.status.shows)
+          <.div(
+            ^.cls := "ui icon buttons",
+            <.button(
+              ^.cls := "ui button",
+              "Cancel"),
+            <.div(
+              ^.cls := "or"),
+            <.button(
+              ^.cls := "ui positive button",
+              "Save")
+          ))
+        ),
+        <.tr(
+          ^.cls := "right aligned",
+          <.td(
+            ^.cls := "ui icon buttons tiny",
+            Button(
+              Button.Props(size = Size.Tiny, icon = Some(IconPause.copyIcon(size = Size.Tiny)))),
+            Button(
+              Button.Props(size = Size.Tiny, icon = Some(IconPlay.copyIcon(size = Size.Tiny))))
+          )
+        ))
+          <.div(Button(
+            Button.Props(size = Size.Tiny, icon = Some(IconPause.copyIcon(size = Size.Tiny)
+          )))
+        //case _                 => step.status.shows
+      }
+    }*/
+
+    def stepDisplay(step: Step): ReactNode =
+      step.status match {
+        case StepState.Running =>
+          <.div(
+            ^.cls := "ui horizontal segments running",
+            <.div(
+              ^.cls := "ui basic segment running",
+              <.p(step.status.shows)
+            ),
+            <.div(
+              ^.cls := "ui basic segment right aligned running",
+              <.div(
+                ^.cls := "ui icon buttons",
+                Button(
+                  Button.Props(icon = Some(IconPause), color = Some("teal"))),
+                Button(
+                  Button.Props(icon = Some(IconStop), color = Some("violet")))
+              )
+            )
+          )
+        case _ => <.p(step.status.shows)
+      }
+
     def stepsTable(p: Props): TagMod =
       <.table(
         ^.cls := "ui selectable compact celled table unstackable",
@@ -176,7 +237,10 @@ object SequenceStepsTableContainer {
                   }
                 ),
                 <.td(i + 1),
-                <.td(step.status.shows),
+                <.td(
+                  step.status == StepState.Running ?= SeqexecStyles.tdNoPadding,
+                  ^.cls := "middle aligned",
+                  stepDisplay(step)),
                 <.td(step.file.getOrElse(""): String),
                 <.td(
                   ^.cls := "collapsing right aligned",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -124,44 +124,6 @@ object SequenceStepsTableContainer {
         )
       )
 
-
-    /*def stepDisplay(step: Step): ReactNode = {
-      println(step.status)
-      step.status match {
-        case StepState.Running => <.div(<.div(step.status.shows))
-        case  _ => <.table(
-          ^.cls := "ui fixed table"
-          <.tr(
-            <.td(step.status.shows)
-          <.div(
-            ^.cls := "ui icon buttons",
-            <.button(
-              ^.cls := "ui button",
-              "Cancel"),
-            <.div(
-              ^.cls := "or"),
-            <.button(
-              ^.cls := "ui positive button",
-              "Save")
-          ))
-        ),
-        <.tr(
-          ^.cls := "right aligned",
-          <.td(
-            ^.cls := "ui icon buttons tiny",
-            Button(
-              Button.Props(size = Size.Tiny, icon = Some(IconPause.copyIcon(size = Size.Tiny)))),
-            Button(
-              Button.Props(size = Size.Tiny, icon = Some(IconPlay.copyIcon(size = Size.Tiny))))
-          )
-        ))
-          <.div(Button(
-            Button.Props(size = Size.Tiny, icon = Some(IconPause.copyIcon(size = Size.Tiny)
-          )))
-        //case _                 => step.status.shows
-      }
-    }*/
-
     def stepProgress(step: Step): ReactNode =
       step.status match {
         case StepState.Running =>
@@ -185,12 +147,11 @@ object SequenceStepsTableContainer {
           <.div(
             ^.cls := "ui horizontal segments running",
             <.div(
-              ^.cls := "ui basic segment running warning",
-              //step.status.shows
+              ^.cls := "ui basic segment running",
               <.p(step.status.shows)
             ),
             <.div(
-              ^.cls := "ui basic segment right aligned running warning",
+              ^.cls := "ui basic segment right aligned running",
               <.div(
                 ^.cls := "ui icon buttons",
                 Button(
@@ -256,7 +217,6 @@ object SequenceStepsTableContainer {
                 ),
                 <.td(i + 1),
                 <.td(
-                  //step.status == StepState.Running ?= SeqexecStyles.tdNoPadding,
                   ^.cls := "middle aligned",
                   stepDisplay(step)),
                 <.td(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -43,56 +43,56 @@ object SequenceStepsTableContainer {
         SeqexecCircuit.dispatch(RequestPause(s))
       }
 
+    def defaultToolbar(p: Props, s: State): ReactNode =
+      <.div(
+        ^.cls := "row",
+        /*p.status.isLogged && p.s.status == SequenceState.Abort ?=
+          <.h3(
+            ^.cls := "ui red header",
+            "Sequence aborted"
+          ),*/
+        p.status.isLogged && p.s.status === SequenceState.Completed ?=
+          <.h3(
+            ^.cls := "ui green header",
+            "Sequence completed"
+          ),
+        p.status.isLogged && p.s.status === SequenceState.Idle ?=
+          Button(
+            Button.Props(
+              icon = Some(IconPlay),
+              labeled = true,
+              onClick = requestRun(p.s),
+              color = Some("blue"),
+              disabled = !p.status.isConnected || s.runRequested),
+            "Run"
+          ),
+        p.status.isLogged && p.s.status === SequenceState.Running ?=
+          Button(
+            Button.Props(
+              icon = Some(IconPause),
+              labeled = true,
+              onClick = requestPause(p.s),
+              color = Some("teal"),
+              disabled = !p.status.isConnected || s.pauseRequested),
+            "Pause"
+          )
+      )
+
+    def configToolbar(p: Props)(i: Int): ReactNode =
+      <.div(
+        ^.cls := "row",
+        Button(Button.Props(icon = Some(IconChevronLeft), onClick = backToSequence(p.s)), "Back"),
+        <.h5(
+          ^.cls := "ui header",
+          SeqexecStyles.inline,
+          s" Configuration for step ${i + 1}"
+        )
+      )
+
     def render(p: Props, s: State) = {
       <.div(
         ^.cls := "ui raised secondary segment",
-        p.stepConfigDisplayed.fold {
-          <.div(
-            ^.cls := "row",
-            /*p.status.isLogged && p.s.status == SequenceState.Abort ?=
-              <.h3(
-                ^.cls := "ui red header",
-                "Sequence aborted"
-              ),*/
-            p.status.isLogged && p.s.status === SequenceState.Completed ?=
-              <.h3(
-                ^.cls := "ui green header",
-                "Sequence completed"
-              ),
-            p.status.isLogged && p.s.status === SequenceState.Idle ?=
-              Button(
-                Button.Props(
-                  icon     = Some(IconPlay),
-                  labeled  = true,
-                  onClick  = requestRun(p.s),
-                  color    = Some("blue"),
-                  disabled = !p.status.isConnected || s.runRequested
-                ),
-                "Run"
-              ),
-            p.status.isLogged && p.s.status === SequenceState.Running ?=
-              Button(
-                Button.Props(
-                  icon     = Some(IconPause),
-                  labeled  = true,
-                  onClick  = requestPause(p.s),
-                  color    = Some("teal"),
-                  disabled = !p.status.isConnected || s.pauseRequested
-                ),
-                "Pause"
-              )
-          )
-        } { i =>
-          <.div(
-            ^.cls := "row",
-            Button(Button.Props(icon = Some(IconChevronLeft), onClick = backToSequence(p.s)), "Back"),
-            <.h5(
-              ^.cls := "ui header",
-              SeqexecStyles.inline,
-              s" Configuration for step ${i + 1}"
-            )
-          )
-        },
+        p.stepConfigDisplayed.fold(defaultToolbar(p, s))(configToolbar(p)),
         Divider(),
         <.div(
           ^.cls := "ui row scroll pane",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -8,7 +8,7 @@ import edu.gemini.seqexec.web.client.model.ModelOps._
 import edu.gemini.seqexec.web.client.semanticui._
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.divider.Divider
-import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconCaretRight, IconInbox, IconPause, IconPlay}
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconCaretRight, IconInbox, IconPause, IconPlay, IconTrash}
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconAttention, IconCheckmark, IconCircleNotched, IconStop}
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconChevronLeft
 import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
@@ -157,7 +157,9 @@ object SequenceStepsTableContainer {
                 Button(
                   Button.Props(icon = Some(IconPause), color = Some("teal"))),
                 Button(
-                  Button.Props(icon = Some(IconStop), color = Some("red")))
+                  Button.Props(icon = Some(IconStop), color = Some("orange"))),
+                Button(
+                  Button.Props(icon = Some(IconTrash), color = Some("red")))
               )
             )
           )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -162,23 +162,41 @@ object SequenceStepsTableContainer {
       }
     }*/
 
+    def stepProgress(step: Step): ReactNode =
+      step.status match {
+        case StepState.Running =>
+          <.div(
+            ^.cls := "ui progress vcentered",
+            <.div(
+              ^.cls := "bar",
+              <.div(
+                ^.cls := "progress")
+            )
+          )
+        case StepState.Completed =>
+          "File completed"
+        case _ =>
+          step.file.getOrElse(""): String
+      }
+
     def stepDisplay(step: Step): ReactNode =
       step.status match {
         case StepState.Running =>
           <.div(
             ^.cls := "ui horizontal segments running",
             <.div(
-              ^.cls := "ui basic segment running",
+              ^.cls := "ui basic segment running warning",
+              //step.status.shows
               <.p(step.status.shows)
             ),
             <.div(
-              ^.cls := "ui basic segment right aligned running",
+              ^.cls := "ui basic segment right aligned running warning",
               <.div(
                 ^.cls := "ui icon buttons",
                 Button(
                   Button.Props(icon = Some(IconPause), color = Some("teal"))),
                 Button(
-                  Button.Props(icon = Some(IconStop), color = Some("violet")))
+                  Button.Props(icon = Some(IconStop), color = Some("red")))
               )
             )
           )
@@ -238,10 +256,12 @@ object SequenceStepsTableContainer {
                 ),
                 <.td(i + 1),
                 <.td(
-                  step.status == StepState.Running ?= SeqexecStyles.tdNoPadding,
+                  //step.status == StepState.Running ?= SeqexecStyles.tdNoPadding,
                   ^.cls := "middle aligned",
                   stepDisplay(step)),
-                <.td(step.file.getOrElse(""): String),
+                <.td(
+                  ^.cls := "middle aligned",
+                  stepProgress(step)),
                 <.td(
                   ^.cls := "collapsing right aligned",
                   IconCaretRight.copyIcon(onClick = displayStepDetails(p.s, i))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/SemanticUI.scala
@@ -34,6 +34,16 @@ object SemanticUI {
   }
 
   @js.native
+  trait JsProgressOptions extends js.Object
+
+  object JsProgressOptions extends JsProgressOptionBuilder(noOpts)
+
+  class JsProgressOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsProgressOptions, JsProgressOptionBuilder](new JsProgressOptionBuilder(_)) {
+    def total(v: Int) = jsOpt("total", v)
+    def value(v: Int) = jsOpt("value", v)
+  }
+
+  @js.native
   trait SemanticCommands extends JQuery {
     def visibility(o: JsVisiblityOptions): this.type = js.native
 
@@ -47,6 +57,8 @@ object SemanticUI {
     def modal(s: String): this.type = js.native
 
     def modal(o: JsModalOptions): this.type = js.native
+
+    def progress(o: JsProgressOptions): this.type = js.native
   }
 
   implicit def jq2Semantic(jq: JQuery): SemanticCommands = jq.asInstanceOf[SemanticCommands]


### PR DESCRIPTION
This is an prototype UI to include buttons for exposure control at the row level and a progress bar for the observation process. There is no functionality attached just the following changes:

* Made the running step taller
* Add buttons for pause/stop/abort at the row level
* Added a progress bar that should display how long to complete the observation

The code doesn't tell much so here is a screenshot

![screenshot 2017-01-06 14 26 34](https://cloud.githubusercontent.com/assets/3615303/21726590/2e07a5d8-d41c-11e6-809f-80663b23a7cd.png)
