### PR TITLE
SEQNG-186: Synchronize operator field across clients

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
@@ -3,7 +3,7 @@ package edu.gemini.seqexec.engine
 import scalaz._
 import Scalaz._
 
-import edu.gemini.seqexec.model.Model.Conditions
+import edu.gemini.seqexec.model.Model.{Conditions, Operator}
 
 /**
   * A Map of `Sequence`s.
@@ -24,11 +24,11 @@ object Engine {
       Engine(q.sequences.mapValues(_.map(f)))
   }
 
-  case class State(conditions: Conditions, sequences: Map[Sequence.Id, Sequence.State])
+  case class State(conditions: Conditions, operator: Option[Operator], sequences: Map[Sequence.Id, Sequence.State])
 
   object State {
 
-    def empty: State = State(Conditions.default, Map.empty)
+    def empty: State = State(Conditions.default, None, Map.empty)
 
   }
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -23,7 +23,7 @@ object Sequence {
 
   type Id = String
 
-  def empty[A](id: Id): Sequence[A] = Sequence(id, SequenceMetadata("", None, None), Nil)
+  def empty[A](id: Id): Sequence[A] = Sequence(id, SequenceMetadata("", None), Nil)
 
   implicit val SequenceFunctor = new Functor[Sequence] {
     def map[A, B](fa: Sequence[A])(f: A => B): Sequence[B] =
@@ -147,8 +147,6 @@ object Sequence {
 
     def setObserver(name: String): State
 
-    def setOperator(name: String): State
-
     /**
       * Current Execution
       */
@@ -227,8 +225,6 @@ object Sequence {
 
       override def getCurrentBreakpoint: Boolean = zipper.focus.breakpoint && zipper.focus.done.isEmpty
 
-      override def setOperator(name: String): State = operatorL.set(self, Some(name))
-
       override def setObserver(name: String): State = observerL.set(self, Some(name))
 
       override val done: List[Step[Result]] = zipper.done
@@ -238,9 +234,6 @@ object Sequence {
 
       private val metadataL: Zipper @> SequenceMetadata =
         zipperL >=> Lens.lensu((x, y) => x.copy(metadata = y), _.metadata)
-
-      private val operatorL: Zipper @> Option[String] =
-        metadataL >=> Lens.lensu((x, y) => x.copy(operator = y), _.operator)
 
       private val observerL: Zipper @> Option[String] =
         metadataL >=> Lens.lensu((x, y) => x.copy(observer = y), _.observer)
@@ -284,8 +277,6 @@ object Sequence {
 
       override def getCurrentBreakpoint: Boolean = false
 
-      override def setOperator(name: String): State = operatorL.set(self, Some(name))
-
       override def setObserver(name: String): State = observerL.set(self, Some(name))
 
       override val done: List[Step[Result]] = seq.steps
@@ -299,9 +290,6 @@ object Sequence {
 
       private val metadataL: Final @> SequenceMetadata =
         sequenceL >=> Lens.lensu((x, y) => x.copy(metadata = y), _.metadata)
-
-      private val operatorL: Final @> Option[String] =
-        metadataL >=> Lens.lensu((x, y) => x.copy(operator = y), _.operator)
 
       private val observerL: Final @> Option[String] =
         metadataL >=> Lens.lensu((x, y) => x.copy(observer = y), _.observer)

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -81,25 +81,25 @@ package object engine {
     modifyS(id)(_.rollback)
 
   def setOperator(name: String): Handle[Unit] =
-    modify(st => Engine.State(st.conditions, st.sequences.mapValues(_.setOperator(name))))
+    modify(st => Engine.State(st.conditions, name.some, st.sequences))
 
   def setObserver(id: Sequence.Id)(name: String): Handle[Unit] =
     modifyS(id)(_.setObserver(name))
 
   def setConditions(conditions: Conditions): Handle[Unit] =
-    modify(st => Engine.State(conditions, st.sequences))
+    modify(st => Engine.State(conditions, st.operator, st.sequences))
 
   def setImageQuality(iq: ImageQuality): Handle[Unit] =
-    modify(st => Engine.State(st.conditions.copy(iq = iq), st.sequences))
+    modify(st => Engine.State(st.conditions.copy(iq = iq), st.operator, st.sequences))
 
   def setWaterVapor(wv: WaterVapor): Handle[Unit] =
-    modify(st => Engine.State(st.conditions.copy(wv = wv), st.sequences))
+    modify(st => Engine.State(st.conditions.copy(wv = wv), st.operator, st.sequences))
 
   def setSkyBackground(sb: SkyBackground): Handle[Unit] =
-    modify(st => Engine.State(st.conditions.copy(sb = sb), st.sequences))
+    modify(st => Engine.State(st.conditions.copy(sb = sb), st.operator, st.sequences))
 
   def setCloudCover(cc: CloudCover): Handle[Unit] =
-    modify(st => Engine.State(st.conditions.copy(cc = cc), st.sequences))
+    modify(st => Engine.State(st.conditions.copy(cc = cc), st.operator, st.sequences))
 
 
   /**
@@ -109,6 +109,7 @@ package object engine {
     modify(
       st => Engine.State(
         st.conditions,
+        st.operator,
         st.sequences.get(id).map(
           t => t.status match {
             case SequenceState.Running => st.sequences
@@ -327,13 +328,14 @@ package object engine {
     modify(
       st => Engine.State(
         st.conditions,
+        st.operator,
         st.sequences.get(id).map(
           s => st.sequences.updated(id, f(s))).getOrElse(st.sequences)
       )
     )
 
   private def putS(id: Sequence.Id)(s: Sequence.State): Handle[Unit] =
-    modify(st => Engine.State(st.conditions, st.sequences.updated(id, s)))
+    modify(st => Engine.State(st.conditions, st.operator, st.sequences.updated(id, s)))
 
   // For introspection
   def printSequenceState(id: Sequence.Id): Handle[Option[Unit]] = getSs(id)((qs: Sequence.State) => Task.now(println(qs)).liftM[HandleStateT])

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -52,7 +52,7 @@ class SequenceSpec extends FlatSpec {
 
   }
 
-  val metadata = SequenceMetadata("F2", None, None)
+  val metadata = SequenceMetadata("F2", None)
 
   def simpleStep(id: Int, breakpoint: Boolean): Step[Action] =
     Step(
@@ -83,12 +83,13 @@ class SequenceSpec extends FlatSpec {
     val qs0: Engine.State =
       Engine.State(
         Conditions.default,
+        None,
         Map(
           (seqId,
            Sequence.State.init(
              Sequence(
                seqId,
-               SequenceMetadata("F2", None, None),
+               SequenceMetadata("F2", None),
                List(simpleStep(1, breakpoint = false), simpleStep(2, breakpoint = true))
              )
            )
@@ -112,12 +113,13 @@ class SequenceSpec extends FlatSpec {
     val qs0: Engine.State =
       Engine.State(
         Conditions.default,
+        None,
         Map(
           (seqId,
            Sequence.State.init(
              Sequence(
                seqId,
-               SequenceMetadata("F2", None, None),
+               SequenceMetadata("F2", None),
                List(simpleStep(1, breakpoint = false), simpleStep(2, breakpoint = true), simpleStep(3, breakpoint = false))
              )
            )
@@ -142,7 +144,6 @@ class SequenceSpec extends FlatSpec {
     }
 
   }
-
 
   // TODO: Share these fixtures with StepSpec
   val result = Result.OK(Result.Observed("dummyId"))

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -95,12 +95,13 @@ class StepSpec extends FlatSpec {
     val qs0: Engine.State =
       Engine.State(
         Conditions.default,
+        None,
         Map(
           (seqId,
            Sequence.State.init(
              Sequence(
                seqId,
-               SequenceMetadata("F2", None, None),
+               SequenceMetadata("F2", None),
                List(
                  Step(
                    1,
@@ -140,12 +141,13 @@ class StepSpec extends FlatSpec {
     val qs0: Engine.State =
       Engine.State(
         Conditions.default,
+        None,
         Map(
           (seqId,
            Sequence.State.Zipper(
              Sequence.Zipper(
                "First",
-               SequenceMetadata("F2", None, None),
+               SequenceMetadata("F2", None),
                Nil,
                Step.Zipper(
                  2,
@@ -206,12 +208,13 @@ class StepSpec extends FlatSpec {
     val qs0: Engine.State =
       Engine.State(
         Conditions.default,
+        None,
         Map(
           (seqId,
            Sequence.State.init(
              Sequence(
                seqId,
-               SequenceMetadata("F2", None, None),
+               SequenceMetadata("F2", None),
                List(
                  Step(
                    1,

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -50,12 +50,13 @@ class packageSpec extends FlatSpec {
   val qs1: Engine.State =
     Engine.State(
       Conditions.default,
+      None,
       Map(
         (seqId,
          Sequence.State.init(
            Sequence(
              "First",
-             SequenceMetadata("F2", None, None),
+             SequenceMetadata("F2", None),
              List(
                Step(
                  1,
@@ -90,7 +91,7 @@ class packageSpec extends FlatSpec {
     Sequence.State.init(
       Sequence(
         "First",
-        SequenceMetadata("GMOS", None, None),
+        SequenceMetadata("GMOS", None),
         List(
           Step(
             1,
@@ -110,8 +111,8 @@ class packageSpec extends FlatSpec {
   val seqId1 = seqId
   val seqId2 = "TEST-02"
   val seqId3 = "TEST-03"
-  val qs2 = Engine.State(Conditions.default, qs1.sequences + (seqId2 -> qs1.sequences(seqId1)))
-  val qs3 = Engine.State(Conditions.default, qs2.sequences + (seqId3 -> seqG))
+  val qs2 = Engine.State(Conditions.default, None, qs1.sequences + (seqId2 -> qs1.sequences(seqId1)))
+  val qs3 = Engine.State(Conditions.default, None, qs2.sequences + (seqId3 -> seqG))
 
   def runToCompletion(q: scalaz.stream.async.mutable.Queue[Event], s0: Engine.State): Engine.State = {
     def isFinished(status: SequenceState): Boolean =

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -123,7 +123,6 @@ object Model {
   // TODO Une a proper instrument class
   case class SequenceMetadata(
     instrument: Instrument,
-    operator: Option[Operator],
     observer: Option[Observer]
   )
 
@@ -139,7 +138,7 @@ object Model {
     * Represents a queue with different levels of details. E.g. it could be a list of Ids
     * Or a list of fully hydrated SequenceViews
     */
-  case class SequencesQueue[T](conditions: Conditions, queue: List[T])
+  case class SequencesQueue[T](conditions: Conditions, operator: Option[Operator], queue: List[T])
 
   // Ported from OCS' SPSiteQuality.java
 

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -17,7 +17,8 @@ object SharedModelArbitraries {
   def sequencesQueueArb[A](implicit arb: Arbitrary[A]): Arbitrary[SequencesQueue[A]] = Arbitrary {
     for {
       b <- Gen.listOfN[A](maxListSize, arb.arbitrary)
-    } yield SequencesQueue(Conditions.default, b)
+      o <- Gen.option(Gen.alphaStr)
+    } yield SequencesQueue(Conditions.default, o, b)
   }
 
   implicit val udArb  = implicitly[Arbitrary[UserDetails]]

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -105,7 +105,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
     val instName = configs.headOption.map(extractInstrumentName).getOrElse("Unknown instrument")
 
-    steps.map(Sequence[Action](obsId.stringValue(), SequenceMetadata(instName, None, None), _))
+    steps.map(Sequence[Action](obsId.stringValue(), SequenceMetadata(instName, None), _))
   }
 
   private def toInstrumentSys(inst: Resource.Instrument): TrySeq[Instrument] = inst match {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -87,6 +87,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
         toSeqexecEvent(ev)(
           SequencesQueue(
             qState.conditions,
+            qState.operator,
             qState.sequences.values.map(
               s => viewSequence(s.toSequence, s.status)
             ).toList

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -1,7 +1,7 @@
 package edu.gemini.seqexec.web.client.components.sequence
 
 import diode.react.ModelProxy
-import edu.gemini.seqexec.model.Model.{Conditions, CloudCover, ImageQuality, SkyBackground, WaterVapor}
+import edu.gemini.seqexec.model.Model.{Operator, Conditions, CloudCover, ImageQuality, SkyBackground, WaterVapor}
 import edu.gemini.seqexec.web.client.semanticui.elements.dropdown.DropdownMenu
 import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
 import edu.gemini.seqexec.web.client.semanticui.elements.input.InputEV
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
   * Display to show headers per sequence
   */
 object HeadersSideBar {
-  case class Props(conditions: ModelProxy[Conditions], status: ModelProxy[ClientStatus])
+  case class Props(model: ModelProxy[HeaderSideBarReader])
 
   case class State(currentText: Option[String])
 
@@ -38,23 +38,23 @@ object HeadersSideBar {
 
     def submitIfChanged: Callback =
       ($.state zip $.props) >>= {
-        case (s, p) => Callback.empty // Callback.when(s.currentText =/= p.operator())(Callback.empty) // We are not submitting until the backend properly update this property
+        case (s, p) => Callback.when(s.currentText =/= p.model().operator)(Callback.empty) // We are not submitting until the backend properly update this property
       }
 
     def iqChanged(iq: ImageQuality): Callback =
-      $.props >>= {_.conditions.dispatchCB(UpdateImageQuality(iq))}
+      $.props >>= {_.model.dispatchCB(UpdateImageQuality(iq))}
 
     def ccChanged(i: CloudCover): Callback =
-      $.props >>= {_.conditions.dispatchCB(UpdateCloudCover(i))}
+      $.props >>= {_.model.dispatchCB(UpdateCloudCover(i))}
 
     def sbChanged(sb: SkyBackground): Callback =
-      $.props >>= {_.conditions.dispatchCB(UpdateSkyBackground(sb))}
+      $.props >>= {_.model.dispatchCB(UpdateSkyBackground(sb))}
 
     def wvChanged(wv: WaterVapor): Callback =
-      $.props >>= {_.conditions.dispatchCB(UpdateWaterVapor(wv))}
+      $.props >>= {_.model.dispatchCB(UpdateWaterVapor(wv))}
 
     def render(p: Props, s: State): ReactTagOf[Div] = {
-      val enabled = p.status().isLogged && p.status().anySelected
+      val enabled = p.model().status.isLogged && p.model().status.anySelected
 
       val operatorEV = ExternalVar(s.currentText.getOrElse(""))(updateState)
       <.div(
@@ -68,15 +68,15 @@ object HeadersSideBar {
             InputEV(InputEV.Props("operator", "operator",
               operatorEV,
               placeholder = "Operator...",
-              disabled = !p.status().isLogged,
+              disabled = !p.model().status.isLogged,
               onBlur = name => Callback.empty// >> p.operator.dispatchCB(UpdateOperator(name)))) TODO Enable when the backend accepts this property
             ))
           ),
 
-          DropdownMenu(DropdownMenu.Props("Image Quality", p.conditions().iq.some, "Select", ImageQuality.all, disabled = !enabled, iqChanged)),
-          DropdownMenu(DropdownMenu.Props("Cloud Cover", p.conditions().cc.some, "Select", CloudCover.all, disabled = !enabled, ccChanged)),
-          DropdownMenu(DropdownMenu.Props("Water Vapor", p.conditions().wv.some, "Select", WaterVapor.all, disabled = !enabled, wvChanged)),
-          DropdownMenu(DropdownMenu.Props("Sky Background", p.conditions().sb.some, "Select", SkyBackground.all, disabled = !enabled, sbChanged))
+          DropdownMenu(DropdownMenu.Props("Image Quality", p.model().conditions.iq.some, "Select", ImageQuality.all, disabled = !enabled, iqChanged)),
+          DropdownMenu(DropdownMenu.Props("Cloud Cover", p.model().conditions.cc.some, "Select", CloudCover.all, disabled = !enabled, ccChanged)),
+          DropdownMenu(DropdownMenu.Props("Water Vapor", p.model().conditions.wv.some, "Select", WaterVapor.all, disabled = !enabled, wvChanged)),
+          DropdownMenu(DropdownMenu.Props("Sky Background", p.model().conditions.sb.some, "Select", SkyBackground.all, disabled = !enabled, sbChanged))
         )
       )
     }
@@ -94,6 +94,6 @@ object HeadersSideBar {
     .componentDidMount(c => c.backend.setInterval(c.backend.submitIfChanged, 2.second))
     .build
 
-  def apply(model: ModelProxy[(ClientStatus, Conditions)]): ReactComponentU[Props, State, Backend, TopNode] =
-    component(Props(model.zoom(_._2), model.zoom(_._1)))
+  def apply(model: ModelProxy[HeaderSideBarReader]): ReactComponentU[Props, State, Backend, TopNode] =
+    component(Props(model))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -112,7 +112,7 @@ object SequenceTabsBody {
 
 object SequenceHeadersAndTable {
   val sequencesDisplayConnect: ReactConnectProxy[(ClientStatus, SequencesOnDisplay)] = SeqexecCircuit.connect(SeqexecCircuit.statusAndSequences)
-  val statusConditionsConnect: ReactConnectProxy[(ClientStatus, Conditions)] = SeqexecCircuit.connect(SeqexecCircuit.statusAndConditions)
+  val headerSideBarConnect: ReactConnectProxy[HeaderSideBarReader] = SeqexecCircuit.connect(SeqexecCircuit.headerSideBarReader)
   private val component = ReactComponentB[Unit]("SequenceHeadersAndTable")
     .stateless
     .render_P(p =>
@@ -120,7 +120,7 @@ object SequenceHeadersAndTable {
         ^.cls := "row",
         <.div(
           ^.cls := "four wide column computer tablet only",
-          statusConditionsConnect(HeadersSideBar.apply)
+          headerSideBarConnect(HeadersSideBar.apply)
         ),
         sequencesDisplayConnect(SequenceTabsBody.apply)
       )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -389,6 +389,7 @@ case class ClientStatus(u: Option[UserDetails], w: WebSocketConnection, selected
   def anySelected: Boolean = selectedSequence.exists(_._2.isDefined)
 }
 
+case class HeaderSideBarReader(status: ClientStatus, conditions: Conditions, operator: Option[Operator])
 /**
   * Contains the model for Diode
   */
@@ -432,6 +433,8 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   val statusAndSearchResults: ModelR[SeqexecAppRootModel, (ClientStatus, Pot[SequencesQueue[SequenceId]])] = SeqexecCircuit.status.zip(SeqexecCircuit.searchResults)
   val statusAndSequences: ModelR[SeqexecAppRootModel, (ClientStatus, SequencesOnDisplay)] = SeqexecCircuit.status.zip(SeqexecCircuit.sequencesOnDisplay)
   val statusAndConditions: ModelR[SeqexecAppRootModel, (ClientStatus, Conditions)] = SeqexecCircuit.status.zip(zoom(_.sequences.conditions))
+  val headerSideBarReader: ModelR[SeqexecAppRootModel, HeaderSideBarReader] =
+    SeqexecCircuit.zoom(c => HeaderSideBarReader(ClientStatus(c.user, c.ws, c.sequencesOnDisplay.currentSequences), c.sequences.conditions, c.sequences.operator))
 
   /**
     * Makes a reference to a sequence on the queue.

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -357,7 +357,7 @@ class WebSocketEventsHandler[M](modelRW: ModelRW[M, (SeqexecAppRootModel.LoadedS
           (q :: seq, eff)
         }
       }
-      updated(value.copy(_1 = SequencesQueue(s.view.conditions, sequencesWithObserver)),
+      updated(value.copy(_1 = SequencesQueue(s.view.conditions, None, sequencesWithObserver)),
               effects.flatten.reduce(_ + _): Effect)
 
     case ServerMessage(s) =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -154,7 +154,7 @@ case class SeqexecAppRootModel(ws: WebSocketConnection,
 
 object SeqexecAppRootModel {
   type LoadedSequences = SequencesQueue[SequenceView]
-  val noSequencesLoaded = SequencesQueue[SequenceView](Conditions.default, Nil)
+  val noSequencesLoaded = SequencesQueue[SequenceView](Conditions.default, None, Nil)
 
   val initial = SeqexecAppRootModel(WebSocketConnection.empty, None, noSequencesLoaded,
     SectionClosed, SectionClosed, SectionClosed, WebSocketsLog(Nil), GlobalLog(Nil), Empty, SequencesOnDisplay.empty)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -36,7 +36,7 @@ object SeqexecWebClient extends ModelBooPicklers {
     .recover {
       case AjaxException(xhr) if xhr.status == HttpStatusCodes.NotFound  =>
         // If not found, we'll consider it like an empty response
-        SequencesQueue(Conditions.default, Nil)
+        SequencesQueue(Conditions.default, None, Nil)
     }
 
   /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/WebSocketsEventsHandlerSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/WebSocketsEventsHandlerSpec.scala
@@ -27,7 +27,7 @@ class WebSocketsEventsHandlerSpec extends FlatSpec with Matchers {
     result.newModelOpt.flatMap(_.user) shouldBe Some(user)
   }
   it should "accept a loaded SequencesQueue" in {
-    val sequences = SequencesQueue(Conditions.default, List.empty[SequenceView])
+    val sequences = SequencesQueue(Conditions.default, None, List.empty[SequenceView])
     val handler = new WebSocketEventsHandler(zoomRW(m => (m.sequences, m.webSocketLog, m.user))((m, v) => m.copy(sequences = v._1, webSocketLog = v._2, user = v._3)))
     val result = handler.handle(ServerMessage(SequenceLoaded(sequences)))
     // No user set

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -107,7 +107,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
                       .fold(Task.fail, Task.now)
                 u     <- se.load(inputQueue, obsId)
                 resp  <- u.fold(_ => NotFound(s"Not found sequence $oid"), _ =>
-                  Ok(SequencesQueue[SequenceId](Conditions.default, List(oid))))
+                  Ok(SequencesQueue[SequenceId](Conditions.default, None, List(oid))))
               } yield resp
             }.handleWith {
               case e: SPBadIDException => BadRequest(s"Bad sequence id $oid")


### PR DESCRIPTION
This PR re enables the operator field on the side bar. It required an update to the backend to move the operator to a higher level along the conditions.

The operator field is getting the same treatment as the observer field and updates will be detected on the background