### PR TITLE
SEQNG-290: Errors loading partially executed sequence

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -2,6 +2,7 @@ package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.engine.Event.start
 import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig}
+import edu.gemini.seqexec.model.Model.F2
 
 import scala.Function.const
 import scalaz._
@@ -51,7 +52,7 @@ class SequenceSpec extends FlatSpec {
 
   }
 
-  val metadata = SequenceMetadata("F2", None, "")
+  val metadata = SequenceMetadata(F2, None, "")
 
   def simpleStep(id: Int, breakpoint: Boolean): Step[Action \/ Result] =
     Step(
@@ -91,7 +92,7 @@ class SequenceSpec extends FlatSpec {
            Sequence.State.init(
              Sequence(
                seqId,
-               SequenceMetadata("F2", None, ""),
+               SequenceMetadata(F2, None, ""),
                List(simpleStep(1, breakpoint = false), simpleStep(2, breakpoint = true))
              )
            )
@@ -120,7 +121,7 @@ class SequenceSpec extends FlatSpec {
            Sequence.State.init(
              Sequence(
                seqId,
-               SequenceMetadata("F2", None, ""),
+               SequenceMetadata(F2, None, ""),
                List(simpleStep(1, breakpoint = false), simpleStep(2, breakpoint = true), simpleStep(3, breakpoint = false))
              )
            )

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -1,6 +1,7 @@
 package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig, StepState}
+import edu.gemini.seqexec.model.Model.F2
 
 import scalaz.syntax.either._
 import org.scalatest._
@@ -96,7 +97,7 @@ class StepSpec extends FlatSpec {
            Sequence.State.init(
              Sequence(
                seqId,
-               SequenceMetadata("F2", None, ""),
+               SequenceMetadata(F2, None, ""),
                List(
                  Step(
                    1,
@@ -145,7 +146,7 @@ class StepSpec extends FlatSpec {
            Sequence.State.Zipper(
              Sequence.Zipper(
                "First",
-               SequenceMetadata("F2", None, ""),
+               SequenceMetadata(F2, None, ""),
                Nil,
                Step.Zipper(
                  2,
@@ -208,7 +209,7 @@ class StepSpec extends FlatSpec {
            Sequence.State.init(
              Sequence(
                seqId,
-               SequenceMetadata("F2", None, ""),
+               SequenceMetadata(F2, None, ""),
                List(
                  Step(
                    1,

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.Semaphore
 import Event._
 import org.scalatest.{FlatSpec, NonImplicitAssertions}
 import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig}
+import edu.gemini.seqexec.model.Model.{F2, GmosS}
 
 import scala.concurrent.duration._
 import scalaz._
@@ -54,7 +55,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
          Sequence.State.init(
            Sequence(
              "First",
-             SequenceMetadata("F2", None, ""),
+             SequenceMetadata(F2, None, ""),
              List(
                Step(
                  1,
@@ -91,7 +92,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
     Sequence.State.init(
       Sequence(
         "First",
-        SequenceMetadata("GMOS", None, ""),
+        SequenceMetadata(GmosS, None, ""),
         List(
           Step(
             1,
@@ -182,7 +183,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
       None,
       Map((seqId, Sequence.State.init(Sequence(
         "First",
-        SequenceMetadata("GMOS", None, ""),
+        SequenceMetadata(GmosS, None, ""),
         List(
           Step(
             1,
@@ -219,7 +220,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
       None,
       Map((seqId, Sequence.State.init(Sequence(
         "First",
-        SequenceMetadata("GMOS", None, ""),
+        SequenceMetadata(GmosS, None, ""),
         List(
           Step(
             1,

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -105,7 +105,26 @@ object Model {
   // TODO This should be a richer type
   type SequenceId = String
   type StepId = Int
-  type Instrument = String
+  sealed trait Instrument
+  case object F2 extends Instrument
+  case object GmosS extends Instrument
+  case object GmosN extends Instrument
+  case object GPI extends Instrument
+  case object GSAOI extends Instrument
+
+  object Instrument {
+    implicit val equal: Equal[Instrument] = Equal.equalA[Instrument]
+    implicit val show: Show[Instrument] = Show.shows({
+      case F2    => "Flamingos2"
+      case GmosS => "GMOS-S"
+      case GmosN => "GMOS-N"
+      case GPI   => "GPI"
+      case GSAOI => "GSAOI"
+    })
+    val gsInstruments = NonEmptyList[Instrument](F2, GmosS, GPI, GSAOI)
+    val gnInstruments = NonEmptyList[Instrument](GmosN)
+  }
+
   type Operator = String
   type Observer = String
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -108,8 +108,8 @@ object QueueTableBody {
                 ),
                 <.td(
                   selectableRowCls.toTagMod,
-                  p.ctl.link(InstrumentPage(s.instrument, s.id.some))(s.instrument).unless(inProcess),
-                  s.instrument.when(inProcess)
+                  p.ctl.link(InstrumentPage(s.instrument, s.id.some))(s.instrument.shows).unless(inProcess),
+                  s.instrument.shows.when(inProcess)
                 ),
                 <.td(
                   selectableRowCls.toTagMod,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -39,7 +39,7 @@ object SeqexecUI {
   case class RouterProps(page: InstrumentPage, router: RouterCtl[InstrumentPage])
 
   private val siteInstruments = Instrument.gsInstruments
-  private val instrumentNames = siteInstruments.map(i => (i.shows, i)).toIList.toList.toMap
+  private val instrumentNames = siteInstruments.map(i => (i.shows, i)).list.toList.toMap
 
   def router: Router[SeqexecPages] = {
     val routerConfig = RouterConfigDsl[SeqexecPages].buildConfig { dsl =>
@@ -55,10 +55,10 @@ object SeqexecUI {
           case (i, Some(s)) => instrumentNames.get(i).map(InstrumentPage(_, s.some))
           case (i, None)    => instrumentNames.get(i).map(InstrumentPage(_, none))
         }(p => (p.instrument.shows, p.obsId))) {
-          case x @ InstrumentPage(i, _) if siteInstruments.toIList.toList.contains(i) => x
+          case x @ InstrumentPage(i, _) if siteInstruments.list.toList.contains(i) => x
         } ~> dynRenderR((p, r) => SeqexecMain(r))
       | dynamicRoute(("/" ~ string("[a-zA-Z0-9-]+")).pmap(i => instrumentNames.get(i).map(InstrumentPage(_, None)))(p => p.instrument.shows)) {
-          case x @ InstrumentPage(i, _) if siteInstruments.toIList.toList.contains(i) => x
+          case x @ InstrumentPage(i, _) if siteInstruments.list.toList.contains(i) => x
         } ~> dynRenderR((p, r) => SeqexecMain(r))
       )
         .notFound(redirectToPage(Root)(Redirect.Push))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -2,7 +2,7 @@ package edu.gemini.seqexec.web.client.components.sequence
 
 import diode.react.ModelProxy
 import edu.gemini.seqexec.model.Model.{SequenceState, Instrument}
-import edu.gemini.seqexec.web.client.model.{InstrumentNames, InstrumentStatus, NavigateTo, SelectIdToDisplay, SelectInstrumentToDisplay}
+import edu.gemini.seqexec.web.client.model.{InstrumentStatus, NavigateTo, SelectIdToDisplay, SelectInstrumentToDisplay}
 import edu.gemini.seqexec.web.client.model.Pages.InstrumentPage
 import edu.gemini.seqexec.web.client.model.SeqexecCircuit
 import edu.gemini.seqexec.web.client.semanticui._
@@ -18,6 +18,7 @@ import scalacss.ScalaCssReact._
 
 import scalaz.std.option._
 import scalaz.syntax.std.option._
+import scalaz.syntax.show._
 
 object InstrumentTab {
   case class Props(t: ModelProxy[Option[InstrumentStatus]])
@@ -49,9 +50,9 @@ object InstrumentTab {
           ),
           SeqexecStyles.activeInstrumentContent.when(sequenceId.isDefined),
           SeqexecStyles.errorTab.when(hasError),
-          dataTab := instrument,
+          dataTab := instrument.shows,
           IconAttention.copyIcon(color = Some("red")).when(hasError),
-          sequenceId.map(id => <.div(<.div(SeqexecStyles.activeInstrumentLabel, instrument), Label(Label.Props(id, color = color, icon = icon)))).getOrElse(instrument)
+          sequenceId.map(id => <.div(<.div(SeqexecStyles.activeInstrumentLabel, instrument.shows), Label(Label.Props(id, color = color, icon = icon)))).getOrElse(instrument.shows)
         )
       }
     }.componentDidMount(ctx =>
@@ -80,7 +81,7 @@ object InstrumentTab {
   */
 object InstrumentsTabs {
   // TODO Consider GN/GS
-  val instrumentConnects = InstrumentNames.instruments.list.toList.map(i => SeqexecCircuit.connect(SeqexecCircuit.instrumentStatusTab(i)))
+  val instrumentConnects = Instrument.gsInstruments.list.toList.map(i => SeqexecCircuit.connect(SeqexecCircuit.instrumentStatusTab(i)))
 
   private val component = ScalaComponent.builder[Unit]("InstrumentsMenu")
     .stateless

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -8,12 +8,14 @@ import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.semanticui._
 import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconInbox
+import edu.gemini.seqexec.model.Model.Instrument
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.{CallbackTo, ScalaComponent, ScalazReact}
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.ScalazReact._
 
 import scalaz.syntax.apply.{^ => _, _}
+import scalaz.syntax.show._
 import scalaz.std.option._
 
 object SequenceStepsTableContainer {
@@ -74,7 +76,7 @@ object SequenceStepsTableContainer {
           ^.classSet(
             "active" -> active
           ),
-          dataTab := tab.instrument,
+          dataTab := tab.instrument.shows,
           tab.sequence().fold(IconMessage(IconMessage.Props(IconInbox, Some("No sequence loaded"), IconMessage.Style.Warning)): VdomNode) { s =>
             SequenceStepsTableContainer(p.p): VdomNode
           }
@@ -95,7 +97,7 @@ object SequenceStepsTableContainer {
     case class Props(s: ClientStatus, d: SequencesOnDisplay)
 
     // TODO Consider GN/GS
-    val instrumentConnects = InstrumentNames.instruments.list.toList.map(i => SeqexecCircuit.connect(SeqexecCircuit.instrumentTabAndStatus(i)))
+    val instrumentConnects = Instrument.gsInstruments.list.toList.map(i => SeqexecCircuit.connect(SeqexecCircuit.instrumentTabAndStatus(i)))
 
     private val component = ScalaComponent.builder[Unit]("SequenceTabsBody")
     .stateless

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -16,7 +16,7 @@ object Pages {
   sealed trait SeqexecPages
 
   case object Root extends SeqexecPages
-  case class InstrumentPage(i: Instrument, obsId: Option[SequenceId]) extends SeqexecPages
+  case class InstrumentPage(instrument: Instrument, obsId: Option[SequenceId]) extends SeqexecPages
 }
 
 // Actions
@@ -83,14 +83,6 @@ object SectionVisibilityState {
 
 case class SequenceTab(instrument: Instrument, sequence: RefTo[Option[SequenceView]], stepConfigDisplayed: Option[Int])
 
-/**
-  * Internal list of object names.
-  * TODO This should belong to the model
-  */
-object InstrumentNames {
-  val instruments = NonEmptyList[Instrument]("Flamingos2", "GMOS-S", "GPI", "GSAOI")
-}
-
 // Model for the tabbed area of sequences
 case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
   // Display a given step on the focused sequence
@@ -129,7 +121,7 @@ case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
 object SequencesOnDisplay {
   val emptySeqRef: RefTo[Option[SequenceView]] = RefTo(new RootModelR(None))
 
-  val empty = SequencesOnDisplay(InstrumentNames.instruments.map(SequenceTab(_, emptySeqRef, None)).toZipper)
+  val empty = SequencesOnDisplay(Instrument.gsInstruments.map(SequenceTab(_, emptySeqRef, None)).toZipper)
 }
 
 case class WebSocketConnection(ws: Pot[WebSocket], nextAttempt: Int)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -21,6 +21,9 @@ trait ArbitrariesWebClient extends ArbitrariesWebCommon {
       } yield i
     }
 
+  implicit val arbInstrument: Arbitrary[Instrument] =
+    Arbitrary { Gen.oneOf(Instrument.gsInstruments.list.toList ++ Instrument.gnInstruments.list.toList) }
+
   implicit val arbSequenceTab: Arbitrary[SequenceTab] =
     Arbitrary {
       for {


### PR DESCRIPTION
We have been searching for this error for a while where in some cases the metadata of a sequence is lost. To fix it I converted the `Instrument` type into an `ADT` thus making it impossible to construct a sequence with invalid metadata. This revealed the issue deep in the engine