### PR TITLE
SEQNG-247: Redirect http calls to https

### DIFF
--- a/app/seqexec-server-gn-test/src/main/resources/app.conf
+++ b/app/seqexec-server-gn-test/src/main/resources/app.conf
@@ -14,6 +14,8 @@ authentication {
 }
 
 web-server {
+  # External url used for redirects
+  externalBaseUrl = "seqexec-test.hi.gemini.edu"
   # TLS Settings
   import "/gemsoft/etc/seqexec/conf.d/tls.conf"
 }

--- a/app/seqexec-server-gs-test/src/main/resources/app.conf
+++ b/app/seqexec-server-gs-test/src/main/resources/app.conf
@@ -14,6 +14,8 @@ authentication {
 }
 
 web-server {
+  # External url used for redirects
+  externalBaseUrl = "seqexec-test.cl.gemini.edu"
   # TLS Settings
   import "/gemsoft/etc/seqexec/conf.d/tls.conf"
 }

--- a/app/seqexec-server-gs/src/main/resources/app.conf
+++ b/app/seqexec-server-gs/src/main/resources/app.conf
@@ -13,6 +13,8 @@ authentication {
 }
 
 web-server {
+    # External url used for redirects
+    externalBaseUrl = "seqexec.cl.gemini.edu"
     # TLS Settings
     import "/gemsoft/etc/seqexec/conf.d/tls.conf"
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -21,8 +21,10 @@ authentication {
 web-server {
     # Interface to listen on, 0.0.0.0 listens in all interfaces, production instances should be more restrictive
     host = "0.0.0.0"
-    # Port to serve http requests
+    # Port to serve https requests
     port = 9090
+    # Port for redirects to https
+    insecurePort = 9091
 }
 
 # Configuration of the seqexec engine

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -25,6 +25,8 @@ web-server {
     port = 9090
     # Port for redirects to https
     insecurePort = 9091
+    # External url used for redirects
+    externalBaseUrl = "localhost"
 }
 
 # Configuration of the seqexec engine

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -13,6 +13,7 @@ import edu.gemini.seqexec.web.server.security.{AuthenticationService, Http4sAuth
 import edu.gemini.seqexec.web.server.security.AuthenticationService.AuthResult
 import edu.gemini.seqexec.web.server.http4s.encoder._
 import edu.gemini.spModel.core.SPBadIDException
+
 import org.http4s._
 import org.http4s.server.syntax._
 import org.http4s.dsl._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -9,7 +9,7 @@ import edu.gemini.seqexec.model.Model.SeqexecEvent
 import edu.gemini.seqexec.server.SeqexecEngine
 import edu.gemini.seqexec.web.server.OcsBuildInfo
 import edu.gemini.seqexec.web.server.security.{AuthenticationConfig, AuthenticationService, LDAPConfig}
-import edu.gemini.web.server.common.{LogInitialization, StaticRoutes}
+import edu.gemini.web.server.common.{LogInitialization, StaticRoutes, RedirectToHttpsRoutes}
 import knobs._
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import org.http4s.server.blaze.BlazeBuilder
@@ -32,7 +32,7 @@ object WebServerLauncher extends ProcessApp with LogInitialization {
   /**
     * Configuration for the web server
     */
-  case class WebServerConfiguration(host: String, port: Int, insecurePort: Int, devMode: Boolean, sslConfig: Option[SSLConfig])
+  case class WebServerConfiguration(host: String, port: Int, insecurePort: Int, externalBaseUrl: String, devMode: Boolean, sslConfig: Option[SSLConfig])
 
   // Attempt to get the configuration file relative to the base dir
   val configurationFile: Task[File] = baseDir.map(f => new File(new File(f, "conf"), "app.conf"))
@@ -54,15 +54,16 @@ object WebServerLauncher extends ProcessApp with LogInitialization {
   // configuration specific to the web server
   val serverConf: Task[WebServerConfiguration] =
     config.map { cfg =>
-      val host = cfg.require[String]("web-server.host")
-      val port = cfg.require[Int]("web-server.port")
-      val insecurePort = cfg.require[Int]("web-server.insecurePort")
-      val devMode = cfg.require[String]("mode")
-      val keystore = cfg.lookup[String]("web-server.tls.keyStore")
-      val keystorePwd = cfg.lookup[String]("web-server.tls.keyStorePwd")
-      val certPwd = cfg.lookup[String]("web-server.tls.certPwd")
-      val sslConfig = (keystore |@| keystorePwd |@| certPwd)(SSLConfig.apply)
-      WebServerConfiguration(host, port, insecurePort, devMode.equalsIgnoreCase("dev"), sslConfig)
+      val host            = cfg.require[String]("web-server.host")
+      val port            = cfg.require[Int]("web-server.port")
+      val insecurePort    = cfg.require[Int]("web-server.insecurePort")
+      val externalBaseUrl = cfg.require[String]("web-server.externalBaseUrl")
+      val devMode         = cfg.require[String]("mode")
+      val keystore        = cfg.lookup[String]("web-server.tls.keyStore")
+      val keystorePwd     = cfg.lookup[String]("web-server.tls.keyStorePwd")
+      val certPwd         = cfg.lookup[String]("web-server.tls.certPwd")
+      val sslConfig       = (keystore |@| keystorePwd |@| certPwd)(SSLConfig.apply)
+      WebServerConfiguration(host, port, insecurePort, externalBaseUrl, devMode.equalsIgnoreCase("dev"), sslConfig)
     }
 
   // Configuration of the ldap clients
@@ -114,7 +115,7 @@ object WebServerLauncher extends ProcessApp with LogInitialization {
 
   def redirectWebServer: Kleisli[Task, WebServerConfiguration, Server] = Kleisli { conf =>
     val builder = BlazeBuilder.bindHttp(conf.insecurePort, conf.host)
-      .mountService(new StaticRoutes(index(conf.devMode, OcsBuildInfo.builtAtMillis), conf.devMode, OcsBuildInfo.builtAtMillis).service, "/")
+      .mountService(RedirectToHttpsRoutes(443, conf.externalBaseUrl).service, "/")
     builder.start
   }
 

--- a/modules/edu.gemini.web.server.common/src/main/scala/edu/gemini/web/server/common/RedirectRoutes.scala
+++ b/modules/edu.gemini.web.server.common/src/main/scala/edu/gemini/web/server/common/RedirectRoutes.scala
@@ -1,0 +1,14 @@
+package edu.gemini.web.server.common
+
+import org.http4s.dsl._
+import org.http4s.{HttpService, Uri}
+
+import scalaz.concurrent.Task
+
+case class RedirectToHttpsRoutes(toPort: Int, externalName: String) {
+  val baseUri = Uri.fromString(s"https://$externalName:$toPort").getOrElse(uri("/"))
+
+  val service = HttpService {
+    case request => MovedPermanently(baseUri.withPath(request.uri.path))
+  }
+}


### PR DESCRIPTION
This is a simple but useful improvement. If you hit the seqexec by mistake using http, it will redirect you to the https secure site

The code is ready but it needs a small change to the firewall rules on each machine that will be requested to ITS