### PR TITLE
SEQNG-134 Implemented Flamingos-2 keywords.

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
@@ -94,6 +94,11 @@ final class Flamingos2Epics(epicsService: CaService) {
 
   def windowCover: Option[String] = Option(f2State.getStringAttribute("windowCover").value)
 
+  // For FITS keywords
+  def health: Option[String] = Option(f2State.getStringAttribute("INHEALTH").value)
+
+  def state: Option[String] = Option(f2State.getStringAttribute("INSTATE").value)
+
 }
 
 object Flamingos2Epics extends EpicsSystem {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Header.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Header.scala
@@ -1,0 +1,80 @@
+package edu.gemini.seqexec.server
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+import edu.gemini.seqexec.model.dhs.ObsId
+import edu.gemini.seqexec.server.ConfigUtilOps._
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.{MOS_PREIMAGING_PROP, READMODE_PROP, ReadMode}
+import edu.gemini.spModel.config2.Config
+import edu.gemini.spModel.data.YesNoType
+import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+
+import scalaz.EitherT
+import scalaz.concurrent.Task
+
+/**
+  * Created by jluhrs on 2/10/17.
+  */
+
+class Flamingos2Header(hs: DhsClient, f2ObsReader: Flamingos2Header.ObsKeywordsReader, f2Reader: Flamingos2Header.InstKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) extends Header {
+  import Header._
+  override def sendBefore(id: ObsId, inst: String): SeqAction[Unit] =  {
+
+    sendKeywords(id, inst, hs, List(
+      buildString(f2ObsReader.getReadMode.map{
+        case ReadMode.BRIGHT_OBJECT_SPEC => "Bright"
+        case ReadMode.MEDIUM_OBJECT_SPEC => "Medium"
+        case ReadMode.FAINT_OBJECT_SPEC  => "Dark"
+      }, "READMODE"),
+      buildInt32(f2ObsReader.getReadMode.map{
+        case ReadMode.BRIGHT_OBJECT_SPEC => 1
+        case ReadMode.MEDIUM_OBJECT_SPEC => 4
+        case ReadMode.FAINT_OBJECT_SPEC  => 8
+      }, "NREADS"),
+      buildBoolean(f2ObsReader.getPreimage.map(_.toBoolean), "PREIMAGE"),
+      buildString(SeqAction(LocalDate.now.format(DateTimeFormatter.ISO_LOCAL_DATE)), "DATE-OBS"),
+      buildString(tcsKeywordsReader.getUT, "TIME-OBS")
+    ))
+  }
+
+  override def sendAfter(id: ObsId, inst: String): SeqAction[Unit] = SeqAction(())
+}
+
+object Flamingos2Header {
+
+  def apply(hs: DhsClient, f2ObsReader: ObsKeywordsReader, f2Reader: InstKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) = new Flamingos2Header(hs, f2ObsReader, f2Reader, tcsKeywordsReader)
+
+  trait ObsKeywordsReader {
+    def getPreimage: SeqAction[YesNoType]
+    def getReadMode: SeqAction[ReadMode]
+  }
+
+  class ObsKeywordsReaderImpl(config: Config) extends ObsKeywordsReader {
+    override def getPreimage: SeqAction[YesNoType] = EitherT(Task.now(config.extract(INSTRUMENT_KEY / MOS_PREIMAGING_PROP)
+      .as[YesNoType].leftMap(SeqexecFailure.Unexpected)))
+
+    override def getReadMode: SeqAction[ReadMode] = EitherT(Task.now(config.extract(INSTRUMENT_KEY / READMODE_PROP)
+      .as[ReadMode].leftMap(SeqexecFailure.Unexpected)))
+  }
+
+  trait InstKeywordsReader {
+    def getHealth: SeqAction[String]
+    def getState: SeqAction[String]
+  }
+
+  object DummyInstKeywordReader extends InstKeywordsReader {
+    override def getHealth: SeqAction[String] = SeqAction("GOOD")
+
+    override def getState: SeqAction[String] = SeqAction("RUNNING")
+  }
+
+  object InstKeywordReaderImpl extends InstKeywordsReader {
+    implicit def fromStringOption(v: Option[String]): SeqAction[String] = SeqAction(v.getOrElse("No Value"))
+
+    override def getHealth: SeqAction[String] = Flamingos2Epics.instance.health
+
+    override def getState: SeqAction[String] = Flamingos2Epics.instance.state
+  }
+
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -40,5 +40,7 @@ seqexec-engine {
     gcalSim = true
     # tcsKeywords = true implies initialization of TCS EPICS. Set to false before commiting to git
     tcsKeywords = false
+    # f2Keywords = true implies initialization of F2 EPICS. Set to false before commiting to git
+    f2Keywords = false
     instForceError = false
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
@@ -31,7 +31,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class SeqexecUIApiRoutesSpec extends FlatSpec with Matchers with UriFunctions with ModelBooPicklers with CaseInsensitiveStringSyntax {
   val config = AuthenticationConfig(devMode = true, Hours(8), "token", "abc", useSSL = false, LDAPConfig(Nil))
-  val engine = SeqexecEngine(Settings(Site.GS, "", LocalDate.now(), "", dhsSim = true, tcsSim = true, instSim = true, gcalSim = true, tcsKeywords = false, instForceError = false))
+  val engine = SeqexecEngine(Settings(Site.GS, "", LocalDate.now(), "", dhsSim = true, tcsSim = true, instSim = true, gcalSim = true, tcsKeywords = false, f2Keywords = false, instForceError = false))
   val authService = AuthenticationService(config)
   val inq: Queue[Event] = async.boundedQueue[Event](10)
   val out: Topic[SeqexecEvent] = async.topic[SeqexecEvent]()


### PR DESCRIPTION
This commit includes all the Flamingos-2 keywords set by Seqexec. There are two keywords in the old Seqexec that are filled with values read from the instrument. I implemented them, only to find that they are not actually sent to the DHS. I left the code in (except for the part that writes the keywords).