### PR TITLE
SEQNG-117: Seqexec auth expiring

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -8,7 +8,7 @@ mode = "dev"
 # Authentication related settings
 authentication {
     # Indicates how long a session is valid in hrs
-    sessionLifeHrs = 8
+    sessionLifeHrs = 2
     # Name of the cookie to store the session
     cookieName = "SeqexecToken"
     # Secret key for JWT tokens

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
@@ -1,15 +1,37 @@
 package edu.gemini.seqexec.web.server.http4s
 
+import java.time.Instant
+
 import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.server.security.AuthenticationService
-import org.http4s.AttributeKey
+import org.http4s.{AttributeKey, Cookie, HttpService, Response}
 
 import scalaz._
 import Scalaz._
 import scalaz.concurrent.Task
 
+
+trait CookiesService {
+  def name: String
+  def ssl: Boolean
+
+  def buildCookie(token: String, expiration: Long): Cookie = {
+    // if successful set a cookie
+    val exp = Instant.now().plusSeconds(expiration)
+    Cookie(name, token, path = "/".some, expires = exp.some, secure = ssl, httpOnly = true)
+  }
+
+}
+
+object CookiesService {
+  def apply(cookieName: String, useSSL: Boolean): CookiesService = new CookiesService {
+    override val name = cookieName
+    override val ssl = useSSL
+  }
+}
+
 object JwtAuthentication {
-  val authenticatedUser = AttributeKey[Option[UserDetails]]("edu.gemini.seqexec.authenticatedUser")
+  val authenticatedUser: AttributeKey[Option[UserDetails]] = AttributeKey[Option[UserDetails]]("edu.gemini.seqexec.authenticatedUser")
 }
 
 case class JwtAuthentication(auth: AuthenticationService, override val optionalAllowed: Boolean) extends TokenAuthenticator[UserDetails] with TokenInCookies {
@@ -17,7 +39,20 @@ case class JwtAuthentication(auth: AuthenticationService, override val optionalA
   override val attributeKey = JwtAuthentication.authenticatedUser
   override val store = (t: String) => auth.decodeToken(t) match {
     case \/-(u) => Task.now(Some(u))
-    case -\/(e) => Task.now(None)
+    case -\/(_) => Task.now(None)
+  }
+  val cookieService = CookiesService(cookieName, auth.config.useSSL)
+  def loginCookie(user: UserDetails): Cookie = {
+    val cookieVal = auth.buildToken(user)
+    cookieService.buildCookie(cookieVal, auth.sessionTimeout.toSeconds.toLong)
+  }
+  override def apply(service: HttpService): HttpService = super.apply(service).andThenK { (resp: Response) =>
+    // If the user has the attribute replace the cookie
+    Task.delay {
+      resp.attributes.get(JwtAuthentication.authenticatedUser).flatten.fold(resp)(user => {
+        resp.addCookie(loginCookie(user))
+      })
+    }
   }
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/JwtAuthentication.scala
@@ -54,9 +54,9 @@ case class JwtAuthentication(auth: AuthenticationService, override val optionalA
   override def apply(service: HttpService): HttpService = super.apply(service).andThenK { (resp: Response) =>
     // If the user has the attribute replace the cookie
     Task.delay {
-      resp.attributes.get(JwtAuthentication.authenticatedUser).flatten.fold(resp)(user => {
+      resp.attributes.get(JwtAuthentication.authenticatedUser).flatten.fold(resp){ user =>
         resp.addCookie(loginCookie(user))
-      })
+      }
     }
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -1,6 +1,5 @@
 package edu.gemini.seqexec.web.server.http4s
 
-import java.time.Instant
 import java.util.logging.Logger
 
 import edu.gemini.pot.sp.SPObservationID
@@ -46,7 +45,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
     awakeEvery(1.seconds)(Strategy.DefaultStrategy, DefaultScheduler).map { _ => Ping() }
   }
 
-  val tokenAuthService = JwtAuthentication(auth, true)
+  val tokenAuthService = JwtAuthentication(auth, optionalAllowed = true)
 
   val publicService: HttpService = GZip { HttpService {
 
@@ -56,11 +55,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
         auth.authenticateUser(u.username, u.password) match {
           case \/-(user) =>
             // if successful set a cookie
-            val cookieVal = auth.buildToken(user)
-            val expiration = Instant.now().plusSeconds(auth.sessionTimeout.toSeconds.toLong)
-            val cookie = Cookie(auth.config.cookieName, cookieVal,
-              path = "/".some, expires = expiration.some, secure = auth.config.useSSL, httpOnly = true)
-            Ok(user).addCookie(cookie)
+            Ok(user).addCookie(tokenAuthService.loginCookie(user))
           case -\/(_) =>
             Unauthorized(Challenge("jwt", "seqexec"))
         }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -60,6 +60,13 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
             Unauthorized(Challenge("jwt", "seqexec"))
         }
       }
+
+      case req @ POST -> Root / "seqexec" / "logout"              =>
+        // Clean the auth cookie
+        val cookie = Cookie(auth.config.cookieName, "", path = "/".some,
+          secure = auth.config.useSSL, maxAge = Some(-1), httpOnly = true)
+        Ok("").removeCookie(cookie)
+
     }}
 
   // Don't gzip log responses
@@ -90,15 +97,6 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
                 scalaz.stream.Process.empty
               )
             )
-
-          case req @ POST -> Root / "seqexec" / "logout"              =>
-            val user = userInRequest(req)
-            user.fold(Unauthorized(Challenge("jwt", "seqexec"))) { _ =>
-              // Clean the auth cookie
-              val cookie = Cookie(auth.config.cookieName, "", path = "/".some,
-                secure = auth.config.useSSL, maxAge = Some(-1), httpOnly = true)
-              Ok("").removeCookie(cookie)
-            }
 
           case req @ GET -> Root / "seqexec" / "sequence" / oid =>
             val user = userInRequest(req)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -55,7 +55,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
         auth.authenticateUser(u.username, u.password) match {
           case \/-(user) =>
             // if successful set a cookie
-            Ok(user).addCookie(tokenAuthService.loginCookie(user))
+            tokenAuthService.loginCookie(user) >>= { cookie => Ok(user).addCookie(cookie) }
           case -\/(_) =>
             Unauthorized(Challenge("jwt", "seqexec"))
         }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/TokenAuthenticator.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/TokenAuthenticator.scala
@@ -55,7 +55,7 @@ trait TokenAuthenticator[A] extends HttpMiddleware {
   def apply(service: HttpService): HttpService = Service.lift { req =>
     getUser(req) flatMap {
       case u @ Some(_)             =>
-        service(req.withAttribute(attributeKey, u))
+        service(req.withAttribute(attributeKey, u)).map(r => r.withAttribute(attributeKey, u))
       case None if optionalAllowed =>
         service(req) // The request is allowed for an anonymous use
       case None                    =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -68,7 +68,7 @@ case class AuthenticationService(config: AuthenticationConfig) extends AuthServi
     */
   def buildToken(u: UserDetails): Task[String] = Task.delay {
     // Given that only this server will need the key we can just use HMAC. 512-bit is the max key size allowed
-    Jwt.encode(JwtClaim(u.asJson.nospaces).issuedNow.expiresIn(30), config.secretKey, JwtAlgorithm.HS512)
+    Jwt.encode(JwtClaim(u.asJson.nospaces).issuedNow.expiresIn(config.sessionLifeHrs.toSeconds.toLong), config.secretKey, JwtAlgorithm.HS512)
   }
 
   /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -11,6 +11,7 @@ import squants.time.Seconds
 import scala.annotation.tailrec
 import scalaz._
 import Scalaz._
+import scalaz.concurrent.Task
 
 sealed trait AuthenticationFailure
 case class UserNotFound(user: String) extends AuthenticationFailure
@@ -65,9 +66,10 @@ case class AuthenticationService(config: AuthenticationConfig) extends AuthServi
   /**
     * From the user details it creates a JSON Web Token
     */
-  def buildToken(u: UserDetails): String =
+  def buildToken(u: UserDetails): Task[String] = Task.delay {
     // Given that only this server will need the key we can just use HMAC. 512-bit is the max key size allowed
     Jwt.encode(JwtClaim(u.asJson.nospaces).issuedNow.expiresIn(30), config.secretKey, JwtAlgorithm.HS512)
+  }
 
   /**
     * Decodes a token out of JSON Web Token

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
@@ -78,9 +78,6 @@ class SeqexecUIApiRoutesSpec extends FlatSpec with Matchers with UriFunctions wi
       // see https://github.com/http4s/http4s/issues/234
       service.apply(Request(uri = uri("/seqexec/logout"))).unsafePerformSync.status should equal(Status.NotFound)
     }
-    it should "reject unauthorized requests" in {
-      service.apply(Request(method = Method.POST, uri = uri("/seqexec/logout"))).unsafePerformSync.status should equal(Status.Unauthorized)
-    }
     it should "remove the cookie on logout" in {
       // First make a valid cookie
       val b = emit(ByteVector.view(Pickle.intoBytes(UserLoginRequest("telops", "pwd"))))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/security/JWTTokensSpec.scala
@@ -15,7 +15,7 @@ class JWTTokensSpec extends FlatSpec with Matchers with PropertyChecks {
   "JWT Tokens" should "encode/decode" in {
     forAll { (u: String, p: String) =>
       val userDetails = UserDetails(u, p)
-      val token = authService.buildToken(userDetails)
+      val token = authService.buildToken(userDetails).unsafePerformSync
       \/-(userDetails) shouldEqual authService.decodeToken(token)
     }
   }


### PR DESCRIPTION
The auth tokens on the seqexec are set to expire n hours after login. This has the effect that on a long night you could still be working and be logged out

This PR sets a shorten time to live but it renews it every time there is activity which is more logical in my opinion