### PR TITLE
Feature/result-error

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -23,7 +23,7 @@ case object Exit extends UserEvent
   */
 sealed trait SystemEvent
 case class Completed(id: Sequence.Id, i: Int, r: Result.Response) extends SystemEvent
-case class Failed[E](id: Sequence.Id, i: Int, e: E) extends SystemEvent
+case class Failed(id: Sequence.Id, i: Int, e: String) extends SystemEvent
 case class Executed(id: Sequence.Id) extends SystemEvent
 case class Executing(id: Sequence.Id) extends SystemEvent
 case class Next(id: Sequence.Id) extends SystemEvent
@@ -39,7 +39,7 @@ object Event {
   def breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean): Event =
     EventUser(Breakpoint(id, step, v))
 
-  def failed[E](id: Sequence.Id, i: Int, e: E): Event = EventSystem(Failed(id, i, e))
+  def failed(id: Sequence.Id, i: Int, e: String): Event = EventSystem(Failed(id, i, e))
   def completed(id: Sequence.Id, i: Int, r: Result.Response): Event = EventSystem(Completed(id, i, r))
   def executed(id: Sequence.Id): Event = EventSystem(Executed(id))
   def executing(id: Sequence.Id): Event = EventSystem(Executing(id))

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
@@ -74,12 +74,16 @@ object Execution {
 /**
   * The result of an `Action`.
   */
-sealed trait Result
+sealed trait Result {
+  val errMsg: Option[String] = None
+}
 
 object Result {
   case class OK(response: Response) extends Result
   // TODO: Replace the message by a richer Error type like `SeqexecFailure`
-  case class Error(msg: String) extends Result
+  case class Error(msg: String) extends Result {
+    override val errMsg: Option[String] = Some(msg)
+  }
 
   sealed trait Response
   case class Configured(r: String) extends Response

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
@@ -78,9 +78,11 @@ sealed trait Result
 
 object Result {
   case class OK(response: Response) extends Result
-  case class Error[E](e: E) extends Result
+  // TODO: Replace the message by a richer Error type like `SeqexecFailure`
+  case class Error(msg: String) extends Result
 
   sealed trait Response
   case class Configured(r: String) extends Response
   case class Observed(fileId: FileId) extends Response
+
 }

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -154,7 +154,7 @@ package object engine {
     * `State`. In the future this function should handle the failed
     * action.
     */
-  def fail[E](q: EventQueue)(id: Sequence.Id)(i: Int, e: E): Handle[Unit] =
+  def fail(q: EventQueue)(id: Sequence.Id)(i: Int, e: String): Handle[Unit] =
     modifyS(id)(_.mark(i)(Result.Error(e))) *>
       switch(q)(id)(SequenceState.Error("There was an error"))
 

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/ExecutionSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/ExecutionSpec.scala
@@ -9,7 +9,7 @@ class ExecuctionSpec extends FlatSpec with Matchers {
 
   val ok: Result = Result.OK(Result.Observed("dummyId"))
   val action: Action = Task(ok)
-  val curr : Execution = Execution(List(ok.right, action.left))
+  val curr: Execution = Execution(List(ok.right, action.left))
 
   "currentify" should "be None only when an Execution is empty" in {
     assert(Execution.currentify(List(action, action)).nonEmpty)
@@ -22,11 +22,11 @@ class ExecuctionSpec extends FlatSpec with Matchers {
   }
 
   "marking an index out of bounds" should "not modify the execution" in {
-    assert(curr.mark(3)(Result.Error(Unit)) === curr)
+    assert(curr.mark(3)(Result.Error("")) === curr)
   }
 
   "marking an index inbound" should "modify the execution" in {
-    assert(curr.mark(1)(Result.Error(Unit)) !== curr)
+    assert(curr.mark(1)(Result.Error("")) !== curr)
   }
 
 }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -215,7 +215,10 @@ class StepSpec extends FlatSpec {
   }
 
   "status" should "be Error when empty" in {
-    assert(Step.status(stepz0.toStep) === StepState.Error("An action errored"))
+    assert(Step.status(stepz0.toStep) === StepState.Error(
+             "This should never happen, please submit a bug report"
+           )
+    )
   }
 
   "status" should "be Error when at least one Action failed" in {
@@ -231,7 +234,7 @@ class StepSpec extends FlatSpec {
           Nil,
           (Execution(List(action.left, action.left, action.left)), Nil)
         ).toStep
-      ) === StepState.Error("An action errored")
+      ) === StepState.Error("Dummy error")
     )
   }
 

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -160,7 +160,7 @@ class StepSpec extends FlatSpec {
   }
 
   val result = Result.OK(Result.Observed("dummyId"))
-  val failure = Result.Error(Unit)
+  val failure = Result.Error("Dummy error")
   val action: Action = Task(result)
   val config: StepConfig = Map()
   def simpleStep(pending: List[Actions], focus: Execution, done: List[Results]): Step.Zipper = {

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -49,7 +49,7 @@ class packageSpec extends FlatSpec {
     _ <- Task(println("System: Start observation"))
     _ <- Task(Thread.sleep(100))
     _ <- Task(println ("System: Complete observation"))
-  } yield Result.Error(Unit)
+  } yield Result.Error("There was an error in this action")
 
   val config: StepConfig = Map()
   val seqId ="TEST-01"

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -28,7 +28,7 @@ object SeqTranslate {
   private val dhsSimulator = DhsClientSim(LocalDate.now)
 
   implicit def toAction(x: SeqAction[Result.Response]): Action = x.run map {
-    case -\/(e) => Result.Error(e)
+    case -\/(e) => Result.Error(SeqexecFailure.explain(e))
     case \/-(r) => Result.OK(r)
   }
 


### PR DESCRIPTION
With this PR an action Error is promoted to the Step status so that it shows up in the UI.

Notice the Error type for the Action has only a `String` parameter representing the error message. This was the simplest option for showing the error message, but we will probably need to do more with the errors than just showing the error message, so in the future that message should probably be replaced by `SeqexecFailure` (or similar) and we'll have to add its own UI component.

I left a TODO in the code for that task and will add a ticket for the task if you are OK with it.

<img width="844" alt="error" src="https://cloud.githubusercontent.com/assets/215438/22429807/9ce5db56-e6ea-11e6-92a7-636fd57cbfb1.png">
.