### PR TITLE
SEQNG-270: Typelevel compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
   - nvm use stable
-  - npm install jsdom@9.12.0
+  - npm install jsdom
 before_script:
   - sudo apt-get install -y rpm
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,9 @@ import sbt.Keys._
 
 name := Settings.Definitions.name
 
-scalaVersion in ThisBuild := Settings.LibraryVersions.scala
+scalaOrganization in ThisBuild := "org.typelevel"
+
+scalaVersion in ThisBuild := Settings.LibraryVersions.scalaVersion
 
 scalacOptions in ThisBuild ++= Settings.Definitions.scalacOptions
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,6 @@ lazy val edu_gemini_seqexec_web = project.in(file("modules/edu.gemini.seqexec.we
 
 // a special crossProject for configuring a JS/JVM/shared structure
 lazy val edu_gemini_seqexec_web_shared = (crossProject.crossType(CrossType.Pure) in file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared"))
-  .settings(commonSettings: _*)
   .dependsOn(edu_gemini_seqexec_model)
   .jvmSettings(
   )
@@ -42,8 +41,10 @@ lazy val edu_gemini_seqexec_web_shared = (crossProject.crossType(CrossType.Pure)
   )
 
 lazy val edu_gemini_seqexec_web_shared_JVM = edu_gemini_seqexec_web_shared.jvm
+  .settings(commonSettings: _*)
 
 lazy val edu_gemini_seqexec_web_shared_JS = edu_gemini_seqexec_web_shared.js
+  .settings(commonJSSettings: _*)
 
 // Project for the server side application
 lazy val edu_gemini_seqexec_web_server = project.in(file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server"))
@@ -92,7 +93,7 @@ lazy val edu_gemini_seqexec_web_server = project.in(file("modules/edu.gemini.seq
 lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client"))
   .enablePlugins(ScalaJSPlugin)
   .enablePlugins(BuildInfoPlugin)
-  .settings(commonSettings: _*)
+  .settings(commonJSSettings: _*)
   .settings(
     // This is a not very nice trick to remove js files that exist on the scala tools
     // library and that conflict with the requested on jsDependencies, in particular
@@ -140,7 +141,7 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
 lazy val edu_gemini_seqexec_web_client_cli = project.in(file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client.cli"))
   .enablePlugins(ScalaJSPlugin)
   .enablePlugins(BuildInfoPlugin)
-  .settings(commonSettings: _*)
+  .settings(commonJSSettings: _*)
   .settings(
     // Write the generated js to the filename seqexec-cli.js
     artifactPath in (Compile, fastOptJS) := (resourceManaged in Compile).value / "seqexec-cli.js",
@@ -195,14 +196,14 @@ lazy val edu_gemini_seqexec_server = project
 // We have to define the project properties at this level
 lazy val edu_gemini_seqexec_model = crossProject.crossType(CrossType.Pure)
   .in(file("modules/edu.gemini.seqexec.model"))
-  .settings(commonSettings: _*)
   .settings(libraryDependencies ++= BooPickle.value +: Monocle.value)
 
 lazy val edu_gemini_seqexec_model_JVM:Project = edu_gemini_seqexec_model.jvm
+  .settings(commonSettings: _*)
 
 lazy val edu_gemini_seqexec_model_JS:Project = edu_gemini_seqexec_model.js
+  .settings(commonJSSettings: _*)
 
-// This should eventually replaced by seqexec_server
 lazy val edu_gemini_seqexec_engine = project
   .in(file("modules/edu.gemini.seqexec.engine"))
   .dependsOn(edu_gemini_seqexec_model_JVM)
@@ -385,7 +386,7 @@ lazy val edu_gemini_p1backend_server = project.in(file("modules/edu.gemini.p1bac
 lazy val edu_gemini_p1backend_client = project.in(file("modules/edu.gemini.p1backend/edu.gemini.p1backend.client"))
   .enablePlugins(ScalaJSPlugin)
   .enablePlugins(BuildInfoPlugin)
-  .settings(commonSettings: _*)
+  .settings(commonJSSettings: _*)
   .settings(
     // This is a not very nice trick to remove js files that exist on the scala tools
     // library and that conflict with the requested on jsDependencies, in particular
@@ -415,11 +416,7 @@ lazy val edu_gemini_p1backend_client = project.in(file("modules/edu.gemini.p1bac
     crossTarget in (Compile, packageJSDependencies) := (resourceManaged in Compile).value,
     libraryDependencies ++= Seq(
       JQuery.value
-    ) ++ ReactScalaJS.value ++ Diode.value,
-    // This is needed to support the TLS compiler and scala.js at the same time
-    libraryDependencies ~= { (libDeps: Seq[ModuleID]) =>
-      libDeps.filterNot(dep => dep.name == "scalajs-compiler")
-    }
+    ) ++ ReactScalaJS.value ++ Diode.value
   )
   .settings(
     buildInfoUsePackageAsPath := true,

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -3,50 +3,10 @@ package edu.gemini.seqexec.model
 import Model._
 import Model.SeqexecEvent._
 import boopickle.Default._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
-
-// Keep the arbitraries in a separate trait to improve caching
-object SharedModelArbitraries {
-  import org.scalacheck.Shapeless._
-  val maxListSize = 2
-
-  // N.B. We don't want to auto derive this to limit the size of the lists for performance reasons
-  def sequencesQueueArb[A](implicit arb: Arbitrary[A]): Arbitrary[SequencesQueue[A]] = Arbitrary {
-    for {
-      b <- Gen.listOfN[A](maxListSize, arb.arbitrary)
-      // We are already testing serialization of conditions and Strings
-      // Let's reduce the test space by only testing the list of items
-    } yield SequencesQueue(Conditions.default, Some("operator"), b)
-  }
-
-  implicit val udArb  = implicitly[Arbitrary[UserDetails]]
-  implicit val svArb  = implicitly[Arbitrary[SequenceView]]
-  // Must define these early on to be used on the events
-  implicit val sqiArb = sequencesQueueArb[SequenceId]
-  implicit val sqvArb = sequencesQueueArb[SequenceView]
-  implicit val coeArb = implicitly[Arbitrary[ConnectionOpenEvent]]
-  implicit val sseArb = implicitly[Arbitrary[SequenceStart]]
-  implicit val seeArb = implicitly[Arbitrary[StepExecuted]]
-  implicit val sceArb = implicitly[Arbitrary[SequenceCompleted]]
-  implicit val sleArb = implicitly[Arbitrary[SequenceLoaded]]
-  implicit val sueArb = implicitly[Arbitrary[SequenceUnloaded]]
-  implicit val sbeArb = implicitly[Arbitrary[StepBreakpointChanged]]
-  implicit val smeArb = implicitly[Arbitrary[StepSkipMarkChanged]]
-  implicit val speArb = implicitly[Arbitrary[SequencePauseRequested]]
-  implicit val lmArb  = implicitly[Arbitrary[NewLogMessage]]
-  implicit val neArb  = implicitly[Arbitrary[NullEvent.type]]
-  implicit val opArb  = implicitly[Arbitrary[OperatorUpdated]]
-  implicit val obArb  = implicitly[Arbitrary[ObserverUpdated]]
-  implicit val iqArb  = implicitly[Arbitrary[ImageQuality]]
-  implicit val wvArb  = implicitly[Arbitrary[WaterVapor]]
-  implicit val sbArb  = implicitly[Arbitrary[SkyBackground]]
-  implicit val ccArb  = implicitly[Arbitrary[CloudCover]]
-  implicit val conArb = implicitly[Arbitrary[Conditions]]
-  implicit val seArb  = implicitly[Arbitrary[SeqexecEvent]]
-}
 
 /**
   * Tests Serialization/Deserialization using BooPickle

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
@@ -10,12 +10,12 @@ import org.scalatest.prop.PropertyChecks
 /**
   * Tests the Monocle Lenses for Seqexec Events
   */
-class LensSpec extends FlatSpec with Matchers with PropertyChecks with ModelBooPicklers {
+class SeqexecEventPrismSpec extends FlatSpec with Matchers  {
   import SharedModelArbitraries._
 
   "Model lenses" should
     "be defined for all types with a queue" in {
-      forAll { (e: SeqexecEvent) =>
+      forAll { (e: Int) =>
         // This test should fail if we forget to update the prism when adding new events
         sePrism.set((e, SequencesQueue(Conditions.default, Some("Operator name"), Nil)))(e) should matchPattern {
           case e: SeqexecModelUpdate if e.view.queue.isEmpty =>

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
@@ -10,12 +10,12 @@ import org.scalatest.prop.PropertyChecks
 /**
   * Tests the Monocle Lenses for Seqexec Events
   */
-class SeqexecEventPrismSpec extends FlatSpec with Matchers  {
+class SeqexecEventPrismSpec extends FlatSpec with Matchers with PropertyChecks {
   import SharedModelArbitraries._
 
   "Model lenses" should
     "be defined for all types with a queue" in {
-      forAll { (e: Int) =>
+      forAll { (e: SeqexecEvent) =>
         // This test should fail if we forget to update the prism when adding new events
         sePrism.set((e, SequencesQueue(Conditions.default, Some("Operator name"), Nil)))(e) should matchPattern {
           case e: SeqexecModelUpdate if e.view.queue.isEmpty =>

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
@@ -1,0 +1,47 @@
+package edu.gemini.seqexec.model
+
+import Model._
+import Model.SeqexecEvent._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary._
+
+// Keep the arbitraries in a separate trait to improve caching
+object SharedModelArbitraries {
+  import org.scalacheck.Shapeless._
+  val maxListSize = 2
+
+  // N.B. We don't want to auto derive this to limit the size of the lists for performance reasons
+  def sequencesQueueArb[A](implicit arb: Arbitrary[A]): Arbitrary[SequencesQueue[A]] = Arbitrary {
+    for {
+      b <- Gen.listOfN[A](maxListSize, arb.arbitrary)
+      // We are already testing serialization of conditions and Strings
+      // Let's reduce the test space by only testing the list of items
+    } yield SequencesQueue(Conditions.default, Some("operator"), b)
+  }
+
+  implicit val udArb  = implicitly[Arbitrary[UserDetails]]
+  implicit val svArb  = implicitly[Arbitrary[SequenceView]]
+  // Must define these early on to be used on the events
+  implicit val sqiArb = sequencesQueueArb[SequenceId]
+  implicit val sqvArb = sequencesQueueArb[SequenceView]
+  implicit val coeArb = implicitly[Arbitrary[ConnectionOpenEvent]]
+  implicit val sseArb = implicitly[Arbitrary[SequenceStart]]
+  implicit val seeArb = implicitly[Arbitrary[StepExecuted]]
+  implicit val sceArb = implicitly[Arbitrary[SequenceCompleted]]
+  implicit val sleArb = implicitly[Arbitrary[SequenceLoaded]]
+  implicit val sueArb = implicitly[Arbitrary[SequenceUnloaded]]
+  implicit val sbeArb = implicitly[Arbitrary[StepBreakpointChanged]]
+  implicit val smeArb = implicitly[Arbitrary[StepSkipMarkChanged]]
+  implicit val speArb = implicitly[Arbitrary[SequencePauseRequested]]
+  implicit val lmArb  = implicitly[Arbitrary[NewLogMessage]]
+  implicit val neArb  = implicitly[Arbitrary[NullEvent.type]]
+  implicit val opArb  = implicitly[Arbitrary[OperatorUpdated]]
+  implicit val obArb  = implicitly[Arbitrary[ObserverUpdated]]
+  implicit val iqArb  = implicitly[Arbitrary[ImageQuality]]
+  implicit val wvArb  = implicitly[Arbitrary[WaterVapor]]
+  implicit val sbArb  = implicitly[Arbitrary[SkyBackground]]
+  implicit val ccArb  = implicitly[Arbitrary[CloudCover]]
+  implicit val conArb = implicitly[Arbitrary[Conditions]]
+  implicit val seArb  = implicitly[Arbitrary[SeqexecEvent]]
+}
+

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GcalControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GcalControllerEpics.scala
@@ -22,6 +22,7 @@ object GcalControllerEpics extends GcalController {
       v match {
         case BinaryOnOff.OFF => LampState.Off
         case BinaryOnOff.ON  => LampState.On
+        case _               => sys.error("Cannot happen")
       }
   }
 
@@ -30,6 +31,7 @@ object GcalControllerEpics extends GcalController {
       v match {
         case LampState.Off => BinaryOnOff.OFF
         case LampState.On  => BinaryOnOff.ON
+        case _             => sys.error("Cannot happen")
       }
   }
 
@@ -38,7 +40,7 @@ object GcalControllerEpics extends GcalController {
       v match {
         case "OPEN"  => Some(Shutter.OPEN)
         case "CLOSE" => Some(Shutter.CLOSED)
-        case _ => None
+        case _       => None
       }
   }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -269,6 +269,7 @@ object SeqTranslate {
         gaos match {
           case AltairConstants.SYSTEM_NAME_PROP                => TrySeq(Altair(inst))
           case edu.gemini.spModel.gemini.gems.Gems.SYSTEM_NAME => TrySeq(Gems(inst))
+          case _                                               => TrySeq.fail(Unexpected("Logical error reading AO system name"))
         }
     }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -283,6 +283,7 @@ object SeqexecEngine {
     val site = cfg.require[String]("seqexec-engine.site") match {
       case "GS" => Site.GS
       case "GN" => Site.GN
+      case _    => Site.GS // Let's default to GS
     }
     val odbHost                 = cfg.require[String]("seqexec-engine.odb")
     val dhsServer               = cfg.require[String]("seqexec-engine.dhsServer")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client.cli/src/main/scala/edu/gemini/seqexec/web/client/cli/SeqexecTerminal.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client.cli/src/main/scala/edu/gemini/seqexec/web/client/cli/SeqexecTerminal.scala
@@ -193,6 +193,8 @@ object SeqexecTerminal extends js.JSApp {
         // Ignore
       case cmd :: _                                             =>
         terminal.error(s"Command '$command' unknown")
+      case cmd                                                  =>
+        terminal.error(s"Command '$command' unknown")
     }
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/FreeLDAPAuthenticationService.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/FreeLDAPAuthenticationService.scala
@@ -115,16 +115,16 @@ class FreeLDAPAuthenticationService(hosts: List[(String, Int)]) extends AuthServ
       runIO(authenticationAndName(usernameWithDomain, password), c)
         .ensuring(IO(c.close())).unsafePerformIO()
     }.leftMap {
-      case e:LDAPException if e.getResultCode == ResultCode.NO_SUCH_OBJECT      =>
+      case e: LDAPException if e.getResultCode == ResultCode.NO_SUCH_OBJECT      =>
         Log.severe(s"Exception connection to LDAP server: ${e.getExceptionMessage}")
         BadCredentials(username)
-      case e:LDAPException if e.getResultCode == ResultCode.INVALID_CREDENTIALS =>
+      case e: LDAPException if e.getResultCode == ResultCode.INVALID_CREDENTIALS =>
         Log.severe(s"Exception connection to LDAP server: ${e.getExceptionMessage}")
         UserNotFound(username)
-      case e:LDAPException =>
+      case e: LDAPException =>
         Log.severe(s"Exception connection to LDAP server: ${e.getExceptionMessage}")
         GenericFailure("LDAP Authentication error")
-      case e:Exception =>
+      case e: Throwable =>
         GenericFailure(e.getMessage)
     }
   }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,14 +1,22 @@
 import Settings.Libraries._
 import sbt.Keys._
-import sbt.{file, project}
+import sbt.{file, ModuleID, project}
 
 /**
   * Define tasks and settings used by module definitions
   */
 object Common {
   lazy val commonSettings = Seq(
+    scalaOrganization := "org.typelevel",
+    scalaVersion := Settings.LibraryVersions.scalaVersion,
+    scalacOptions ++= Settings.Definitions.scalacOptions,
+
     // Common libraries
-    libraryDependencies ++= Seq(ScalaZCore.value, BooPickle.value) ++ TestLibs.value
+    libraryDependencies ++= Seq(ScalaZCore.value) ++ TestLibs.value,
+    // This is needed to support the TLS compiler and scala.js at the same time
+    libraryDependencies ~= { (libDeps: Seq[ModuleID]) =>
+      libDeps.filterNot(dep => dep.name == "scalajs-compiler")
+    }
   )
 
   // This function allows triggered compilation to run only when scala files changes

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -14,9 +14,20 @@ object Common {
     // Common libraries
     libraryDependencies ++= Seq(ScalaZCore.value) ++ TestLibs.value,
     // This is needed to support the TLS compiler and scala.js at the same time
+    // Maybe eventually be used when we can compile both jvm and js with typelevel
     libraryDependencies ~= { (libDeps: Seq[ModuleID]) =>
       libDeps.filterNot(dep => dep.name == "scalajs-compiler")
     }
+  )
+
+  lazy val commonJSSettings = Seq(
+    // The typelevel compiler is not compatible with JS
+    // scalaOrganization := "org.typelevel",
+    scalaVersion := Settings.LibraryVersions.scalaJSVersion,
+    scalacOptions ++= Settings.Definitions.scalacOptions,
+
+    // Common libraries
+    libraryDependencies ++= Seq(ScalaZCore.value) ++ TestLibs.value
   )
 
   // This function allows triggered compilation to run only when scala files changes

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -27,7 +27,7 @@ object Settings {
 
   /** Library versions */
   object LibraryVersions {
-    val scala        = "2.11.11"
+    val scalaVersion = "2.11.11-bin-typelevel-4"
 
     // ScalaJS libraries
     val scalaDom     = "0.9.2"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -27,7 +27,9 @@ object Settings {
 
   /** Library versions */
   object LibraryVersions {
-    val scalaVersion = "2.11.11-bin-typelevel-4"
+    val scalaCommonVersion = "2.11.11"
+    val scalaVersion       = s"$scalaCommonVersion-bin-typelevel-4"
+    val scalaJSVersion     = scalaCommonVersion
 
     // ScalaJS libraries
     val scalaDom     = "0.9.2"


### PR DESCRIPTION
This PR uses the typelevel compiler on ocs3. I found troubles compiling the JS side, while it compiles files it produces invalid js that fails on tests and on creating an executable js for the browser

Hence, I'm only use typelevel for the JVM side until this can be fixed. I'm planning to create a minimal demo to submit for a fix

Using the typelevel compiler requires some code changes especially on terms of more strict match exhaustiveness