### PR TITLE
Engine experiments for potential improvements

### DIFF
--- a/modules/engine-prototype/README.md
+++ b/modules/engine-prototype/README.md
@@ -1,0 +1,46 @@
+# Seqexec engine cats/fs2 prototype
+
+## Goals and status
+
+- Get hands on expertise in libraries we'd to migrate to: `cats`, `cats-effect`,
+  `fs2`, `monocle`. This is also useful to better assess future porting efforts.
+- A new model, that needs to be further developed, optimized for manipulation
+  instead of execution. Pending Steps are not wrapped in `Task`s so they are
+  easier to modify. Each type of Step comes with `_.execute` method where the
+  actual execution is defined.
+- Synchronous-like control of execution even though there is asynchronicity
+  under the hood where needed. What to do after an execution is decided where
+  the execution takes place, there are no system events that need to re-handled
+  from the top.
+- No `Process`es (or fs2 `Stream`) are used internally, only the new equivalent
+  of `Task`s in fs2/cats: the `Effect` type class. Monad transformers like
+  `StateT` or `EitherT` are not needed now.
+- Concurrent shared state through `fs2` `Signal`s. This is a wrapper for the
+  `Ref`, the fundamental concurrently safe mutable variable in `fs2`. `Signal`
+  adds the possibility of obtaining an output stream with every state update.
+- Error handling: There is now a hint of how to handle errors from subsystems
+  but this needs to be further developed. Some examples of how to handle
+  exceptions also need to be provided.
+- At least a single test needs to be written showing the prototype can run a
+  dummy sequence properly.
+
+## Out of scope
+
+ * Execution DSL: A set of helper functions to be used as a *mini-language* to
+   define Step executions easily where signal updates are hidden. The code
+   defining the step executions should not know anything about updating the
+   state. 4-5 days.
+ * Loading: Reading from the ODB would be easy but converting it to the new
+   model would take some effort: ~4-5 days.
+ * Printing State: The internal model would have to be converted to the state
+   needed by the UI. 3-4 days.
+ * Breakpoints: This should be easy now. 1 day.
+ * Multiple Sequences: This would be the same as the real seqexec with a map
+   of Sequences. Most of the work here would be direct port of what we have to
+   `fs2`/`cats-effect`. For example, using `join`, instead of `mergeN` for each
+   Sequence `Process`/`Stream`. 2 days.
+ * Parallel Sequences: This would be the same as of now with the concept of
+   `Resources` but done at the Step level. 1 day
+ * Tests: Our current tests are not that comprehensive so many of them would be
+   not worth porting. Most of the tests would have to be written from scratch.
+   4-5 days.

--- a/modules/engine-prototype/README.md
+++ b/modules/engine-prototype/README.md
@@ -4,43 +4,93 @@
 
 - Get hands on expertise in libraries we'd to migrate to: `cats`, `cats-effect`,
   `fs2`, `monocle`. This is also useful to better assess future porting efforts.
+
 - A new model, that needs to be further developed, optimized for manipulation
-  instead of execution. Pending Steps are not wrapped in `Task`s so they are
-  easier to modify. Each type of Step comes with `_.execute` method where the
-  actual execution is defined.
+  instead of execution. Pending Steps are not wrapped in `Task`s (or now the
+  equivalent `Effect` type class) so they are easier to modify. Each type of
+  Step, when in *Pending* position only, comes with `_.execute` method where the
+  actual execution for that particular Step. From the application State there is
+  a Prism to this method that indicates when the `execute` method is there. So
+  it's only possible to perform an execution when the whole State is in the
+  right position.
+
 - Synchronous-like control of execution even though there is asynchronicity
   under the hood where needed. What to do after an execution is decided where
   the execution takes place, there are no system events that need to re-handled
   from the top.
-- No `Process`es (or fs2 `Stream`) are used internally, only the new equivalent
-  of `Task`s in fs2/cats: the `Effect` type class. Monad transformers like
-  `StateT` or `EitherT` are not needed now.
+
+- No `Process`es (or `fs2` `Stream`) are used internally, only the new
+  equivalent of `Task`s in `cats-effect`: the `Effect` type class. Monad
+  transformers like `StateT` or `EitherT` are not needed for the core
+  functionality.
+
 - Concurrent shared state through `fs2` `Signal`s. This is a wrapper for the
   `Ref`, the fundamental concurrently safe mutable variable in `fs2`. `Signal`
-  adds the possibility of obtaining an output stream with every state update.
-- Error handling: There is now a hint of how to handle errors from subsystems
-  but this needs to be further developed. Some examples of how to handle
-  exceptions also need to be provided.
-- At least a single test needs to be written showing the prototype can run a
-  dummy sequence properly.
+  adds the possibility of obtaining an output stream with every State update.
 
-## Out of scope
+- Error handling: There is now a hint of how to handle errors from subsystems
+  but this would need to be further developed with the introduction of failed
+  `Step`s where the *correct* data is still there, and the error is pointed
+  exactly where it happened within the `Step`. I had the intention of showing
+  Some examples of traditional exception handling from the top of a `Process`
+  (now `Stream`s) but is still missing.
+
+- ADTs in anger. This is something that I explored without having a clear idea
+  beforehand. For example, in a GMOS Sequence it should be possible only to run
+  GMOS Steps (which have their own distinct type different to F2 Steps). There
+  is also ADTs for differentiate between Steps: Pending, Current, Done Steps are
+  distinct types, so it should be impossible to do things like executing a Done
+  Step, or putting a Pending Step in the list of Done Steps. Because there is a
+  lot of shared data between the different types of Steps there is also the
+  concept of `core` Step which should be used internally for every type of Step.
+
+  However, in order to be able to use comfortably these deep ADTs several
+  lens/prisms would need to be written. I'm also not satisfied of how I abused
+  Scala objects as namespaces which in hindsight looks messy so I'm looking for
+  simpler solution to encode deeply nested ADTs in Scala.
+
+- Concurrency encapsulated in its own object. `fs2` `Signal`s provides a good
+  enough set of primitives, so that object is mostly wrappers of those with
+  specialized signatures for the engine so it feels more natural. Many of the
+  necessary wrappers are still missing but eventually, if further developed, it
+  should serve as a mini-DSL to define Step executions easily.
+
+## Effort evaluation of what is missing
 
  * Execution DSL: A set of helper functions to be used as a *mini-language* to
    define Step executions easily where signal updates are hidden. The code
    defining the step executions should not know anything about updating the
-   state. 4-5 days.
- * Loading: Reading from the ODB would be easy but converting it to the new
-   model would take some effort: ~4-5 days.
+   state.
+
+ * Sequence Loading: Reading from the ODB should be easy but the keywords to the new
+   model would take some effort.
+
  * Printing State: The internal model would have to be converted to the state
-   needed by the UI. 3-4 days.
- * Breakpoints: This should be easy now. 1 day.
- * Multiple Sequences: This would be the same as the real seqexec with a map
+   needed by the UI. Under the hood it all follows the pattern of
+   zipping/unzipping which is what we are using now, but because the internal
+   model is now completely different it would have to be written from scratch
+   (arguably, without `Task`s in the Pending Steps it should be easier though)
+
+ * Breakpoints: This should be easy as it is now.
+
+ * Multiple Sequences: This would be the same as the current engine with a map
    of Sequences. Most of the work here would be direct port of what we have to
-   `fs2`/`cats-effect`. For example, using `join`, instead of `mergeN` for each
-   Sequence `Process`/`Stream`. 2 days.
+   `fs2`/`cats-effect`. For example, using `fs2` `join`, instead of
+   `scalaz-stream` `mergeN` for each Sequence `Process`/`Stream`. I'm not
+   entirely sure `join` and `mergeN` are semantically equivalent so this task
+   may become more difficult than it seems.
+
  * Parallel Sequences: This would be the same as of now with the concept of
-   `Resources` but done at the Step level. 1 day
+   `Resources` but done at the Step level. It should be trivial.
+
+ * Lens/Prism. Many more lens than what we have now would need to be defined in
+   order to work effectively with the new model. It would be cumbersome to
+   define them but once there, maintenance shouldn't be a problem and the
+   consumer code would be very easy to write, provided we are familiar with the
+   concept of Lens/Prism (which in our team is fine) but it could be a
+   considerable knowledge barrier if we want to involve more people.
+   
  * Tests: Our current tests are not that comprehensive so many of them would be
-   not worth porting. Most of the tests would have to be written from scratch.
-   4-5 days.
+   not worth porting. Most of the tests would have to be written from scratch
+   but this would be the task that would take the most time of all the listed
+   above.

--- a/modules/engine-prototype/build.sbt
+++ b/modules/engine-prototype/build.sbt
@@ -1,0 +1,24 @@
+import Dependencies._
+
+lazy val root = (project in file(".")).
+  settings(
+    inThisBuild(List(
+      organization := "edu.gemini",
+      scalaVersion := "2.12.1",
+      scalacOptions ++= Seq(
+        "-feature",
+        "-language:higherKinds",
+        "-language:existentials"
+      ),
+      version      := "0.1.0-SNAPSHOT"
+    )),
+    name := "engine",
+    libraryDependencies ++= Seq(
+      cats,
+      catsEffect,
+      fs2,
+      monocle,
+      monocleMacro,
+      scalaTest % Test
+    )
+  )

--- a/modules/engine-prototype/project/Dependencies.scala
+++ b/modules/engine-prototype/project/Dependencies.scala
@@ -1,0 +1,10 @@
+import sbt._
+
+object Dependencies {
+  lazy val cats = "org.typelevel" %% "cats" % "0.9.0"
+  lazy val catsEffect = "org.typelevel" %% "cats-effect" % "0.3"
+  lazy val fs2 = "co.fs2" %% "fs2-core" % "0.10.0-M2"
+  lazy val monocle = "com.github.julien-truffaut" %% "monocle-core" % "1.4.0"
+  lazy val monocleMacro = "com.github.julien-truffaut" %% "monocle-macro" % "1.4.0"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
+}

--- a/modules/engine-prototype/project/build.properties
+++ b/modules/engine-prototype/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/modules/engine-prototype/src/main/scala/engine/Event.scala
+++ b/modules/engine-prototype/src/main/scala/engine/Event.scala
@@ -1,0 +1,7 @@
+package engine
+
+sealed trait Event
+object Event {
+  case object Start extends Event
+  case object Stop extends Event
+}

--- a/modules/engine-prototype/src/main/scala/engine/Execution.scala
+++ b/modules/engine-prototype/src/main/scala/engine/Execution.scala
@@ -1,0 +1,17 @@
+package engine
+
+import cats.effect.Effect
+
+object Execution {
+
+  def configureTCS[F[_]](implicit F: Effect[F]): F[Either[Failure, OK]]  = ???
+
+  def configureInst[F[_]](name: String)(implicit F: Effect[F]): F[Either[Failure, OK]]  = ???
+
+  def observe[F[_]](implicit F: Effect[F]): F[Option[String]] = ???
+
+  type Failure = Unit
+
+  type OK = Unit
+
+}

--- a/modules/engine-prototype/src/main/scala/engine/Resource.scala
+++ b/modules/engine-prototype/src/main/scala/engine/Resource.scala
@@ -1,0 +1,32 @@
+package engine
+
+/**
+  * A Seqexec resource represents any system that can be only used by one single agent.
+  *
+  */
+sealed trait Resource
+object Resource {
+
+  case object P1 extends Resource
+  case object OI extends Resource
+  // Mount and science fold cannot be controlled independently. Maybe in the future.
+  // For now, I replaced them with TCS
+  //  case object Mount extends Resource
+  //  case object ScienceFold extends Resource
+  case object TCS extends Resource
+  case object Gcal extends Resource
+  case object Gems extends Resource
+  case object Altair extends Resource
+
+  trait Instrument extends Resource
+  object Instrument {
+    case object GMOS extends Instrument
+    case object F2 extends Instrument
+    case object GSAOI extends Instrument
+    case object GPI extends Instrument
+    case object NIRI extends Instrument
+    case object NIFS extends Instrument
+    case object GNIRS extends Instrument
+  }
+
+}

--- a/modules/engine-prototype/src/main/scala/engine/Sequence.scala
+++ b/modules/engine-prototype/src/main/scala/engine/Sequence.scala
@@ -1,0 +1,91 @@
+package engine
+
+import scala.concurrent.ExecutionContext
+
+import cats.{FlatMap, Functor}
+import cats.data.NonEmptyList
+import cats.effect.Effect
+import cats.effect.implicits._
+import cats.implicits._
+
+import fs2.Stream
+import fs2.async
+import fs2.async.mutable.Signal
+
+import monocle.{Lens, Prism}
+import monocle.macros.GenLens
+
+sealed trait Sequence
+object Sequence {
+
+  sealed trait F2 extends Sequence
+  object F2 {
+
+    final case class Ready(
+      done: List[Step.F2.Done],
+      pending: List[Step.F2.Pending],
+      current: Step.F2.Current
+    ) extends F2
+
+    final case class Done(done: NonEmptyList[Step.F2.Done]) extends F2
+
+  }
+
+  final case class State(sequence: Sequence, status: Status)
+
+  object State {
+
+    val sequence: Lens[State, Sequence] = GenLens[State](_.sequence)
+
+    val status: Lens[State, Status] = GenLens[State](_.status)
+
+    val current: Prism[State, Step.F2.Current] = ???
+
+    val standard: Prism[State, Step.F2.Current.Pending.Standard] = ???
+
+    val ready: Prism[State, Step.F2.Current.Pending] = ???
+
+    // Thread safe mutable but careful need to be careful not to block for very long.
+    case class Mutable[F[_]](signal: Signal[F, Sequence.State]) {
+
+      def getStatus(implicit F: Functor[F]): F[Status] = signal.get.map(_.status)
+
+      def setStatus(s: Status)(implicit F: Functor[F]): F[Sequence.State] =
+        signal.modify(State.status.set(s)).map(_.now)
+
+
+      def getSequence(implicit F: Functor[F]): F[Sequence] = signal.get.map(_.sequence)
+
+      def setSequence(seq: Sequence)(implicit F: Functor[F]): F[Sequence.State] =
+        signal.modify(State.sequence.set(seq)).map(_.now)
+
+
+      val getState: F[Sequence.State] = signal.get
+
+      def setState(st: Sequence.State): F[Unit] = signal.set(st)
+
+
+      // is it worth making Sequence.State.Monad a righteous Monad?
+      def withState(f: Sequence.State => F[Sequence.State])(implicit F: FlatMap[F]): F[Sequence.State] =
+        signal.get.flatMap(f)
+
+
+      def modify(f: Sequence.State => Sequence.State)(implicit F: Functor[F]): F[Sequence.State] =
+        signal.modify(f).map(_.now)
+
+    }
+
+    object Mutable {
+
+      def stream[F[_]](st0: Sequence.State)(handle: (Mutable[F]) => F[Unit])(implicit F: Effect[F], ec: ExecutionContext): Stream[F, Sequence.State] =
+        Stream.force(
+          async.signalOf[F, Sequence.State](st0).flatMap(sig =>
+            async.fork(handle(Mutable(sig))) *> sig.discrete.pure[F]
+          )
+        )
+
+    }
+
+  }
+
+}

--- a/modules/engine-prototype/src/main/scala/engine/Status.scala
+++ b/modules/engine-prototype/src/main/scala/engine/Status.scala
@@ -1,0 +1,19 @@
+package engine
+
+sealed trait Status
+object Status {
+  case object Running extends Status
+  case object Waiting extends Status
+  case object Finished extends Status
+  case object Failed extends Status
+
+
+//   whenRunning(sig)(f: ) = sig.get.flatMap(st =>
+//     sig.get.flatMap(st =>
+//       st.status match {
+//         case Status.Running => fa
+//         case _ => F.pure(Unit)
+//       }
+// )
+
+}

--- a/modules/engine-prototype/src/main/scala/engine/Step.scala
+++ b/modules/engine-prototype/src/main/scala/engine/Step.scala
@@ -1,0 +1,251 @@
+package engine
+
+import scala.concurrent.ExecutionContext
+
+import cats.implicits._
+import cats.effect.Effect
+
+sealed trait Step
+object Step {
+
+  // Whatever is shared among all Steps. Notice it doesn't // extend Step
+  // because it's meant to be used only internally
+  case class Core(
+    id: String,
+    config: Core.Configuration,
+    breakpoint: Boolean
+  )
+
+  object Core {
+    case class Configuration()
+  }
+
+  sealed trait F2 extends Step
+  object F2 {
+
+    case class Done(core: Core, fileId: String) extends F2
+
+    sealed trait Pending extends F2
+    object Pending {
+      case class Standard(core: Core) extends Pending
+      case class Flat(core: Core) extends Pending
+      case class Dark(core: Core) extends Pending
+    }
+
+    sealed trait Ongoing extends F2
+    object Ongoing {
+      final case class Standard(core: Core, tcsConfigured: Boolean, instConfigured: Boolean) extends Ongoing
+    }
+
+    sealed trait Failed extends F2
+    object Failed {
+      final case class Standard(core: Core, tcsFailed: Boolean, instFailed: Boolean, observationFailed: Boolean) extends F2
+      // TODO: final case class Standard(core: Core, tcsFailure: Option[Failure], instFailure: Option[Failure]) extends F2
+    }
+
+    sealed trait Current extends F2 {
+
+      // Accessor to the core Step
+      val core: Core = ???
+
+    }
+
+    object Current {
+      // Only a Pending Step in Current can be executed
+      sealed trait Pending extends Current {
+
+        def execute[F[_]](m: Sequence.State.Mutable[F])(implicit F: Effect[F], ec: ExecutionContext): F[Unit]
+
+      }
+
+      object Pending {
+
+        case class Standard(step: F2.Pending.Standard) extends Pending {
+
+          def execute[F[_]](m: Sequence.State.Mutable[F])(implicit F: Effect[F], ec: ExecutionContext): F[Unit] = {
+
+            def configureTCS: F[Boolean] =
+              Execution.configureTCS.flatMap {
+                case Right(_) =>
+                  m.modify(
+                    Sequence.State.current.modify {
+                      case Pending.Standard(s) => Ongoing.Standard(
+                        F2.Ongoing.Standard(s.core, tcsConfigured = true, instConfigured = false)
+                      )
+                      case Ongoing.Standard(s) => Ongoing.Standard(
+                        F2.Ongoing.Standard(s.core, tcsConfigured = true, instConfigured = true)
+                      )
+                      case Failed.Standard(s) => Failed.Standard(
+                        F2.Failed.Standard(
+                          s.core,
+                          tcsFailed = false,
+                          instFailed = true,
+                          observationFailed = true
+                        )
+                      ) // Instrument already failed
+                    }
+                  ) *> true.pure[F]
+
+                case Left(_) =>
+                  m.modify(
+                    Sequence.State.current.modify {
+                      case Failed.Standard(s) => Failed.Standard(
+                        F2.Failed.Standard(
+                          s.core,
+                          tcsFailed = true,
+                          instFailed = true,
+                          observationFailed = false
+                        )
+                      )
+                      // Instrument didn't fail yet
+                      case s => Failed.Standard(
+                        F2.Failed.Standard(
+                          s.core,
+                          tcsFailed = true,
+                          instFailed = false,
+                          observationFailed = false
+                        )
+                      )
+                    }
+                  ) *> false.pure[F]
+
+              }
+
+            def configureInst: F[Boolean] =
+              Execution.configureInst("F2").flatMap {
+                case Right(_) =>
+                  m.modify(
+                    Sequence.State.current.modify {
+                      case Pending.Standard(s) => Ongoing.Standard(
+                        F2.Ongoing.Standard(s.core, tcsConfigured = false, instConfigured = true)
+                      )
+                      case Ongoing.Standard(s) => Ongoing.Standard(
+                        F2.Ongoing.Standard(s.core, tcsConfigured = true, instConfigured = true)
+                      )
+                      case Failed.Standard(s) => Failed.Standard(
+                        F2.Failed.Standard(
+                          s.core,
+                          tcsFailed = true,
+                          instFailed = false,
+                          observationFailed = false
+                        )
+                      ) // Instrument already failed
+                    }
+                  ) *> true.pure[F]
+
+                case Left(_) =>
+                  m.modify(
+                    Sequence.State.current.modify {
+                      case Failed.Standard(s) => Failed.Standard(
+                        F2.Failed.Standard(
+                          s.core,
+                          tcsFailed = true,
+                          instFailed = true,
+                          observationFailed = false
+                        )
+                      )
+                      // TCS didn't fail yet
+                      case s => Failed.Standard(
+                        F2.Failed.Standard(
+                          s.core,
+                          tcsFailed = false,
+                          instFailed = true,
+                          observationFailed = false
+                        )
+                      )
+                    }
+                  ) *> false.pure[F]
+              }
+
+              // XXX: Check running status
+              both(configureTCS, configureInst).flatMap {
+              case (true, true) =>
+                  // XXX: Check running status
+                  Execution.observe.flatMap {
+                    case Some(fileId) => execute(m) // XXX: Shift current focus
+                    case None =>
+                      m.modify(
+                        Sequence.State.current.modify(s =>
+                          Failed.Standard(
+                            F2.Failed.Standard(
+                              s.core,
+                              tcsFailed = false,
+                              instFailed = false,
+                              observationFailed = true
+                            )
+                          )
+                        )
+                      ).void
+                  }
+
+              case (_, _) => F.pure(Unit)
+            }
+          }
+        }
+      }
+
+      sealed trait Ongoing extends Current
+      object Ongoing {
+        case class Standard(step: F2.Ongoing.Standard) extends Ongoing
+      }
+
+      sealed trait Failed extends Current
+      object Failed {
+        case class Standard(step: F2.Failed.Standard) extends Failed
+      }
+    }
+
+  }
+
+  sealed trait GMOS extends Step
+  case object GMOS
+
+  // This won't be accepted in cats-effect
+  // https://gist.github.com/djspiewak/a775b73804c581f4028fea2e98482b3c but with
+  // fs2 it should be possible, `parallelSequence` is already there.
+  private def both[F[_], A, B](fa: F[A], fb: F[B])(implicit F: Effect[F]): F[(A, B)] = ???
+
+}
+
+// current match {
+//   // No current Step
+//   case None => pending match {
+//     // No pending steps, done
+//     case Nil => m.setStatus(Status.Finished).void
+//     // More pending steps
+//     case (next :: remainder) => next.execute(m).flatMap {
+//       case Left(e) => m.setState(
+//         Sequence.State(
+//           F2(done, remainder, Some(Left(e))),
+//           Status.Failed
+//         )
+//       )
+//       case Right(d) => m.setSequence(
+//         F2((d :: done), remainder, None)
+//       ).flatMap(_.sequence.execute(m))
+//     }
+//   }
+//   case Some(_) => F.pure(Unit) // Event: Tried execute Sequence with an already ongoing step.
+// }
+// }
+
+
+//   // Alternative:
+//   // async.parallelSequence(List(Execution.configureTCS, Execution.configureInst("F2"))).flatMap(...)
+//   (for {
+//      t1 <- async.start(
+//        Execution.configureTCS
+//          //.flatMap(// x => sig.modify(Sequence.State.current.set(Some(Right(Ongoing())))) *> F.pure(x))
+//      )
+//      t2 <- async.start(Execution.configureInst("F2"))
+//      r1 <- t1
+//      r2 <- t2
+//    } yield (r1, r2)).flatMap {
+//     case (Right(_), Right(_)) =>
+//         Execution.observe.map {
+//           case Right(_) => ??? // Right(Done())
+//           case Left(_) => ??? // Left(Failed())
+//         }
+//     case _ => ??? // F.pure(Left(Failed()))
+//   }
+// }

--- a/modules/engine-prototype/src/main/scala/engine/package.scala
+++ b/modules/engine-prototype/src/main/scala/engine/package.scala
@@ -1,0 +1,46 @@
+import scala.concurrent.ExecutionContext
+
+import cats.Apply
+import cats.implicits._
+import cats.effect.Effect
+
+import fs2.Stream
+import fs2.async
+import fs2.async.mutable.Queue
+
+package object engine {
+
+  def run[F[_]](in: Queue[F, Event])(st0: Sequence.State)(implicit F: Effect[F], ec: ExecutionContext): Stream[F, Sequence.State] =
+    Sequence.State.Mutable.stream[F](st0: Sequence.State)(m => forever(reader(in)(m)))
+
+  def reader[F[_]](in: Queue[F, Event])(m: Sequence.State.Mutable[F])(implicit F: Effect[F], ec: ExecutionContext): F[Unit] =
+    in.dequeue1.flatMap {
+      case Event.Start => m.withState(st0 =>
+        st0.status match {
+          case Status.Waiting => {
+            val st1 = Sequence.State.status.set(Status.Running)(st0)
+            st1 match {
+              // Execute only when the State is in ready position. If it's not
+              // it's either already executing or it doesn't make sense to execute,
+              // like when it's done.
+              case Sequence.State.ready(p) => async.fork(p.execute(m)) *> F.pure(st1)
+              case _ => F.pure(st1)
+            }
+          }
+          case _ => F.pure(st0) // Event: Status not Waiting, dont't change Status
+        }
+      ).void
+
+    case Event.Stop  => m.modify(st =>
+      st.status match {
+        case Status.Running => Sequence.State.status.set(Status.Waiting)(st)
+        // Leave status as it is
+        case _ => st // Event: Status not Running, no need to stop
+      }
+    ).void
+  }
+
+  // This won't be accepted upstream because it would have to be Lazy (ApplyLazy
+  // typeclass would be needed too)
+  private def forever[F[_], A, B](fa: F[A])(implicit F: Apply[F]): F[B] = fa *> forever(fa)
+}

--- a/modules/engine-prototype/src/test/scala/engine/packageSpec.scala
+++ b/modules/engine-prototype/src/test/scala/engine/packageSpec.scala
@@ -1,0 +1,9 @@
+package engine
+
+import org.scalatest._
+
+class engineSpec extends FlatSpec with Matchers {
+  "The Hello object" should "say hello" in {
+    engine.run shouldEqual "hello"
+  }
+}


### PR DESCRIPTION
This is still half-baked but I left it as it is today because I had already spent quite some time and I think it's good enough to concretize the ideas I put forward some time ago.

I started by trying to get rid of `Process`s internally and use only `Task`s but found it too difficult to separate that aspect of the other improvements I initially proposed, so almost everything is in there.

The previous `scalaz-stream` `Process` is now `fs2` `Stream`. I started using the current `fs2` `Task`s but it's going be deprecated in favor of the `cats-effect` `Effect` type class which is what I ended up using instead. `scalaz` `Task` are quite different from what is being used in `fs2`/`cats-effect`. Asynchronicity is now explicit, you have to explicitly write when you want to fork, and although I agree this is a better approach in general, our asynchronous code would need a major rewrite even if we only focus on the `fs2` migration and ignore the rest of the improvements.

**This PR is not intended for merging**, only to identify what could be extracted into some kind of separate component that could be simpler instead of keep writing *ad-hoc* fixes to the current engine which is making it increasingly more difficult to understand (at least for me).