### PR TITLE
Fixes warning

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GwsEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GwsEpics.scala
@@ -23,7 +23,7 @@ final class GwsEpics private (epicsService: CaService) {
   def windVelocity: Option[Velocity] = Option(state.getDoubleAttribute("windspee").value).map(v => MetersPerSecond(v.doubleValue))
   def airPressure: Option[Pressure] = Option(state.getDoubleAttribute("pressure").value).map(v => Bars(v.doubleValue*Milli))
   def ambientT: Option[Temperature] = Option(state.getDoubleAttribute("tambient").value).map(v => Celsius(v.doubleValue))
-  def health: Option[Int] = Option(state.getIntegerAttribute("health").value)
+  def health: Option[Int] = Option(state.getIntegerAttribute("health").value.intValue)
   def dewPoint: Option[Temperature] = Option(state.getDoubleAttribute("dewpoint").value).map(v => Celsius(v.doubleValue))
   def windDirection: Option[Angle] = Option(state.getDoubleAttribute("winddire").value).map(v => Degrees(v.doubleValue))
 


### PR DESCRIPTION
While compiling I noted a warning in `GwsEpics`:

```
[warn] /Users/cquiroz/Projects/ocs3/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GwsEpics.scala:26: Suspicious application of an implicit view (scala.this.Predef.Integer2int) in the argument to Option.apply.
[warn]   def health: Option[Int] = Option(state.getIntegerAttribute("health").value)
```

This PR fixes that hidden implicit conversion