### PR TITLE
Send distinct engine event when trying to run a Sequence where some resource are busy

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -38,6 +38,7 @@ sealed trait SystemEvent
 case class Completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]) extends SystemEvent
 case class PartialResult[R<:PartialVal](id: Sequence.Id, i: Int, r: Partial[R]) extends SystemEvent
 case class Failed(id: Sequence.Id, i: Int, e: Result.Error) extends SystemEvent
+case class Busy(id: Sequence.Id) extends SystemEvent
 case class Executed(id: Sequence.Id) extends SystemEvent
 case class Executing(id: Sequence.Id) extends SystemEvent
 case class Finished(id: Sequence.Id) extends SystemEvent
@@ -63,6 +64,7 @@ object Event {
   def failed(id: Sequence.Id, i: Int, e: Result.Error): Event = EventSystem(Failed(id, i, e))
   def completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]): Event = EventSystem(Completed(id, i, r))
   def partial[R<:PartialVal](id: Sequence.Id, i: Int, r: Partial[R]): Event = EventSystem(PartialResult(id, i, r))
+  def busy(id: Sequence.Id): Event = EventSystem(Busy(id))
   def executed(id: Sequence.Id): Event = EventSystem(Executed(id))
   def executing(id: Sequence.Id): Event = EventSystem(Executing(id))
   def finished(id: Sequence.Id): Event = EventSystem(Finished(id))

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -57,11 +57,11 @@ package object engine {
     */
   def switch(q: EventQueue)(id: Sequence.Id)(st: SequenceState): Handle[Unit] =
     resources.flatMap(
-      ores => getS(id).flatMap {
+      other => getS(id).flatMap {
         case Some(seq) =>
           if (st === SequenceState.Running)
             // No resources being used by other running sequences
-            if (seq.toSequence.resources.intersect(ores).isEmpty)
+            if (seq.toSequence.resources.intersect(other).isEmpty)
               putS(id)(Sequence.State.status.set(seq, st))
             // Some resources are being used
             else send(q)(busy(id))

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -36,6 +36,8 @@ object Model {
 
     case class SequenceRefreshed(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
+    case class ResourcesBusy(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+
     //Generic update. It will probably become useless if we have a special Event for every case.
     case class SequenceUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -59,6 +59,7 @@ trait ModelBooPicklers {
     .addConcreteType[ObserverUpdated]
     .addConcreteType[OperatorUpdated]
     .addConcreteType[ConditionsUpdated]
+    .addConcreteType[ResourcesBusy]
 
   implicit val cloudCoverPickler = compositePickler[CloudCover]
     .addConcreteType[CloudCover.Any.type]

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -153,8 +153,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.Completed(_, _, _)     => NewLogMessage("Action completed")
       case engine.PartialResult(_, _, _) => SequenceUpdated(svs)
       case engine.Failed(_, _, _)        => NewLogMessage("Action failed")
-      // TODO: Does it need a different event?
-      case engine.Busy(_)                => SequenceRefreshed(svs)
+      case engine.Busy(_)                => ResourcesBusy(svs)
       case engine.Executed(_)            => StepExecuted(svs)
       case engine.Executing(_)           => NewLogMessage("Executing")
       case engine.Finished(_)            => SequenceCompleted(svs)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -153,6 +153,8 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.Completed(_, _, _)     => NewLogMessage("Action completed")
       case engine.PartialResult(_, _, _) => SequenceUpdated(svs)
       case engine.Failed(_, _, _)        => NewLogMessage("Action failed")
+      // TODO: Does it need a different event?
+      case engine.Busy(_)                => SequenceRefreshed(svs)
       case engine.Executed(_)            => StepExecuted(svs)
       case engine.Executing(_)           => NewLogMessage("Executing")
       case engine.Finished(_)            => SequenceCompleted(svs)


### PR DESCRIPTION
Now instead of doing nothing, it explicitly sends an event indicating that the Sequence couldn't be run because some resources are busy.

The *Run* button in the UI still appears greyed out after this event but I don't think it's worth fixing because I think we shouldn't even show the *Run* button when there are busy resources (to be done in another PR).

This event will be used only when trying to run the sequence through the HTTP API. 