### PR TITLE
SEQNG-205: Add NullEvent for events that should not be sent to the client

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -49,6 +49,7 @@ object Model {
     // TODO: msg should be LogMsg bit it does IO when getting a timestamp, it
     // has to be embedded in a `Task`
     case class NewLogMessage(msg: String) extends SeqexecEvent
+    case object NullEvent extends SeqexecEvent
 
     // Some useful Monocle lenses
     val obsNameL = GenLens[SequenceView](_.metadata.name)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -56,6 +56,7 @@ trait ModelBooPicklers {
     .addConcreteType[SequenceUpdated]
     .addConcreteType[SequenceRefreshed]
     .addConcreteType[NewLogMessage]
+    .addConcreteType[NullEvent.type]
     .addConcreteType[ObserverUpdated]
     .addConcreteType[OperatorUpdated]
     .addConcreteType[ConditionsUpdated]

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -38,6 +38,7 @@ object SharedModelArbitraries {
   implicit val smeArb = implicitly[Arbitrary[StepSkipMarkChanged]]
   implicit val speArb = implicitly[Arbitrary[SequencePauseRequested]]
   implicit val lmArb  = implicitly[Arbitrary[NewLogMessage]]
+  implicit val neArb  = implicitly[Arbitrary[NullEvent.type]]
   implicit val opArb  = implicitly[Arbitrary[OperatorUpdated]]
   implicit val obArb  = implicitly[Arbitrary[ObserverUpdated]]
   implicit val iqArb  = implicitly[Arbitrary[ImageQuality]]

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
@@ -23,6 +23,7 @@ class LensSpec extends FlatSpec with Matchers with PropertyChecks with ModelBooP
           case e: SeqexecModelUpdate if e.view.queue.isEmpty =>
           case e: ConnectionOpenEvent                        =>
           case e: NewLogMessage                              =>
+          case NullEvent                                     =>
         }
       }
     }


### PR DESCRIPTION
At the moment every time the ODB is polled a log message is created and sent to the client wasting bandwidth. This PR adds a new type of `NullEvent` that is not sent to the client