### PR TITLE
SEQNG-198: Store settings for production servers locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,3 @@ buildinfo.properties
 # Node modules
 node_modules/
 
-# Resources for standalone apps
-app/seqexec-server-gs/src/main/resources/

--- a/app/seqexec-server-gn-test/src/main/resources/app.conf
+++ b/app/seqexec-server-gn-test/src/main/resources/app.conf
@@ -7,14 +7,19 @@ mode = "production"
 
 # Authentication related settings
 authentication {
-    # Secret key for JWT tokens
-    secretKey = "8g8fBTDD5X9hwmPjumSCnsHtDTHOyITs8ATjsA"
-    # List of LDAP servers, the list is used in a failover fashion
-    ldapURLs = ["ldap://mkodc-wv1.gemini.edu:3268", "ldap://hbfdc-wv1.gemini.edu:3268"]
+  # List of LDAP servers, the list is used in a failover fashion
+  ldapURLs = ["ldap://mkodc-wv1.gemini.edu:3268", "ldap://hbfdc-wv1.gemini.edu:3268"]
+  # Secret key for JWT tokens
+  import "/gemsoft/etc/seqexec/conf.d/auth.conf"
+}
+
+web-server {
+  # TLS Settings
+  import "/gemsoft/etc/seqexec/conf.d/tls.conf"
 }
 
 # Configuration of the seqexec engine
 seqexec-engine {
     # host for the test odb
-    odb = "gnodb.gemini.edu"
+    odb = "gnodbtest2.gemini.edu"
 }

--- a/app/seqexec-server-gs-test/src/main/resources/app.conf
+++ b/app/seqexec-server-gs-test/src/main/resources/app.conf
@@ -7,10 +7,15 @@ mode = "production"
 
 # Authentication related settings
 authentication {
-    # Secret key for JWT tokens
-    secretKey = "9b8!STk3S#PGxjiUZs*QCXbbKvlzFKxF5VGdwz56"
-    # List of LDAP servers, the list is used in a failover fashion
-    ldapURLs = ["ldap://cpodc-wv1.gemini.edu:3268", "ldap://sbfdc-wv1.gemini.edu:3268"]
+  # List of LDAP servers, the list is used in a failover fashion
+  ldapURLs = ["ldap://cpodc-wv1.gemini.edu:3268", "ldap://sbfdc-wv1.gemini.edu:3268"]
+  # Secret key for JWT tokens
+  import "/gemsoft/etc/seqexec/conf.d/auth.conf"
+}
+
+web-server {
+  # TLS Settings
+  import "/gemsoft/etc/seqexec/conf.d/tls.conf"
 }
 
 # Configuration of the seqexec engine

--- a/app/seqexec-server-gs/src/main/resources/app.conf
+++ b/app/seqexec-server-gs/src/main/resources/app.conf
@@ -1,0 +1,34 @@
+#
+# Seqexec server configuration for production at GS
+#
+
+mode = "production"
+
+# Authentication related settings
+authentication {
+    # List of LDAP servers, the list is used in a failover fashion
+    ldapURLs = ["ldap://cpodc-wv1.gemini.edu:3268", "ldap://sbfdc-wv1.gemini.edu:3268"]
+    # Secret key for JWT tokens
+    import "/gemsoft/etc/seqexec/conf.d/auth.conf"
+}
+
+web-server {
+    # TLS Settings
+    import "/gemsoft/etc/seqexec/conf.d/tls.conf"
+}
+
+# Configuration of the seqexec engine
+seqexec-engine {
+    # host for the test odb
+    odb = "gsodb.gemini.edu"
+    dhsSim = false
+    tcsSim = false
+    instSim = false
+    gcalSim = false
+    odbNotifications = true
+    tcsKeywords = true
+    f2Keywords = true
+    gwskeywords = true
+    odbQueuePollingInterval = "3 seconds"
+    tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gws= ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"
+}

--- a/build.sbt
+++ b/build.sbt
@@ -287,16 +287,6 @@ lazy val seqexec_server = preventPublication(project.in(file("app/seqexec-server
     }
   )
 
-lazy val seqexecTestServerSettings = Seq(
-  // Put the jre on the RPM
-  linuxPackageMappings in Rpm += {
-    val jresDir = (ocsJreDir in ThisBuild).value
-    // RPM are of interest only for linux 64 bit
-    val linux64Jre = jresDir.toPath.resolve("linux").resolve("JRE64_1.8")
-    packageDirectoryAndContentsMapping((linux64Jre.toFile, (rpmPrefix in Rpm).value.map(_ + "").getOrElse("")))
-  }
-)
-
 /**
   * Project for the seqexec test server at GS on Linux 64
   */
@@ -307,7 +297,6 @@ lazy val seqexec_server_gs_test = preventPublication(project.in(file("app/seqexe
   .enablePlugins(JavaServerAppPackaging)
   .settings(seqexecCommonSettings: _*)
   .settings(seqexecRPMSettings: _*)
-  .settings(seqexecTestServerSettings: _*)
   .settings(deployedAppMappings: _*)
   .settings(embeddedJreSettingsLinux64: _*)
   .settings(
@@ -324,7 +313,6 @@ lazy val seqexec_server_gn_test = preventPublication(project.in(file("app/seqexe
   .enablePlugins(JavaServerAppPackaging)
   .settings(seqexecCommonSettings: _*)
   .settings(seqexecRPMSettings: _*)
-  .settings(seqexecTestServerSettings: _*)
   .settings(deployedAppMappings: _*)
   .settings(embeddedJreSettingsLinux64: _*)
   .settings(
@@ -343,23 +331,10 @@ lazy val seqexec_server_gs = preventPublication(project.in(file("app/seqexec-ser
   .settings(seqexecRPMSettings: _*)
   .settings(deployedAppMappings: _*)
   .settings(embeddedJreSettingsLinux64: _*)
-  .settings(configurationFromSVN: _*)
   .settings(
     description := "Seqexec Gemini South server production",
     applicationConfName := "seqexec",
-    applicationConfSite := DeploymentSite.GS,
-
-    // Download the configuration from svn
-    packageZipTarball in Universal := ((packageZipTarball in Universal).dependsOn(downloadConfiguration)).value,
-    packageBin in Rpm := ((packageBin in Rpm).dependsOn(downloadConfiguration)).value,
-
-    // Put the jre on the RPM
-    linuxPackageMappings in Rpm += {
-      val jresDir = (ocsJreDir in ThisBuild).value
-      // RPM are of interest only for linux 64 bit
-      val linux64Jre = jresDir.toPath.resolve("linux").resolve("JRE64_1.8")
-      packageDirectoryAndContentsMapping((linux64Jre.toFile, (rpmPrefix in Rpm).value.map(_ + "").getOrElse("")))
-    }
+    applicationConfSite := DeploymentSite.GS
   ).dependsOn(seqexec_server)
 
 // Root web project

--- a/project/AppsCommon.scala
+++ b/project/AppsCommon.scala
@@ -98,20 +98,6 @@ object AppsCommon {
 
   lazy val embeddedJreSettingsLinux64 = embeddedJreSettings(DeploymentTarget.Linux64)
 
-  lazy val configurationFromSVN = Seq(
-    // Download the configuration from svn
-    downloadConfiguration := {
-      import sys.process._
-      // This incarnation will get the configuration from svn. Note that we use the local svn client so you need
-      // to have it setup including your credentials
-      val targetFile = (resourceDirectory in Compile).value / "app.conf"
-      val targetDir = targetFile.getParentFile.getAbsolutePath
-      val exitCode = s"svn co http://source.gemini.edu/software/ocs3/trunk/configurations/${applicationConfName.value}/production/${applicationConfSite.value.site}/ $targetDir".!
-      if (exitCode == 0) Seq(targetFile) else throw new RuntimeException("Settings download failed")
-    }
-
-  )
-
   /**
     * Settings for meta projects to make them non-publishable
     */

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "0.2.0"
+version in ThisBuild := "0.3.0"
 


### PR DESCRIPTION
This PR simplifies the settings used for the production and test seqexec servers. All settings are now in github and the private ones are stored locally on each host. In particular the certificates keystore are on the hosts. They are version controlled but stored in a separate repository

Version number is increased for the next release