### PR TITLE
SEQNG-290: Errors loading partially executed sequences

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -7,6 +7,7 @@ import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.model.p1.immutable.Site
 import edu.gemini.seqexec.engine
 import edu.gemini.seqexec.engine.{Action, Engine, Event, EventSystem, Executed, Failed, Result, Sequence}
+import edu.gemini.seqexec.engine.{EventUser, Load}
 import edu.gemini.seqexec.server.ConfigUtilOps._
 
 import scalaz._
@@ -106,9 +107,17 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
           SequencesQueue(
             qState.conditions,
             qState.operator,
-            qState.sequences.values.map(
-              s => viewSequence(s.toSequence, s.status)
-            ).toList
+            qState.sequences.values.map{
+              s =>
+              ev match {
+                case EventUser(Load(_, sequence)) =>
+                  viewSequence(s.toSequence.copy(metadata = sequence.metadata), s.status)
+
+                case _                            =>
+                  viewSequence(s.toSequence, s.status)
+
+              }
+            }.toList
           )
         )
     }


### PR DESCRIPTION
I've been tracking a bug where the metadata of a sequence isn't properly sent to the client when a sequence is partially executed. This is not a full solution and I'm presenting this only to start the conversation

This is an ad-hoc fix for one of the cases when this happens. When a partially run sequence is added to the queue the metadata doesn't include instrument nor name. There is another case not fixed but it should have the same root cause

I'm fairly sure there is a deeper cause for this but I can't really follow the code 

WDYT?