### PR TITLE
Preparation for release

### DIFF
--- a/app/seqexec-server-test-l64/src/main/resources/app.conf
+++ b/app/seqexec-server-test-l64/src/main/resources/app.conf
@@ -14,5 +14,5 @@ authentication {
 # Configuration of the seqexec engine
 seqexec-engine {
     # host for the test odb
-    odb = "gsodbtest2.gemini.edu"
+    odb = "gsodb.gemini.edu"
 }


### PR DESCRIPTION
This is a small change to make the test seqexec connect to the production odb

Note that this won't write to the ODB, only read programs to make it easier for our users

Do you think they should use the test ODB/OT?