### PR TITLE
SEQNG-83: Epics configuration for systems

### DIFF
--- a/app/seqexec-server-gs/src/main/resources/app.conf
+++ b/app/seqexec-server-gs/src/main/resources/app.conf
@@ -31,4 +31,5 @@ seqexec-engine {
     gwskeywords = true
     odbQueuePollingInterval = "3 seconds"
     tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gws= ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"
+    epics_ca_addr_list = "172.17.2.255 172.17.3.50 172.17.3.40 172.17.102.130 172.17.102.139 172.17.102.138 172.17.65.255"
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.locks.ReentrantLock
 import java.util.{Timer, TimerTask}
 import java.util.logging.Logger
 
-import edu.gemini.epics.EpicsService
 import edu.gemini.seqexec.server.EpicsCommand._
 import edu.gemini.seqexec.server.tcs.{BinaryOnOff, BinaryYesNo}
 
@@ -30,7 +29,7 @@ final class TcsEpics(epicsService: CaService, tops: Map[String, String]) {
   import TcsEpics._
   import EpicsCommand.setParameter
 
-  val TCS_TOP = tops.get("tcs").getOrElse("")
+  val TCS_TOP = tops.getOrElse("tcs", "")
 
   // This is a bit ugly. Commands are triggered from the main apply record, so I just choose an arbitrary command here.
   // Triggering that command will trigger all the marked commands.

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -50,4 +50,5 @@ seqexec-engine {
     instForceError = false
     odbQueuePollingInterval = "10 seconds"
     tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gws= ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"
+    epics_ca_addr_list = "127.0.0.1"
 }


### PR DESCRIPTION
This has been bothering me for a while. EPICS gets initialized from the system environment variable, but when it is not present we get an NPE

This PR adds a configuration variable to set it explicitly. If not present the system will revert to the environment variable