### PR TITLE
SEQNG-224: Fixed the type of some EPICS channels.

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/resources/Flamingos2.xml
+++ b/modules/edu.gemini.seqexec.server/src/main/resources/Flamingos2.xml
@@ -41,11 +41,13 @@
         </command>
         <command name="flamingos2::config">
             <description>Setup a Configuration</description>
+            <!--
             <parameter name="useElectronicOffsetting">
                 <channel>wfs:followA.K</channel>
                 <type>INTEGER</type>
                 <description>0 Electronic Offsets</description>
             </parameter>
+            -->
             <parameter name="filter">
                 <channel>instrumentSetup.F</channel>
                 <type>STRING</type>

--- a/modules/edu.gemini.seqexec.server/src/main/resources/Tcs.xml
+++ b/modules/edu.gemini.seqexec.server/src/main/resources/Tcs.xml
@@ -1008,7 +1008,7 @@
         <top>tcs</top>
         <attribute name="decson">
             <channel>chopControl.VALB</channel>
-            <type>STRING</type>
+            <type>INTEGER</type>
             <description>SCS DECS on flag</description>
             <top>m2</top>
         </attribute>
@@ -1377,7 +1377,7 @@
         </attribute>
         <attribute name="chopon">
             <channel>chopControl.VALA</channel>
-            <type>STRING</type>
+            <type>INTEGER</type>
             <description>SCS Chop on flag</description>
             <top>m2</top>
         </attribute>
@@ -1595,7 +1595,7 @@
         </attribute>
         <attribute name="agHwParked">
             <channel>hwParked</channel>
-            <type>STRING</type>
+            <type>INTEGER</type>
             <description>AcqCam parked</description>
             <top>ag</top>
         </attribute>
@@ -1681,7 +1681,7 @@
         </attribute>
         <attribute name="sfParked">
             <channel>sfParked</channel>
-            <type>STRING</type>
+            <type>INTEGER</type>
             <description>Science Fold parked</description>
             <top>ag</top>
         </attribute>
@@ -2383,7 +2383,8 @@
         <top>oiwfs</top>
         <attribute name="intTime">
             <channel>dc:intTime.VAL</channel>
-            <type>DOUBLE</type>
+            <!--Should be changed to DOUBLE when the EPICS DB is corrected-->
+            <type>STRING</type>
             <description>Integration time</description>
         </attribute>
     </Status>

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
@@ -48,7 +48,7 @@ final class Flamingos2Epics(epicsService: CaService) {
   object configCmd extends EpicsCommand {
     override val cs = Option(epicsService.getCommandSender("flamingos2::config"))
 
-    val useElectronicOffsetting = cs.map(_.getInteger("useElectronicOffsetting"))
+    val useElectronicOffsetting = cs.map(_.addInteger("useElectronicOffsetting", "wfs:followA.K", "Enable electronic Offsets", false))
     def setUseElectronicOffsetting(v: Integer): SeqAction[Unit] = setParameter(useElectronicOffsetting, v)
 
     val filter = cs.map(_.getString("filter"))


### PR DESCRIPTION
A couple of channels were created as String parameters, but when trying to use them they were searched as Int parameters. That caused the NullPointerException.