### PR TITLE
SEQNG-132 Real values for OCS keywords.

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
@@ -1,8 +1,9 @@
 package edu.gemini.seqexec.server
 
 import edu.gemini.seqexec.model.dhs.ObsId
-
-import edu.gemini.seqexec.server.DhsClient._
+import edu.gemini.spModel.obscomp.InstConstants._
+import edu.gemini.spModel.config2.{Config, ItemKey}
+import edu.gemini.spModel.seqcomp.SeqConfigNames._
 
 /**
   * Created by jluhrs on 1/31/17.
@@ -63,6 +64,27 @@ trait ObsKeywordsReader {
   def getObsId: SeqAction[String]
   def getObservatory: SeqAction[String]
   def getTelescope: SeqAction[String]
+}
+
+case class ObsKeywordReaderImpl(config: Config, telescope: String) extends ObsKeywordsReader {
+  override def getObsType: SeqAction[String] = SeqAction(
+    config.getItemValue(new ItemKey(OBSERVE_KEY, OBSERVE_TYPE_PROP)).toString)
+
+  override def getObsClass: SeqAction[String] = SeqAction(
+    config.getItemValue(new ItemKey(OBSERVE_KEY, OBS_CLASS_PROP)).toString)
+
+  override def getGemPrgId: SeqAction[String] = SeqAction(
+    config.getItemValue(new ItemKey(OCS_KEY, PROGRAMID_PROP)).toString)
+
+  override def getObsId: SeqAction[String] = {
+    val v = config.getItemValue(new ItemKey(OCS_KEY, OBSERVATIONID_PROP)).toString.split("-").toList.lastOption.getOrElse("")
+
+    SeqAction(v)
+  }
+
+  override def getObservatory: SeqAction[String] = SeqAction(telescope)
+
+  override def getTelescope: SeqAction[String] = SeqAction(telescope)
 }
 
 object DummyObsKeywordsReader extends ObsKeywordsReader {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -30,6 +30,7 @@ web-server {
 # Configuration of the seqexec engine
 seqexec-engine {
     # host for the odb
+    site = "GS"
     odb = "localhost"
     dhsServer = "http://cpodhsxx:9090/axis2/services/dhs/images"
     dhsSim = true

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
@@ -12,7 +12,6 @@ import edu.gemini.seqexec.model.Model.SeqexecEvent.ConnectionOpenEvent
 import edu.gemini.seqexec.model.{ModelBooPicklers, UserDetails, UserLoginRequest}
 import edu.gemini.seqexec.server.SeqexecEngine
 import edu.gemini.seqexec.server.SeqexecEngine.Settings
-
 import org.http4s._
 import org.http4s.headers.`Set-Cookie`
 import org.http4s.util.CaseInsensitiveStringSyntax
@@ -20,6 +19,7 @@ import org.http4s.websocket.WebsocketBits
 import scodec.bits.ByteVector
 import squants.time._
 import boopickle.Default._
+import edu.gemini.model.p1.immutable.Site
 
 import scalaz.stream.Process.emit
 import scalaz.stream.Process
@@ -27,12 +27,11 @@ import scalaz.stream.async
 import scalaz.OptionT
 import scalaz.concurrent.Task
 import scalaz.stream.async.mutable.{Queue, Topic}
-
 import org.scalatest.{FlatSpec, Matchers}
 
 class SeqexecUIApiRoutesSpec extends FlatSpec with Matchers with UriFunctions with ModelBooPicklers with CaseInsensitiveStringSyntax {
   val config = AuthenticationConfig(devMode = true, Hours(8), "token", "abc", useSSL = false, LDAPConfig(Nil))
-  val engine = SeqexecEngine(Settings("", LocalDate.now(), "", dhsSim = true, tcsSim = true, instSim = true, gcalSim = true, instForceError = false))
+  val engine = SeqexecEngine(Settings(Site.GS, "", LocalDate.now(), "", dhsSim = true, tcsSim = true, instSim = true, gcalSim = true, instForceError = false))
   val authService = AuthenticationService(config)
   val inq: Queue[Event] = async.boundedQueue[Event](10)
   val out: Topic[SeqexecEvent] = async.topic[SeqexecEvent]()


### PR DESCRIPTION
Still missing the observer/operator names, and the current observing conditions. Those features will require a bit more work, so I'll put them in separate tasks. The main complication is that most of the OCS keywords are set when the sequence is loaded, but the observer/operator names and the current observing conditions are set when the sequence is run. I would need a mechanism to inject those values in the already constructed Actions. Maybe just rebuild the whole sequence?