### PR TITLE
SEQNG-302: Exception when loading a sequence without steps

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
@@ -32,6 +32,7 @@ case class Execution(execution: List[Action \/ Result]) {
     if (execution.forall(_.isLeft)) Status.Waiting
     // Empty execution is handled here
     else if (execution.all(finished)) Status.Completed
+    else if (isEmpty) Status.Completed
     else Status.Running
 
   /**
@@ -75,8 +76,8 @@ object Execution {
     ar match {
       case (-\/(_)) => false
       case (\/-(r)) => r match {
-        case Result.Partial(_,_) => false
-        case _                   => true
+        case Result.Partial(_, _) => false
+        case _                    => true
       }
     }
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -145,7 +145,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     val configs = sequenceConfig.getAllSteps.toList
 
     val steps = configs.zipWithIndex.map {
-      case (c, i) => step(obsId, i, c, i == (configs.length-1))
+      case (c, i) => step(obsId, i, c, i == (configs.length - 1))
     }.separate
 
     val instName = configs.headOption.map(extractInstrumentName).getOrElse(SeqexecFailure.UnrecognizedInstrument("UNKNOWN").left)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
@@ -159,7 +159,7 @@ object SequenceDefaultToolbar {
                 dataTooltip = Some(runContinueTooltip),
                 disabled = !p.status.isConnected || s.runRequested || s.syncRequested),
               runContinueButton
-            ).when(p.s.hasError),
+            ).when(p.s.hasError && p.s.steps.nonEmpty),
             Button(
               Button.Props(
                 icon = Some(IconRefresh),
@@ -179,7 +179,7 @@ object SequenceDefaultToolbar {
                 dataTooltip = Some(runContinueTooltip),
                 disabled = !p.status.isConnected || s.runRequested || s.syncRequested),
               runContinueButton
-            ).when(p.s.status === SequenceState.Idle),
+            ).when(p.s.status === SequenceState.Idle && p.s.steps.nonEmpty),
             Button(
               Button.Props(
                 icon = Some(IconPause),


### PR DESCRIPTION
After #283 we can now load empty sequences, however running them produces an exception and it puts the engine on an infinite loop

This PR fixes both problems and also removes the buttons on the UI to run empty sequences