### PR TITLE
SEQNG-97: Add and update observe control buttons based on existing seqexec 

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -114,8 +114,10 @@ object Model {
       metadata.instrument match {
         // Note the F2 doesn't suppor these operations but we'll simulate them
         // for demonstration purposes
-        case "Flamingos2" if status == SequenceState.Running => List(PauseImmediatelyObservation, PauseGracefullyObservation, StopImmediatelyObservation, StopGracefullyObservation)
-        case "Flamingos2" if stepStatus == StepState.Paused  => List(ResumeObservation)
+        //case "Flamingos2" if status == SequenceState.Running => List(PauseImmediatelyObservation, PauseGracefullyObservation, StopImmediatelyObservation, StopGracefullyObservation, AbortObservation)
+        // Regular instrument that support pause/stop/abort
+        case "Flamingos2" if status == SequenceState.Running => List(PauseObservation, StopObservation, AbortObservation)
+        case "Flamingos2" if stepStatus == StepState.Paused  => List(ResumeObservation, StopObservation, AbortObservation)
         case _                                               => Nil
       }
 


### PR DESCRIPTION
Updated according to the latest comments from @andrewwstephens 

Added abort button for Nod&Shuffle mode:

![screenshot 2017-01-11 09 43 44](https://cloud.githubusercontent.com/assets/3615303/21849143/10006bb8-d7e3-11e6-8ff3-9953b057b403.png)

Added stop/abort buttons in pause mode

![screenshot 2017-01-11 09 44 00](https://cloud.githubusercontent.com/assets/3615303/21849151/19c502da-d7e3-11e6-950e-d0d57aa4e9d8.png)
