### PR TITLE
SEQNG-162: Improve text fields change detection

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -1,14 +1,16 @@
 package edu.gemini.seqexec.web.client.components.sequence
 
 import diode.react.ModelProxy
-
 import edu.gemini.seqexec.web.client.components.DropdownMenu
 import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
-import edu.gemini.seqexec.web.client.semanticui.elements.input.Input
+import edu.gemini.seqexec.web.client.semanticui.elements.input.InputEV
 import edu.gemini.seqexec.web.client.model._
-
-import japgolly.scalajs.react.{ReactComponentB, Callback}
+import japgolly.scalajs.react.{BackendScope, Callback, ReactComponentB, ReactComponentU, TopNode}
+import japgolly.scalajs.react.extra.{ExternalVar, TimerSupport}
 import japgolly.scalajs.react.vdom.prefix_<^._
+import org.scalajs.dom.html.Div
+
+import scala.concurrent.duration._
 
 /**
   * Display to show headers per sequence
@@ -16,9 +18,19 @@ import japgolly.scalajs.react.vdom.prefix_<^._
 object HeadersSideBar {
   case class Props(operator: ModelProxy[Option[String]], status: ModelProxy[ClientStatus])
 
-  val component = ReactComponentB[Props]("HeadersSideBar")
-    .stateless
-    .render_P(p =>
+  case class State(currentText: Option[String])
+
+  class Backend(val $: BackendScope[Props, State]) extends TimerSupport {
+    def updateState(value: String): Callback =
+      $.modState(_.copy(currentText = Some(value)))
+
+    def submitIfChanged: Callback =
+      ($.state zip $.props) >>= {
+        case (s, p) => Callback.when(s.currentText != p.operator())(Callback.empty) // We aro not submiting until the backend properly update this property
+      }
+
+    def render(p: Props, s: State): ReactTagOf[Div] = {
+      val operatorEV = ExternalVar(s.currentText.getOrElse(""))(updateState)
       <.div(
         ^.cls := "ui raised secondary segment",
         <.h4("Headers"),
@@ -27,11 +39,12 @@ object HeadersSideBar {
           <.div(
             ^.cls := "required field",
             Label(Label.Props("Operator", "operator")),
-            Input(Input.Props("operator", "operator",
-              p.operator().getOrElse(""),
+            InputEV(InputEV.Props("operator", "operator",
+              operatorEV,
               placeholder = "Operator...",
               disabled = !p.status().isLogged,
-              onBlur = name => p.operator.dispatchCB(UpdateOperator(name))))
+              onBlur = name => Callback.empty// >> p.operator.dispatchCB(UpdateOperator(name)))) TODO Enable when the backend accepts this property
+            ))
           ),
           DropdownMenu(DropdownMenu.Props("Image Quality", "Select", List("IQ20", "IQ70", "IQ85", "Any"))),
           DropdownMenu(DropdownMenu.Props("Cloud Cover", "Select", List("CC20", "CC50", "CC70", "CC80", "CC90", "Any"))),
@@ -39,8 +52,21 @@ object HeadersSideBar {
           DropdownMenu(DropdownMenu.Props("Sky Background", "Select", List("SB20", "SB50", "SB80", "Any")))
         )
       )
-    )
+    }
+  }
+
+  private val component = ReactComponentB[Props]("HeadersSideBar")
+    .initialState(State(None))
+    .renderBackend[Backend]
+    .configure(TimerSupport.install)
+    .shouldComponentUpdate { f =>
+      // If the state changes, don't update the UI
+      f.$.state == f.nextState
+    }
+    // Every 2 seconds check if the field has changed and submit
+    .componentDidMount(c => c.backend.setInterval(c.backend.submitIfChanged, 2.second))
     .build
 
-  def apply(operator: ModelProxy[Option[String]], status: ModelProxy[ClientStatus]) = component(Props(operator, status))
+  def apply(operator: ModelProxy[Option[String]], status: ModelProxy[ClientStatus]): ReactComponentU[Props, State, Backend, TopNode] =
+    component(Props(operator, status))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
@@ -7,15 +7,20 @@ import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.input.InputEV
 import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
+
 import japgolly.scalajs.react.extra.{ExternalVar, TimerSupport}
 import japgolly.scalajs.react.vdom.prefix_<^._
 import japgolly.scalajs.react.{BackendScope, Callback, CallbackTo, ReactComponentB, ReactComponentU, ScalazReact, TopNode}
 import japgolly.scalajs.react.ScalazReact._
+
 import org.scalajs.dom.html.Div
 
 import scalaz.syntax.equal._
 import scalaz.syntax.std.boolean._
-import scalaz.std.AllInstances._
+import scalaz.syntax.std.option._
+import scalaz.std.string._
+import scalaz.std.option._
+
 import scala.concurrent.duration._
 
 object SequenceObserverField {
@@ -25,14 +30,14 @@ object SequenceObserverField {
 
   class Backend(val $: BackendScope[Props, State]) extends TimerSupport {
     def updateObserver(s: SequenceView, name: String): CallbackTo[Unit] =
-      $.props >>= {p => Callback.when(p.isLogged)(Callback(SeqexecCircuit.dispatch(UpdateObserver(s, name)))) }
+      $.props >>= { p => Callback.when(p.isLogged)(Callback(SeqexecCircuit.dispatch(UpdateObserver(s, name)))) }
 
     def updateState(value: String): Callback =
-      $.state >>= {s => Callback.when(!s.currentText.contains(value))($.modState(_.copy(currentText = Some(value)))) }
+      $.state >>= { s => Callback.when(!s.currentText.contains(value))($.modState(_.copy(currentText = Some(value)))) }
 
     def submitIfChanged: Callback =
       ($.state zip $.props) >>= {
-        case (s, p) => Callback.when(s.currentText != p.s.metadata.observer)(updateObserver(p.s, s.currentText.getOrElse("")))
+        case (s, p) => Callback.when(s.currentText =/= p.s.metadata.observer)(updateObserver(p.s, s.currentText.getOrElse("")))
       }
 
     def setupTimer: Callback =
@@ -40,13 +45,19 @@ object SequenceObserverField {
       setInterval(submitIfChanged, 2.second)
 
     def render(p: Props, s: State): ReactTagOf[Div] = {
-      val observerEV = ExternalVar(s.currentText.getOrElse(""))(updateState)
+      val observerEV = ExternalVar(~s.currentText)(updateState)
       <.div(
         ^.cls := "ui form",
         <.div(
           ^.cls := "required field",
           Label(Label.Props("Observer", "")),
-          InputEV(InputEV.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", observerEV, placeholder = "Observer...", disabled = !p.isLogged, onBlur = _ => submitIfChanged))
+          InputEV(InputEV.Props(
+            p.s.metadata.instrument + ".observer",
+            p.s.metadata.instrument + ".observer",
+            observerEV,
+            placeholder = "Observer...",
+            disabled = !p.isLogged,
+            onBlur = _ => submitIfChanged))
         )
       )
     }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
@@ -35,6 +35,9 @@ object SequenceObserverField {
         case (s, p) => Callback.when(s.currentText != p.s.metadata.observer)(updateObserver(p.s, s.currentText.getOrElse("")))
       }
 
+    def setupTimer: Callback =
+      $.props >>= {p => Callback.when(p.isLogged)(setInterval(submitIfChanged, 2.second)) }
+
     def render(p: Props, s: State) = {
       val observerEV = ExternalVar(s.currentText.getOrElse(""))(updateState)
       <.div(
@@ -47,13 +50,14 @@ object SequenceObserverField {
       )
     }
   }
+
   private val component = ReactComponentB[Props]("SequenceObserverField")
     .initialState(State(None))
     .renderBackend[Backend]
     .configure(TimerSupport.install)
     .componentWillMount(f => f.backend.$.props >>= {p => f.backend.updateState(p.s.metadata.observer.getOrElse(""))})
     // Every 2 seconds check if the field has changed and submit
-    .componentDidMount(c => c.backend.setInterval(c.backend.submitIfChanged, 2.second))
+    .componentDidMount(c => c.backend.setupTimer)
     .componentWillReceiveProps { f =>
       // Update the observer field
       println("UPD " + f.nextProps.s.metadata.observer + "->" + f.$.state.currentText)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
@@ -28,7 +28,7 @@ object SequenceObserverField {
       $.props >>= {p => Callback.when(p.isLogged)(Callback(SeqexecCircuit.dispatch(UpdateObserver(s, name)))) }
 
     def updateState(value: String): Callback =
-      $.state >>= {s => Callback.when(s.currentText != Some(s))($.modState(_.copy(currentText = Some(value)))) }
+      $.state >>= {s => Callback.when(!s.currentText.contains(s))($.modState(_.copy(currentText = Some(value)))) }
 
     def submitIfChanged: Callback =
       ($.state zip $.props) >>= {
@@ -40,6 +40,7 @@ object SequenceObserverField {
 
     def render(p: Props, s: State) = {
       val observerEV = ExternalVar(s.currentText.getOrElse(""))(updateState)
+      println("Render " + observerEV.value)
       <.div(
         ^.cls := "ui form",
         <.div(
@@ -60,8 +61,6 @@ object SequenceObserverField {
     .componentDidMount(c => c.backend.setupTimer)
     .componentWillReceiveProps { f =>
       // Update the observer field
-      println("UPD " + f.nextProps.s.metadata.observer + "->" + f.$.state.currentText)
-      println("UPD " + ((f.nextProps.s.metadata.observer.map(_.toString) =/= f.$.state.currentText) && f.nextProps.s.metadata.observer.nonEmpty))
       Callback.when((f.nextProps.s.metadata.observer =/= f.$.state.currentText) && f.nextProps.s.metadata.observer.nonEmpty)(f.$.modState(_.copy(currentText = f.nextProps.s.metadata.observer)))
     }
     .build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
@@ -1,0 +1,118 @@
+package edu.gemini.seqexec.web.client.components.sequence
+
+import edu.gemini.seqexec.model.Model.{SequenceState, SequenceView}
+import edu.gemini.seqexec.web.client.model._
+import edu.gemini.seqexec.web.client.model.ModelOps._
+import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
+import edu.gemini.seqexec.web.client.semanticui.elements.input.Input
+import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
+
+import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.{Callback, ReactComponentB}
+import japgolly.scalajs.react.ScalazReact._
+
+import scalaz.syntax.equal._
+import scalaz.syntax.std.boolean._
+
+object SequenceDefaultToolbar {
+  case class Props(s: SequenceView, status: ClientStatus, nextStepToRun: Int)
+  case class State(runRequested: Boolean, pauseRequested: Boolean)
+  private  val ST = ReactS.Fix[State]
+
+  def requestRun(s: SequenceView) =
+    ST.retM(Callback { SeqexecCircuit.dispatch(RequestRun(s)) }) >> ST.mod(_.copy(runRequested = true, pauseRequested = false)).liftCB
+
+  def requestPause(s: SequenceView) =
+    ST.retM(Callback { SeqexecCircuit.dispatch(RequestPause(s)) }) >> ST.mod(_.copy(runRequested = false, pauseRequested = true)).liftCB
+
+  def updateObserver(s: SequenceView, name: String) =
+    Callback(SeqexecCircuit.dispatch(UpdateObserver(s, name)))
+
+  val component = ReactComponentB[Props]("SequencesDefaultToolbar")
+    .initialState(State(runRequested = false, pauseRequested = false))
+    .renderPS( ($, p, s) =>
+      <.div(
+        ^.cls := "row",
+        p.status.isLogged && p.s.status === SequenceState.Completed ?=
+          <.h3(
+            ^.cls := "ui green header",
+            "Sequence completed"
+          ),
+        <.div(
+          ^.cls := "ui two column grid",
+          <.div(
+            ^.cls := "ui row",
+            <.div(
+              ^.cls := "left bottom aligned six wide column",
+              p.status.isLogged && p.s.hasError ?=
+                Button(
+                  Button.Props(
+                    icon = Some(IconPlay),
+                    labeled = true,
+                    onClick = $.runState(requestRun(p.s)),
+                    color = Some("blue"),
+                    dataTooltip = Some(s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} the sequence from the step ${p.nextStepToRun + 1}"),
+                    disabled = !p.status.isConnected || s.runRequested),
+                  s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} from step ${p.nextStepToRun + 1}"
+                ),
+              p.status.isLogged && p.s.status === SequenceState.Idle ?=
+                Button(
+                  Button.Props(
+                    icon = Some(IconPlay),
+                    labeled = true,
+                    onClick = $.runState(requestRun(p.s)),
+                    color = Some("blue"),
+                    dataTooltip = Some(s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} the sequence from the step ${p.nextStepToRun + 1}"),
+                    disabled = !p.status.isConnected || s.runRequested),
+                  s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} from step ${p.nextStepToRun + 1}"
+                ),
+              p.status.isLogged && p.s.status === SequenceState.Running ?=
+                Button(
+                  Button.Props(
+                    icon = Some(IconPause),
+                    labeled = true,
+                    onClick = $.runState(requestPause(p.s)),
+                    color = Some("teal"),
+                    dataTooltip = Some("Pause the sequence after the current step completes"),
+                    disabled = !p.status.isConnected || s.pauseRequested),
+                  "Pause"
+                ),
+              p.status.isLogged && p.s.status === SequenceState.Paused ?=
+                Button(
+                  Button.Props(
+                    icon = Some(IconPlay),
+                    labeled = true,
+                    onClick = $.runState(requestPause(p.s)),
+                    color = Some("teal"),
+                    disabled = !p.status.isConnected),
+                  "Continue from step 1"
+                )
+              ),
+              <.div(
+                ^.cls := "right column",
+                ^.classSet(
+                  "ten wide" -> p.status.isLogged,
+                  "sixteen wide" -> !p.status.isLogged
+                ),
+                <.div(
+                  ^.cls := "ui form",
+                  <.div(
+                    ^.cls := "required field",
+                    Label(Label.Props("Observer", "")),
+                    Input(Input.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", p.s.metadata.observer.getOrElse(""), placeholder = "Observer...", disabled = !p.status.isLogged, onBlur = name => updateObserver(p.s, name)))
+                  )
+                )
+              )
+            )
+          )
+      )
+    ).componentWillReceiveProps { f =>
+      // Update state of run requested depending on the run state
+      val runStateCB =
+        Callback.when(f.nextProps.s.status === SequenceState.Running && f.$.state.runRequested)(f.$.modState(_.copy(runRequested = false)))
+      runStateCB
+    }.build
+
+  def apply(p: Props) = component(p)
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
@@ -15,6 +15,28 @@ import japgolly.scalajs.react.ScalazReact._
 import scalaz.syntax.equal._
 import scalaz.syntax.std.boolean._
 
+object SequenceObserverField {
+  case class Props(s: SequenceView, isLogged: Boolean)
+
+  def updateObserver(s: SequenceView, name: String) =
+    Callback(SeqexecCircuit.dispatch(UpdateObserver(s, name)))
+
+  private val component = ReactComponentB[Props]("SequenceObserverField")
+    .renderPS( ($, p, s) =>
+      <.div(
+        ^.cls := "ui form",
+        <.div(
+          ^.cls := "required field",
+          Label(Label.Props("Observer", "")),
+          Input(Input.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", p.s.metadata.observer.getOrElse(""), placeholder = "Observer...", disabled = !p.isLogged, onBlur = name => updateObserver(p.s, name)))
+        )
+      )
+    )
+    .build
+
+  def apply(p: Props) = component(p)
+}
+
 object SequenceDefaultToolbar {
   case class Props(s: SequenceView, status: ClientStatus, nextStepToRun: Int)
   case class State(runRequested: Boolean, pauseRequested: Boolean)
@@ -25,9 +47,6 @@ object SequenceDefaultToolbar {
 
   def requestPause(s: SequenceView) =
     ST.retM(Callback { SeqexecCircuit.dispatch(RequestPause(s)) }) >> ST.mod(_.copy(runRequested = false, pauseRequested = true)).liftCB
-
-  def updateObserver(s: SequenceView, name: String) =
-    Callback(SeqexecCircuit.dispatch(UpdateObserver(s, name)))
 
   val component = ReactComponentB[Props]("SequencesDefaultToolbar")
     .initialState(State(runRequested = false, pauseRequested = false))
@@ -95,14 +114,7 @@ object SequenceDefaultToolbar {
                   "ten wide" -> p.status.isLogged,
                   "sixteen wide" -> !p.status.isLogged
                 ),
-                <.div(
-                  ^.cls := "ui form",
-                  <.div(
-                    ^.cls := "required field",
-                    Label(Label.Props("Observer", "")),
-                    Input(Input.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", p.s.metadata.observer.getOrElse(""), placeholder = "Observer...", disabled = !p.status.isLogged, onBlur = name => updateObserver(p.s, name)))
-                  )
-                )
+                SequenceObserverField(SequenceObserverField.Props(p.s, p.status.isLogged))
               )
             )
           )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
@@ -29,7 +29,7 @@ object SequenceObserverField {
       Callback(SeqexecCircuit.dispatch(UpdateObserver(s, name)))
 
     def updateState(value: String): Callback =
-      $.modState(_.copy(currentText = Some(value)))
+      $.state >>= {s => Callback.when(s.currentText != Some(s))($.modState(_.copy(currentText = Some(value)))) }
 
     def submitIfChanged: Callback =
       ($.state zip $.props) >>= {
@@ -43,7 +43,7 @@ object SequenceObserverField {
         <.div(
           ^.cls := "required field",
           Label(Label.Props("Observer", "")),
-          InputEV(InputEV.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", observerEV, placeholder = "Observer...", disabled = !p.isLogged, onBlur = name => updateObserver(p.s, name)))
+          InputEV(InputEV.Props(p.s.metadata.instrument + ".observer", p.s.metadata.instrument + ".observer", observerEV, placeholder = "Observer...", disabled = !p.isLogged, onBlur = _ => submitIfChanged))
         )
       )
     }
@@ -144,9 +144,7 @@ object SequenceDefaultToolbar {
       )
     ).componentWillReceiveProps { f =>
       // Update state of run requested depending on the run state
-      val runStateCB =
-        Callback.when(f.nextProps.s.status === SequenceState.Running && f.$.state.runRequested)(f.$.modState(_.copy(runRequested = false)))
-      runStateCB
+      Callback.when(f.nextProps.s.status === SequenceState.Running && f.$.state.runRequested)(f.$.modState(_.copy(runRequested = false)))
     }.build
 
   def apply(p: Props) = component(p)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -318,6 +318,7 @@ class WebSocketEventsHandler[M](modelRW: ModelRW[M, (SeqexecAppRootModel.LoadedS
         case q                                => q
       }
       updated(value.copy(_1 = SequencesQueue(sequencesWithObserver)))
+      // updated(value.copy(_1 = s.view))
 
     case ServerMessage(s) =>
       // Ignore unknown events

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/Input.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/Input.scala
@@ -56,7 +56,7 @@ object Input {
       )
     }.componentWillMount { $ =>
       // Update state of the input if the property has changed
-      Callback.when(($.props.value /== $.state.value) && !$.state.changed)($.setState(State($.props.value)))
+      Callback.when(($.props.value =/= $.state.value) && !$.state.changed)($.setState(State($.props.value)))
     }.build
 
   def apply(p: Props): ReactComponentU[Props, State, Unit, TopNode] = component(p)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/InputEV.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/InputEV.scala
@@ -60,10 +60,10 @@ object InputEV {
       )
     }.componentWillMount { $ =>
       // Update state of the input if the property has changed
-      Callback.when(($.props.value.value /== $.state.value) && !$.state.changed)($.setState(State($.props.value.value)))
+      Callback.when(($.props.value.value =/= $.state.value) && !$.state.changed)($.setState(State($.props.value.value)))
     }.componentWillReceiveProps { f =>
       // Update state of the input if the property has changed
-      Callback.when((f.nextProps.value.value /== f.$.state.value) && !f.$.state.changed)(f.$.setState(State(f.nextProps.value.value)))
+      Callback.when((f.nextProps.value.value =/= f.$.state.value) && !f.$.state.changed)(f.$.setState(State(f.nextProps.value.value)))
     }.build
 
   def apply(p: Props): ReactComponentU[Props, State, Unit, TopNode] = component(p)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/InputEV.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/InputEV.scala
@@ -42,7 +42,7 @@ object InputEV {
   def onBlur(c: ChangeCallback): ReactST[CallbackTo, State, Unit] =
     ST.get.liftCB.flatMap(v => ST.retM(c(v.value)))
 
-  private def component = ReactComponentB[Props]("InputEV")
+  private val component = ReactComponentB[Props]("InputEV")
     .initialState(State(""))
     .renderPS { ($, p, s) =>
       <.input(
@@ -60,7 +60,10 @@ object InputEV {
       )
     }.componentWillMount { $ =>
       // Update state of the input if the property has changed
-      Callback.when(($.props.value.value /== $.state.value) && !$.state.changed)($.setState(State($.props.value.value, false)))
+      Callback.when(($.props.value.value /== $.state.value) && !$.state.changed)($.setState(State($.props.value.value)))
+    }.componentWillReceiveProps { f =>
+      // Update state of the input if the property has changed
+      Callback.when((f.nextProps.value.value /== f.$.state.value) && !f.$.state.changed)(f.$.setState(State(f.nextProps.value.value)))
     }.build
 
   def apply(p: Props): ReactComponentU[Props, State, Unit, TopNode] = component(p)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/InputEV.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/input/InputEV.scala
@@ -42,7 +42,7 @@ object InputEV {
   def onBlur(c: ChangeCallback): ReactST[CallbackTo, State, Unit] =
     ST.get.liftCB.flatMap(v => ST.retM(c(v.value)))
 
-  private val component = ReactComponentB[Props]("InputEV")
+  private def component = ReactComponentB[Props]("InputEV")
     .initialState(State(""))
     .renderPS { ($, p, s) =>
       <.input(


### PR DESCRIPTION
This is one of the trickiust UI related PRs so far. It enables the observer and operator field to autodetect when they change and submit to the backend. It is not ideal to do this on every char typed, lest it produce too much traffic, so the interim solution was to submit when the input field looses focus. However this fails if the user stay on the text field

The solution un this PR sets up a timer to detect changes every 2 seconds and submits

Several border cases made this a bit harder but it seems to work satisfactorily and has been tested with multiple clients to do the right thing

As usual for UI PRs the code doesn't tell that much