### PR TITLE
SEQNG-243: Anonymize sensitive data on client feed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val edu_gemini_seqexec_web_server = project.in(file("modules/edu.gemini.seq
   .enablePlugins(BuildInfoPlugin)
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(UnboundId, JwtCore, Slf4jJuli, Knobs) ++ Http4s,
+    libraryDependencies ++= Seq(UnboundId, JwtCore, Slf4jJuli, Knobs) ++ Http4s ++ Monocle,
 
     // Settings to optimize the use of sbt-revolver
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val edu_gemini_seqexec_web_server = project.in(file("modules/edu.gemini.seq
   .enablePlugins(BuildInfoPlugin)
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(UnboundId, JwtCore, Slf4jJuli, Knobs) ++ Http4s ++ Monocle,
+    libraryDependencies ++= Seq(UnboundId, JwtCore, Slf4jJuli, Knobs) ++ Http4s,
 
     // Settings to optimize the use of sbt-revolver
 
@@ -205,7 +205,7 @@ lazy val edu_gemini_seqexec_engine = project
 // We have to define the project properties at this level
 lazy val edu_gemini_seqexec_model = crossProject.crossType(CrossType.Pure)
   .in(file("modules/edu.gemini.seqexec.model"))
-  .settings(libraryDependencies ++= Seq(BooPickle.value, ScalaZCore.value) ++ TestLibs.value)
+  .settings(libraryDependencies ++= Seq(BooPickle.value, ScalaZCore.value) ++ TestLibs.value ++ Monocle.value)
 
 lazy val edu_gemini_seqexec_model_JVM:Project = edu_gemini_seqexec_model.jvm
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -55,13 +55,9 @@ object Model {
     val eachL = Traversal.fromTraverse[List, SequenceView]
     val sequencesQueueL = GenLens[SequencesQueue[SequenceView]](_.queue)
     val ssLens = GenLens[SequenceStart](_.view)
-    val ssPrism = Optional[SeqexecEvent, SequenceStart] {
-      case e: SequenceStart => Some(e)
-      case _ => None
-    }(_ => identity)
 
     // Prism to focus on only the SeqexecEvents that have a queue
-    // There is a risk that we forget to update this when adding a new element
+    // Unfortunately it doesn't seem to exist a more generic form to build this one
     val sePrism = Prism.partial[SeqexecEvent, (SeqexecEvent, SequencesQueue[SequenceView])]{
       case e @ StepExecuted(v)           => (e, v)
       case e @ SequenceStart(v)          => (e, v)

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -2,6 +2,7 @@ package edu.gemini.seqexec.model
 
 import Model._
 import Model.SeqexecEvent._
+import Model.SeqexecModelUpdate
 import boopickle.Default._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
@@ -44,6 +45,7 @@ object SharedModelArbitraries {
   implicit val sbArb  = implicitly[Arbitrary[SkyBackground]]
   implicit val ccArb  = implicitly[Arbitrary[CloudCover]]
   implicit val conArb = implicitly[Arbitrary[Conditions]]
+  implicit val seArb  = implicitly[Arbitrary[SeqexecEvent]]
 }
 
 /**

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
@@ -1,0 +1,29 @@
+package edu.gemini.seqexec.model
+
+import Model._
+import Model.SeqexecEvent._
+import Model.SeqexecModelUpdate
+import boopickle.Default._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary._
+import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.prop.PropertyChecks
+
+/**
+  * Tests the Monocle Lenses for Seqexec Events
+  */
+class LensSpec extends FlatSpec with Matchers with PropertyChecks with ModelBooPicklers {
+  import SharedModelArbitraries._
+
+  "Model lenses" should
+    "be defined for all types with a queue" in {
+      forAll { (e: SeqexecEvent) =>
+        // This test should fail if we forget to update the prism when adding new events
+        sePrism.set((e, SequencesQueue(Conditions.default, Some("Operator name"), Nil)))(e) should matchPattern {
+          case e: SeqexecModelUpdate if e.view.queue.isEmpty =>
+          case e: ConnectionOpenEvent                        =>
+          case e: NewLogMessage                              =>
+        }
+      }
+    }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -5,7 +5,8 @@ import java.util.logging.Logger
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.engine
 import edu.gemini.seqexec.model.Model.{Conditions, SeqexecEvent, SequenceId, SequencesQueue}
-import edu.gemini.seqexec.model.Model.SeqexecEvent.ConnectionOpenEvent
+import edu.gemini.seqexec.model.Model.{SeqexecModelUpdate, SequenceView}
+import edu.gemini.seqexec.model.Model.SeqexecEvent._
 import edu.gemini.seqexec.model._
 import edu.gemini.seqexec.server.SeqexecEngine
 import edu.gemini.seqexec.web.common._
@@ -83,15 +84,73 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
         Ok()
       }
   }
+  import monocle.{Getter, Lens, Optional, Prism}
+  import monocle.macros.GenLens
+  import monocle.macros.GenPrism
+  import monocle.Traversal
 
+  val obsNameL = GenLens[SequenceView](_.metadata.name)
+  val eachL = Traversal.fromTraverse[List, SequenceView]
+  val sequencesQueueL = GenLens[SequencesQueue[SequenceView]](_.queue)
+  val ssLens = GenLens[SequenceStart](_.view)
+  val ssPrism = Optional[SeqexecEvent, SequenceStart] {
+    case e: SequenceStart => Some(e)
+    case _ => None
+  }(_ => identity)
+
+  // Prism to focus on only the SeqexecEvents that have a queue
+  // There is a risk that we forget to update this when adding a new element
+  val sePrism = Prism.partial[SeqexecEvent, (SeqexecEvent, SequencesQueue[SequenceView])]{
+    case e @ StepExecuted(v)           => (e, v)
+    case e @ SequenceStart(v)          => (e, v)
+    case e @ SequenceCompleted(v)      => (e, v)
+    case e @ SequenceLoaded(_, v)      => (e, v)
+    case e @ SequenceUnloaded(_, v)    => (e, v)
+    case e @ StepBreakpointChanged(v)  => (e, v)
+    case e @ OperatorUpdated(v)        => (e, v)
+    case e @ ObserverUpdated(v)        => (e, v)
+    case e @ ConditionsUpdated(v)      => (e, v)
+    case e @ StepSkipMarkChanged(v)    => (e, v)
+    case e @ SequencePauseRequested(v) => (e, v)
+    case e @ SequenceRefreshed(v)      => (e, v)
+    case e @ ResourcesBusy(v)          => (e, v)
+    case e @ SequenceUpdated(v)        => (e, v)
+  } { case (e, q) =>
+    e match {
+      case SequenceStart(_)           => SequenceStart(q)
+      case StepExecuted(_)            => StepExecuted(q)
+      case SequenceCompleted(_)       => SequenceCompleted(q)
+      case e @ SequenceLoaded(_, v)   => e.copy(view = q)
+      case e @ SequenceUnloaded(_, v) => e.copy(view = q)
+      case StepBreakpointChanged(_)   => StepBreakpointChanged(q)
+      case OperatorUpdated(_)         => OperatorUpdated(q)
+      case ObserverUpdated(_)         => ObserverUpdated(q)
+      case ConditionsUpdated(_)       => ConditionsUpdated(q)
+      case StepSkipMarkChanged(_)     => StepSkipMarkChanged(q)
+      case SequencePauseRequested(_)  => SequencePauseRequested(q)
+      case SequenceRefreshed(_)       => SequenceRefreshed(q)
+      case ResourcesBusy(_)           => ResourcesBusy(q)
+      case SequenceUpdated(_)         => SequenceUpdated(q)
+      case e                          => e
+    }
+  }
+  val tupleLens = Lens[(SeqexecEvent, SequencesQueue[SequenceView]), SequencesQueue[SequenceView]](_._2)(v => t => t.copy(_2 = v))
+  //val modelUpdatePrism = ssPrism choice sePrism
   val protectedServices: AuthedService[AuthResult] =
     AuthedService {
       case GET -> Root / "seqexec" / "events" as user        =>
         // Stream seqexec events to clients and a ping
+        def anonymize(e: SeqexecEvent) = {
+            val sequenceNameL = sePrism composeLens tupleLens composeLens sequencesQueueL composeTraversal eachL composeLens obsNameL
+            // Hide the name for anonymous users
+            sequenceNameL.set("")(e)
+        }
+        // If the user didn't login, anonymize
+        val anonymizeF: SeqexecEvent => SeqexecEvent = user.fold(_ => anonymize _, _ => identity _)
         WS(
           Exchange(
             Process.emit(Binary(trimmedArray(ConnectionOpenEvent(user.toOption)))) ++
-              (pingProcess merge engineOutput.subscribe.map(v => Binary(trimmedArray(v)))),
+              (pingProcess merge engineOutput.subscribe.map(anonymizeF).map(v => Binary(trimmedArray(v)))),
             scalaz.stream.Process.empty
           )
         )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -5,7 +5,6 @@ import java.util.logging.Logger
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.seqexec.engine
 import edu.gemini.seqexec.model.Model.{Conditions, SeqexecEvent, SequenceId, SequencesQueue}
-import edu.gemini.seqexec.model.Model.{SeqexecModelUpdate, SequenceView}
 import edu.gemini.seqexec.model.Model.SeqexecEvent._
 import edu.gemini.seqexec.model._
 import edu.gemini.seqexec.server.SeqexecEngine
@@ -84,64 +83,11 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (engine.EventQueue
         Ok()
       }
   }
-  import monocle.{Getter, Lens, Optional, Prism}
-  import monocle.macros.GenLens
-  import monocle.macros.GenPrism
-  import monocle.Traversal
-
-  val obsNameL = GenLens[SequenceView](_.metadata.name)
-  val eachL = Traversal.fromTraverse[List, SequenceView]
-  val sequencesQueueL = GenLens[SequencesQueue[SequenceView]](_.queue)
-  val ssLens = GenLens[SequenceStart](_.view)
-  val ssPrism = Optional[SeqexecEvent, SequenceStart] {
-    case e: SequenceStart => Some(e)
-    case _ => None
-  }(_ => identity)
-
-  // Prism to focus on only the SeqexecEvents that have a queue
-  // There is a risk that we forget to update this when adding a new element
-  val sePrism = Prism.partial[SeqexecEvent, (SeqexecEvent, SequencesQueue[SequenceView])]{
-    case e @ StepExecuted(v)           => (e, v)
-    case e @ SequenceStart(v)          => (e, v)
-    case e @ SequenceCompleted(v)      => (e, v)
-    case e @ SequenceLoaded(_, v)      => (e, v)
-    case e @ SequenceUnloaded(_, v)    => (e, v)
-    case e @ StepBreakpointChanged(v)  => (e, v)
-    case e @ OperatorUpdated(v)        => (e, v)
-    case e @ ObserverUpdated(v)        => (e, v)
-    case e @ ConditionsUpdated(v)      => (e, v)
-    case e @ StepSkipMarkChanged(v)    => (e, v)
-    case e @ SequencePauseRequested(v) => (e, v)
-    case e @ SequenceRefreshed(v)      => (e, v)
-    case e @ ResourcesBusy(v)          => (e, v)
-    case e @ SequenceUpdated(v)        => (e, v)
-  } { case (e, q) =>
-    e match {
-      case SequenceStart(_)           => SequenceStart(q)
-      case StepExecuted(_)            => StepExecuted(q)
-      case SequenceCompleted(_)       => SequenceCompleted(q)
-      case e @ SequenceLoaded(_, v)   => e.copy(view = q)
-      case e @ SequenceUnloaded(_, v) => e.copy(view = q)
-      case StepBreakpointChanged(_)   => StepBreakpointChanged(q)
-      case OperatorUpdated(_)         => OperatorUpdated(q)
-      case ObserverUpdated(_)         => ObserverUpdated(q)
-      case ConditionsUpdated(_)       => ConditionsUpdated(q)
-      case StepSkipMarkChanged(_)     => StepSkipMarkChanged(q)
-      case SequencePauseRequested(_)  => SequencePauseRequested(q)
-      case SequenceRefreshed(_)       => SequenceRefreshed(q)
-      case ResourcesBusy(_)           => ResourcesBusy(q)
-      case SequenceUpdated(_)         => SequenceUpdated(q)
-      case e                          => e
-    }
-  }
-  val tupleLens = Lens[(SeqexecEvent, SequencesQueue[SequenceView]), SequencesQueue[SequenceView]](_._2)(v => t => t.copy(_2 = v))
-  //val modelUpdatePrism = ssPrism choice sePrism
   val protectedServices: AuthedService[AuthResult] =
     AuthedService {
       case GET -> Root / "seqexec" / "events" as user        =>
         // Stream seqexec events to clients and a ping
         def anonymize(e: SeqexecEvent) = {
-            val sequenceNameL = sePrism composeLens tupleLens composeLens sequencesQueueL composeTraversal eachL composeLens obsNameL
             // Hide the name for anonymous users
             sequenceNameL.set("")(e)
         }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -108,9 +108,9 @@ object Settings {
       "org.http4s" %% "http4s-blaze-client" % LibraryVersions.http4s,
       "org.http4s" %% "http4s-scala-xml"    % LibraryVersions.http4s)
 
-    val Monocle  = Seq(
-      "com.github.julien-truffaut" %%  "monocle-core"  % LibraryVersions.monocle,
-      "com.github.julien-truffaut" %%  "monocle-macro" % LibraryVersions.monocle)
+    val Monocle  = Def.setting(Seq(
+      "com.github.julien-truffaut" %%% "monocle-core"  % LibraryVersions.monocle,
+      "com.github.julien-truffaut" %%% "monocle-macro" % LibraryVersions.monocle))
 
     // Client Side JS libraries
     val ReactScalaJS = Def.setting(Seq(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -51,6 +51,7 @@ object Settings {
     val jwt          = "0.12.1"
     val slf4j        = "1.7.25"
     val knobs        = "4.0.31-scalaz-7.2"
+    val monocle      = "1.4.0"
 
     // test libraries
     val scalaTest             = "3.0.3"
@@ -106,6 +107,10 @@ object Settings {
     val Http4sClient  = Seq(
       "org.http4s" %% "http4s-blaze-client" % LibraryVersions.http4s,
       "org.http4s" %% "http4s-scala-xml"    % LibraryVersions.http4s)
+
+    val Monocle  = Seq(
+      "com.github.julien-truffaut" %%  "monocle-core"  % LibraryVersions.monocle,
+      "com.github.julien-truffaut" %%  "monocle-macro" % LibraryVersions.monocle)
 
     // Client Side JS libraries
     val ReactScalaJS = Def.setting(Seq(


### PR DESCRIPTION
We are hiding some data, specifically the observation name, for anonymous users. However this is enforced at the UI level but the data is present on the WebSocket stream. This PR adds a filter so that anonymous and logged in users can get different data

Note that I started using [Monocle](http://julien-truffaut.github.io/Monocle/) for lenses. @tpolecat and @swalker2m, please let me know if that's ok