### PR TITLE
SEQNG-229: Display the title on the client

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -74,7 +74,7 @@ object LoginBox {
             ^.action := "#",
             <.div(
               ^.cls :="required field",
-              Label(Label.Props("Username", "username")),
+              Label(Label.Props("Username", Some("username"))),
               <.div(
                 ^.cls :="ui icon input",
                 <.input(
@@ -90,7 +90,7 @@ object LoginBox {
             ),
             <.div(
               ^.cls :="required field",
-              Label(Label.Props("Password", "password")),
+              Label(Label.Props("Password", Some("password"))),
               <.div(
                 ^.cls := "ui icon input",
                 <.input(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -100,7 +100,7 @@ object QueueTableBody {
     }
     .build
 
-  def apply(p: ModelProxy[(ClientStatus, LoadedSequences)]) = component(Props(p))
+  def apply(p: ModelProxy[(ClientStatus, LoadedSequences)]): Unmounted[Props, Unit, Unit] = component(Props(p))
 
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -5,6 +5,7 @@ import edu.gemini.seqexec.model.Model.{SequenceState, SequenceView}
 import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.model.ModelOps._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconAttention, IconCheckmark, IconCircleNotched}
+import edu.gemini.seqexec.web.client.semanticui.elements.table.TableHeader
 import edu.gemini.seqexec.web.client.services.HtmlConstants.{iconEmpty, nbsp}
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react._
@@ -24,7 +25,9 @@ object QueueTableBody {
   def emptyRow(k: String): VdomTagOf[TableRow] = {
     <.tr(
       ^.key := k, // React requires unique keys
-      <.td(iconEmpty),
+      <.td(
+        ^.cls := "collapsing",
+        iconEmpty),
       <.td(nbsp),
       <.td(nbsp),
       <.td(nbsp),
@@ -73,8 +76,8 @@ object QueueTableBody {
                   s.metadata.instrument
                 ),
                 <.td(
-                  SeqexecStyles.notInMobile//,
-                  //s.error.map(e => <.p(IconAttention, s" $e")).getOrElse(<.p("-"))
+                  SeqexecStyles.notInMobile,
+                  s.metadata.name
                 )
               )
             case (_, i) =>
@@ -105,11 +108,11 @@ object QueueTableSection {
           <.thead(
             <.tr(
               SeqexecStyles.notInMobile,
-              <.th(iconEmpty),
-              <.th("Obs ID"),
-              <.th("State"),
-              <.th("Instrument"),
-              <.th("Notes")
+              TableHeader(TableHeader.Props(collapsing = true),  iconEmpty),
+              TableHeader("Obs ID"),
+              TableHeader("State"),
+              TableHeader("Instrument"),
+              TableHeader("Obs. Name")
             )
           ),
           queueConnect(QueueTableBody(_))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -72,7 +72,7 @@ object HeadersSideBar {
           ^.cls := "ui form",
           <.div(
             ^.cls := "required field",
-            Label(Label.Props("Operator", "operator")),
+            Label(Label.Props("Operator", Some("operator"))),
             InputEV(InputEV.Props("operator", "operator",
               operatorEV,
               placeholder = "Operator...",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
@@ -93,7 +93,8 @@ object SequenceDefaultToolbar {
 
   private def component = ScalaComponent.builder[Props]("SequencesDefaultToolbar")
     .initialState(State(runRequested = false, pauseRequested = false, syncRequested = false))
-    .renderPS( ($, p, s) =>
+    .renderPS{ ($, p, s) =>
+      val isLogged = p.status.isLogged
       <.div(
         ^.cls := "ui column grid",
         <.div(
@@ -104,13 +105,13 @@ object SequenceDefaultToolbar {
               ^.cls := "ui form",
               <.div(
                 ^.cls := "field",
-                Label(Label.Props(s"Name: ${p.s.metadata.name}"))
+                Label(Label.Props(s"Name: ${p.s.metadata.name}")).when(isLogged)
               )
             ),
             <.h3(
               ^.cls := "ui green header",
               "Sequence complete"
-            ).when(p.status.isLogged && p.s.status === SequenceState.Completed),
+            ).when(isLogged && p.s.status === SequenceState.Completed),
             Button(
               Button.Props(
                 icon = Some(IconPlay),
@@ -120,7 +121,7 @@ object SequenceDefaultToolbar {
                 dataTooltip = Some(s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} the sequence from the step ${p.nextStepToRun + 1}"),
                 disabled = !p.status.isConnected || s.runRequested || s.syncRequested),
               s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} from step ${p.nextStepToRun + 1}"
-            ).when(p.status.isLogged && p.s.hasError),
+            ).when(isLogged && p.s.hasError),
             Button(
               Button.Props(
                 icon = Some(IconRefresh),
@@ -129,7 +130,7 @@ object SequenceDefaultToolbar {
                 dataTooltip = Some(s"Sync sequence"),
                 disabled = !p.status.isConnected || s.runRequested || s.syncRequested),
               s" Sync"
-            ).when(p.status.isLogged && p.s.status === SequenceState.Idle),
+            ).when(isLogged && p.s.status === SequenceState.Idle),
             Button(
               Button.Props(
                 icon = Some(IconPlay),
@@ -139,7 +140,7 @@ object SequenceDefaultToolbar {
                 dataTooltip = Some(s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} the sequence from the step ${p.nextStepToRun + 1}"),
                 disabled = !p.status.isConnected || s.runRequested || s.syncRequested),
               s"${p.s.isPartiallyExecuted ? "Continue" | "Run"} from step ${p.nextStepToRun + 1}"
-            ).when(p.status.isLogged && p.s.status === SequenceState.Idle),
+            ).when(isLogged && p.s.status === SequenceState.Idle),
             Button(
               Button.Props(
                 icon = Some(IconPause),
@@ -149,7 +150,7 @@ object SequenceDefaultToolbar {
                 dataTooltip = Some("Pause the sequence after the current step completes"),
                 disabled = !p.status.isConnected || s.pauseRequested || s.syncRequested),
               "Pause"
-            ).when(p.status.isLogged && p.s.status === SequenceState.Running),
+            ).when(isLogged && p.s.status === SequenceState.Running),
             Button(
               Button.Props(
                 icon = Some(IconPlay),
@@ -158,19 +159,19 @@ object SequenceDefaultToolbar {
                 color = Some("teal"),
                 disabled = !p.status.isConnected || s.syncRequested),
               "Continue from step 1"
-            ).when(p.status.isLogged && p.s.status === SequenceState.Paused)
+            ).when(isLogged && p.s.status === SequenceState.Paused)
           ),
           <.div(
             ^.cls := "right column",
             ^.classSet(
-              "eight wide computer six wide tablet sixteen wide mobile" -> p.status.isLogged,
-              "sixteen wide" -> !p.status.isLogged
+              "eight wide computer six wide tablet sixteen wide mobile" -> isLogged,
+              "sixteen wide" -> !isLogged
             ),
-            SequenceObserverField(SequenceObserverField.Props(p.s, p.status.isLogged))
+            SequenceObserverField(SequenceObserverField.Props(p.s, isLogged))
           )
         )
     )
-    ).componentWillReceiveProps { f =>
+    }.componentWillReceiveProps { f =>
       // Update state of run requested depending on the run state
       Callback.when(f.nextProps.s.status === SequenceState.Running && f.state.runRequested)(f.modState(_.copy(runRequested = false)))
     }.build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceDefaultToolbar.scala
@@ -48,7 +48,7 @@ object SequenceObserverField {
         ^.cls := "ui form",
         <.div(
           ^.cls := "required field",
-          Label(Label.Props("Observer", "")),
+          Label(Label.Props("Observer")),
           InputEV(InputEV.Props(
             p.s.metadata.instrument + ".observer",
             p.s.metadata.instrument + ".observer",
@@ -100,6 +100,13 @@ object SequenceDefaultToolbar {
           ^.cls := "ui row",
           <.div(
             ^.cls := "left column bottom aligned eight wide computer ten wide tablet only",
+            <.div(
+              ^.cls := "ui form",
+              <.div(
+                ^.cls := "field",
+                Label(Label.Props(s"Name: ${p.s.metadata.name}"))
+              )
+            ),
             <.h3(
               ^.cls := "ui green header",
               "Sequence complete"
@@ -152,16 +159,16 @@ object SequenceDefaultToolbar {
                 disabled = !p.status.isConnected || s.syncRequested),
               "Continue from step 1"
             ).when(p.status.isLogged && p.s.status === SequenceState.Paused)
+          ),
+          <.div(
+            ^.cls := "right column",
+            ^.classSet(
+              "eight wide computer six wide tablet sixteen wide mobile" -> p.status.isLogged,
+              "sixteen wide" -> !p.status.isLogged
             ),
-            <.div(
-              ^.cls := "right column",
-              ^.classSet(
-                "eight wide computer six wide tablet sixteen wide mobile" -> p.status.isLogged,
-                "sixteen wide" -> !p.status.isLogged
-              ),
-              SequenceObserverField(SequenceObserverField.Props(p.s, p.status.isLogged))
-            )
+            SequenceObserverField(SequenceObserverField.Props(p.s, p.status.isLogged))
           )
+        )
     )
     ).componentWillReceiveProps { f =>
       // Update state of run requested depending on the run state

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -8,6 +8,7 @@ import diode.util.RunAfterJS
 import diode._
 import edu.gemini.seqexec.model.{ModelBooPicklers, UserDetails}
 import edu.gemini.seqexec.model.Model._
+import edu.gemini.seqexec.web.client.model.SeqexecAppRootModel.LoadedSequences
 import edu.gemini.seqexec.model.Model.SeqexecEvent.{ConnectionOpenEvent, SequenceCompleted}
 import edu.gemini.seqexec.web.client.model.SeqexecCircuit.SearchResults
 import edu.gemini.seqexec.web.client.model.ModelOps._
@@ -26,7 +27,7 @@ import Scalaz._
 /**
   * Handles sequence execution actions
   */
-class SequenceExecutionHandler[M](modelRW: ModelRW[M, SeqexecAppRootModel.LoadedSequences]) extends ActionHandler(modelRW) {
+class SequenceExecutionHandler[M](modelRW: ModelRW[M, LoadedSequences]) extends ActionHandler(modelRW) {
   implicit val runner = new RunAfterJS
 
   override def handle: PartialFunction[Any, ActionResult[M]] = {
@@ -296,7 +297,7 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
 /**
   * Handles messages received over the WS channel
   */
-class WebSocketEventsHandler[M](modelRW: ModelRW[M, (SeqexecAppRootModel.LoadedSequences, WebSocketsLog, Option[UserDetails])]) extends ActionHandler(modelRW) {
+class WebSocketEventsHandler[M](modelRW: ModelRW[M, (LoadedSequences, WebSocketsLog, Option[UserDetails])]) extends ActionHandler(modelRW) {
   implicit val runner = new RunAfterJS
 
   override def handle = {
@@ -394,6 +395,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   val sequencesOnDisplay: ModelR[SeqexecAppRootModel, SequencesOnDisplay] = zoom(_.sequencesOnDisplay)
 
   val statusAndSequences: ModelR[SeqexecAppRootModel, (ClientStatus, SequencesOnDisplay)] = SeqexecCircuit.status.zip(SeqexecCircuit.sequencesOnDisplay)
+  val statusAndLoadedSequences: ModelR[SeqexecAppRootModel, (ClientStatus, LoadedSequences)] = SeqexecCircuit.status.zip(zoom(_.sequences))
   val statusAndConditions: ModelR[SeqexecAppRootModel, (ClientStatus, Conditions)] = SeqexecCircuit.status.zip(zoom(_.sequences.conditions))
   def headerSideBarReader: ModelR[SeqexecAppRootModel, HeaderSideBarReader] =
     SeqexecCircuit.zoom(c => HeaderSideBarReader(ClientStatus(c.user, c.ws, c.sequencesOnDisplay.currentSequences), c.sequences.conditions, c.sequences.operator))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
@@ -5,13 +5,13 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 
 object Label {
-  case class Props(text: String, htmlFor: String)
+  case class Props(text: String, htmlFor: Option[String] = None)
 
   private val component = ScalaComponent.builder[Props]("Label")
     .stateless
     .renderPC((_, p, c) =>
       <.label(
-        ^.htmlFor := p.htmlFor,
+        ^.htmlFor :=? p.htmlFor,
         p.text,
         c
       )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/table/TableHeader.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/table/TableHeader.scala
@@ -15,6 +15,10 @@ object TableHeader {
     key: String = ""
   )
 
+  object Props {
+    def zero = Props()
+  }
+
   private val component = ScalaComponent.builder[Props]("th")
     .stateless
     .renderPC((_, p, c) =>
@@ -47,4 +51,5 @@ object TableHeader {
     ).build
 
   def apply(p: Props, children: VdomNode*): Unmounted[Props, Unit, Unit] = component(p)(children: _*)
+  def apply(children: VdomNode*): Unmounted[Props, Unit, Unit] = component(Props.zero)(children: _*)
 }


### PR DESCRIPTION
This PR updates the UI to show the observation name on the screen. Note that this is hidden for anonymous users. This is disabled only on the UI, In a future PR the feed will anonymize such data to avoid potential disclosures