### PR TITLE
SEQNG-249 Rewrote automatic load to remove calls to unsafePerformAsync

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -3,6 +3,7 @@ package edu.gemini.seqexec.engine
 import edu.gemini.seqexec.model.Model.{CloudCover, Conditions, ImageQuality, SkyBackground, WaterVapor}
 import Result.{OK, Partial, PartialVal, RetVal}
 import scalaz.concurrent.Task
+import scalaz.stream.Process
 
 /**
   * Anything that can go through the Event Queue.
@@ -28,7 +29,7 @@ case class SetWaterVapor(wv: WaterVapor) extends UserEvent
 case class SetSkyBackground(wv: SkyBackground) extends UserEvent
 case class SetCloudCover(cc: CloudCover) extends UserEvent
 case object Poll extends UserEvent
-case class GetState(f: (Engine.State) => Task[Unit]) extends UserEvent
+case class GetState(f: (Engine.State) => Task[Option[Process[Task, Event]]]) extends UserEvent
 case class Log(msg: String) extends UserEvent
 
 /**
@@ -58,7 +59,7 @@ object Event {
   def setSkyBackground(sb: SkyBackground): Event = EventUser(SetSkyBackground(sb))
   def setCloudCover(cc: CloudCover): Event = EventUser(SetCloudCover(cc))
   val poll: Event = EventUser(Poll)
-  def getState(f: (Engine.State) => Task[Unit]): Event = EventUser(GetState(f))
+  def getState(f: (Engine.State) => Task[Option[Process[Task, Event]]]): Event = EventUser(GetState(f))
   def logMsg(msg: String): Event = EventUser(Log(msg))
 
   def failed(id: Sequence.Id, i: Int, e: Result.Error): Event = EventSystem(Failed(id, i, e))

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -246,7 +246,7 @@ package object engine {
     )
   }
 
-  private def getState(f: Engine.State => Task[Unit]): HandleP[Unit] = get.flatMap(s => HandleP(f(s).liftM[HandleStateT].map((_, None))))
+  private def getState(f: Engine.State => Task[Option[Process[Task, Event]]]): HandleP[Unit] = get.flatMap(s => HandleP(f(s).liftM[HandleStateT].map((Unit, _))))
 
   /**
     * Given the index of the completed `Action` in the current `Execution`, it

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -199,7 +199,7 @@ class packageSpec extends FlatSpec {
 
     val result = Nondeterminism[Task].both(
         q.enqueueOne(start(seqId)) *> Task.apply(startedFlag.acquire) *>
-          q.enqueueOne(Event.getState{_ => Task.delay{finishFlag.release}}),
+          q.enqueueOne(Event.getState{_ => Task.delay{finishFlag.release} *> Task.delay(None)}),
         process(q.dequeue)(qs).drop(1).takeThrough(a => !isFinished(a._2.sequences(seqId).status)).run
       ).timed(5.seconds).unsafePerformSyncAttempt
     assert(result.isRight)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -130,28 +130,24 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
     }).run.map(_ => i)
   }
 
-  def load(q: EventQueue, seqId: SPObservationID): Task[SeqexecFailure \/ Unit] = {
+  def load(q: EventQueue, seqId: SPObservationID): Task[SeqexecFailure \/ Unit] = loadEvents(seqId).flatMapF(q.enqueueAll(_).map(_.right)).run
+
+  def loadEvents(seqId: SPObservationID): SeqAction[List[Event]] = {
     val t: EitherT[Task, SeqexecFailure, (List[SeqexecFailure], Option[Sequence[Action]])] = for {
-      odbSeq       <- EitherT(Task(odbProxy.read(seqId)))
+      odbSeq       <- EitherT(Task.delay(odbProxy.read(seqId)))
       progIdString <- EitherT(Task.delay(odbSeq.extract(OCS_KEY / InstConstants.PROGRAMID_PROP).as[String].leftMap(ConfigUtilOps.explainExtractError)))
       progId       <- EitherT.fromTryCatchNonFatal(Task.now(SPProgramID.toProgramID(progIdString))).leftMap(e => SeqexecFailure.SeqexecException(e): SeqexecFailure)
       name         <- EitherT(odbClient.observationTitle(progId, seqId.toString).map(_.leftMap(ConfigUtilOps.explainExtractError)))
     } yield translator.sequence(translatorSettings)(seqId, odbSeq, name)
 
-    val u = t.flatMapF{
-      case (err :: _, None)  => q.enqueueOne(Event.logMsg(SeqexecFailure.explain(err))).map(_.right)
-      case (errs, Some(seq)) =>
-        (if(errs.isEmpty) Task(()) else q.enqueueAll(errs.map(e => Event.logMsg(SeqexecFailure.explain(e))))) *> Task.delay {
-          q.enqueueOne(Event.load(seqId.stringValue(), seq)).unsafePerformAsync(x => ()).right[SeqexecFailure]
-        }
-      case _                 => Task(().right)
+    t.map{
+      case (err :: _, None)  => List(Event.logMsg(SeqexecFailure.explain(err)))
+      case (errs, Some(seq)) => Event.load(seqId.stringValue, seq) :: errs.map(e => Event.logMsg(SeqexecFailure.explain(e)))
+      case _                 => List()
     }
-    u.run
   }
 
-  def unload(q: EventQueue, seqId: SPObservationID): Task[SeqexecFailure \/ Unit] = {
-    q.enqueueOne(Event.unload(seqId.stringValue)).map(_.right)
-  }
+  def unload(seqId: SPObservationID): Event = Event.unload(seqId.stringValue)
 
   private def toSeqexecEvent(ev: engine.Event)(svs: SequencesQueue[SequenceView]): SeqexecEvent = ev match {
     case engine.EventUser(ue) => ue match {
@@ -228,17 +224,20 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
     SequenceView(seq.id, seq.metadata, st, engineSteps(seq), None)
   }
 
-  private def refreshSequenceList(q: EventQueue): Engine.State => Task[Unit] = (st: Engine.State) => {
+  private def refreshSequenceList(q: EventQueue): Engine.State => Task[Option[Process[Task, Event]]] = (st: Engine.State) => {
 
     val seqexecList = st.sequences.keys.toSeq.map(v => new SPObservationID(v))
 
-    def loads(odbList: Seq[SPObservationID]): Seq[Task[SeqexecFailure \/ Unit]] = odbList.diff(seqexecList).map(id => load(q, id))
+    def loads(odbList: Seq[SPObservationID]): Task[List[Event]] = odbList.diff(seqexecList).toList.map(id => loadEvents(id)).sequenceU.map(_.flatten).run.map(_.valueOr( r => List(Event.logMsg(SeqexecFailure.explain(r)))))
 
-    def unloads(odbList: Seq[SPObservationID]): Seq[Task[SeqexecFailure \/ Unit]] = seqexecList.diff(odbList).map(id => unload(q, id))
+    def unloads(odbList: Seq[SPObservationID]): Seq[Event] = seqexecList.diff(odbList).map(id => unload(id))
 
-    odbProxy.queuedSequences().flatMap(seqs => EitherT(Nondeterminism[Task].gatherUnordered(loads(seqs) ++
-      unloads(seqs)).map(_.sequenceU))
-    ).run.map(_ => ())
+    val x = odbProxy.queuedSequences().flatMapF(seqs => loads(seqs).map(ee => (ee ++ unloads(seqs)).right)).run
+    val y = x.map(_.valueOr(r => List(Event.logMsg(SeqexecFailure.explain(r)))))
+    y.map{ee =>
+      if(ee.isEmpty) None
+      else Some(Process.emitAll(ee).evalMap(Task.delay(_)))
+    }
   }
 
 }


### PR DESCRIPTION
Used the feature implemented in SEQNG-241 to remove the use of Queue.enqueueOne and the calls to unsafePerformAsync.
I  paid more attention to the managing of errors when loading sequences, and I think I may have fixed SEQNG-237.