### PR TITLE
SEQNG-253: Test file to stress websockets

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/misc/wsstress.yml
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/misc/wsstress.yml
@@ -1,0 +1,21 @@
+config:
+  target: "ws://localhost:9090/api/seqexec/events"
+  phases:
+    -
+      duration: 120
+      arrivalRate: 50
+      rampTo: 100
+  ws:
+    # Ignore SSL certificate errors
+    # - useful in *development* with self-signed certs
+    rejectUnauthorized: false
+scenarios:
+  -
+    engine: "ws"
+    flow:
+      -
+        send: "hello"
+      -
+        think: 1
+      -
+        send: "world"


### PR DESCRIPTION
I did some stress test for websockets on the application using artillery. This is the file used to do the testing

Some more information was written on the wiki at https://github.com/gemini-hlsw/ocs3/wiki/Stress-testing