### PR TITLE
SEQNG-59: Protected routes for Seqexec Engine commands

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
@@ -12,7 +12,7 @@ object JwtAuthentication {
   val authenticatedUser = AttributeKey[Option[UserDetails]]("edu.gemini.seqexec.authenticatedUser")
 }
 
-case class JwtAuthentication(auth: AuthenticationService) extends TokenAuthenticator[UserDetails] with TokenInCookies {
+case class JwtAuthentication(auth: AuthenticationService, override val optionalAllowed: Boolean) extends TokenAuthenticator[UserDetails] with TokenInCookies {
   override val cookieName = auth.config.cookieName
   override val attributeKey = JwtAuthentication.authenticatedUser
   override val store = (t: String) => auth.decodeToken(t) match {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -20,7 +20,7 @@ import scalaz.concurrent.Task
   */
 class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: engine.EventQueue, se: SeqexecEngine) extends BooEncoders {
 
-  val tokenAuthService = JwtAuthentication(auth)
+  val tokenAuthService = JwtAuthentication(auth, false)
 
   val commands = Commands(se.odbProxy)
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -20,7 +20,7 @@ import scalaz.concurrent.Task
   */
 class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: engine.EventQueue, se: SeqexecEngine) extends BooEncoders {
 
-  val tokenAuthService = JwtAuthentication(auth, false)
+  val tokenAuthService = JwtAuthentication(auth, auth.config.devMode)
 
   val commands = Commands(se.odbProxy)
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -46,7 +46,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
     awakeEvery(1.seconds)(Strategy.DefaultStrategy, DefaultScheduler).map { _ => Ping() }
   }
 
-  val tokenAuthService = JwtAuthentication(auth)
+  val tokenAuthService = JwtAuthentication(auth, true)
 
   val publicService: HttpService = GZip { HttpService {
 


### PR DESCRIPTION
This is a small change that improves security closing the option to do unauthorized seqexec commands using e.g. curl

Given that this is useful for development it remains possible  in dev mode