### PR TITLE
Respond with a dummy SequencesQueue when loading a Sequence

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -16,9 +16,8 @@ object SharedModelArbitraries {
   // N.B. We don't want to auto derive this to limit the size of the lists for performance reasons
   def sequencesQueueArb[A](implicit arb: Arbitrary[A]): Arbitrary[SequencesQueue[A]] = Arbitrary {
     for {
-      a <- implicitly[Arbitrary[Conditions]].arbitrary
       b <- Gen.listOfN[A](maxListSize, arb.arbitrary)
-    } yield SequencesQueue(a, b)
+    } yield SequencesQueue(Conditions.default, b)
   }
 
   implicit val udArb  = implicitly[Arbitrary[UserDetails]]

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -106,7 +106,8 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
                     \/.fromTryCatchNonFatal(new SPObservationID(oid))
                       .fold(Task.fail, Task.now)
                 u     <- se.load(inputQueue, obsId)
-                resp  <- u.fold(_ => NotFound(s"Not found sequence $oid"), _ => Ok(oid))
+                resp  <- u.fold(_ => NotFound(s"Not found sequence $oid"), _ =>
+                  Ok(SequencesQueue[SequenceId](Conditions.default, List(oid))))
               } yield resp
             }.handleWith {
               case e: SPBadIDException => BadRequest(s"Bad sequence id $oid")


### PR DESCRIPTION
This avoids a brief error message that was showing in the UI while loading. The
default conditions returned don't seem to used anywhere.

In the end there was an issue with that response. I think it's alright to send the default conditions because I don't think it's used anywhere, but I might be wrong.