### PR TITLE
SEQNG-172 Made systems configured in step depend on step type.

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Resource.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Resource.scala
@@ -8,11 +8,20 @@ sealed trait Resource
 
 object Resource {
 
-  case object GMOS extends Resource
-  case object F2 extends Resource
   case object P1 extends Resource
   case object OI extends Resource
   case object Mount extends Resource
   case object ScienceFold extends Resource
+  case object Gcal extends Resource
+  case object Gems extends Resource
+  case object Altair extends Resource
+  trait Instrument extends Resource
+  case object GMOS extends Instrument
+  case object F2 extends Instrument
+  case object GSAOI extends Instrument
+  case object GPI extends Instrument
+  case object NIRI extends Instrument
+  case object NIFS extends Instrument
+  case object GNIRS extends Instrument
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -123,7 +123,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     stepType match {
       case CelestialObject(inst) => toInstrumentSys(inst).map(_ :: List(Tcs(systems.tcs), Gcal(systems.gcal, site == Site.GS)))
       case FlatOrArc(inst)       => toInstrumentSys(inst).map(_ :: List(Gcal(systems.gcal, site == Site.GS)))
-      case _ => TrySeq.fail(Unexpected(s"Unsupported step type ${stepType.toString}"))
+      case _                     => TrySeq.fail(Unexpected(s"Unsupported step type ${stepType.toString}"))
     }
   }
 
@@ -147,7 +147,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     case CelestialObject(inst) => calcInstHeader(config, inst).map(_ :: commonHeaders(config))
     case FlatOrArc(inst)       => calcInstHeader(config, inst).map(_ :: commonHeaders(config)) //TODO: Add GCAL keywords here
     case DarkOrBias(inst)      => calcInstHeader(config, inst).map(_ :: commonHeaders(config))
-    case st@_                  => TrySeq.fail(Unexpected("Unsupported step type " + st.toString))
+    case st                    => TrySeq.fail(Unexpected("Unsupported step type " + st.toString))
   }
 
 }
@@ -193,7 +193,7 @@ object SeqTranslate {
   private def extractInstrument(config: Config): TrySeq[Resource.Instrument] = {
     config.extract(INSTRUMENT_KEY / INSTRUMENT_NAME_PROP).as[String].leftMap(explainExtractError).flatMap{
       case Flamingos2.name => TrySeq(Resource.F2)
-      case ins@_           => TrySeq.fail(UnrecognizedInstrument(ins))
+      case ins             => TrySeq.fail(UnrecognizedInstrument(ins))
     }
   }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -2,13 +2,16 @@ package edu.gemini.seqexec.server
 
 import edu.gemini.model.p1.immutable.Site
 import edu.gemini.pot.sp.SPObservationID
-import edu.gemini.seqexec.engine.{Action, Result, Resource, Sequence, Step}
+import edu.gemini.seqexec.engine.{Action, Resource, Result, Sequence, Step}
 import edu.gemini.seqexec.model.Model.SequenceMetadata
 import edu.gemini.seqexec.model.dhs.ImageFileId
 import edu.gemini.seqexec.server.ConfigUtilOps._
 import edu.gemini.seqexec.server.DhsClient.{KeywordBag, StringKeyword}
-import edu.gemini.seqexec.server.SeqexecFailure.UnrecognizedInstrument
+import edu.gemini.seqexec.server.SeqTranslate.{Settings, Systems}
+import edu.gemini.seqexec.server.SeqexecFailure.{Unexpected, UnrecognizedInstrument}
+import edu.gemini.spModel.ao.AOConstants._
 import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
+import edu.gemini.spModel.gemini.altair.AltairConstants
 import edu.gemini.spModel.obscomp.InstConstants._
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 
@@ -19,7 +22,7 @@ import scalaz.concurrent.Task
 /**
   * Created by jluhrs on 9/14/16.
   */
-class SeqTranslate(site: Site) {
+class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   import SeqTranslate._
 
@@ -28,18 +31,9 @@ class SeqTranslate(site: Site) {
     case \/-(r) => Result.OK(r)
   }
 
-  private def step(systems: Systems, settings: Settings)(obsId: SPObservationID, i: Int, config: Config, last: Boolean): SeqexecFailure \/ Step[Action] = {
+  private def step(obsId: SPObservationID, i: Int, config: Config, last: Boolean): TrySeq[Step[Action]] = {
 
-    def buildStep(inst: Instrument, instHeaders: List[Header]): Step[Action] = {
-      // TODO: The contents of `sys` should depend on the kind of step.
-      val sys = List(Tcs(systems.tcs), Gcal(systems.gcal, site == Site.GS), inst)
-      val headers = List(new StandardHeader(systems.dhs,
-        ObsKeywordReaderImpl(config, site.name.replace(' ', '-')),
-        if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader,
-        if (settings.gwsKeywords) GwsKeywordsReaderImpl else DummyGwsKeywordsReader,
-        // TODO: Replace Unit by something that can read the State
-        StateKeywordsReader(Unit)
-      )) ++ instHeaders
+    def buildStep(inst: Instrument, sys: List[System], headers: List[Header], resources: Set[Resource]): Step[Action] = {
 
       def observe(config: Config): SeqAction[ObserveResult] = {
         val dataId: SeqAction[String] = EitherT(Task(config.extract(OBSERVE_KEY / DATA_LABEL_PROP).as[String].leftMap(e =>
@@ -72,8 +66,7 @@ class SeqTranslate(site: Site) {
         i,
         None,
         config.toStepConfig,
-        // TODO: Lookup which resources are needed depending on the type of Step.
-        instrumentResources(inst),
+        resources,
         false,
         (if(i == 0) List(List(toAction(systems.odb.sequenceStart(obsId, "").map(_ => Result.Ignored))))
         else List())
@@ -88,34 +81,26 @@ class SeqTranslate(site: Site) {
       )
     }
 
-    val instName = extractInstrumentName(config)
 
-    instName match {
-      case Flamingos2.name => buildStep(Flamingos2(systems.flamingos2), List(
-        Flamingos2Header(systems.dhs, new Flamingos2Header.ObsKeywordsReaderImpl(config),
-          if(settings.f2Keywords) Flamingos2Header.InstKeywordReaderImpl else Flamingos2Header.DummyInstKeywordReader,
-          if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader
-        ))
-      ).right
-      case _               => UnrecognizedInstrument(instName.toString).left[Step[Action]]
-    }
+    for {
+      stepType <- calcStepType(config)
+      inst     <- toInstrumentSys(stepType.instrument)
+      systems  <- calcSystems(stepType)
+      headers  <- calcHeaders(config, stepType)
+      resources <- calcResources(stepType)
+    } yield buildStep(inst, systems, headers, resources)
 
-  }
-
-  def instrumentResources(inst: Instrument): Set[Resource] = inst match {
-    case Flamingos2(_) => Set(Resource.Mount, Resource.ScienceFold, Resource.F2)
-    case _             => Set.empty
   }
 
   private def extractInstrumentName(config: Config): String =
     // This is too weak. We may want to use the extractors used in ITC
     config.getItemValue(new ItemKey(INSTRUMENT_KEY, INSTRUMENT_NAME_PROP)).toString
 
-  def sequence(systems: Systems, settings: Settings)(obsId: SPObservationID, sequenceConfig: ConfigSequence): SeqexecFailure \/ Sequence[Action] = {
+  def sequence(settings: Settings)(obsId: SPObservationID, sequenceConfig: ConfigSequence): SeqexecFailure \/ Sequence[Action] = {
     val configs = sequenceConfig.getAllSteps.toList
 
     val steps = configs.zipWithIndex.traverseU {
-      case (c, i) => step(systems, settings)(obsId, i, c, i == (configs.length-1))
+      case (c, i) => step(obsId, i, c, i == (configs.length-1))
     }
 
     val instName = configs.headOption.map(extractInstrumentName).getOrElse("Unknown instrument")
@@ -123,10 +108,52 @@ class SeqTranslate(site: Site) {
     steps.map(Sequence[Action](obsId.stringValue(), SequenceMetadata(instName, None, None), _))
   }
 
+  private def toInstrumentSys(inst: Resource.Instrument): TrySeq[Instrument] = inst match {
+    case Resource.F2 => TrySeq(Flamingos2(systems.flamingos2))
+    case _           => TrySeq.fail(Unexpected(s"Instrument ${inst.toString} not supported."))
+  }
+
+  private def calcResources(stepType: StepType): TrySeq[Set[Resource]] = stepType match {
+    case CelestialObject(inst) => TrySeq(Set(inst, Resource.Mount, Resource.ScienceFold, Resource.Gcal))
+    case FlatOrArc(inst)       => TrySeq(Set(inst, Resource.Gcal, Resource.ScienceFold))
+    case _                     => TrySeq.fail(Unexpected(s"Unsupported step type ${stepType.toString}"))
+  }
+
+  private def calcSystems(stepType: StepType): TrySeq[List[System]] = {
+    stepType match {
+      case CelestialObject(inst) => toInstrumentSys(inst).map(_ :: List(Tcs(systems.tcs), Gcal(systems.gcal, site == Site.GS)))
+      case FlatOrArc(inst)       => toInstrumentSys(inst).map(_ :: List(Gcal(systems.gcal, site == Site.GS)))
+      case _ => TrySeq.fail(Unexpected(s"Unsupported step type ${stepType.toString}"))
+    }
+  }
+
+  private def calcInstHeader(config: Config, inst: Resource.Instrument): TrySeq[Header] = inst match {
+    case Resource.F2 =>  TrySeq(Flamingos2Header(systems.dhs, new Flamingos2Header.ObsKeywordsReaderImpl(config),
+      if(settings.f2Keywords) Flamingos2Header.InstKeywordReaderImpl else Flamingos2Header.DummyInstKeywordReader,
+      if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader))
+    case _           =>  TrySeq.fail(Unexpected(s"Instrument ${inst.toString} not supported."))
+  }
+
+  private def commonHeaders(config: Config): List[Header] = List(new StandardHeader(systems.dhs,
+    ObsKeywordReaderImpl(config, site.name.replace(' ', '-')),
+    if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader,
+    if (settings.gwsKeywords) GwsKeywordsReaderImpl else DummyGwsKeywordsReader,
+    // TODO: Replace Unit by something that can read the State
+    StateKeywordsReader(Unit)
+  ))
+
+
+  private def calcHeaders(config: Config, stepType: StepType): TrySeq[List[Header]] = stepType match {
+    case CelestialObject(inst) => calcInstHeader(config, inst).map(_ :: commonHeaders(config))
+    case FlatOrArc(inst)       => calcInstHeader(config, inst).map(_ :: commonHeaders(config)) //TODO: Add GCAL keywords here
+    case DarkOrBias(inst)      => calcInstHeader(config, inst).map(_ :: commonHeaders(config))
+    case st@_                  => TrySeq.fail(Unexpected("Unsupported step type " + st.toString))
+  }
+
 }
 
 object SeqTranslate {
-  def apply(site: Site) = new SeqTranslate(site)
+  def apply(site: Site, systems: Systems, settings: Settings) = new SeqTranslate(site, systems, settings)
 
   case class Systems(
                       odb: ODBProxy,
@@ -141,5 +168,56 @@ object SeqTranslate {
                       f2Keywords: Boolean,
                       gwsKeywords: Boolean
                      )
+
+
+  private sealed trait StepType {
+    val instrument: Resource.Instrument
+  }
+
+  private final case class CelestialObject(override val instrument: Resource.Instrument) extends StepType
+  private final case class Dark(override val instrument: Resource.Instrument) extends StepType
+  private final case class NodAndShuffle(override val instrument: Resource.Instrument) extends StepType
+  private final case class Gems(override val instrument: Resource.Instrument) extends StepType
+  private final case class Altair(override val instrument: Resource.Instrument) extends StepType
+  private final case class FlatOrArc(override val instrument: Resource.Instrument) extends StepType
+  private final case class DarkOrBias(override val instrument: Resource.Instrument) extends StepType
+  private case object AlignAndCalib extends StepType {
+    override val instrument = Resource.GPI
+  }
+
+
+
+  def explainExtractError(e: ExtractFailure): SeqexecFailure =
+    SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))
+
+  private def extractInstrument(config: Config): TrySeq[Resource.Instrument] = {
+    config.extract(INSTRUMENT_KEY / INSTRUMENT_NAME_PROP).as[String].leftMap(explainExtractError).flatMap{
+      case Flamingos2.name => TrySeq(Resource.F2)
+      case ins@_           => TrySeq.fail(UnrecognizedInstrument(ins))
+    }
+  }
+
+  private def calcStepType(config: Config): TrySeq[StepType] = {
+    def extractGaos(inst: Resource.Instrument): TrySeq[StepType] = config.extract(new ItemKey(AO_CONFIG_NAME) / AO_SYSTEM_PROP).as[String] match {
+      case -\/(ConfigUtilOps.ConversionError(_,_)) => TrySeq.fail(Unexpected("Unable to get AO system from sequence"))
+      case -\/(ConfigUtilOps.KeyNotFound(_))       => TrySeq(CelestialObject(inst))
+      case \/-(gaos)                               => gaos match {
+        case AltairConstants.SYSTEM_NAME_PROP                => TrySeq(Altair(inst))
+        case edu.gemini.spModel.gemini.gems.Gems.SYSTEM_NAME => TrySeq(Gems(inst))
+      }
+    }
+
+
+    ( config.extract(OBSERVE_KEY / OBSERVE_TYPE_PROP).as[String].leftMap(explainExtractError)
+      |@| extractInstrument(config) ) { (obsType, inst) =>
+      obsType match {
+        case SCIENCE_OBSERVE_TYPE                     => extractGaos(inst)
+        case BIAS_OBSERVE_TYPE | DARK_OBSERVE_TYPE    => TrySeq(DarkOrBias(inst))
+        case FLAT_OBSERVE_TYPE | ARC_OBSERVE_TYPE | CAL_OBSERVE_TYPE
+                                                      => TrySeq(FlatOrArc(inst))
+        case _                                        => TrySeq.fail(Unexpected("Unknown step type " + obsType))
+      }
+    }.join
+  }
 
 }


### PR DESCRIPTION
The original goal was to not configure TCS for calibration steps. In the road towards that goal I implemented the identification of step types, which I think is the big contribution of this PR.
I am not totally sure about one aspect of the implementation thought. The type of step determines the resources used, the systems that must be configured, and the headers. I created classes for the types, and separate functions to calculate the resources, systems and headers. There is some repeated code between those functions, so maybe they could be consolidated. The other aspect that may be changed is that I think there should be a relationship between resources and systems.