### PR TITLE
SEQNG-97: Add and update observe control buttons based on existing seqexec

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -110,11 +110,12 @@ object Model {
      * Returns the observation operations allowed
      * TODO Convert to an Instrument-level typeclass
      */
-    def allowedObservationOperations: List[ObservationOperations] =
+    def allowedObservationOperations(stepStatus: StepState): List[ObservationOperations] =
       metadata.instrument match {
         // Note the F2 doesn't suppor these operations but we'll simulate them
         // for demonstration purposes
         case "Flamingos2" if status == SequenceState.Running => List(PauseImmediatelyObservation, PauseGracefullyObservation, StopImmediatelyObservation, StopGracefullyObservation)
+        case "Flamingos2" if stepStatus == StepState.Paused  => List(ResumeObservation)
         case _                                               => Nil
       }
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -114,7 +114,7 @@ object Model {
       metadata.instrument match {
         // Note the F2 doesn't suppor these operations but we'll simulate them
         // for demonstration purposes
-        case "Flamingos2" if status == SequenceState.Running => List(PauseObservation, StopObservation, AbortObservation)
+        case "Flamingos2" if status == SequenceState.Running => List(PauseImmediatelyObservation, PauseGracefullyObservation, StopImmediatelyObservation, StopGracefullyObservation)
         case _                                               => Nil
       }
 
@@ -154,7 +154,12 @@ object Model {
   // Operations possible at the observation level
   sealed trait ObservationOperations
   case object PauseObservation extends ObservationOperations
-  case object ResumeObservation extends ObservationOperations
   case object StopObservation extends ObservationOperations
   case object AbortObservation extends ObservationOperations
+  case object ResumeObservation extends ObservationOperations
+  // Operations for Hamamatsu
+  case object PauseImmediatelyObservation extends ObservationOperations
+  case object StopImmediatelyObservation extends ObservationOperations
+  case object PauseGracefullyObservation extends ObservationOperations
+  case object StopGracefullyObservation extends ObservationOperations
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -141,8 +141,8 @@ object SequenceStepsTableContainer {
           step.file.getOrElse(""): String
       }
 
-    def observationControlButtons(s: SequenceView): List[ReactNode] = {
-      s.allowedObservationOperations.map {
+    def observationControlButtons(s: SequenceView, step: Step): List[ReactNode] = {
+      s.allowedObservationOperations(step.status).map {
         case PauseObservation            =>
           Button(Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure")))
         case StopObservation             =>
@@ -163,24 +163,27 @@ object SequenceStepsTableContainer {
       }
     }
 
-    def stepDisplay(p: Props, step: Step): ReactNode =
-      step.status match {
-        case StepState.Running =>
+    def controlButtons(loggedIn: Boolean, sequenceView: SequenceView, step: Step): ReactNode =
+        <.div(
+          ^.cls := "ui horizontal segments running",
           <.div(
-            ^.cls := "ui horizontal segments running",
+            ^.cls := "ui basic segment running",
+            <.p(step.status.shows)
+          ),
+          loggedIn ?= <.div(
+            ^.cls := "ui basic segment right aligned running",
             <.div(
-              ^.cls := "ui basic segment running",
-              <.p(step.status.shows)
-            ),
-            p.status.isLogged ?= <.div(
-              ^.cls := "ui basic segment right aligned running",
-              <.div(
-                ^.cls := "ui icon buttons",
-                observationControlButtons(p.s)
-              )
+              ^.cls := "ui icon buttons",
+              observationControlButtons(sequenceView, step)
             )
           )
-        case _                => <.p(step.status.shows)
+        )
+
+
+    def stepDisplay(p: Props, step: Step): ReactNode =
+      step.status match {
+        case StepState.Running | StepState.Paused => controlButtons(p.status.isLogged, p.s, step)
+        case _                                    => <.p(step.status.shows)
       }
 
     def stepsTable(p: Props): TagMod =

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -154,7 +154,7 @@ object SequenceStepsTableContainer {
       }
     }
 
-    def stepDisplay(sequenceView: SequenceView, step: Step): ReactNode =
+    def stepDisplay(p: Props, step: Step): ReactNode =
       step.status match {
         case StepState.Running =>
           <.div(
@@ -163,11 +163,11 @@ object SequenceStepsTableContainer {
               ^.cls := "ui basic segment running",
               <.p(step.status.shows)
             ),
-            <.div(
+            p.status.isLogged ?= <.div(
               ^.cls := "ui basic segment right aligned running",
               <.div(
                 ^.cls := "ui icon buttons",
-                observationControlButtons(sequenceView)
+                observationControlButtons(p.s)
               )
             )
           )
@@ -228,7 +228,7 @@ object SequenceStepsTableContainer {
                 <.td(i + 1),
                 <.td(
                   ^.cls := "middle aligned",
-                  stepDisplay(p.s, step)),
+                  stepDisplay(p, step)),
                 <.td(
                   ^.cls := "middle aligned",
                   stepProgress(step)),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -141,7 +141,20 @@ object SequenceStepsTableContainer {
           step.file.getOrElse(""): String
       }
 
-    def stepDisplay(step: Step): ReactNode =
+    def observationControlButtons(s: SequenceView): List[ReactNode] = {
+      s.allowedObservationOperations.map {
+        case PauseObservation  =>
+          Button(Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure")))
+        case ResumeObservation =>
+          Button(Button.Props(icon = Some(IconPlay), color = Some("blue"), dataTooltip = Some("Resume the current exposure")))
+        case StopObservation   =>
+          Button(Button.Props(icon = Some(IconStop), color = Some("orange"), dataTooltip = Some("Stop the current exposure early")))
+        case AbortObservation  =>
+          Button(Button.Props(icon = Some(IconTrash), color = Some("red"), dataTooltip = Some("Abort the current exposure")))
+      }
+    }
+
+    def stepDisplay(sequenceView: SequenceView, step: Step): ReactNode =
       step.status match {
         case StepState.Running =>
           <.div(
@@ -154,16 +167,11 @@ object SequenceStepsTableContainer {
               ^.cls := "ui basic segment right aligned running",
               <.div(
                 ^.cls := "ui icon buttons",
-                Button(
-                  Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure"))),
-                Button(
-                  Button.Props(icon = Some(IconStop), color = Some("orange"), dataTooltip = Some("Stop the current exposure early"))),
-                Button(
-                  Button.Props(icon = Some(IconTrash), color = Some("red"), dataTooltip = Some("Abort the current exposure")))
+                observationControlButtons(sequenceView)
               )
             )
           )
-        case _ => <.p(step.status.shows)
+        case _                => <.p(step.status.shows)
       }
 
     def stepsTable(p: Props): TagMod =
@@ -220,7 +228,7 @@ object SequenceStepsTableContainer {
                 <.td(i + 1),
                 <.td(
                   ^.cls := "middle aligned",
-                  stepDisplay(step)),
+                  stepDisplay(p.s, step)),
                 <.td(
                   ^.cls := "middle aligned",
                   stepProgress(step)),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -155,11 +155,11 @@ object SequenceStepsTableContainer {
               <.div(
                 ^.cls := "ui icon buttons",
                 Button(
-                  Button.Props(icon = Some(IconPause), color = Some("teal"))),
+                  Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure"))),
                 Button(
-                  Button.Props(icon = Some(IconStop), color = Some("orange"))),
+                  Button.Props(icon = Some(IconStop), color = Some("orange"), dataTooltip = Some("Stop the current exposure early"))),
                 Button(
-                  Button.Props(icon = Some(IconTrash), color = Some("red")))
+                  Button.Props(icon = Some(IconTrash), color = Some("red"), dataTooltip = Some("Abort the current exposure")))
               )
             )
           )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -143,14 +143,23 @@ object SequenceStepsTableContainer {
 
     def observationControlButtons(s: SequenceView): List[ReactNode] = {
       s.allowedObservationOperations.map {
-        case PauseObservation  =>
+        case PauseObservation            =>
           Button(Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure")))
-        case ResumeObservation =>
-          Button(Button.Props(icon = Some(IconPlay), color = Some("blue"), dataTooltip = Some("Resume the current exposure")))
-        case StopObservation   =>
+        case StopObservation             =>
           Button(Button.Props(icon = Some(IconStop), color = Some("orange"), dataTooltip = Some("Stop the current exposure early")))
-        case AbortObservation  =>
+        case AbortObservation            =>
           Button(Button.Props(icon = Some(IconTrash), color = Some("red"), dataTooltip = Some("Abort the current exposure")))
+        case ResumeObservation           =>
+          Button(Button.Props(icon = Some(IconPlay), color = Some("blue"), dataTooltip = Some("Resume the current exposure")))
+        // Hamamatsu operations
+        case PauseImmediatelyObservation =>
+          Button(Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure immediately")))
+        case PauseGracefullyObservation  =>
+          Button(Button.Props(icon = Some(IconPause), color = Some("teal"), basic = true, dataTooltip = Some("Pause the current exposure gracefully")))
+        case StopImmediatelyObservation  =>
+          Button(Button.Props(icon = Some(IconStop), color = Some("orange"), dataTooltip = Some("Stop the current exposure immediately")))
+        case StopGracefullyObservation   =>
+          Button(Button.Props(icon = Some(IconStop), color = Some("orange"), basic = true, dataTooltip = Some("Stop the current exposure gracefully")))
       }
     }
 
@@ -188,11 +197,11 @@ object SequenceStepsTableContainer {
               "Step"
             ),
             <.th(
-              ^.cls := "six wide",
+              ^.cls := "eight wide",
               "State"
             ),
             <.th(
-              ^.cls := "ten wide",
+              ^.cls := "eight wide",
               "File"
             ),
             <.th(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/button/Button.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/button/Button.scala
@@ -27,21 +27,22 @@ object Button {
   case object ResetType extends Type
   case object SubmitType extends Type
 
-  case class Props(state: ButtonState    = Inactive,
-                   emphasis: Emphasis    = NoEmphasis,
-                   animated: Animated    = NotAnimated,
-                   icon: Option[Icon]    = None,
-                   size: Size            = Size.NotSized,
-                   buttonType: Type      = ButtonType,
-                   form: Option[String]  = None,
-                   basic: Boolean        = false,
-                   inverted: Boolean     = false,
-                   circular: Boolean     = false,
-                   labeled: Boolean      = false,
-                   disabled: Boolean     = false,
-                   tabIndex: Option[Int] = None,
-                   color: Option[String] = None,
-                   onClick: Callback     = Callback.empty)
+  case class Props(state      : ButtonState    = Inactive,
+                   emphasis   : Emphasis       = NoEmphasis,
+                   animated   : Animated       = NotAnimated,
+                   icon       : Option[Icon]   = None,
+                   size       : Size           = Size.NotSized,
+                   buttonType : Type           = ButtonType,
+                   form       : Option[String] = None,
+                   basic      : Boolean        = false,
+                   inverted   : Boolean        = false,
+                   circular   : Boolean        = false,
+                   labeled    : Boolean        = false,
+                   disabled   : Boolean        = false,
+                   tabIndex   : Option[Int]    = None,
+                   color      : Option[String] = None,
+                   onClick    : Callback       = Callback.empty,
+                   dataTooltip: Option[String] = None)
 
   def classSet(p: Props) =
     ^.classSet(
@@ -78,6 +79,7 @@ object Button {
           }),
           p.form.map(f => formId := f),
           p.color.map(u => ^.cls := u),
+          p.dataTooltip.map(t => dataTooltip := t),
           classSet(p),
           ^.onClick --> p.onClick,
           p.icon,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/button/Button.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/button/Button.scala
@@ -5,6 +5,7 @@ import edu.gemini.seqexec.web.client.semanticui._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.prefix_<^._
+import scalacss.ScalaCssReact._
 
 object Button {
   sealed trait ButtonState
@@ -27,22 +28,23 @@ object Button {
   case object ResetType extends Type
   case object SubmitType extends Type
 
-  case class Props(state      : ButtonState    = Inactive,
-                   emphasis   : Emphasis       = NoEmphasis,
-                   animated   : Animated       = NotAnimated,
-                   icon       : Option[Icon]   = None,
-                   size       : Size           = Size.NotSized,
-                   buttonType : Type           = ButtonType,
-                   form       : Option[String] = None,
-                   basic      : Boolean        = false,
-                   inverted   : Boolean        = false,
-                   circular   : Boolean        = false,
-                   labeled    : Boolean        = false,
-                   disabled   : Boolean        = false,
-                   tabIndex   : Option[Int]    = None,
-                   color      : Option[String] = None,
-                   onClick    : Callback       = Callback.empty,
-                   dataTooltip: Option[String] = None)
+  case class Props(state      : ButtonState                    = Inactive,
+                   emphasis   : Emphasis                       = NoEmphasis,
+                   animated   : Animated                       = NotAnimated,
+                   icon       : Option[Icon]                   = None,
+                   size       : Size                           = Size.NotSized,
+                   buttonType : Type                           = ButtonType,
+                   form       : Option[String]                 = None,
+                   basic      : Boolean                        = false,
+                   inverted   : Boolean                        = false,
+                   circular   : Boolean                        = false,
+                   labeled    : Boolean                        = false,
+                   disabled   : Boolean                        = false,
+                   tabIndex   : Option[Int]                    = None,
+                   color      : Option[String]                 = None,
+                   onClick    : Callback                       = Callback.empty,
+                   dataTooltip: Option[String]                 = None,
+                   extraStyles: List[scalacss.internal.StyleA] = Nil)
 
   def classSet(p: Props) =
     ^.classSet(
@@ -72,6 +74,7 @@ object Button {
       if (p.animated == NotAnimated)
         <.button(
           ^.cls := "ui button",
+          p.extraStyles.map(styleaToTagMod),
           ^.`type` := (p.buttonType match {
             case ButtonType => "button"
             case SubmitType => "submit"

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/package.scala
@@ -4,7 +4,8 @@ import japgolly.scalajs.react.vdom.prefix_<^._
 
 package object semanticui {
   // Custom attributes used by SemanticUI
-  val dataTab = "data-tab".reactAttr
-  val formId = "form".reactAttr
+  val dataTab     = "data-tab".reactAttr
+  val dataTooltip = "data-tooltip".reactAttr
+  val formId      = "form".reactAttr
 
 }


### PR DESCRIPTION
This is a small change to the observation control buttons adding tooltips and making them instrument and state dependent

Here's a screenshot

![screenshot 2017-01-09 10 03 44](https://cloud.githubusercontent.com/assets/3615303/21770866/f1a7f6a2-d663-11e6-8b79-a3eaa83657f2.png)
