### PR TITLE
SEQNG-114 Implemented partial results from Actions.

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -1,5 +1,7 @@
 package edu.gemini.seqexec.engine
 
+import Result.{RetVal, PartialVal, OK, Partial}
+
 /**
   * Anything that can go through the Event Queue.
   */
@@ -22,8 +24,9 @@ case object Exit extends UserEvent
   * Events generated internally by the Engine.
   */
 sealed trait SystemEvent
-case class Completed(id: Sequence.Id, i: Int, r: Result.Response) extends SystemEvent
-case class Failed(id: Sequence.Id, i: Int, e: String) extends SystemEvent
+case class Completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]) extends SystemEvent
+case class PartialResult[R<:PartialVal](id: Sequence.Id, i: Int, r: Partial[R]) extends SystemEvent
+case class Failed(id: Sequence.Id, i: Int, e: Result.Error) extends SystemEvent
 case class Executed(id: Sequence.Id) extends SystemEvent
 case class Executing(id: Sequence.Id) extends SystemEvent
 case class Finished(id: Sequence.Id) extends SystemEvent
@@ -38,8 +41,9 @@ object Event {
   def breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean): Event =
     EventUser(Breakpoint(id, step, v))
 
-  def failed(id: Sequence.Id, i: Int, e: String): Event = EventSystem(Failed(id, i, e))
-  def completed(id: Sequence.Id, i: Int, r: Result.Response): Event = EventSystem(Completed(id, i, r))
+  def failed(id: Sequence.Id, i: Int, e: Result.Error): Event = EventSystem(Failed(id, i, e))
+  def completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]): Event = EventSystem(Completed(id, i, r))
+  def partial[R<:PartialVal](id: Sequence.Id, i: Int, r: Partial[R]): Event = EventSystem(PartialResult(id, i, r))
   def executed(id: Sequence.Id): Event = EventSystem(Executed(id))
   def executing(id: Sequence.Id): Event = EventSystem(Executing(id))
   def finished(id: Sequence.Id): Event = EventSystem(Finished(id))

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -21,9 +21,7 @@ class packageSpec extends FlatSpec {
     *
     */
   val configureTcs: Action  = for {
-    _ <- Task(println("System: Start TCS configuration"))
     _ <- Task(Thread.sleep(200))
-    _ <- Task(println ("System: Complete TCS configuration"))
   } yield Result.OK(Result.Configured("TCS"))
 
   /**
@@ -31,9 +29,7 @@ class packageSpec extends FlatSpec {
     *
     */
   val configureInst: Action  = for {
-    _ <- Task(println("System: Start Instrument configuration"))
     _ <- Task(Thread.sleep(200))
-    _ <- Task(println("System: Complete Instrument configuration"))
   } yield Result.OK(Result.Configured("Instrument"))
 
   /**
@@ -41,15 +37,11 @@ class packageSpec extends FlatSpec {
     *
     */
   val observe: Action  = for {
-    _ <- Task(println("System: Start observation"))
     _ <- Task(Thread.sleep(200))
-    _ <- Task(println ("System: Complete observation"))
 } yield Result.OK(Result.Observed("DummyFileId"))
 
   val faulty: Action  = for {
-    _ <- Task(println("System: Start observation"))
     _ <- Task(Thread.sleep(100))
-    _ <- Task(println ("System: Complete observation"))
   } yield Result.Error("There was an error in this action")
 
   val config: StepConfig = Map()

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -82,8 +82,6 @@ object Model {
     val status: StepState
     val breakpoint: Boolean
     val skip: Boolean
-    val configStatus: Map[SystemName, ActionStatus]
-    val observeStatus: ActionStatus
     val fileId: Option[dhs.ObsId]
   }
 
@@ -93,9 +91,9 @@ object Model {
     override val status: StepState,
     override val breakpoint: Boolean,
     override val skip: Boolean,
-    override val configStatus: Map[SystemName, ActionStatus],
-    override val observeStatus: ActionStatus,
-    override val fileId: Option[dhs.ObsId]
+    override val fileId: Option[dhs.ObsId],
+    configStatus: Map[SystemName, ActionStatus],
+    observeStatus: ActionStatus
   ) extends Step
   // Other kinds of Steps to be defined.
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -86,11 +86,12 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
     }
     case engine.EventSystem(se) => se match {
       // TODO: Sequence completed event not emited by engine.
-      case engine.Completed(_, _, _) => NewLogMessage("Action completed")
-      case engine.Failed(_, _, _)    => NewLogMessage("Action failed")
-      case engine.Executed(_)        => StepExecuted(svs)
-      case engine.Executing(_)       => NewLogMessage("Executing")
-      case engine.Finished(_)        => SequenceCompleted(svs)
+      case engine.Completed(_, _, _)     => NewLogMessage("Action completed")
+      case engine.PartialResult(_, _, _) => SequenceUpdated(svs)
+      case engine.Failed(_, _, _)        => NewLogMessage("Action failed")
+      case engine.Executed(_)            => StepExecuted(svs)
+      case engine.Executing(_)           => NewLogMessage("Executing")
+      case engine.Finished(_)            => SequenceCompleted(svs)
     }
   }
 


### PR DESCRIPTION
The main idea to provide partial results for an Action is to divide the Action in several sub-actions. Each actions ends and gives as a result a value and the next action, except for the last one that only gives the final result. The execution engine treats all of them as the same Action when it comes to the action status, and stores the last partial result in the state.
The partial results don't have an effect in the client, yet.