### PR TITLE
Remove upickle dependency

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -8,7 +8,7 @@ import sbt.{file, project}
 object Common {
   lazy val commonSettings = Seq(
     // Common libraries
-    libraryDependencies ++= Seq(ScalaZCore.value, UPickle.value, BooPickle.value) ++ TestLibs.value
+    libraryDependencies ++= Seq(ScalaZCore.value, BooPickle.value) ++ TestLibs.value
   )
 
   // This function allows triggered compilation to run only when scala files changes

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -31,7 +31,6 @@ object Settings {
     val scalaDom     = "0.9.1"
     val scalajsReact = "0.11.3"
     val scalaCSS     = "0.5.0"
-    val uPickle      = "0.4.0"
     val booPickle    = "1.2.6"
     val diode        = "1.1.1"
     val javaTimeJS   = "0.2.0"
@@ -89,7 +88,6 @@ object Settings {
     val Knobs       = "io.verizon.knobs"   %% "core"                              % LibraryVersions.knobs
 
     val Squants     = Def.setting("org.typelevel" %%% "squants"              % LibraryVersions.squants)
-    val UPickle     = Def.setting("com.lihaoyi"   %%% "upickle"              % LibraryVersions.uPickle)
     val BooPickle   = Def.setting("io.suzaku"     %%% "boopickle"            % LibraryVersions.booPickle)
     val JavaTimeJS  = Def.setting("org.scala-js"  %%% "scalajs-java-time"    % LibraryVersions.javaTimeJS)
     val JavaLogJS   = Def.setting("org.scala-js"  %%% "scalajs-java-logging" % LibraryVersions.javaLogJS)


### PR DESCRIPTION
At the beginning of the project we had the client talk json via upickle to the backend but then we switched to binary. However we still had a little use for upickle when doing the construction of the JSON Web tokens.

This PR remove that dependencies and uses argonaut instead which is already a dependency