### PR TITLE
Setters for Operator and Observer names in the server side

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -17,6 +17,8 @@ case class Start(id: Sequence.Id) extends UserEvent
 case class Pause(id: Sequence.Id) extends UserEvent
 case class Load(id: Sequence.Id, sequence: Sequence[Action]) extends UserEvent
 case class Breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean) extends UserEvent
+case class SetOperator(id: Sequence.Id, name: String) extends UserEvent
+case class SetObserver(id: Sequence.Id, name: String) extends UserEvent
 case object Poll extends UserEvent
 case object Exit extends UserEvent
 
@@ -35,11 +37,12 @@ object Event {
 
   def start(id: Sequence.Id): Event = EventUser(Start(id))
   def pause(id: Sequence.Id): Event = EventUser(Pause(id))
+  def load(id: Sequence.Id, sequence: Sequence[Action]): Event = EventUser(Load(id, sequence))
+  def breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean): Event = EventUser(Breakpoint(id, step, v))
+  def setOperator(id: Sequence.Id, name: String): Event = EventUser(SetOperator(id, name))
+  def setObersver(id: Sequence.Id, name: String): Event = EventUser(SetObserver(id, name))
   val poll: Event = EventUser(Poll)
   val exit: Event = EventUser(Exit)
-  def load(id: Sequence.Id, sequence: Sequence[Action]): Event = EventUser(Load(id, sequence))
-  def breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean): Event =
-    EventUser(Breakpoint(id, step, v))
 
   def failed(id: Sequence.Id, i: Int, e: Result.Error): Event = EventSystem(Failed(id, i, e))
   def completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]): Event = EventSystem(Completed(id, i, r))

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -17,7 +17,7 @@ case class Start(id: Sequence.Id) extends UserEvent
 case class Pause(id: Sequence.Id) extends UserEvent
 case class Load(id: Sequence.Id, sequence: Sequence[Action]) extends UserEvent
 case class Breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean) extends UserEvent
-case class SetOperator(id: Sequence.Id, name: String) extends UserEvent
+case class SetOperator(name: String) extends UserEvent
 case class SetObserver(id: Sequence.Id, name: String) extends UserEvent
 case object Poll extends UserEvent
 case object Exit extends UserEvent
@@ -39,8 +39,8 @@ object Event {
   def pause(id: Sequence.Id): Event = EventUser(Pause(id))
   def load(id: Sequence.Id, sequence: Sequence[Action]): Event = EventUser(Load(id, sequence))
   def breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean): Event = EventUser(Breakpoint(id, step, v))
-  def setOperator(id: Sequence.Id, name: String): Event = EventUser(SetOperator(id, name))
-  def setObersver(id: Sequence.Id, name: String): Event = EventUser(SetObserver(id, name))
+  def setOperator(name: String): Event = EventUser(SetOperator(name))
+  def setObserver(id: Sequence.Id, name: String): Event = EventUser(SetObserver(id, name))
   val poll: Event = EventUser(Poll)
   val exit: Event = EventUser(Exit)
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -8,13 +8,17 @@ import Scalaz._
 /**
   * A list of `Step`s grouped by target and instrument.
   */
-case class Sequence[+A](id: Sequence.Id, metadata: SequenceMetadata, steps: List[Step[A]])
+case class Sequence[+A](
+  id: Sequence.Id,
+  metadata: SequenceMetadata,
+  steps: List[Step[A]]
+)
 
 object Sequence {
 
   type Id = String
 
-  def empty[A](id: Id): Sequence[A] = Sequence(id, SequenceMetadata(""), Nil)
+  def empty[A](id: Id): Sequence[A] = Sequence(id, SequenceMetadata("", "", ""), Nil)
 
   implicit val SequenceFunctor = new Functor[Sequence] {
     def map[A, B](fa: Sequence[A])(f: A => B): Sequence[B] =

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -224,21 +224,30 @@ object Sequence {
 
       override def getCurrentBreakpoint: Boolean = zipper.focus.breakpoint && zipper.focus.done.isEmpty
 
-      override def setOperator(name: String): State = ???
+      override def setOperator(name: String): State = operatorL.set(self, Some(name))
 
-      override def setObserver(name: String): State = ???
+      override def setObserver(name: String): State = observerL.set(self, Some(name))
 
       override val done: List[Step[Result]] = zipper.done
 
+      private val zipperL: Zipper @> Sequence.Zipper =
+        Lens.lensu((qs, z) => qs.copy(zipper = z), _.zipper)
+
+      private val metadataL: Zipper @> SequenceMetadata =
+        zipperL >=> Lens.lensu((x, y) => x.copy(metadata = y), _.metadata)
+
+      private val operatorL: Zipper @> Option[String] =
+        metadataL >=> Lens.lensu((x, y) => x.copy(operator = y), _.operator)
+
+      private val observerL: Zipper @> Option[String] =
+        metadataL >=> Lens.lensu((x, y) => x.copy(observer = y), _.observer)
+
       override def mark(i: Int)(r: Result): State = {
 
-        val zipper: Zipper @> Sequence.Zipper =
-          Lens.lensu((qs, z) => qs.copy(zipper = z), _.zipper)
-
-        val currentExecutionL: Zipper @> Execution = zipper >=> Sequence.Zipper.current
+        val currentExecutionL: Zipper @> Execution = zipperL >=> Sequence.Zipper.current
 
         val currentFileIdL: Zipper @> Option[FileId] =
-          zipper >=> Sequence.Zipper.focus >=> Step.Zipper.fileId
+          zipperL >=> Sequence.Zipper.focus >=> Step.Zipper.fileId
 
         val z: Zipper = r match {
             case Result.OK(Result.Observed(fileId)) => currentFileIdL.set(self, fileId.some)
@@ -272,15 +281,27 @@ object Sequence {
 
       override def getCurrentBreakpoint: Boolean = false
 
-      override def setOperator(name: String): State = ???
+      override def setOperator(name: String): State = operatorL.set(self, Some(name))
 
-      override def setObserver(name: String): State = ???
+      override def setObserver(name: String): State = observerL.set(self, Some(name))
 
       override val done: List[Step[Result]] = seq.steps
 
       override def mark(i: Int)(r: Result): State = self
 
       override val toSequence: Sequence[Action \/ Result] = seq.map(_.right)
+
+      private val sequenceL: Final @> Sequence[Result] =
+        Lens.lensu((x, y) => x.copy(seq = y), _.seq)
+
+      private val metadataL: Final @> SequenceMetadata =
+        sequenceL >=> Lens.lensu((x, y) => x.copy(metadata = y), _.metadata)
+
+      private val operatorL: Final @> Option[String] =
+        metadataL >=> Lens.lensu((x, y) => x.copy(operator = y), _.operator)
+
+      private val observerL: Final @> Option[String] =
+        metadataL >=> Lens.lensu((x, y) => x.copy(observer = y), _.observer)
 
     }
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -142,6 +142,10 @@ object Sequence {
 
     def getCurrentBreakpoint: Boolean
 
+    def setObserver(name: String): State
+
+    def setOperator(name: String): State
+
     /**
       * Current Execution
       */
@@ -220,6 +224,10 @@ object Sequence {
 
       override def getCurrentBreakpoint: Boolean = zipper.focus.breakpoint && zipper.focus.done.isEmpty
 
+      override def setOperator(name: String): State = ???
+
+      override def setObserver(name: String): State = ???
+
       override val done: List[Step[Result]] = zipper.done
 
       override def mark(i: Int)(r: Result): State = {
@@ -263,6 +271,10 @@ object Sequence {
       override def setBreakpoint(stepId: Step.Id, v: Boolean): State = self
 
       override def getCurrentBreakpoint: Boolean = false
+
+      override def setOperator(name: String): State = ???
+
+      override def setObserver(name: String): State = ???
 
       override val done: List[Step[Result]] = seq.steps
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -18,7 +18,7 @@ object Sequence {
 
   type Id = String
 
-  def empty[A](id: Id): Sequence[A] = Sequence(id, SequenceMetadata("", "", ""), Nil)
+  def empty[A](id: Id): Sequence[A] = Sequence(id, SequenceMetadata("", None, None), Nil)
 
   implicit val SequenceFunctor = new Functor[Sequence] {
     def map[A, B](fa: Sequence[A])(f: A => B): Sequence[B] =

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -66,8 +66,8 @@ package object engine {
     modifyS(id)(_.rollback)
 
 
-  def setOperator(id: Sequence.Id)(name: String): Handle[Unit] =
-    modifyS(id)(_.setOperator(name))
+  def setOperator(name: String): Handle[Unit] =
+    modify(_.mapValues(_.setOperator(name)))
 
   def setObserver(id: Sequence.Id)(name: String): Handle[Unit] =
     modifyS(id)(_.setObserver(name))
@@ -210,7 +210,7 @@ package object engine {
       case Load(id, seq) => log("Output: Sequence loaded") *> load(id, seq)
       case Breakpoint(id, step, v) => log("Output: breakpoint changed") *>
         modifyS(id)(_.setBreakpoint(step, v))
-      case SetOperator(id, name)   => log("Output: Setting Operator name") *> setOperator(id)(name)
+      case SetOperator(name)       => log("Output: Setting Operator name") *> setOperator(name)
       case SetObserver(id, name)   => log("Output: Setting Observer name") *> setObserver(id)(name)
       case Poll                    => log("Output: Polling current state")
       case Exit                    => log("Bye") *> close(q)

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -45,7 +45,7 @@ package object engine {
   /**
     * Type constructor where all Seqexec side effect are managed.
     *
-    * It's named `Handle` after `fs2.Handle` in order to facilitate a future
+    * It's named `Handle` after `fs2.Handle` in order to give a hint in a future
     * migration.
     */
   type Handle[A] = HandleStateT[Task, A]
@@ -64,6 +64,13 @@ package object engine {
 
   def rollback(q: EventQueue)(id: Sequence.Id): Handle[Unit] =
     modifyS(id)(_.rollback)
+
+
+  def setOperator(id: Sequence.Id)(name: String): Handle[Unit] =
+    modifyS(id)(_.setOperator(name))
+
+  def setObserver(id: Sequence.Id)(name: String): Handle[Unit] =
+    modifyS(id)(_.setObserver(name))
 
   /**
     * Loads a sequence
@@ -203,6 +210,8 @@ package object engine {
       case Load(id, seq) => log("Output: Sequence loaded") *> load(id, seq)
       case Breakpoint(id, step, v) => log("Output: breakpoint changed") *>
         modifyS(id)(_.setBreakpoint(step, v))
+      case SetOperator(id, name)   => log("Output: Setting Operator name") *> setOperator(id)(name)
+      case SetObserver(id, name)   => log("Output: Setting Observer name") *> setObserver(id)(name)
       case Poll                    => log("Output: Polling current state")
       case Exit                    => log("Bye") *> close(q)
     }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -53,7 +53,7 @@ class SequenceSpec extends FlatSpec {
 
   }
 
-  val metadata = SequenceMetadata("F2")
+  val metadata = SequenceMetadata("F2", None, None)
 
   def simpleStep(id: Int, breakpoint: Boolean): Step[Action] = Step(id, None, config, breakpoint,
     List(
@@ -76,7 +76,7 @@ class SequenceSpec extends FlatSpec {
     val qs0: EngineState = Map((seqId, Sequence.State.init(
       Sequence(
         seqId,
-        SequenceMetadata("F2"),
+        SequenceMetadata("F2", None, None),
         List(simpleStep(1, false), simpleStep(2, true))
       )
     )))
@@ -97,7 +97,7 @@ class SequenceSpec extends FlatSpec {
     val qs0: EngineState = Map((seqId, Sequence.State.init(
       Sequence(
         seqId,
-        SequenceMetadata("F2"),
+        SequenceMetadata("F2", None, None),
         List(simpleStep(1, false), simpleStep(2, true), simpleStep(3, false))
       )
     )))

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -88,7 +88,7 @@ class StepSpec extends FlatSpec {
     val qs0: EngineState = Map((seqId, Sequence.State.init(
       Sequence(
         seqId,
-        SequenceMetadata("F2"),
+        SequenceMetadata("F2", None, None),
         List(
           Step(
             1,
@@ -124,7 +124,7 @@ class StepSpec extends FlatSpec {
     val qs0: EngineState = Map((seqId, Sequence.State.Zipper(
       Sequence.Zipper(
         "First",
-        SequenceMetadata("F2"),
+        SequenceMetadata("F2", None, None),
         List(),
         Step.Zipper(
           2,
@@ -180,7 +180,7 @@ class StepSpec extends FlatSpec {
     val qs0: EngineState = Map((seqId, Sequence.State.init(
       Sequence(
         seqId,
-        SequenceMetadata("F2"),
+        SequenceMetadata("F2", None, None),
         List(
           Step(
             1,

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -45,11 +45,11 @@ class packageSpec extends FlatSpec {
   } yield Result.Error("There was an error in this action")
 
   val config: StepConfig = Map()
-  val seqId ="TEST-01"
+  val seqId = "TEST-01"
   val qs1: EngineState = Map((seqId, Sequence.State.init(
     Sequence(
       "First",
-      SequenceMetadata("F2"),
+      SequenceMetadata("F2", None, None),
       List(
         Step(
           1,

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -117,8 +117,8 @@ object Model {
   // TODO Une a proper instrument class
   case class SequenceMetadata(
     instrument: Instrument,
-    operator: Operator,
-    observer: Observer
+    operator: Option[Operator],
+    observer: Option[Observer]
   )
 
   case class SequenceView (

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -46,6 +46,8 @@ object Model {
   type SequenceId = String
   type StepId = Int
   type Instrument = String
+  type Operator = String
+  type Observer = String
 
   implicit val equal: Equal[SequenceId] = Equal.equalA[SequenceId]
 
@@ -113,7 +115,11 @@ object Model {
     * Metadata about the sequence required on the exit point
     */
   // TODO Une a proper instrument class
-  case class SequenceMetadata(instrument: Instrument)
+  case class SequenceMetadata(
+    instrument: Instrument,
+    operator: Operator,
+    observer: Observer
+  )
 
   case class SequenceView (
     id: SequenceId,

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -22,6 +22,10 @@ object Model {
 
     case class StepBreakpointChanged(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
+    case class OperatorUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+
+    case class ObserverUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+
     case class StepSkipMarkChanged(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
     case class SequencePauseRequested(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -104,7 +104,7 @@ class SeqTranslate(site: Site) {
 
     val instName = configs.headOption.map(extractInstrumentName).getOrElse("Unknown instrument")
 
-    steps.map(Sequence[Action](obsId.stringValue(), SequenceMetadata(instName), _))
+    steps.map(Sequence[Action](obsId.stringValue(), SequenceMetadata(instName, "", ""), _))
   }
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -104,7 +104,7 @@ class SeqTranslate(site: Site) {
 
     val instName = configs.headOption.map(extractInstrumentName).getOrElse("Unknown instrument")
 
-    steps.map(Sequence[Action](obsId.stringValue(), SequenceMetadata(instName, "", ""), _))
+    steps.map(Sequence[Action](obsId.stringValue(), SequenceMetadata(instName, None, None), _))
   }
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -52,15 +52,13 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
                     v: Boolean): Task[SeqexecFailure \/ Unit]=
     q.enqueueOne(Event.breakpoint(seqId.stringValue(), stepId, v)).map(_.right)
 
-  def setOperator(q: engine.EventQueue,
-                  seqId: SPObservationID,
-                  name: String): Task[SeqexecFailure \/ Unit] =
-    q.enqueueOne(Event.setOperator(seqId.stringValue(), name)).map(_.right)
+  def setOperator(q: engine.EventQueue, name: String): Task[SeqexecFailure \/ Unit] =
+    q.enqueueOne(Event.setOperator(name)).map(_.right)
 
   def setObserver(q: engine.EventQueue,
                   seqId: SPObservationID,
                   name: String): Task[SeqexecFailure \/ Unit] =
-    q.enqueueOne(Event.setOperator(seqId.stringValue(), name)).map(_.right)
+    q.enqueueOne(Event.setObserver(seqId.stringValue(), name)).map(_.right)
 
   // TODO: Add seqId: SPObservationID as parameter
   def setSkipMark(q: engine.EventQueue, id: SPObservationID, stepId: edu.gemini.seqexec.engine.Step.Id): Task[SeqexecFailure \/ Unit] = ???
@@ -94,7 +92,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.Pause(_)            => SequencePauseRequested(svs)
       case engine.Load(_, _)          => SequenceLoaded(svs)
       case engine.Breakpoint(_, _, _) => StepBreakpointChanged(svs)
-      case engine.SetOperator(_, _)   => OperatorUpdated(svs)
+      case engine.SetOperator(_)      => OperatorUpdated(svs)
       case engine.SetObserver(_, _)   => ObserverUpdated(svs)
       case engine.Poll                => SequenceRefreshed(svs)
       case engine.Exit                => NewLogMessage("Exit requested by user")

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -52,6 +52,16 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
                     v: Boolean): Task[SeqexecFailure \/ Unit]=
     q.enqueueOne(Event.breakpoint(seqId.stringValue(), stepId, v)).map(_.right)
 
+  def setOperator(q: engine.EventQueue,
+                  seqId: SPObservationID,
+                  name: String): Task[SeqexecFailure \/ Unit] =
+    q.enqueueOne(Event.setOperator(seqId.stringValue(), name)).map(_.right)
+
+  def setObserver(q: engine.EventQueue,
+                  seqId: SPObservationID,
+                  name: String): Task[SeqexecFailure \/ Unit] =
+    q.enqueueOne(Event.setOperator(seqId.stringValue(), name)).map(_.right)
+
   // TODO: Add seqId: SPObservationID as parameter
   def setSkipMark(q: engine.EventQueue, id: SPObservationID, stepId: edu.gemini.seqexec.engine.Step.Id): Task[SeqexecFailure \/ Unit] = ???
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -84,6 +84,8 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.Pause(_)            => SequencePauseRequested(svs)
       case engine.Load(_, _)          => SequenceLoaded(svs)
       case engine.Breakpoint(_, _, _) => StepBreakpointChanged(svs)
+      case engine.SetOperator(_, _)   => OperatorUpdated(svs)
+      case engine.SetObserver(_, _)   => ObserverUpdated(svs)
       case engine.Poll                => SequenceRefreshed(svs)
       case engine.Exit                => NewLogMessage("Exit requested by user")
     }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -57,6 +57,26 @@ object SeqexecWebClient extends ModelBooPicklers {
   }
 
   /**
+    * Requests the backend to set the operator name of a sequence
+    */
+  def setOperator(s: SequenceView, name: String): Future[RegularCommand] = {
+    Ajax.post(
+      url = s"$baseUrl/commands/${s.id}/operator/${name}",
+      responseType = "arraybuffer"
+    ).map(unpickle[RegularCommand])
+  }
+
+  /**
+    * Requests the backend to set the observer name of a sequence
+    */
+  def setObserver(s: SequenceView, name: String): Future[RegularCommand] = {
+    Ajax.post(
+      url = s"$baseUrl/commands/${s.id}/observer/${name}",
+      responseType = "arraybuffer"
+    ).map(unpickle[RegularCommand])
+  }
+
+  /**
     * Requests the backend to send a copy of the current state
     */
   def refresh(): Future[RegularCommand] = {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -61,7 +61,7 @@ object SeqexecWebClient extends ModelBooPicklers {
     */
   def setOperator(s: SequenceView, name: String): Future[RegularCommand] = {
     Ajax.post(
-      url = s"$baseUrl/commands/${s.id}/operator/${name}",
+      url = s"$baseUrl/commands/operator/${name}",
       responseType = "arraybuffer"
     ).map(unpickle[RegularCommand])
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -59,14 +59,8 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: engine.Event
 
       } yield resp
 
-    case POST -> Root / obsId / "operator" / name =>
-      for {
-        obs   <-
-          \/.fromTryCatchNonFatal(new SPObservationID(obsId))
-            .fold(e => Task.fail(e), Task.now)
-        _     <- se.setOperator(inputQueue, obs, name)
-        resp  <- Ok(s"Set operator name to $name for sequence $obs")
-      } yield resp
+    case POST -> Root / "operator" / name =>
+      se.setOperator(inputQueue, name) *> Ok(s"Set operator name to $name")
 
     case POST -> Root / obsId / "observer" / name =>
       for {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -56,6 +56,25 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: engine.Event
         newVal <- \/.fromTryCatchNonFatal(bp.toBoolean).fold(e => Task.fail(e), Task.now)
         _      <- se.setBreakpoint(inputQueue, obs, step, newVal)
         resp   <- Ok(s"Set breakpoint in step $step of sequence $obsId")
+
+      } yield resp
+
+    case POST -> Root / obsId / "operator" / name =>
+      for {
+        obs   <-
+          \/.fromTryCatchNonFatal(new SPObservationID(obsId))
+            .fold(e => Task.fail(e), Task.now)
+        _     <- se.setOperator(inputQueue, obs, name)
+        resp  <- Ok(s"Set operator name to $name for sequence $obs")
+      } yield resp
+
+    case POST -> Root / obsId / "observer" / name =>
+      for {
+        obs   <-
+          \/.fromTryCatchNonFatal(new SPObservationID(obsId))
+            .fold(e => Task.fail(e), Task.now)
+        _     <- se.setObserver(inputQueue, obs, name)
+        resp  <- Ok(s"Set observer name to $name for sequence $obs")
       } yield resp
 
     case GET -> Root / "refresh" =>


### PR DESCRIPTION
This is the server part for SEQNG-139. From the client it should be possible to be possible to call the functions wrapping the AJAX requests.

The primary place to store the names is in the Sequence metadata of the engine.

I wasn't sure about the format for the URL routes for the setters, so if you prefer a different scheme I can change it.