### PR TITLE
SEQNG-148 SEQNG-149 Add default keyword values for Operator, Observer and Raw observing conditions

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -35,7 +35,9 @@ class SeqTranslate(site: Site) {
       val sys = List(Tcs(systems.tcs), inst)
       val headers = List(new StandardHeader(systems.dhs,
         ObsKeywordReaderImpl(config, site.name.replace(' ', '-')),
-        if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader
+        if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader,
+        // TODO: Replace Unit by something that can read the State
+        StateKeywordsReader(Unit)
       )) ++ instHeaders
 
       def observe(config: Config): SeqAction[ObserveResult] = {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
@@ -78,7 +78,7 @@ case class ObsKeywordReaderImpl(config: Config, telescope: String) extends ObsKe
       .recoverWith[ConfigUtilOps.ExtractFailure, StandardGuideOptions.Value] {
         case ConfigUtilOps.KeyNotFound(_)         => StandardGuideOptions.Value.park.right
         case e@ConfigUtilOps.ConversionError(_,_) => e.left
-      }.leftMap(e =>SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
+      }.leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
   ))
 
   private val headerPrivacy: Boolean = config.extract(HEADER_VISIBILITY_KEY).as[Visibility].getOrElse(Visibility.PUBLIC) match {
@@ -94,7 +94,7 @@ case class ObsKeywordReaderImpl(config: Config, telescope: String) extends ObsKe
         config.extract(PROPRIETARY_MONTHS_KEY).as[Integer].recoverWith[ConfigUtilOps.ExtractFailure, Integer]{
           case ConfigUtilOps.KeyNotFound(_) => (new Integer(0)).right
           case e@ConfigUtilOps.ConversionError(_, _) => e.left
-        }.leftMap(e =>SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
+        }.leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
           .map(v => (LocalDate.now(ZoneId.of("GMT")).plusMonths(v.toLong).format(DateTimeFormatter.ISO_LOCAL_DATE)))))
     }
     else SeqAction(LocalDate.now(ZoneId.of("GMT")).format(DateTimeFormatter.ISO_LOCAL_DATE))
@@ -106,6 +106,10 @@ case class StateKeywordsReader(state: Unit) {
   // TODO: "observer" should be the default when not set in state
   def getObserverName: SeqAction[String] = SeqAction("observer")
   def getOperatorName: SeqAction[String] = SeqAction("ssa")
+  def getRawImageQuality: SeqAction[String] = SeqAction("UNKNOWN")
+  def getRawCloudCover: SeqAction[String] = SeqAction("UNKNOWN")
+  def getRawWaterVapor: SeqAction[String] = SeqAction("UNKNOWN")
+  def getRawBackgroundLight: SeqAction[String] = SeqAction("UNKNOWN")
 }
 
 class StandardHeader(
@@ -227,7 +231,11 @@ class StandardHeader(
       buildString(obsReader.getOiwfsGuide.map(_.toString), "OIWFS_ST"),
       buildString(obsReader.getAowfsGuide.map(_.toString), "AOWFS_ST"),
       buildString(stateReader.getObserverName, "OBSERVER"),
-      buildString(stateReader.getObserverName, "SSA")
+      buildString(stateReader.getObserverName, "SSA"),
+      buildString(stateReader.getRawImageQuality, "RAWIQ"),
+      buildString(stateReader.getRawCloudCover, "RAWCC"),
+      buildString(stateReader.getRawWaterVapor, "RAWWV"),
+      buildString(stateReader.getRawBackgroundLight, "RAWBG")
     )) *>
     pwfs1Keywords *>
     pwfs2Keywords *>


### PR DESCRIPTION
For now the default values for the keywords are always sent even if they are changed in the UI.

We need some way to access the application state at the time we are sending the keywords.