### PR TITLE
SEQNG-158 Initial support for resource management

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Resource.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Resource.scala
@@ -1,0 +1,18 @@
+package edu.gemini.seqexec.engine
+
+/**
+  * A Seqexec resource represents any system that can be only used by one single agent.
+  *
+  */
+sealed trait Resource
+
+object Resource {
+
+  case object GMOS extends Resource
+  case object F2 extends Resource
+  case object P1 extends Resource
+  case object OI extends Resource
+  case object Mount extends Resource
+  case object ScienceFold extends Resource
+
+}

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -12,7 +12,12 @@ case class Sequence[+A](
   id: Sequence.Id,
   metadata: SequenceMetadata,
   steps: List[Step[A]]
-)
+) {
+
+  // The Monoid mappend of a Set is a Set union
+  val resources: Set[Resource] = steps.foldMap(_.resources)
+
+}
 
 object Sequence {
 

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -55,12 +55,18 @@ class SequenceSpec extends FlatSpec {
 
   val metadata = SequenceMetadata("F2", None, None)
 
-  def simpleStep(id: Int, breakpoint: Boolean): Step[Action] = Step(id, None, config, breakpoint,
-    List(
-      List(action, action), // Execution
-      List(action) // Execution
+  def simpleStep(id: Int, breakpoint: Boolean): Step[Action] =
+    Step(
+      id,
+      None,
+      config,
+      Set.empty,
+      breakpoint,
+      List(
+        List(action, action), // Execution
+        List(action) // Execution
+      )
     )
-  )
 
   def runToCompletion(q: scalaz.stream.async.mutable.Queue[Event], s0: EngineState): EngineState = {
     def isFinished(status: SequenceState): Boolean =
@@ -131,7 +137,7 @@ class SequenceSpec extends FlatSpec {
       case x::xs => (Execution(x.map(_.left)), xs)
     }
 
-    Step.Zipper(1, None, config, false, pending, focus, done, rollback)
+    Step.Zipper(1, None, config, Set.empty, false, pending, focus, done, rollback)
   }
   val stepz0: Step.Zipper   = simpleStep(Nil, Execution.empty, Nil)
   val stepza0: Step.Zipper  = simpleStep(List(List(action)), Execution.empty, Nil)

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -55,6 +55,7 @@ class packageSpec extends FlatSpec {
           1,
           None,
           config,
+          Set.empty,
           false,
           List(
             List(configureTcs, configureInst), // Execution
@@ -65,6 +66,7 @@ class packageSpec extends FlatSpec {
           2,
           None,
           config,
+          Set.empty,
           false,
           List(
             List(configureTcs, configureInst), // Execution

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -71,6 +71,8 @@ class SeqTranslate(site: Site) {
         i,
         None,
         config.toStepConfig,
+        // TODO: Lookup which resources are needed depending on the type of Step.
+        Set.empty,
         false,
         (if(i == 0) List(List(toAction(systems.odb.sequenceStart(obsId, "").map(_ => Result.Ignored))))
         else List())


### PR DESCRIPTION
Sequences can be now run in parallel when there are no `Resource`s shared among other *running* Sequences. Otherwise the Sequence can't be run.

The primary store for resources is the `Step`, from there the resources needed by a `Sequence` are calculated.

This is an initial implementation, there are still several things to polish. Off the top of my head:

 - Find out at load time resources are needed for each Step. The test use synthetic Sequences with resources hardcoded, but in the real application there is no way to create them.
 - Complete types of resources.
 - Check resources in Pending steps only. Now it takes into account the completed ones too. - Provide some kind of feedback when a attempting to run a Sequence fails because of shared resources.
 - Add flag to indicate which Sequences would be ready for running.
 - More testing.