### PR TITLE
Pin the jsdom version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
   - nvm use stable
-  - npm install jsdom
+  - npm install jsdom@9.12.0
 before_script:
   - sudo apt-get install -y rpm
 script:


### PR DESCRIPTION
jsdom has been updated on travis but the latest version isn't compatible with scala.js breaking the build

This PR pins the jsdom version