### PR TITLE
SEQNG-139A: Add Operator and Astronomer name to the client

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -55,6 +55,8 @@ trait ModelBooPicklers {
     .addConcreteType[SequenceUpdated]
     .addConcreteType[SequenceRefreshed]
     .addConcreteType[NewLogMessage]
+    .addConcreteType[ObserverUpdated]
+    .addConcreteType[OperatorUpdated]
 
   /**
     * In most cases http4s will use the limit of a byte buffer but not for websockets

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -34,6 +34,8 @@ object SharedModelArbitraries {
   implicit val smeArb = implicitly[Arbitrary[StepSkipMarkChanged]]
   implicit val speArb = implicitly[Arbitrary[SequencePauseRequested]]
   implicit val lmArb  = implicitly[Arbitrary[NewLogMessage]]
+  implicit val opArb  = implicitly[Arbitrary[OperatorUpdated]]
+  implicit val obArb  = implicitly[Arbitrary[ObserverUpdated]]
 }
 
 /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -18,14 +18,6 @@ object HeadersSideBar {
           ^.cls := "ui form",
           <.div(
             ^.cls := "required field",
-            <.label("Observer"),
-            <.input(
-              ^.`type` :="text",
-              ^.autoComplete :="off"
-            )
-          ),
-          <.div(
-            ^.cls := "required field",
             <.label("Operator"),
             <.input(
               ^.`type` :="text",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -127,13 +127,17 @@ object SequenceDefaultToolbar {
                 )
               ),
               <.div(
-                ^.cls := "right ten wide column",
+                ^.cls := "right column",
+                ^.classSet(
+                  "ten wide" -> p.status.isLogged,
+                  "sixteen wide" -> !p.status.isLogged
+                ),
                 <.div(
                   ^.cls := "ui form",
                   <.div(
                     ^.cls := "required field",
                     Label(Label.Props("Observer", "")),
-                    Input(Input.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", s.observer.getOrElse(""), placeholder = "Observer...", onBlur = name => $.runState(updateObserver(p.s)(name))))
+                    Input(Input.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", s.observer.getOrElse(""), placeholder = "Observer...", disabled = !p.status.isLogged, onBlur = name => $.runState(updateObserver(p.s)(name))))
                   )
                 )
               )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -54,7 +54,7 @@ object StepConfigToolbar {
 
 object SequenceDefaultToolbar {
   case class Props(s: SequenceView, status: ClientStatus, nextStepToRun: Int)
-  case class State(runRequested: Boolean, pauseRequested: Boolean, observer: Option[String])
+  case class State(runRequested: Boolean, pauseRequested: Boolean)
   val ST = ReactS.Fix[State]
 
   def requestRun(s: SequenceView) =
@@ -64,10 +64,10 @@ object SequenceDefaultToolbar {
     ST.retM(Callback { SeqexecCircuit.dispatch(RequestPause(s)) }) >> ST.mod(_.copy(runRequested = false, pauseRequested = true)).liftCB
 
   def updateObserver(s: SequenceView)(name: String) =
-    ST.retM(Callback {SeqexecCircuit.dispatch(UpdateObserver(s, name))}) >> ST.mod(_.copy(observer = Some(name))).liftCB
+    ST.retM(Callback {SeqexecCircuit.dispatch(UpdateObserver(s, name))})
 
   val component = ReactComponentB[Props]("SequencesStepsToolbar")
-    .initialState(State(runRequested = false, pauseRequested = false, observer = None))
+    .initialState(State(runRequested = false, pauseRequested = false))
     .renderPS( ($, p, s) =>
       <.div(
         ^.cls := "row",
@@ -137,7 +137,7 @@ object SequenceDefaultToolbar {
                   <.div(
                     ^.cls := "required field",
                     Label(Label.Props("Observer", "")),
-                    Input(Input.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", s.observer.getOrElse(""), placeholder = "Observer...", disabled = !p.status.isLogged, onBlur = name => $.runState(updateObserver(p.s)(name))))
+                    Input(Input.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", p.s.metadata.observer.getOrElse(""), placeholder = "Observer...", disabled = !p.status.isLogged, onBlur = name => $.runState(updateObserver(p.s)(name))))
                   )
                 )
               )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -13,6 +13,8 @@ import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
 import edu.gemini.seqexec.web.client.semanticui.elements.table.TableHeader
 import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
+import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
+import edu.gemini.seqexec.web.client.semanticui.elements.input.Input
 import edu.gemini.seqexec.web.client.services.HtmlConstants.iconEmpty
 import japgolly.scalajs.react.vdom.ReactTagOf
 import japgolly.scalajs.react.vdom.prefix_<^._
@@ -127,11 +129,8 @@ object SequenceDefaultToolbar {
                   ^.cls := "ui form",
                   <.div(
                     ^.cls := "required field",
-                    <.label("Observer"),
-                    <.input(
-                      ^.`type` :="text",
-                      ^.autoComplete :="off"
-                    )
+                    Label(Label.Props("Observer", "")),
+                    Input(Input.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", placeholder = "Observer...", onChange = s => Callback.log(s)))
                   )
                 )
               )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -157,7 +157,7 @@ object SequenceDefaultToolbar {
 /**
   * Container for a table with the steps
   */
-object SequenceStepsTableContainer {
+object StepsTableContainer {
   case class State(nextScrollPos  : Double,
                    nextStepToRun  : Int,
                    onHover        : Option[Int],
@@ -396,21 +396,16 @@ object SequenceStepsTableContainer {
 
     def render(p: Props, s: State): ReactTagOf[Div] = {
       <.div(
-        ^.cls := "ui raised secondary segment",
-        p.stepConfigDisplayed.fold(SequenceDefaultToolbar(SequenceDefaultToolbar.Props(p.s, p.status, s.nextStepToRun)): ReactNode)(step => StepConfigToolbar(StepConfigToolbar.Props(p.s, step)): ReactNode),
-        Divider(),
-        <.div(
-          ^.cls := "ui row scroll pane",
-          SeqexecStyles.stepsListPane,
-          ^.ref := scrollRef,
-          p.stepConfigDisplayed.map { i =>
-            // TODO consider the failure case
-            val step = p.s.steps(i)
-            configTable(step)
-          }.getOrElse {
-            stepsTable(p, s)
-          }
-        )
+        ^.cls := "ui row scroll pane",
+        SeqexecStyles.stepsListPane,
+        ^.ref := scrollRef,
+        p.stepConfigDisplayed.map { i =>
+          // TODO consider the failure case
+          val step = p.s.steps(i)
+          configTable(step)
+        }.getOrElse {
+          stepsTable(p, s)
+        }
       )
     }
   }
@@ -501,6 +496,24 @@ object SequenceStepsTableContainer {
         )
       }
     }.build
+
+  def apply(s: SequenceView, status: ClientStatus, stepConfigDisplayed: Option[Int]) = component(Props(s, status, stepConfigDisplayed))
+}
+
+
+object SequenceStepsTableContainer {
+  case class Props(s: SequenceView, status: ClientStatus, stepConfigDisplayed: Option[Int])
+
+  val component = ReactComponentB[Props]("SequenceStepsTableContainer")
+    .stateless
+    .render_P(p =>
+      <.div(
+        ^.cls := "ui raised secondary segment",
+        p.stepConfigDisplayed.fold(SequenceDefaultToolbar(SequenceDefaultToolbar.Props(p.s, p.status, 1)): ReactNode)(step => StepConfigToolbar(StepConfigToolbar.Props(p.s, step)): ReactNode),
+        Divider(),
+        StepsTableContainer(p.s, p.status, p.stepConfigDisplayed)
+      )
+    ).build
 
   def apply(s: SequenceView, status: ClientStatus, stepConfigDisplayed: Option[Int]) = component(Props(s, status, stepConfigDisplayed))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -66,7 +66,7 @@ object SequenceDefaultToolbar {
   def updateObserver(s: SequenceView)(name: String) =
     ST.retM(Callback {SeqexecCircuit.dispatch(UpdateObserver(s, name))})
 
-  val component = ReactComponentB[Props]("SequencesStepsToolbar")
+  val component = ReactComponentB[Props]("SequencesDefaultToolbar")
     .initialState(State(runRequested = false, pauseRequested = false))
     .renderPS( ($, p, s) =>
       <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -27,10 +27,32 @@ import org.scalajs.dom.raw.{Element, HTMLElement, Node}
 import org.scalajs.dom.document
 import org.scalajs.dom.html.Div
 
+object StepConfigToolbar {
+  case class Props(s: SequenceView, step: Int)
+
+  def backToSequence(s: SequenceView): Callback = Callback {SeqexecCircuit.dispatch(UnShowStep(s))}
+
+  val component = ReactComponentB[Props]("StepConfigToolbar")
+    .stateless
+    .render_P( p =>
+      <.div(
+        ^.cls := "row",
+        Button(Button.Props(icon = Some(IconChevronLeft), onClick = backToSequence(p.s)), "Back"),
+        <.h5(
+          ^.cls := "ui header",
+          SeqexecStyles.inline,
+          s" Configuration for step ${p.step + 1}"
+        )
+      )
+    ).build
+
+  def apply(p: Props) = component(p)
+}
+
 object SequenceDefaultToolbar {
   case class Props(s: SequenceView, status: ClientStatus, runRequested: Boolean, nextStepToRun: Int, pauseRequested: Boolean)
 
-  val component = ReactComponentB[Props]("StepsTable")
+  val component = ReactComponentB[Props]("SequencesStepsToolbar")
     .stateless
     .render_P( p =>
       <.div(
@@ -136,17 +158,6 @@ object SequenceStepsTableContainer {
       $.modState(_.copy(runRequested = false, pauseRequested = true)) >> Callback {
         SeqexecCircuit.dispatch(RequestPause(s))
       }
-
-    def configToolbar(p: Props)(i: Int): ReactNode =
-      <.div(
-        ^.cls := "row",
-        Button(Button.Props(icon = Some(IconChevronLeft), onClick = backToSequence(p.s)), "Back"),
-        <.h5(
-          ^.cls := "ui header",
-          SeqexecStyles.inline,
-          s" Configuration for step ${i + 1}"
-        )
-      )
 
     def configTable(step: Step): TagMod =
       <.table(
@@ -378,7 +389,7 @@ object SequenceStepsTableContainer {
     def render(p: Props, s: State): ReactTagOf[Div] = {
       <.div(
         ^.cls := "ui raised secondary segment",
-        p.stepConfigDisplayed.fold(SequenceDefaultToolbar(SequenceDefaultToolbar.Props(p.s, p.status, s.runRequested, s.nextStepToRun, s.pauseRequested)): ReactNode)(configToolbar(p)),
+        p.stepConfigDisplayed.fold(SequenceDefaultToolbar(SequenceDefaultToolbar.Props(p.s, p.status, s.runRequested, s.nextStepToRun, s.pauseRequested)): ReactNode)(step => StepConfigToolbar(StepConfigToolbar.Props(p.s, step)): ReactNode),
         Divider(),
         <.div(
           ^.cls := "ui row scroll pane",
@@ -399,8 +410,6 @@ object SequenceStepsTableContainer {
   def requestPause(s: SequenceView): Callback = Callback {SeqexecCircuit.dispatch(RequestPause(s))}
 
   def displayStepDetails(s: SequenceView, i: Int): Callback = Callback {SeqexecCircuit.dispatch(ShowStep(s, i))}
-
-  def backToSequence(s: SequenceView): Callback = Callback {SeqexecCircuit.dispatch(UnShowStep(s))}
 
   // Reference to the specifc DOM marked by the name `scrollRef`
   private val scrollRef = Ref[HTMLElement]("scrollRef")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -23,6 +23,8 @@ import scala.concurrent.duration._
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 import scala.scalajs.js.typedarray.{ArrayBuffer, TypedArrayBuffer}
 import scalaz.{-\/, \/, \/-}
+import scalaz.syntax.equal._
+import scalaz.std.string._
 
 /**
   * Handles actions related to search
@@ -77,6 +79,13 @@ class SequenceExecutionHandler[M](modelRW: ModelRW[M, SeqexecAppRootModel.Loaded
 
     case RunPauseFailed(s) =>
       noChange
+
+    case UpdateObserver(sequence, name) =>
+      updated(value.copy(queue = value.queue.collect {
+        case s if s.metadata.instrument === sequence.metadata.instrument =>
+          sequence.copy(metadata = s.metadata.copy(observer = Some(name)))
+        case s                  => s
+      }))
 
     case FlipSkipStep(sequence, step) =>
       updated(value.copy(queue = value.queue.collect {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -305,7 +305,12 @@ class WebSocketEventsHandler[M](modelRW: ModelRW[M, (SeqexecAppRootModel.LoadedS
       updated(value.copy(_1 = sv), audioEffect)
 
     case ServerMessage(s: SeqexecModelUpdate) =>
-      updated(value.copy(_1 = s.view))
+      // Replace the observer if not set and logged in
+      val sequencesWithObserver = s.view.queue.collect {
+        case q if q.metadata.observer.isEmpty => q.copy(metadata = q.metadata.copy(observer = value._3.map(_.displayName)))
+        case q                                => q
+      }
+      updated(value.copy(_1 = SequencesQueue(sequencesWithObserver)))
 
     case ServerMessage(s) =>
       // Ignore unknown events

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -81,11 +81,13 @@ class SequenceExecutionHandler[M](modelRW: ModelRW[M, SeqexecAppRootModel.Loaded
       noChange
 
     case UpdateObserver(sequence, name) =>
-      updated(value.copy(queue = value.queue.collect {
+      val updateObserverE = Effect(SeqexecWebClient.setObserver(sequence, name).map(_ => NoAction))
+      val updatedSequences = value.copy(queue = value.queue.collect {
         case s if s.metadata.instrument === sequence.metadata.instrument =>
           sequence.copy(metadata = s.metadata.copy(observer = Some(name)))
         case s                  => s
-      }))
+      })
+      updated(updatedSequences, updateObserverE)
 
     case FlipSkipStep(sequence, step) =>
       updated(value.copy(queue = value.queue.collect {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -61,6 +61,7 @@ case class ServerMessage(e: SeqexecEvent) extends Action
 // Temporal actions for UI prototyping
 case class FlipSkipStep(view: SequenceView, step: Step) extends Action
 case class FlipBreakpointStep(view: SequenceView, step: Step) extends Action
+case class UpdateObserver(view: SequenceView, name: String) extends Action
 
 // End Actions
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/Input.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/Input.scala
@@ -4,14 +4,18 @@ import japgolly.scalajs.react.{Callback, CallbackTo, ReactComponentB, ReactEvent
 import japgolly.scalajs.react.ScalazReact._
 import japgolly.scalajs.react.vdom.prefix_<^._
 
+import scalaz.syntax.equal._
+import scalaz.std.string._
+
 object Input {
   type ChangeCallback = String => Callback
 
   case class Props(name: String,
                    id: String,
+                   value: String,
                    inputType: InputType = TextInput,
                    placeholder: String = "",
-                   onChange: ChangeCallback = s => Callback.empty) // callback for parents of this component
+                   onBlur: ChangeCallback = s => Callback.empty) // callback for parents of this component
 
   sealed trait InputType
   case object TextInput extends InputType
@@ -20,12 +24,15 @@ object Input {
   // Use state monad to hold the state of the system
   val ST = ReactS.Fix[String]
 
-  def onTextChange(c: ChangeCallback)(e: ReactEventI):ReactST[CallbackTo, String, Unit] = {
+  def onTextChange(e: ReactEventI): ReactST[CallbackTo, String, Unit] = {
     // Capture the value outside setState, react reuses the events
     val v = e.target.value
     // First update the internal state, then call the outside listener
-    ST.set(v).liftCB >> ST.retM(c(v))
+    ST.set(v).liftCB
   }
+
+  def onBlur(c: ChangeCallback): ReactST[CallbackTo, String, Unit] =
+    ST.get.liftCB.flatMap(v => ST.retM(c(v)))
 
   def component = ReactComponentB[Props]("Icon")
     .initialState("")
@@ -39,10 +46,13 @@ object Input {
         ^.name := p.name,
         ^.id := p.id,
         ^.value := s,
-        ^.onChange ==> $._runState(onTextChange(p.onChange))
+        ^.onChange ==> $._runState(onTextChange),
+        ^.onBlur   --> $.runState(onBlur(p.onBlur))
       )
-    }
-    .build
+    }.componentWillMount { $ =>
+      // Update state of the input if the property has changed
+      Callback.when($.props.value /== $.state)($.setState($.props.value))
+    }.build
 
   def apply(p: Props) = component(p)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/Input.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/Input.scala
@@ -15,6 +15,7 @@ object Input {
                    value: String,
                    inputType: InputType = TextInput,
                    placeholder: String = "",
+                   disabled: Boolean = false,
                    onBlur: ChangeCallback = s => Callback.empty) // callback for parents of this component
 
   sealed trait InputType
@@ -46,6 +47,7 @@ object Input {
         ^.name := p.name,
         ^.id := p.id,
         ^.value := s,
+        ^.disabled := p.disabled,
         ^.onChange ==> $._runState(onTextChange),
         ^.onBlur   --> $.runState(onBlur(p.onBlur))
       )


### PR DESCRIPTION
This is the first PR for SEQNG-139. It enables the Observer text fiel on the UI at the sequence level. It took quite a bit of effort to get it to play correctly given the way React works, there maybe still some use cases not covered

The field will take the name of the logged in user and will update the backend when loosing the focus.

Still missing:

[ ] Update the backend before run
[ ] Update the backend while running
[ ] More testing
[ ] Complete the Operator field

Here's a screenshot in FF

 
![screenshot 2017-03-02 15 52 33](https://cloud.githubusercontent.com/assets/3615303/23522051/5417a556-ff60-11e6-886f-2b0695567306.png)
