### PR TITLE
SEQNG-281: Display on the queue the selected tab

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -1,11 +1,11 @@
 package edu.gemini.seqexec.web.client.components
 
 import diode.react.ModelProxy
-import edu.gemini.seqexec.model.Model.{SequenceState, SequenceView}
+import edu.gemini.seqexec.model.Model.SequenceState
 import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.model.Pages._
 import edu.gemini.seqexec.web.client.model.ModelOps._
-import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconAttention, IconCheckmark, IconCircleNotched}
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconAttention, IconCheckmark, IconCircleNotched, IconSelectedRadio}
 import edu.gemini.seqexec.web.client.semanticui.elements.table.TableHeader
 import edu.gemini.seqexec.web.client.services.HtmlConstants.{iconEmpty, nbsp}
 import japgolly.scalajs.react.vdom.html_<^._
@@ -15,6 +15,7 @@ import org.scalajs.dom.html.TableRow
 
 import scalacss.ScalaCssReact._
 import scalaz.syntax.show._
+import scalaz.syntax.equal._
 import scalaz.syntax.std.option._
 
 object QueueTableBody {
@@ -40,9 +41,9 @@ object QueueTableBody {
     )
   }
 
-  def showSequence(p: Props, s: SequenceView): Callback =
+  def showSequence(p: Props, s: SequenceInQueue): Callback =
     // Request to display the selected sequence
-    p.sequences.dispatchCB(NavigateTo(InstrumentPage(s.metadata.instrument, s.id.some))) >> p.sequences.dispatchCB(SelectToDisplay(s))
+    p.sequences.dispatchCB(NavigateTo(InstrumentPage(s.instrument, s.id.some))) >> p.sequences.dispatchCB(SelectIdToDisplay(s.id))
 
   private val component = ScalaComponent.builder[Props]("QueueTableBody")
     .render_P { p =>
@@ -60,13 +61,14 @@ object QueueTableBody {
           )
         ),
         <.tbody(
-          sequences.queue.map(Some.apply).padTo(minRows, None).zipWithIndex.collect {
+          sequences.map(Some.apply).padTo(minRows, None).zipWithIndex.collect {
             case (Some(s), i) =>
               <.tr(
                 ^.classSet(
-                  "positive" -> (s.status == SequenceState.Completed),
-                  "warning"  -> (s.status == SequenceState.Running),
-                  "negative" -> s.hasError
+                  "positive" -> (s.status === SequenceState.Completed),
+                  "warning"  -> (s.status === SequenceState.Running),
+                  "negative" -> s.status.hasError,
+                  "active"   -> s.active
                 ),
                 ^.key := s"item.queue.$i",
                 ^.onClick --> showSequence(p, s),
@@ -76,7 +78,7 @@ object QueueTableBody {
                     case SequenceState.Completed                   => IconCheckmark
                     case SequenceState.Running                     => IconCircleNotched.copy(IconCircleNotched.p.copy(loading = true))
                     case SequenceState.Error(_)                    => IconAttention
-                    case _                                         => iconEmpty
+                    case _                                         => if (s.active) IconSelectedRadio else iconEmpty
                   }
                 ),
                 <.td(
@@ -87,11 +89,11 @@ object QueueTableBody {
                   s.status.shows + s.runningStep.map(u => s" ${u._1 + 1}/${u._2}").getOrElse("")
                 ),
                 <.td(
-                  s.metadata.instrument
+                  s.instrument
                 ),
                 <.td(
                   SeqexecStyles.notInMobile,
-                  s.metadata.name
+                  s.name
                 ).when(isLogged)
               )
             case (_, i) =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -73,6 +73,12 @@ object QueueTableBody {
                 }
               val stepAtText = s.status.shows + s.runningStep.map(u => s" ${u._1 + 1}/${u._2}").getOrElse("")
               val inProcess = s.status.isInProcess
+              val selectableRowCls = List(
+                  ^.classSet(
+                    "selectable" -> !inProcess
+                  ),
+                  SeqexecStyles.linkeableRows.when(inProcess)
+                )
               <.tr(
                 ^.classSet(
                   "positive" -> (s.status === SequenceState.Completed),
@@ -84,44 +90,29 @@ object QueueTableBody {
                 ^.onClick --> showSequence(p, s),
                 <.td(
                   ^.cls := "collapsing",
-                  ^.classSet(
-                    "selectable" -> !inProcess
-                  ),
-                  SeqexecStyles.linkeableRows.when(inProcess),
+                  selectableRowCls.toTagMod,
                   p.ctl.link(InstrumentPage(s.instrument, s.id.some))(leftColumnIcon).unless(inProcess),
                   leftColumnIcon.when(inProcess)
                 ),
                 <.td(
                   ^.cls := "collapsing",
-                  ^.classSet(
-                    "selectable" -> !inProcess
-                  ),
-                  SeqexecStyles.linkeableRows.when(inProcess),
+                  selectableRowCls.toTagMod,
                   p.ctl.link(InstrumentPage(s.instrument, s.id.some))(s.id).unless(inProcess),
                   (s.id).when(inProcess)
                 ),
                 <.td(
                   ^.cls := "collapsing",
-                  ^.classSet(
-                    "selectable" -> !inProcess
-                  ),
-                  SeqexecStyles.linkeableRows.when(inProcess),
+                  selectableRowCls.toTagMod,
                   p.ctl.link(InstrumentPage(s.instrument, s.id.some))(stepAtText).unless(inProcess),
                   stepAtText.when(inProcess)
                 ),
                 <.td(
-                  ^.classSet(
-                    "selectable" -> !inProcess
-                  ),
-                  SeqexecStyles.linkeableRows.when(inProcess),
+                  selectableRowCls.toTagMod,
                   p.ctl.link(InstrumentPage(s.instrument, s.id.some))(s.instrument).unless(inProcess),
                   s.instrument.when(inProcess)
                 ),
                 <.td(
-                  ^.classSet(
-                    "selectable" -> !inProcess
-                  ),
-                  SeqexecStyles.linkeableRows.when(inProcess),
+                  selectableRowCls.toTagMod,
                   SeqexecStyles.notInMobile,
                   p.ctl.link(InstrumentPage(s.instrument, s.id.some))(s.name).unless(inProcess),
                   s.name.when(inProcess)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -31,6 +31,13 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     marginRight(1.5.em)
   )
 
+  val linkeableRows: StyleA = style(
+    unsafeRoot(".ui.table tbody tr td.selectable > a:not(.ui)")(
+      paddingTop(0.5.em),
+      paddingBottom(0.5.em)
+    )
+  )
+
   val logo: StyleA = style(
     height(45.px),
     width(45.px)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -62,10 +62,11 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     overflow.auto
   )
 
-  val queueListPane: StyleA = style {
-    maxHeight(13.1.em)
+  val queueListPane: StyleA = style (
+    maxHeight(13.5.em),
+    minHeight(13.5.em),
     marginTop(0.px).important
-  }
+  )
 
   val searchResultListPane: StyleA = style {
     maxHeight(10.3.em)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -14,19 +14,19 @@ object SeqexecMain {
   private val lbConnect = SeqexecCircuit.connect(_.uiModel.loginBox)
   private val logConnect = SeqexecCircuit.connect(_.uiModel.globalLog)
 
-  private val component = ScalaComponent.builder[Unit]("SeqexecUI")
+  private val component = ScalaComponent.builder[RouterCtl[SeqexecPages]]("SeqexecUI")
     .stateless
     .render_P(p =>
       <.div(
         NavBar(),
-        QueueArea(),
+        QueueArea(p),
         SequenceArea(),
         logConnect(LogArea.apply),
         lbConnect(LoginBox.apply)
       )
     ).build
 
-  def apply() = component()
+  def apply(ctl: RouterCtl[SeqexecPages]) = component(ctl)
 }
 
 /**
@@ -43,13 +43,13 @@ object SeqexecUI {
         <.div(r.render()).render
 
       (emptyRule
-      | staticRoute(root, Root) ~> renderR(r => SeqexecMain())
+      | staticRoute(root, Root) ~> renderR(r => SeqexecMain(r))
       | dynamicRoute(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+").option).caseClass[InstrumentPage]) {
           case x @ InstrumentPage(i, _) if InstrumentNames.instruments.list.toList.contains(i) => x
-        } ~> dynRenderR((p, r) => SeqexecMain())
+        } ~> dynRenderR((p, r) => SeqexecMain(r))
       | dynamicRoute(("/" ~ string("[a-zA-Z0-9-]+")).pmap(i => Some(InstrumentPage(i, None)))(i => i.i)) {
           case x @ InstrumentPage(i, _) if InstrumentNames.instruments.list.toList.contains(i) => x
-        } ~> dynRenderR((p, r) => SeqexecMain())
+        } ~> dynRenderR((p, r) => SeqexecMain(r))
       )
         .notFound(redirectToPage(Root)(Redirect.Push))
         // Runtime verification that all pages are routed

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -15,6 +15,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.{Callback, ScalaComponent}
 
 import scalacss.ScalaCssReact._
+
 import scalaz.std.option._
 import scalaz.syntax.std.option._
 
@@ -62,7 +63,7 @@ object InstrumentTab {
           JsTabOptions
             .onVisible { (x: Instrument) =>
               ctx.props.t().map(_.idState).foreach { sequence =>
-                val updateModelCB = sequence.map(seq => ctx.props.t.dispatchCB(NavigateTo(InstrumentPage(x, seq._1.some))) >> ctx.props.t.dispatchCB(SelectIdToDisplay(x, seq._1)))
+                val updateModelCB = sequence.map(seq => ctx.props.t.dispatchCB(NavigateTo(InstrumentPage(x, seq._1.some))) >> ctx.props.t.dispatchCB(SelectIdToDisplay(seq._1)))
                   .getOrElse(ctx.props.t.dispatchCB(NavigateTo(InstrumentPage(x, none))) >> ctx.props.t.dispatchCB(SelectInstrumentToDisplay(x)))
                 // runNow as we are outside react loop
                 updateModelCB.runNow()

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
@@ -34,6 +34,11 @@ object ModelOps {
       case SequenceState.Error(_) => true
       case _                      => false
     }
+
+    def isInProcess: Boolean = s match {
+      case SequenceState.Idle => false
+      case _                  => true
+    }
   }
 
   implicit class SequenceViewOps(val s: SequenceView) extends AnyVal {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
@@ -20,13 +20,20 @@ object ModelOps {
     case SequenceState.Error(_)  => s"Error at step "
   }
 
-  implicit val steStateShow: Show[StepState] = Show.shows[StepState] {
+  implicit val stepStateShow: Show[StepState] = Show.shows[StepState] {
     case StepState.Pending    => "Pending"
     case StepState.Completed  => "Done"
     case StepState.Skipped    => "Skipped"
     case StepState.Error(msg) => s"Error $msg"
     case StepState.Running    => "Running"
     case StepState.Paused     => "Paused"
+  }
+
+  implicit class SequenceStateOps(val s: SequenceState) extends AnyVal {
+    def hasError: Boolean = s match {
+      case SequenceState.Error(_) => true
+      case _                      => false
+    }
   }
 
   implicit class SequenceViewOps(val s: SequenceView) extends AnyVal {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -161,7 +161,7 @@ case class SeqexecUIModel(navLocation: Pages.SeqexecPages,
                           sequencesOnDisplay: SequencesOnDisplay)
 
 object SeqexecUIModel {
-  private val noSequencesLoaded = SequencesQueue[SequenceView](Conditions.default, None, Nil)
+  val noSequencesLoaded = SequencesQueue[SequenceView](Conditions.default, None, Nil)
   val initial = SeqexecUIModel(Pages.Root, None, noSequencesLoaded,
     SectionClosed, GlobalLog(Nil), SequencesOnDisplay.empty)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -33,7 +33,7 @@ case object Logout extends Action
 
 // Action to select a sequence for display
 case class SelectToDisplay(s: SequenceView) extends Action
-case class SelectIdToDisplay(i: Instrument, id: SequenceId) extends Action
+case class SelectIdToDisplay(id: SequenceId) extends Action
 case class SelectInstrumentToDisplay(i: Instrument) extends Action
 
 // Actions related to executing sequences
@@ -107,12 +107,6 @@ case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
     copy(instrumentSequences = q | instrumentSequences)
   }
 
-  def focusOnId(i: Instrument, id: SequenceId): SequencesOnDisplay = {
-    // Focus on the instrument and id
-    val q = instrumentSequences.findZ(s => s.instrument === i && s.sequence().exists(_.id === id))
-    copy(instrumentSequences = q | instrumentSequences)
-  }
-
   def focusOnInstrument(i: Instrument): SequencesOnDisplay = {
     // Focus on the instrument
     val q = instrumentSequences.findZ(s => s.instrument === i)
@@ -120,6 +114,10 @@ case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
   }
 
   def isAnySelected: Boolean = instrumentSequences.toStream.exists(_.sequence().isDefined)
+
+  // Is the id on the sequences area?
+  def idDisplayed(id: SequenceId): Boolean =
+    instrumentSequences.withFocus.toStream.find { case (s, a) => a && s.sequence().exists(_.id === id)}.isDefined
 
   def instrument(i: Instrument): Option[(SequenceTab, Boolean)] =
     instrumentSequences.withFocus.toStream.find(_._1.instrument === i)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SequenceDisplayHandlerSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SequenceDisplayHandlerSpec.scala
@@ -14,10 +14,10 @@ class SequenceDisplayHandlerSpec extends FlatSpec with Matchers with PropertyChe
 
   "SequenceDisplayHandler" should "ignore setting a sequence for an unknown sequence" in {
     forAll { (sequence: SequenceView) =>
-      val handler = new SequenceDisplayHandler(new RootModelRW(SequencesOnDisplay.empty))
+      val handler = new SequenceDisplayHandler(new RootModelRW((SequencesOnDisplay.empty, SeqexecUIModel.noSequencesLoaded)))
       val result = handler.handle(SelectToDisplay(sequence))
       result should matchPattern {
-        case ModelUpdate(SequencesOnDisplay(t)) if t.findNext(_.sequence === SeqexecCircuit.sequenceRef(sequence.id)).isEmpty =>
+        case ModelUpdate((SequencesOnDisplay(t), _)) if t.findNext(_.sequence === SeqexecCircuit.sequenceRef(sequence.id)).isEmpty =>
       }
     }
   }


### PR DESCRIPTION
This PR indicates on the queue table what's the selected tab on the sequence area. It also has some UI improvements for queue tables with man entries

This change is motivated by difficulties on seeing the current state when there are many sequences on the queue.

Here's a screenshot with one sequence running and another being displayed

![screenshot 2017-07-04 17 04 57](https://user-images.githubusercontent.com/3615303/27842797-1f0517ae-60db-11e7-8a25-7993fcfbf61a.png)
