### PR TITLE
Fixed bug that made the sequence appear as running in the clients after it was paused.

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -28,6 +28,9 @@ object Model {
 
     case class SequenceRefreshed(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
+    //Generic update. It will probably become useless if we have a special Event for every case.
+    case class SequenceUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+
     // TODO: msg should be LogMsg bit it does IO when getting a timestamp, it
     // has to be embedded in a `Task`
     case class NewLogMessage(msg: String) extends SeqexecEvent

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -52,6 +52,7 @@ trait ModelBooPicklers {
     .addConcreteType[StepBreakpointChanged]
     .addConcreteType[StepSkipMarkChanged]
     .addConcreteType[SequencePauseRequested]
+    .addConcreteType[SequenceUpdated]
     .addConcreteType[SequenceRefreshed]
     .addConcreteType[NewLogMessage]
 


### PR DESCRIPTION
The problem was that the sequence was being stopped but when that happened, the event sent to the clients was a NewLogMessage, without the new state of the sequence. I created a new type of event, a generic update, to send the new state to the clients.