### PR TITLE
SEQNG-177 Make Conditions globally readable by the client

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
@@ -28,8 +28,7 @@ object Engine {
 
   object State {
 
-    // WORST sets the value ANY for every condition
-    def empty: State = State(Conditions.worst, Map.empty)
+    def empty: State = State(Conditions.default, Map.empty)
 
   }
 

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -82,7 +82,7 @@ class SequenceSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
-        Conditions.worst,
+        Conditions.default,
         Map(
           (seqId,
            Sequence.State.init(
@@ -111,7 +111,7 @@ class SequenceSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
-        Conditions.worst,
+        Conditions.default,
         Map(
           (seqId,
            Sequence.State.init(

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -94,7 +94,7 @@ class StepSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
-        Conditions.worst,
+        Conditions.default,
         Map(
           (seqId,
            Sequence.State.init(
@@ -139,7 +139,7 @@ class StepSpec extends FlatSpec {
     // Engine state with one idle sequence partially executed. One Step completed, two to go.
     val qs0: Engine.State =
       Engine.State(
-        Conditions.worst,
+        Conditions.default,
         Map(
           (seqId,
            Sequence.State.Zipper(
@@ -205,7 +205,7 @@ class StepSpec extends FlatSpec {
     val q = async.boundedQueue[Event](10)
     val qs0: Engine.State =
       Engine.State(
-        Conditions.worst,
+        Conditions.default,
         Map(
           (seqId,
            Sequence.State.init(

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -49,7 +49,7 @@ class packageSpec extends FlatSpec {
   val seqId = "TEST-01"
   val qs1: Engine.State =
     Engine.State(
-      Conditions.worst,
+      Conditions.default,
       Map(
         (seqId,
          Sequence.State.init(
@@ -110,8 +110,8 @@ class packageSpec extends FlatSpec {
   val seqId1 = seqId
   val seqId2 = "TEST-02"
   val seqId3 = "TEST-03"
-  val qs2 = Engine.State(Conditions.worst, qs1.sequences + (seqId2 -> qs1.sequences(seqId1)))
-  val qs3 = Engine.State(Conditions.worst, qs2.sequences + (seqId3 -> seqG))
+  val qs2 = Engine.State(Conditions.default, qs1.sequences + (seqId2 -> qs1.sequences(seqId1)))
+  val qs3 = Engine.State(Conditions.default, qs2.sequences + (seqId3 -> seqG))
 
   def runToCompletion(q: scalaz.stream.async.mutable.Queue[Event], s0: Engine.State): Engine.State = {
     def isFinished(status: SequenceState): Boolean =

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -139,7 +139,7 @@ object Model {
     * Represents a queue with different levels of details. E.g. it could be a list of Ids
     * Or a list of fully hydrated SequenceViews
     */
-  case class SequencesQueue[T](queue: List[T])
+  case class SequencesQueue[T](conditions: Conditions, queue: List[T])
 
   // Ported from OCS' SPSiteQuality.java
 
@@ -174,6 +174,8 @@ object Model {
       SkyBackground.Percent20,
       WaterVapor.Percent20
     )
+
+    val default = worst // Taken from ODB
 
     implicit val equalConditions: Equal[Conditions] = Equal.equalA[Conditions]
 

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.prop.PropertyChecks
 // Keep the arbitraries in a separate trait to improve caching
 object SharedModelArbitraries {
   import org.scalacheck.Shapeless._
-  val maxListSize = 5
+  val maxListSize = 4
 
   // N.B. We don't want to auto derive this to limit the size of the lists for performance reasons
   def sequencesQueueArb[A](implicit arb: Arbitrary[A]): Arbitrary[SequencesQueue[A]] = Arbitrary {

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -16,8 +16,9 @@ object SharedModelArbitraries {
   // N.B. We don't want to auto derive this to limit the size of the lists for performance reasons
   def sequencesQueueArb[A](implicit arb: Arbitrary[A]): Arbitrary[SequencesQueue[A]] = Arbitrary {
     for {
-      a <- Gen.listOfN[A](maxListSize, arb.arbitrary)
-    } yield SequencesQueue(a)
+      a <- implicitly[Arbitrary[Conditions]].arbitrary
+      b <- Gen.listOfN[A](maxListSize, arb.arbitrary)
+    } yield SequencesQueue(a, b)
   }
 
   implicit val udArb  = implicitly[Arbitrary[UserDetails]]

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.prop.PropertyChecks
 // Keep the arbitraries in a separate trait to improve caching
 object SharedModelArbitraries {
   import org.scalacheck.Shapeless._
-  val maxListSize = 4
+  val maxListSize = 2
 
   // N.B. We don't want to auto derive this to limit the size of the lists for performance reasons
   def sequencesQueueArb[A](implicit arb: Arbitrary[A]): Arbitrary[SequencesQueue[A]] = Arbitrary {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -74,6 +74,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case (ev, qState) =>
         toSeqexecEvent(ev)(
           SequencesQueue(
+            qState.conditions,
             qState.sequences.values.map(
               s => viewSequence(s.toSequence, s.status)
             ).toList

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -147,7 +147,7 @@ case class SeqexecAppRootModel(ws: WebSocketConnection,
 
 object SeqexecAppRootModel {
   type LoadedSequences = SequencesQueue[SequenceView]
-  val noSequencesLoaded = SequencesQueue[SequenceView](Nil)
+  val noSequencesLoaded = SequencesQueue[SequenceView](Conditions.default, Nil)
 
   val initial = SeqexecAppRootModel(WebSocketConnection.empty, None, noSequencesLoaded,
     SectionClosed, SectionClosed, SectionClosed, WebSocketsLog(Nil), GlobalLog(Nil), Empty, SequencesOnDisplay.empty)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -34,7 +34,9 @@ object SeqexecWebClient extends ModelBooPicklers {
     )
     .map(unpickle[SequencesQueue[SequenceId]])
     .recover {
-      case AjaxException(xhr) if xhr.status == HttpStatusCodes.NotFound  => SequencesQueue(Nil) // If not found, we'll consider it like an empty response
+      case AjaxException(xhr) if xhr.status == HttpStatusCodes.NotFound  =>
+        // If not found, we'll consider it like an empty response
+        SequencesQueue(Conditions.default, Nil)
     }
 
   /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/WebSocketsEventsHandlerSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/WebSocketsEventsHandlerSpec.scala
@@ -1,7 +1,7 @@
 package edu.gemini.seqexec.web.client.model
 
 import edu.gemini.seqexec.model.Model.SeqexecEvent.{ConnectionOpenEvent, SequenceLoaded}
-import edu.gemini.seqexec.model.Model.{SequenceView, SequencesQueue}
+import edu.gemini.seqexec.model.Model.{Conditions, SequenceView, SequencesQueue}
 import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.web.client.model.SeqexecCircuit.zoomRW
 import edu.gemini.seqexec.web.common.ArbitrariesWebCommon
@@ -27,7 +27,7 @@ class WebSocketsEventsHandlerSpec extends FlatSpec with Matchers {
     result.newModelOpt.flatMap(_.user) shouldBe Some(user)
   }
   it should "accept a loaded SequencesQueue" in {
-    val sequences = SequencesQueue(List.empty[SequenceView])
+    val sequences = SequencesQueue(Conditions.default, List.empty[SequenceView])
     val handler = new WebSocketEventsHandler(zoomRW(m => (m.sequences, m.webSocketLog, m.user))((m, v) => m.copy(sequences = v._1, webSocketLog = v._2, user = v._3)))
     val result = handler.handle(ServerMessage(SequenceLoaded(sequences)))
     // No user set

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -106,9 +106,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
                     \/.fromTryCatchNonFatal(new SPObservationID(oid))
                       .fold(Task.fail, Task.now)
                 u     <- se.load(inputQueue, obsId)
-                resp  <- u.fold(_ => NotFound(s"Not found sequence $oid"), _ =>
-                  // TODO: Get previously set conditions? How?
-                  Ok(SequencesQueue[SequenceId](Conditions.default, List(oid))))
+                resp  <- u.fold(_ => NotFound(s"Not found sequence $oid"), _ => Ok(oid))
               } yield resp
             }.handleWith {
               case e: SPBadIDException => BadRequest(s"Bad sequence id $oid")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -4,7 +4,7 @@ import java.util.logging.Logger
 
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.engine
-import edu.gemini.seqexec.model.Model.{SeqexecEvent, SequenceId, SequencesQueue}
+import edu.gemini.seqexec.model.Model.{Conditions, SeqexecEvent, SequenceId, SequencesQueue}
 import edu.gemini.seqexec.model.Model.SeqexecEvent.ConnectionOpenEvent
 import edu.gemini.seqexec.model._
 import edu.gemini.seqexec.server.SeqexecEngine
@@ -106,7 +106,9 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
                     \/.fromTryCatchNonFatal(new SPObservationID(oid))
                       .fold(Task.fail, Task.now)
                 u     <- se.load(inputQueue, obsId)
-                resp  <- u.fold(_ => NotFound(s"Not found sequence $oid"), _ => Ok(SequencesQueue[SequenceId](List(oid))))
+                resp  <- u.fold(_ => NotFound(s"Not found sequence $oid"), _ =>
+                  // TODO: Get previously set conditions? How?
+                  Ok(SequencesQueue[SequenceId](Conditions.default, List(oid))))
               } yield resp
             }.handleWith {
               case e: SPBadIDException => BadRequest(s"Bad sequence id $oid")


### PR DESCRIPTION
Now the client can access the conditions by looking them up in `SequencesQueue`.

The tests are now slower, now they take ~22 min instead of 8 min, because after introducing the conditions there are more combinations of Arbitrary `SequenceQueue`s to test the serialization, so any ideas about how to reduce the number of tests while actually including the Conditions in the serializations tests are welcome. I wrote in the commit message of the tests what I already tried.

Another thing to watch out is that now the HTTP response to a Sequence load request is just its id instead of a `SequencesQueue`. Everything seems to be working fine but I'm 100% sure there are no issues related to this change. Including the previously set conditions in the response would have been tricky.

I have the uneasy feeling that I'm forgetting something in this PR but I don't know exactly what it is.