### PR TITLE
SEQNG-99: Add missing buttons for sequence control

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -88,6 +88,7 @@ object Model {
     case object Completed         extends SequenceState
     case object Running           extends SequenceState
     case object Idle              extends SequenceState
+    case object Paused            extends SequenceState
     case class Error(msg: String) extends SequenceState
 
     implicit val equal: Equal[SequenceState] = Equal.equalA[SequenceState]

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -45,14 +45,22 @@ object Model {
 
   implicit val equal: Equal[SequenceId] = Equal.equalA[SequenceId]
 
-  sealed trait StepState
+  sealed trait StepState {
+    def canRunFrom: Boolean = false
+  }
   object StepState {
-    case object Pending extends StepState
+    case object Pending extends StepState {
+      override val canRunFrom = true
+    }
     case object Completed extends StepState
     case object Skipped extends StepState
-    case class Error(msg: String) extends StepState
+    case class Error(msg: String) extends StepState {
+      override val canRunFrom = true
+    }
     case object Running extends StepState
-    case object Paused extends StepState
+    case object Paused extends StepState {
+      override val canRunFrom = true
+    }
 
     implicit val equal: Equal[StepState] = Equal.equalA[StepState]
   }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -127,6 +127,13 @@ object Model {
      * TODO Convert to an Instrument-level typeclass
      */
     def allowedSequenceOperations: List[SequenceOperations] = Nil
+
+    def nextStepToRun: Option[Int] =
+      steps match {
+        case x if x.forall(_.status == StepState.Pending)   => Some(0) // No steps have been executed, start at 0
+        case x if x.forall(_.status == StepState.Completed) => None // All steps have been executed
+        case x                                              => Option(x.indexWhere((s: Step) => s.status != StepState.Completed)).filter(_ != -1)
+      }
   }
 
   /**

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -142,6 +142,8 @@ object Model {
         case x if x.forall(_.status == StepState.Completed) => None // All steps have been executed
         case x                                              => Option(x.indexWhere((s: Step) => s.status != StepState.Completed)).filter(_ != -1)
       }
+
+    def isPartiallyExecuted: Boolean = steps.exists(_.status == StepState.Completed)
   }
 
   /**

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -140,6 +140,7 @@ object Model {
       steps match {
         case x if x.forall(_.status == StepState.Pending)   => Some(0) // No steps have been executed, start at 0
         case x if x.forall(_.status == StepState.Completed) => None // All steps have been executed
+        case x if x.exists(_.status == StepState.Paused)    => Option(x.indexWhere((s: Step) => s.status != StepState.Completed)).filter(_ != -1).map(_ + 1)
         case x                                              => Option(x.indexWhere((s: Step) => s.status != StepState.Completed)).filter(_ != -1)
       }
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -17,6 +17,7 @@ trait ModelBooPicklers {
     .addConcreteType[SequenceState.Completed.type]
     .addConcreteType[SequenceState.Running.type]
     .addConcreteType[SequenceState.Error]
+    .addConcreteType[SequenceState.Paused.type]
     .addConcreteType[SequenceState.Idle.type]
 
   implicit val actionStatusPickler = compositePickler[ActionStatus]

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -373,6 +373,8 @@ object SequenceStepsTableContainer {
       }
       // Run both callbacks, to update the runRequested state and the scroll position
       runStateCB *> scrollStateCB *> nextStepToRunCB
+    }.componentWillMount { f =>
+      f.modState(_.copy(nextStepToRun = f.props.s.nextStepToRun.getOrElse(0)))
     }.componentWillUpdate { f =>
       // Called before the DOM is rendered on the updated props. This is the chance
       // to update the scroll position if needed

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -233,7 +233,6 @@ object SequenceStepsTableContainer {
           p.s.steps.zipWithIndex.map {
             case (step, i) =>
               <.tr(
-                ^.onClick --> selectRow(step, i),
                 // Available row states: http://semantic-ui.com/collections/table.html#positive--negative
                 ^.classSet(
                   "positive" -> (step.status === StepState.Completed),
@@ -245,6 +244,7 @@ object SequenceStepsTableContainer {
                 ),
                 step.status == StepState.Running ?= SeqexecStyles.stepRunning,
                 <.td(
+                  ^.onDoubleClick --> selectRow(step, i),
                   step.status match {
                     case StepState.Completed       => IconCheckmark
                     case StepState.Running         => IconCircleNotched.copyIcon(loading = true)
@@ -254,11 +254,15 @@ object SequenceStepsTableContainer {
                     case _                         => iconEmpty
                   }
                 ),
-                <.td(i + 1),
                 <.td(
+                  ^.onDoubleClick --> selectRow(step, i),
+                  i + 1),
+                <.td(
+                  ^.onDoubleClick --> selectRow(step, i),
                   ^.cls := "middle aligned",
                   stepDisplay(p, step)),
                 <.td(
+                  ^.onDoubleClick --> selectRow(step, i),
                   ^.cls := "middle aligned",
                   stepProgress(step)),
                 <.td(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -198,7 +198,7 @@ object SequenceStepsTableContainer {
       }
 
     def selectRow(step: Step, index: Int): Callback =
-      $.modState(_.copy(nextStepToRun = index))
+      Callback.when(step.status.canRunFrom)($.modState(_.copy(nextStepToRun = index)))
 
     def stepsTable(p: Props, s: State): TagMod =
       <.table(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -75,6 +75,26 @@ object SequenceStepsTableContainer {
               color = Some("teal"),
               disabled = !p.status.isConnected || s.pauseRequested),
             "Pause"
+          ),
+        p.status.isLogged && p.s.status === SequenceState.Paused ?=
+          Button(
+            Button.Props(
+              icon = Some(IconPause),
+              labeled = true,
+              onClick = requestPause(p.s),
+              color = Some("teal"),
+              disabled = !p.status.isConnected),
+            "Continue"
+          ),
+        p.status.isLogged && p.s.status === SequenceState.Running ?=
+          Button(
+            Button.Props(
+              icon = Some(IconPause),
+              labeled = true,
+              onClick = requestPause(p.s),
+              color = Some("orange"),
+              disabled = !p.status.isConnected),
+            "Stop"
           )
       )
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -63,6 +63,7 @@ object SequenceStepsTableContainer {
               labeled = true,
               onClick = requestRun(p.s),
               color = Some("blue"),
+              dataTooltip = Some("Run the sequence from the first unexecuted step"),
               disabled = !p.status.isConnected || s.runRequested),
             "Run"
           ),
@@ -73,6 +74,7 @@ object SequenceStepsTableContainer {
               labeled = true,
               onClick = requestPause(p.s),
               color = Some("teal"),
+              dataTooltip = Some("Pause the sequence after the current step completes"),
               disabled = !p.status.isConnected || s.pauseRequested),
             "Pause"
           ),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -307,6 +307,10 @@ object SequenceStepsTableContainer {
       val runStateCB =
         Callback.when(f.nextProps.s.status === SequenceState.Running && f.$.state.runRequested)(f.$.modState(_.copy(runRequested = false)))
 
+      // Override the manually selected step to run if the state changes
+      val nextStepToRunCB =
+        Callback.when(f.nextProps.s.status != f.currentProps.s.status)(f.$.modState(_.copy(nextStepToRun = f.nextProps.s.nextStepToRun.getOrElse(0))))
+
       // Called when the props have changed. At this time we can recalculate
       // if the scroll position needs to be updated and store it in the State
       val div = scrollRef(f.$)
@@ -363,7 +367,7 @@ object SequenceStepsTableContainer {
         }
       }
       // Run both callbacks, to update the runRequested state and the scroll position
-      runStateCB *> scrollStateCB
+      runStateCB *> scrollStateCB *> nextStepToRunCB
     }.componentWillUpdate { f =>
       // Called before the DOM is rendered on the updated props. This is the chance
       // to update the scroll position if needed

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -20,6 +20,7 @@ import scala.annotation.tailrec
 import scalacss.ScalaCssReact._
 import scalaz.syntax.show._
 import scalaz.syntax.equal._
+import scalaz.syntax.std.boolean._
 import org.scalajs.dom.raw.{Element, HTMLElement, Node}
 import org.scalajs.dom.document
 
@@ -62,9 +63,9 @@ object SequenceStepsTableContainer {
               labeled = true,
               onClick = requestRun(p.s),
               color = Some("blue"),
-              dataTooltip = Some(s"Run the sequence from the step ${s.nextStepToRun + 1}"),
+              dataTooltip = Some(s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} the sequence from the step ${s.nextStepToRun + 1}"),
               disabled = !p.status.isConnected || s.runRequested),
-            s"Run from step ${s.nextStepToRun + 1}"
+            s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} from step ${s.nextStepToRun + 1}"
           ),
         p.status.isLogged && p.s.status === SequenceState.Running ?=
           Button(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
@@ -12,6 +12,7 @@ object ModelOps {
     case SequenceState.Completed => "Complete"
     case SequenceState.Running   => "Running"
     case SequenceState.Idle      => "Idle"
+    case SequenceState.Paused    => "Paused"
     case SequenceState.Error(e)  => s"Error $e"
   }
 


### PR DESCRIPTION
This PR is another mockup of the UI updating the sequence control buttons. After some discussions this has been distilled to 2 buttons: `Run sequence from step N` and `Pause`

At the beginning we should start from step 1

![screenshot 2017-01-11 17 40 41](https://cloud.githubusercontent.com/assets/3615303/21865549/512ea716-d825-11e6-829c-20900796afd1.png)

However the user can select starting from a later step clicking the correct row:

![screenshot 2017-01-11 17 40 47](https://cloud.githubusercontent.com/assets/3615303/21865559/60c565d4-d825-11e6-8572-b6d824763072.png)

Once we run only Pause is visible

![screenshot 2017-01-11 09 43 44](https://cloud.githubusercontent.com/assets/3615303/21865572/746b3a00-d825-11e6-8998-ebbb81375b48.png)

And if we pause we return to the `Run from step N` where N is the next step to be executed and it can be again overriden manually:

![screenshot 2017-01-11 17 39 53](https://cloud.githubusercontent.com/assets/3615303/21865585/8db1e090-d825-11e6-9516-43ba008ea3ad.png)

