### PR TITLE
SEQNG-173 Make `Conditions` a global value in Engine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ lazy val edu_gemini_seqexec_server = project
 lazy val edu_gemini_seqexec_engine = project
   .in(file("modules/edu.gemini.seqexec.engine"))
   .dependsOn(edu_gemini_seqexec_model_JVM)
-  .settings(libraryDependencies ++= Seq(ScalaZStream, SeqexecOdb) ++ TestLibs.value)
+  .settings(libraryDependencies ++= Seq(ScalaZStream) ++ TestLibs.value)
 
 // Unfortunately crossProject doesn't seem to work properly at the module/build.sbt level
 // We have to define the project properties at this level

--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ lazy val edu_gemini_seqexec_server = project
 lazy val edu_gemini_seqexec_engine = project
   .in(file("modules/edu.gemini.seqexec.engine"))
   .dependsOn(edu_gemini_seqexec_model_JVM)
-  .settings(libraryDependencies ++= Seq(ScalaZStream) ++ TestLibs.value)
+  .settings(libraryDependencies ++= Seq(ScalaZStream, SeqexecOdb) ++ TestLibs.value)
 
 // Unfortunately crossProject doesn't seem to work properly at the module/build.sbt level
 // We have to define the project properties at this level

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
@@ -3,6 +3,8 @@ package edu.gemini.seqexec.engine
 import scalaz._
 import Scalaz._
 
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+
 /**
   * A Map of `Sequence`s.
   */
@@ -22,11 +24,12 @@ object Engine {
       Engine(q.sequences.mapValues(_.map(f)))
   }
 
-  case class State(sequences: Map[Sequence.Id, Sequence.State])
+  case class State(conditions: Conditions, sequences: Map[Sequence.Id, Sequence.State])
 
   object State {
 
-    def empty: State = State(Map.empty)
+    // WORST sets the value ANY for every condition
+    def empty: State = State(Conditions.WORST, Map.empty)
 
   }
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
@@ -3,7 +3,7 @@ package edu.gemini.seqexec.engine
 import scalaz._
 import Scalaz._
 
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+import edu.gemini.seqexec.model.Model.Conditions
 
 /**
   * A Map of `Sequence`s.
@@ -29,7 +29,7 @@ object Engine {
   object State {
 
     // WORST sets the value ANY for every condition
-    def empty: State = State(Conditions.WORST, Map.empty)
+    def empty: State = State(Conditions.worst, Map.empty)
 
   }
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -1,5 +1,7 @@
 package edu.gemini.seqexec.engine
 
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+
 import Result.{RetVal, PartialVal, OK, Partial}
 
 /**
@@ -19,6 +21,7 @@ case class Load(id: Sequence.Id, sequence: Sequence[Action]) extends UserEvent
 case class Breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean) extends UserEvent
 case class SetOperator(name: String) extends UserEvent
 case class SetObserver(id: Sequence.Id, name: String) extends UserEvent
+case class SetConditions(conditions: Conditions) extends UserEvent
 case object Poll extends UserEvent
 case object Exit extends UserEvent
 
@@ -41,6 +44,7 @@ object Event {
   def breakpoint(id: Sequence.Id, step: Step.Id, v: Boolean): Event = EventUser(Breakpoint(id, step, v))
   def setOperator(name: String): Event = EventUser(SetOperator(name))
   def setObserver(id: Sequence.Id, name: String): Event = EventUser(SetObserver(id, name))
+  def setConditions(conditions: Conditions): Event = EventUser(SetConditions(conditions))
   val poll: Event = EventUser(Poll)
   val exit: Event = EventUser(Exit)
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -1,6 +1,6 @@
 package edu.gemini.seqexec.engine
 
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+import edu.gemini.seqexec.model.Model.Conditions
 
 import Result.{RetVal, PartialVal, OK, Partial}
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -81,7 +81,7 @@ package object engine {
     modifyS(id)(_.rollback)
 
   def setOperator(name: String): Handle[Unit] =
-    modify(x => Engine.State(x.sequences.mapValues(_.setOperator(name))))
+    modify(st => Engine.State(st.conditions, st.sequences.mapValues(_.setOperator(name))))
 
   def setObserver(id: Sequence.Id)(name: String): Handle[Unit] =
     modifyS(id)(_.setObserver(name))
@@ -91,14 +91,15 @@ package object engine {
     */
   def load(id: Sequence.Id, seq: Sequence[Action]): Handle[Unit] =
     modify(
-      s => Engine.State(
-        s.sequences.get(id).map(
+      st => Engine.State(
+        st.conditions,
+        st.sequences.get(id).map(
           t => t.status match {
-            case SequenceState.Running => s.sequences
-            case _                     => s.sequences.updated(id, Sequence.State.init(seq))
+            case SequenceState.Running => st.sequences
+            case _                     => st.sequences.updated(id, Sequence.State.init(seq))
           }
         ).getOrElse(
-          s.sequences.updated(id, Sequence.State.init(seq))
+          st.sequences.updated(id, Sequence.State.init(seq))
         )
       )
     )
@@ -304,13 +305,14 @@ package object engine {
   private def modifyS(id: Sequence.Id)(f: Sequence.State => Sequence.State): Handle[Unit] =
     modify(
       st => Engine.State(
+        st.conditions,
         st.sequences.get(id).map(
           s => st.sequences.updated(id, f(s))).getOrElse(st.sequences)
       )
     )
 
   private def putS(id: Sequence.Id)(s: Sequence.State): Handle[Unit] =
-    modify(x => Engine.State(x.sequences.updated(id, s)))
+    modify(st => Engine.State(st.conditions, st.sequences.updated(id, s)))
 
   // For introspection
   def printSequenceState(id: Sequence.Id): Handle[Option[Unit]] = getSs(id)((qs: Sequence.State) => Task.now(println(qs)).liftM[HandleStateT])

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -4,8 +4,7 @@ import java.io.{PrintWriter, StringWriter}
 
 import edu.gemini.seqexec.engine.Event._
 import edu.gemini.seqexec.engine.Result.{PartialVal, RetVal}
-import edu.gemini.seqexec.model.Model.SequenceState
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+import edu.gemini.seqexec.model.Model.{SequenceState, Conditions}
 
 import scalaz._
 import Scalaz._

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -5,6 +5,7 @@ import java.io.{PrintWriter, StringWriter}
 import edu.gemini.seqexec.engine.Event._
 import edu.gemini.seqexec.engine.Result.{PartialVal, RetVal}
 import edu.gemini.seqexec.model.Model.SequenceState
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
 
 import scalaz._
 import Scalaz._
@@ -85,6 +86,10 @@ package object engine {
 
   def setObserver(id: Sequence.Id)(name: String): Handle[Unit] =
     modifyS(id)(_.setObserver(name))
+
+  def setConditions(conditions: Conditions): Handle[Unit] =
+    modify(st => Engine.State(st.conditions, st.sequences))
+
 
   /**
     * Loads a sequence
@@ -231,6 +236,7 @@ package object engine {
         modifyS(id)(_.setBreakpoint(step, v))
       case SetOperator(name)       => log("Output: Setting Operator name") *> setOperator(name)
       case SetObserver(id, name)   => log("Output: Setting Observer name") *> setObserver(id)(name)
+      case SetConditions(conds)    => log("Output: Setting conditions") *> setConditions(conds)
       case Poll                    => log("Output: Polling current state")
       case Exit                    => log("Bye") *> close(q)
     }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -1,11 +1,8 @@
 package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.engine.Event.start
-import edu.gemini.seqexec.model.Model.SequenceState
 import edu.gemini.seqexec.model.Model.SequenceState.{Error, Idle}
-import edu.gemini.seqexec.model.Model.{SequenceMetadata, StepConfig}
-
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig}
 
 import scala.Function.const
 import scalaz._
@@ -85,7 +82,7 @@ class SequenceSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
-        Conditions.WORST,
+        Conditions.worst,
         Map(
           (seqId,
            Sequence.State.init(
@@ -114,7 +111,7 @@ class SequenceSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
-        Conditions.WORST,
+        Conditions.worst,
         Map(
           (seqId,
            Sequence.State.init(

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -5,6 +5,8 @@ import edu.gemini.seqexec.model.Model.SequenceState
 import edu.gemini.seqexec.model.Model.SequenceState.{Error, Idle}
 import edu.gemini.seqexec.model.Model.{SequenceMetadata, StepConfig}
 
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+
 import scala.Function.const
 import scalaz._
 import Scalaz._
@@ -83,15 +85,16 @@ class SequenceSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
+        Conditions.WORST,
         Map(
           (seqId,
-          Sequence.State.init(
-            Sequence(
-              seqId,
-              SequenceMetadata("F2", None, None),
-              List(simpleStep(1, false), simpleStep(2, true))
-            )
-          )
+           Sequence.State.init(
+             Sequence(
+               seqId,
+               SequenceMetadata("F2", None, None),
+               List(simpleStep(1, false), simpleStep(2, true))
+             )
+           )
           )
         )
       )
@@ -111,6 +114,7 @@ class SequenceSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
+        Conditions.WORST,
         Map(
           (seqId,
            Sequence.State.init(

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -2,6 +2,8 @@ package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.model.Model.{SequenceMetadata, SequenceState, StepConfig, StepState}
 
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+
 import scalaz.syntax.either._
 import org.scalatest._
 import Matchers._
@@ -94,6 +96,7 @@ class StepSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
+        Conditions.WORST,
         Map(
           (seqId,
            Sequence.State.init(
@@ -138,6 +141,7 @@ class StepSpec extends FlatSpec {
     // Engine state with one idle sequence partially executed. One Step completed, two to go.
     val qs0: Engine.State =
       Engine.State(
+        Conditions.WORST,
         Map(
           (seqId,
            Sequence.State.Zipper(
@@ -203,6 +207,7 @@ class StepSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
+        Conditions.WORST,
         Map(
           (seqId,
            Sequence.State.init(

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -1,8 +1,6 @@
 package edu.gemini.seqexec.engine
 
-import edu.gemini.seqexec.model.Model.{SequenceMetadata, SequenceState, StepConfig, StepState}
-
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig, StepState}
 
 import scalaz.syntax.either._
 import org.scalatest._
@@ -96,7 +94,7 @@ class StepSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
-        Conditions.WORST,
+        Conditions.worst,
         Map(
           (seqId,
            Sequence.State.init(
@@ -141,7 +139,7 @@ class StepSpec extends FlatSpec {
     // Engine state with one idle sequence partially executed. One Step completed, two to go.
     val qs0: Engine.State =
       Engine.State(
-        Conditions.WORST,
+        Conditions.worst,
         Map(
           (seqId,
            Sequence.State.Zipper(
@@ -207,7 +205,7 @@ class StepSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
-        Conditions.WORST,
+        Conditions.worst,
         Map(
           (seqId,
            Sequence.State.init(

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -2,9 +2,11 @@ package edu.gemini.seqexec.engine
 
 import Result._
 import Event._
+import org.scalatest.FlatSpec
+
 import edu.gemini.seqexec.model.Model.SequenceState.{Idle, Error}
 import edu.gemini.seqexec.model.Model.{SequenceMetadata, SequenceState, StepConfig}
-import org.scalatest.FlatSpec
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
 
 import scalaz.syntax.apply._
 import scalaz.syntax.foldable._
@@ -48,6 +50,7 @@ class packageSpec extends FlatSpec {
   val seqId = "TEST-01"
   val qs1: Engine.State =
     Engine.State(
+      Conditions.WORST,
       Map(
         (seqId,
          Sequence.State.init(
@@ -108,8 +111,8 @@ class packageSpec extends FlatSpec {
   val seqId1 = seqId
   val seqId2 = "TEST-02"
   val seqId3 = "TEST-03"
-  val qs2 = Engine.State(qs1.sequences + (seqId2 -> qs1.sequences(seqId1)))
-  val qs3 = Engine.State(qs2.sequences + (seqId3 -> seqG))
+  val qs2 = Engine.State(Conditions.WORST, qs1.sequences + (seqId2 -> qs1.sequences(seqId1)))
+  val qs3 = Engine.State(Conditions.WORST, qs2.sequences + (seqId3 -> seqG))
 
   def runToCompletion(q: scalaz.stream.async.mutable.Queue[Event], s0: Engine.State): Engine.State = {
     def isFinished(status: SequenceState): Boolean =

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -5,8 +5,7 @@ import Event._
 import org.scalatest.FlatSpec
 
 import edu.gemini.seqexec.model.Model.SequenceState.{Idle, Error}
-import edu.gemini.seqexec.model.Model.{SequenceMetadata, SequenceState, StepConfig}
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig}
 
 import scalaz.syntax.apply._
 import scalaz.syntax.foldable._
@@ -50,7 +49,7 @@ class packageSpec extends FlatSpec {
   val seqId = "TEST-01"
   val qs1: Engine.State =
     Engine.State(
-      Conditions.WORST,
+      Conditions.worst,
       Map(
         (seqId,
          Sequence.State.init(
@@ -111,8 +110,8 @@ class packageSpec extends FlatSpec {
   val seqId1 = seqId
   val seqId2 = "TEST-02"
   val seqId3 = "TEST-03"
-  val qs2 = Engine.State(Conditions.WORST, qs1.sequences + (seqId2 -> qs1.sequences(seqId1)))
-  val qs3 = Engine.State(Conditions.WORST, qs2.sequences + (seqId3 -> seqG))
+  val qs2 = Engine.State(Conditions.worst, qs1.sequences + (seqId2 -> qs1.sequences(seqId1)))
+  val qs3 = Engine.State(Conditions.worst, qs2.sequences + (seqId3 -> seqG))
 
   def runToCompletion(q: scalaz.stream.async.mutable.Queue[Event], s0: Engine.State): Engine.State = {
     def isFinished(status: SequenceState): Boolean =

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -178,8 +178,7 @@ object Model {
     implicit val equalConditions: Equal[Conditions] = Equal.equalA[Conditions]
 
     implicit val showConditions: Show[Conditions] = Show.shows[Conditions] {
-      case Conditions(cc, iq, sb, wv) =>
-        List(cc.shows, iq.shows, sb.shows, wv.shows).intercalate(", ")
+      case Conditions(cc, iq, sb, wv) => List(cc, iq, sb, wv).mkString(", ")
     }
 
   }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -26,6 +26,8 @@ object Model {
 
     case class ObserverUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
+    case class ConditionsUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+
     case class StepSkipMarkChanged(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
     case class SequencePauseRequested(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -58,7 +58,7 @@ trait ModelBooPicklers {
     .addConcreteType[ObserverUpdated]
     .addConcreteType[OperatorUpdated]
 
-  implicit val conditionsPickler = compositePickler[Model.Conditions]
+  implicit val conditionsPickler = generatePickler[Model.Conditions]
 
   implicit val cloudCoverPickler = compositePickler[CloudCover]
     .addConcreteType[CloudCover.Percent50.type]

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -58,6 +58,32 @@ trait ModelBooPicklers {
     .addConcreteType[ObserverUpdated]
     .addConcreteType[OperatorUpdated]
 
+  implicit val conditionsPickler = compositePickler[Model.Conditions]
+
+  implicit val cloudCoverPickler = compositePickler[CloudCover]
+    .addConcreteType[CloudCover.Percent50.type]
+    .addConcreteType[CloudCover.Percent70.type]
+    .addConcreteType[CloudCover.Percent80.type]
+    .addConcreteType[CloudCover.Any.type]
+
+  implicit val imageQualityPickler = compositePickler[ImageQuality]
+    .addConcreteType[ImageQuality.Percent20.type]
+    .addConcreteType[ImageQuality.Percent70.type]
+    .addConcreteType[ImageQuality.Percent85.type]
+    .addConcreteType[ImageQuality.Any.type]
+
+  implicit val skyBackgroundPickler = compositePickler[SkyBackground]
+    .addConcreteType[SkyBackground.Percent20.type]
+    .addConcreteType[SkyBackground.Percent50.type]
+    .addConcreteType[SkyBackground.Percent80.type]
+    .addConcreteType[SkyBackground.Any.type]
+
+  implicit val waterVaporPickler = compositePickler[WaterVapor]
+    .addConcreteType[WaterVapor.Percent20.type]
+    .addConcreteType[WaterVapor.Percent50.type]
+    .addConcreteType[WaterVapor.Percent80.type]
+    .addConcreteType[WaterVapor.Any.type]
+
   /**
     * In most cases http4s will use the limit of a byte buffer but not for websockets
     * This method trims the binary array to be sent on the WS channel

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -7,6 +7,7 @@ import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.model.p1.immutable.Site
 import edu.gemini.seqexec.{engine, server}
 import edu.gemini.seqexec.engine.{Engine, Event, EventSystem, Executed, Failed, Result, Sequence}
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
 
 import scalaz._
 import Scalaz._
@@ -61,6 +62,9 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
                   name: String): Task[SeqexecFailure \/ Unit] =
     q.enqueueOne(Event.setObserver(seqId.stringValue(), name)).map(_.right)
 
+  def setConditions(q: engine.EventQueue, conditions: Conditions): Task[SeqexecFailure \/ Unit] =
+    q.enqueueOne(Event.setConditions(conditions)).map(_.right)
+
   // TODO: Add seqId: SPObservationID as parameter
   def setSkipMark(q: engine.EventQueue, id: SPObservationID, stepId: edu.gemini.seqexec.engine.Step.Id): Task[SeqexecFailure \/ Unit] = ???
 
@@ -113,6 +117,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.Breakpoint(_, _, _) => StepBreakpointChanged(svs)
       case engine.SetOperator(_)      => OperatorUpdated(svs)
       case engine.SetObserver(_, _)   => ObserverUpdated(svs)
+      case engine.SetConditions(_)    => ConditionsUpdated(svs)
       case engine.Poll                => SequenceRefreshed(svs)
       case engine.Exit                => NewLogMessage("Exit requested by user")
     }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -7,7 +7,6 @@ import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.model.p1.immutable.Site
 import edu.gemini.seqexec.{engine, server}
 import edu.gemini.seqexec.engine.{Engine, Event, EventSystem, Executed, Failed, Result, Sequence}
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
 
 import scalaz._
 import Scalaz._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -3,6 +3,7 @@ package edu.gemini.seqexec.web.client.services
 import java.util.logging.LogRecord
 
 import edu.gemini.seqexec.model.{ModelBooPicklers, UserDetails, UserLoginRequest}
+import edu.gemini.seqexec.model.Model.Conditions
 import edu.gemini.seqexec.web.common._
 import edu.gemini.seqexec.web.common.LogMessage._
 import org.scalajs.dom.ext.{Ajax, AjaxException}
@@ -73,6 +74,17 @@ object SeqexecWebClient extends ModelBooPicklers {
     Ajax.post(
       url = s"$baseUrl/commands/${s.id}/observer/${name}",
       responseType = "arraybuffer"
+    ).map(unpickle[RegularCommand])
+  }
+
+  /**
+    * Requests the backend to set the Conditions globally
+    */
+  def setConditions(conditions: Conditions): Future[RegularCommand] = {
+    Ajax.post(
+      url = s"$baseUrl/commands/conditions",
+      responseType = "arraybuffer",
+      data = Pickle.intoBytes(conditions)
     ).map(unpickle[RegularCommand])
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.server.Commands
 import edu.gemini.seqexec.server.SeqexecEngine
 import edu.gemini.seqexec.engine
+import edu.gemini.seqexec.model.Model.Conditions
 import edu.gemini.seqexec.web.server.model.CommandsModel._
 import edu.gemini.seqexec.web.server.http4s.encoder._
 import edu.gemini.seqexec.web.server.security.AuthenticationService
@@ -70,6 +71,11 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: engine.Event
         _     <- se.setObserver(inputQueue, obs, name)
         resp  <- Ok(s"Set observer name to $name for sequence $obs")
       } yield resp
+
+    case req @ POST -> Root / "conditions" =>
+      req.decode[Conditions] (conditions =>
+        se.setConditions(inputQueue, conditions) *> Ok(s"Set conditions to $conditions")
+      )
 
     case GET -> Root / "refresh" =>
       se.requestRefresh(inputQueue) *> NoContent()

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/encoder/BooEncoders.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/encoder/BooEncoders.scala
@@ -1,7 +1,7 @@
 package edu.gemini.seqexec.web.server.http4s.encoder
 
 import edu.gemini.seqexec.model._
-import edu.gemini.seqexec.model.Model.{SequenceId, SequencesQueue}
+import edu.gemini.seqexec.model.Model.{Conditions, SequenceId, SequencesQueue}
 import edu.gemini.seqexec.web.common._
 import boopickle.Default._
 
@@ -19,4 +19,5 @@ trait BooEncoders {
   implicit val logMessageDecoder     = booOf[LogMessage]
   implicit val commandsEncoder       = booEncoderOf[CliCommand]
   implicit val sequenceIdEncoder     = booEncoderOf[SequencesQueue[SequenceId]]
+  implicit val conditionsEncoder     = booOf[Conditions]
 }


### PR DESCRIPTION
This is still not ready to merge because I have to implement the conditions in the server but I wanted to get early feedback at engine level in case I'm doing something wrong.

Notice that now `Conditions` is imported from the ODB modell, so the `SeqexecODB` dependency was added to the `engine`.

`Conditions.WORST`, which under the hood sets all conditions to `ANY`, is the default value but you might want some other default.