### PR TITLE
SENQG-285: Match scala compiler params of the gem project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,17 @@ lazy val edu_gemini_web_server_common = project
     libraryDependencies ++= Seq(ScalaZConcurrent) ++ Http4s
   )
 
+lazy val edu_gemini_web_client_facades = project
+  .in(file("modules/edu.gemini.web.client.facades"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(commonJSSettings: _*)
+  .settings(
+    scalacOptions ~= (_.filterNot(Set(
+      // By necessity facades will have unused params
+      "-Ywarn-unused:params"
+    ))),
+    libraryDependencies += JQuery.value
+  )
 // Root web project
 lazy val edu_gemini_seqexec_web = project.in(file("modules/edu.gemini.seqexec.web"))
   .settings(commonSettings: _*)
@@ -127,7 +138,7 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
     buildInfoObject := "OcsBuildInfo",
     buildInfoPackage := "edu.gemini.seqexec.web.client"
   )
-  .dependsOn(edu_gemini_seqexec_web_shared_JS % "compile->compile;test->test", edu_gemini_seqexec_model_JS % "compile->compile;test->test")
+  .dependsOn(edu_gemini_web_client_facades, edu_gemini_seqexec_web_shared_JS % "compile->compile;test->test", edu_gemini_seqexec_model_JS % "compile->compile;test->test")
 
 // List all the modules and their inter dependencies
 lazy val edu_gemini_seqexec_server = project

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -278,12 +278,12 @@ package object engine {
     /**
       * Log info lifted into Handle.
       */
-    def info(msg: String): HandleP[Unit] = pure({(logger.info(msg), None); ()})
+    def info(msg: String): HandleP[Unit] = pure((logger.info(msg), None)).void
 
     /**
       * Log warning lifted into Handle.
       */
-    def warning(msg: String): HandleP[Unit] = pure({(logger.warning(msg), None); ()})
+    def warning(msg: String): HandleP[Unit] = pure((logger.warning(msg), None)).void
   }
 
   /**
@@ -386,8 +386,8 @@ package object engine {
     modify(st => Engine.State(st.conditions, st.operator, st.sequences.updated(id, s)))
 
   // For debugging
-  def printSequenceState(id: Sequence.Id): HandleP[Option[Unit]] =
-    getSs(id)((qs: Sequence.State) => {Task.now(println(qs)).liftM[HandleStateT]; ()})
+  def printSequenceState(id: Sequence.Id): HandleP[Unit] =
+    getSs(id)((qs: Sequence.State) => Task.now(println(qs)).liftM[HandleStateT]).void
 
   // The `Catchable` instance of `Handle`` needs to be manually written.
   // Without it it's not possible to use `Handle` as a scalaz-stream process effects.

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -243,7 +243,7 @@ package object engine {
   }
 
   private def getState(f: Engine.State => Task[Option[Process[Task, Event]]]): HandleP[Unit] =
-    get.flatMap(s => HandleP(f(s).liftM[HandleStateT].map((Unit, _))))
+    get.flatMap(s => HandleP[Unit](f(s).liftM[HandleStateT].map(((), _))))
 
   /**
     * Given the index of the completed `Action` in the current `Execution`, it
@@ -278,12 +278,12 @@ package object engine {
     /**
       * Log info lifted into Handle.
       */
-    def info(msg: String): HandleP[Unit] = pure((logger.info(msg), None))
+    def info(msg: String): HandleP[Unit] = pure({(logger.info(msg), None); ()})
 
     /**
       * Log warning lifted into Handle.
       */
-    def warning(msg: String): HandleP[Unit] = pure((logger.warning(msg), None))
+    def warning(msg: String): HandleP[Unit] = pure({(logger.warning(msg), None); ()})
   }
 
   /**
@@ -356,7 +356,7 @@ package object engine {
 
   def pure[A](a: A): HandleP[A] = Applicative[HandleP].pure(a)
 
-  private val unit: HandleP[Unit] = pure(Unit)
+  private val unit: HandleP[Unit] = pure(())
 
   val get: HandleP[Engine.State] =
     MonadState[Handle, Engine.State].get.toHandleP
@@ -386,7 +386,8 @@ package object engine {
     modify(st => Engine.State(st.conditions, st.operator, st.sequences.updated(id, s)))
 
   // For debugging
-  def printSequenceState(id: Sequence.Id): HandleP[Option[Unit]] = getSs(id)((qs: Sequence.State) => Task.now(println(qs)).liftM[HandleStateT])
+  def printSequenceState(id: Sequence.Id): HandleP[Option[Unit]] =
+    getSs(id)((qs: Sequence.State) => {Task.now(println(qs)).liftM[HandleStateT]; ()})
 
   // The `Catchable` instance of `Handle`` needs to be manually written.
   // Without it it's not possible to use `Handle` as a scalaz-stream process effects.

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerEpics.scala
@@ -37,7 +37,7 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
   )
 
   def setDCConfig(dc: DCConfig): SeqAction[Unit] = for {
-    _ <- Flamingos2Epics.instance.dcConfigCmd.setExposureTime(dc.t.toSeconds)
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setExposureTime(dc.t.toSeconds.toDouble)
     _ <- Flamingos2Epics.instance.dcConfigCmd.setNumReads(dc.n.getCount)
     _ <- Flamingos2Epics.instance.dcConfigCmd.setReadoutMode(encode(dc.r))
     _ <- Flamingos2Epics.instance.dcConfigCmd.setBiasMode(encode(dc.b))

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
@@ -2,7 +2,7 @@ package edu.gemini.seqexec.server
 
 import java.util.logging.Logger
 
-import edu.gemini.epics.acm.CaService
+import edu.gemini.epics.acm.{CaParameter, CaService}
 
 final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) {
 
@@ -24,7 +24,7 @@ final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) 
     val readoutMode = cs.map(_.getString("readoutMode"))
     def setReadoutMode(v: String): SeqAction[Unit] = setParameter(readoutMode, v)
 
-    val exposureTime = cs.map(_.getDouble("exposureTime"))
+    val exposureTime: Option[CaParameter[java.lang.Double]] = cs.map(_.getDouble("exposureTime"))
     def setExposureTime(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](exposureTime, v)
 
   }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Header.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Header.scala
@@ -17,7 +17,7 @@ import scalaz.concurrent.Task
   * Created by jluhrs on 2/10/17.
   */
 
-class Flamingos2Header(hs: DhsClient, f2ObsReader: Flamingos2Header.ObsKeywordsReader, f2Reader: Flamingos2Header.InstKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) extends Header {
+class Flamingos2Header(hs: DhsClient, f2ObsReader: Flamingos2Header.ObsKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) extends Header {
   import Header._
   import Header.Implicits._
   override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] =  {
@@ -44,7 +44,8 @@ class Flamingos2Header(hs: DhsClient, f2ObsReader: Flamingos2Header.ObsKeywordsR
 object Flamingos2Header {
   import Header.Implicits._
 
-  def apply(hs: DhsClient, f2ObsReader: ObsKeywordsReader, f2Reader: InstKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) = new Flamingos2Header(hs, f2ObsReader, f2Reader, tcsKeywordsReader)
+  def apply(hs: DhsClient, f2ObsReader: ObsKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) =
+    new Flamingos2Header(hs, f2ObsReader, tcsKeywordsReader)
 
   trait ObsKeywordsReader {
     def getPreimage: SeqAction[YesNoType]

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GcalControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GcalControllerEpics.scala
@@ -177,6 +177,6 @@ object GcalControllerEpics extends GcalController {
     else for {
       _ <- params.sequence
       _ <- GcalEpics.instance.post
-    } yield TrySeq(())
+    } yield ()
   }
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosControllerEpics.scala
@@ -86,9 +86,9 @@ object GmosControllerEpics extends GmosSouthController {
     case s            => DC.setShutterState(encode(s))
   }
 
-  private def roiNumUsed(s: RegionsOfInterest): Int = s match {
-    case RegionsOfInterest(\/-(rois)) => rois.length
-    case RegionsOfInterest(-\/(b))    => 1
+  private def roiNumUsed(s: RegionsOfInterest): Int = s.rois match {
+    case \/-(rois) => rois.length
+    case -\/(b)    => 1
   }
 
   // Parameters to define a ROI
@@ -136,9 +136,9 @@ object GmosControllerEpics extends GmosSouthController {
     }
   }
 
-  private def setROI(binning: CCDBinning, s: RegionsOfInterest): SeqAction[Unit] = s match {
-    case RegionsOfInterest(-\/(b))    => roiParameters(binning, 1, ROIValues.builtInROI(b))
-    case RegionsOfInterest(\/-(rois)) => rois.zipWithIndex.map { case (roi, i) =>
+  private def setROI(binning: CCDBinning, s: RegionsOfInterest): SeqAction[Unit] = s.rois match {
+    case -\/(b)    => roiParameters(binning, 1, ROIValues.builtInROI(b))
+    case \/-(rois) => rois.zipWithIndex.map { case (roi, i) =>
       roiParameters(binning, i, ROIValues.fromOCS(roi))
     }.sequenceU.flatMap(_ => SeqAction.void)
   }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosEpics.scala
@@ -85,7 +85,7 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::dcconfig"))
 
     val roiNumUsed: Option[CaParameter[JDouble]] = cs.map(_.addDouble("roiNumUsed", GMOS_TOP + "dc:roiNumrois", "Number of ROI used", false))
-    def setRoiNumUsed(v: Int): SeqAction[Unit] = setParameter(roiNumUsed, java.lang.Double.valueOf(v))
+    def setRoiNumUsed(v: Int): SeqAction[Unit] = setParameter(roiNumUsed, java.lang.Double.valueOf(v.toDouble))
 
     val rois: Map[Int, RoiParameters] = (1 to 5).map(i => i -> RoiParameters(cs, i))(breakOut)
 
@@ -93,7 +93,7 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
     def setShutterState(v: String): SeqAction[Unit] = setParameter(shutterState, v)
 
     val exposureTime: Option[CaParameter[JDouble]] = cs.map(_.getDouble("exposureTime"))
-    def setExposureTime(v: Duration): SeqAction[Unit] = setParameter(exposureTime, JDouble.valueOf(v.toSeconds))
+    def setExposureTime(v: Duration): SeqAction[Unit] = setParameter(exposureTime, JDouble.valueOf(v.toSeconds.toDouble))
 
     val ampCount: Option[CaParameter[String]] = cs.map(_.getString("ampCount"))
     def setAmpCount(v: String): SeqAction[Unit] = setParameter(ampCount, v)
@@ -105,10 +105,10 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
     def setGainSetting(v: String): SeqAction[Unit] = setParameter(gainSetting, v)
 
     val ccdXBinning: Option[CaParameter[JDouble]] = cs.map(_.addDouble("ccdXBinning", GMOS_TOP + "dc:roiXBin", "CCD X Binning Value", false))
-    def setCcdXBinning(v: Int): SeqAction[Unit] = setParameter(ccdXBinning, java.lang.Double.valueOf(v))
+    def setCcdXBinning(v: Int): SeqAction[Unit] = setParameter(ccdXBinning, java.lang.Double.valueOf(v.toDouble))
 
     val ccdYBinning: Option[CaParameter[JDouble]] = cs.map(_.addDouble("ccdYBinning", GMOS_TOP + "dc:roiYBin", "CCD Y Binning Value", false))
-    def setCcdYBinning(v: Int): SeqAction[Unit] = setParameter(ccdYBinning, java.lang.Double.valueOf(v))
+    def setCcdYBinning(v: Int): SeqAction[Unit] = setParameter(ccdYBinning, java.lang.Double.valueOf(v.toDouble))
 
     val nsPairs: Option[CaParameter[Integer]] = cs.map(_.getInteger("nsPairs"))
     def setNsPairs(v: Integer): SeqAction[Unit] = setParameter(nsPairs, v)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosHeader.scala
@@ -182,7 +182,7 @@ object GmosHeader {
     override def dcName: SeqAction[String] = SeqAction(Header.StrDefault)
     override def detectorType: SeqAction[String] = SeqAction(Header.StrDefault)
     override def detectorId: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def exposureTime: SeqAction[Double] = SeqAction(Header.IntDefault)
+    override def exposureTime: SeqAction[Double] = SeqAction(Header.DoubleDefault)
     override def adcUsed: SeqAction[Int] = SeqAction(Header.IntDefault)
     override def adcPrismEntSt: SeqAction[Double] = SeqAction(Header.DoubleDefault)
     override def adcPrismEntEnd: SeqAction[Double] = SeqAction(Header.DoubleDefault)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouthController.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouthController.scala
@@ -85,7 +85,7 @@ object GmosSouthController {
         case (BuiltinROI.CUSTOM, r) if r.nonEmpty => \/.right(new RegionsOfInterest(\/.right(r)) {})
         case _ => \/.left(Unexpected("Inconsistent values for GMOS regions of interest"))
       }
-    def unapply(r: RegionsOfInterest): Option[BuiltinROI \/ List[ROI]] = Some(r.rois)
+    def unapply(r: RegionsOfInterest): Some[BuiltinROI \/ List[ROI]] = Some(r.rois)
   }
 
   final case class DCConfig(t: ExposureTime, b: BiasTime, s: ShutterState, r: CCDReadout, bi: CCDBinning, roi: RegionsOfInterest)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -140,8 +140,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
       case _         => false
     }
 
-  def sequence(settings: Settings)
-              (obsId: SPObservationID, sequenceConfig: ConfigSequence, name: String):
+  def sequence(obsId: SPObservationID, sequenceConfig: ConfigSequence, name: String):
       (List[SeqexecFailure], Option[Sequence[Action \/ Result]]) = {
 
     val configs = sequenceConfig.getAllSteps.toList
@@ -204,7 +203,6 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   private def calcInstHeader(config: Config, inst: Resource.Instrument): TrySeq[Header] = inst match {
     case Resource.F2   =>  TrySeq(Flamingos2Header(systems.dhs, new Flamingos2Header.ObsKeywordsReaderImpl(config),
-      if (settings.f2Keywords) Flamingos2Header.InstKeywordReaderImpl else Flamingos2Header.DummyInstKeywordReader,
       if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader))
     case Resource.GMOS =>
       val tcsReader: TcsKeywordsReader = if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -283,7 +283,10 @@ object SeqexecEngine {
 
   def apply(settings: Settings) = new SeqexecEngine(settings)
 
-  private def decodeTops(s: String): Map[String, String] = s.split("=|,").grouped(2).map { case Array(k, v) => k.trim -> v.trim }.toMap
+  private def decodeTops(s: String): Map[String, String] =
+    s.split("=|,").grouped(2).collect {
+      case Array(k, v) => k.trim -> v.trim
+    }.toMap
 
   private def initSmartGCal(smartGCalHost: String, smartGCalLocation: String): Task[Unit] = {
     // SmartGCal always talks to GS
@@ -316,6 +319,8 @@ object SeqexecEngine {
     val smartGCalHost           = cfg.require[String]("seqexec-engine.smartGCalHost")
     val smartGCalDir            = cfg.require[String]("seqexec-engine.smartGCalDir")
 
+    val taskUnit = Task.now(())
+    
     // TODO: Review initialization of EPICS systems
     def initEpicsSystem[T](sys: EpicsSystem[T], tops: Map[String, String]): Task[Unit] =
       Task.delay(
@@ -329,7 +334,6 @@ object SeqexecEngine {
         }
       ) *> taskUnit
 
-    val taskUnit = Task.now(())
     // Ensure there is a valid way to init CaService either from
     // the configuration file or from the environment
     val caInit   = caAddrList.map(a => Task.delay(CaService.setAddressList(a))).getOrElse {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -288,10 +288,10 @@ object SeqexecEngine {
       case Array(k, v) => k.trim -> v.trim
     }.toMap
 
-  private def initSmartGCal(smartGCalHost: String, smartGCalLocation: String): Task[Unit] = {
+  private def initSmartGCal(smartGCalHost: String, smartGCalLocation: String): Task[edu.gemini.seqexec.odb.TrySeq[Unit]] = {
     // SmartGCal always talks to GS
     val peer = new Peer(smartGCalHost, 8443, Site.GS)
-    Task.delay(Paths.get(smartGCalLocation)) >>= {p => Task.delay(SmartGcal.initialize(peer, p)) *> Task.now(()) }
+    Task.delay(Paths.get(smartGCalLocation)).map { p => SmartGcal.initialize(peer, p) }
   }
 
   def seqexecConfiguration: Kleisli[Task, Config, Settings] = Kleisli { cfg: Config => {
@@ -320,7 +320,7 @@ object SeqexecEngine {
     val smartGCalDir            = cfg.require[String]("seqexec-engine.smartGCalDir")
 
     val taskUnit = Task.now(())
-    
+
     // TODO: Review initialization of EPICS systems
     def initEpicsSystem[T](sys: EpicsSystem[T], tops: Map[String, String]): Task[Unit] =
       Task.delay(

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
@@ -275,7 +275,7 @@ class StandardHeader(
         buildDouble(target.getProperMotionRA.orDefault, baseName + "APMRA"),
         buildDouble(target.getParallax.orDefault, baseName + "APARAL")
       ) ++ extras)
-      else SeqAction(List())
+      else SeqAction(())
     }
 
     def standardGuiderKeywords(guideWith: SeqAction[StandardGuideOptions.Value], baseName: String,

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
@@ -288,7 +288,7 @@ object TcsControllerEpics extends TcsController {
     _ <- TcsEpics.instance.wavelSourceA.setWavel(c.wavelB.self.toMicrons)
     _ <- TcsEpics.instance.wavelSourceA.setWavel(c.wavelB.self.toMicrons)
     _ <- TcsEpics.instance.m2Beam.setBeam(encode(c.m2beam))
-  } yield TrySeq(())
+  } yield ()
 
   implicit private val encodeNodChopOption: EncodeEpicsValue[NodChopTrackingOption, String] =
     EncodeEpicsValue { (op: NodChopTrackingOption) =>
@@ -298,7 +298,7 @@ object TcsControllerEpics extends TcsController {
       }
     }
 
-  private def setProbeTrackingConfig(s: TcsEpics.ProbeGuideCmd, c: ProbeTrackingConfig) = for {
+  private def setProbeTrackingConfig(s: TcsEpics.ProbeGuideCmd, c: ProbeTrackingConfig): SeqAction[Unit] = for {
     _ <- s.setNodachopa(encode(c.getNodChop.get(NodChop(Beam.A, Beam.A))))
     _ <- s.setNodachopb(encode(c.getNodChop.get(NodChop(Beam.A, Beam.B))))
     _ <- s.setNodachopc(encode(c.getNodChop.get(NodChop(Beam.A, Beam.C))))
@@ -308,7 +308,7 @@ object TcsControllerEpics extends TcsController {
     _ <- s.setNodcchopa(encode(c.getNodChop.get(NodChop(Beam.C, Beam.A))))
     _ <- s.setNodcchopb(encode(c.getNodChop.get(NodChop(Beam.C, Beam.B))))
     _ <- s.setNodcchopc(encode(c.getNodChop.get(NodChop(Beam.C, Beam.C))))
-  } yield TrySeq(())
+  } yield ()
 
   private def setGuiderWfs(on: TcsEpics.WfsObserveCmd, off: EpicsCommand, c: GuiderSensorOption): SeqAction[Unit] =
     c match {
@@ -390,6 +390,6 @@ object TcsControllerEpics extends TcsController {
     _ <- setM2Guide(gc.m2Guide)
     _ <- TcsEpics.instance.post
     _ <- EitherT(Task(Log.info("TCS guide command post").right))
-  } yield TrySeq(())
+  } yield ()
 
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/SeqexecApp.scala
@@ -34,5 +34,6 @@ object SeqexecApp extends JSApp {
 
     // Render the UI using React
     SeqexecUI.router().renderIntoDOM(document.getElementById("content"))
+    ()
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -60,7 +60,7 @@ object LoginBox {
       )
     }
 
-    def render(p: Props, s: State): TagOf[Div] =
+    def render(s: State): TagOf[Div] =
       <.div(
         ^.cls := "ui modal",
         <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -4,7 +4,7 @@ import diode.react.ModelProxy
 import edu.gemini.seqexec.model.UserDetails
 import japgolly.scalajs.react.{BackendScope, Callback, CallbackTo, ReactEventFromInput, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
-import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+import edu.gemini.web.client.facades.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
@@ -7,7 +7,7 @@ import edu.gemini.seqexec.web.client.model.Pages.Root
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import edu.gemini.seqexec.web.client.OcsBuildInfo
-import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+import edu.gemini.web.client.facades.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.semanticui.elements.menu.HeaderItem

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
@@ -76,7 +76,7 @@ object ConnectionState {
 
   case class Props(u: WebSocketConnection)
 
-  def formatTime(delay: Long): String = if (delay < 1000) {
+  def formatTime(delay: Int): String = if (delay < 1000) {
     f"${delay / 1000.0}%.1f"
   } else {
     f"${delay / 1000}%d"

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -42,7 +42,7 @@ object QueueTableBody {
     )
   }
 
-  def showSequence(p: Props, s: SequenceInQueue): Callback =
+  def showSequence(s: SequenceView): Callback =
     // Request to display the selected sequence
     p.sequences.dispatchCB(NavigateTo(InstrumentPage(s.instrument, s.id.some))) >> p.sequences.dispatchCB(SelectIdToDisplay(s.id))
 
@@ -87,7 +87,7 @@ object QueueTableBody {
                   "active"   -> (s.active && !inProcess)
                 ),
                 ^.key := s"item.queue.$i",
-                ^.onClick --> showSequence(p, s),
+                ^.onClick --> showSequence(s),
                 <.td(
                   ^.cls := "collapsing",
                   selectableRowCls.toTagMod,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -42,7 +42,7 @@ object QueueTableBody {
     )
   }
 
-  def showSequence(s: SequenceView): Callback =
+  def showSequence(p: Props, s: SequenceInQueue): Callback =
     // Request to display the selected sequence
     p.sequences.dispatchCB(NavigateTo(InstrumentPage(s.instrument, s.id.some))) >> p.sequences.dispatchCB(SelectIdToDisplay(s.id))
 
@@ -87,7 +87,7 @@ object QueueTableBody {
                   "active"   -> (s.active && !inProcess)
                 ),
                 ^.key := s"item.queue.$i",
-                ^.onClick --> showSequence(s),
+                ^.onClick --> showSequence(p, s),
                 <.td(
                   ^.cls := "collapsing",
                   selectableRowCls.toTagMod,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -6,7 +6,7 @@ import edu.gemini.seqexec.web.client.model.{InstrumentStatus, NavigateTo, Select
 import edu.gemini.seqexec.web.client.model.Pages.InstrumentPage
 import edu.gemini.seqexec.web.client.model.SeqexecCircuit
 import edu.gemini.seqexec.web.client.semanticui._
-import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+import edu.gemini.web.client.facades.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.semanticui.elements.label.Label

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -80,8 +80,8 @@ object StepsTableContainer {
           step.file.getOrElse(""): String
       }
 
-    def observationControlButtons(s: SequenceView, step: Step): TagMod = {
-      s.allowedObservationOperations(step).map {
+    def observationControlButtons(s: SequenceView): TagMod = {
+      s.allowedObservationOperations.map {
         case PauseObservation            =>
           Button(Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure")))
         case StopObservation             =>
@@ -119,7 +119,7 @@ object StepsTableContainer {
             SeqexecStyles.buttonsRow,
             <.div(
               ^.cls := "ui icon buttons",
-              observationControlButtons(sequenceView, step)
+              observationControlButtons(sequenceView)
             )
           ).when(loggedIn)
         )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
@@ -61,7 +61,7 @@ object ModelOps {
      * Returns the observation operations allowed
      * TODO Convert to an Instrument-level typeclass
      */
-    def allowedObservationOperations(step: Step): List[ObservationOperations] =
+    def allowedObservationOperations: List[ObservationOperations] =
       s.metadata.instrument match {
         case _                                                 => Nil
       }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -261,7 +261,7 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
 
     val ws = new WebSocket(url)
 
-    def onOpen: Unit = {
+    def onOpen(): Unit = {
       logger.info(s"Connected to $url")
       SeqexecCircuit.dispatch(Connected(ws, 0))
     }
@@ -274,11 +274,11 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
       }
     }
 
-    def onError: Unit =
+    def onError(): Unit =
       // Unfortunately reading the event is not cross-browser safe
       logger.severe("Error on websocket")
 
-    def onClose: Unit =
+    def onClose(): Unit =
       // Increase the delay to get exponential backoff with a minimum of 200ms and a max of 1m
       SeqexecCircuit.dispatch(ConnectionClosed(math.min(60000, math.max(200, nextDelay * 2))))
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -261,7 +261,7 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
 
     val ws = new WebSocket(url)
 
-    def onOpen(e: Event): Unit = {
+    def onOpen: Unit = {
       logger.info(s"Connected to $url")
       SeqexecCircuit.dispatch(Connected(ws, 0))
     }
@@ -274,19 +274,19 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
       }
     }
 
-    def onError(e: ErrorEvent): Unit =
+    def onError: Unit =
       // Unfortunately reading the event is not cross-browser safe
       logger.severe("Error on websocket")
 
-    def onClose(e: CloseEvent): Unit =
+    def onClose: Unit =
       // Increase the delay to get exponential backoff with a minimum of 200ms and a max of 1m
       SeqexecCircuit.dispatch(ConnectionClosed(math.min(60000, math.max(200, nextDelay * 2))))
 
     ws.binaryType = "arraybuffer"
-    ws.onopen = onOpen _
+    ws.onopen = _ => onOpen
     ws.onmessage = onMessage _
-    ws.onerror = onError _
-    ws.onclose = onClose _
+    ws.onerror = _ => onError
+    ws.onclose = _ => onClose
     Connecting
   }.recover {
     case _: Throwable => NoAction

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/dropdown/DropdownMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/dropdown/DropdownMenu.scala
@@ -51,7 +51,7 @@ object DropdownMenu {
       Callback {
         // Enable menu on Semantic UI
         import org.querki.jquery.$
-        import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+        import edu.gemini.web.client.facades.semanticui.SemanticUI._
 
         $(ctx.getDOMNode).find(".ui.dropdown").dropdown(
           JsDropdownOptions

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/message/CloseableMessage.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/message/CloseableMessage.scala
@@ -37,7 +37,7 @@ object CloseableMessage extends Message {
       Callback {
         // Need to go into jQuery and semantic to enable the close button
         import org.querki.jquery.$
-        import edu.gemini.seqexec.web.client.semanticui.SemanticUI._
+        import edu.gemini.web.client.facades.semanticui.SemanticUI._
         import org.scalajs.dom.Element
 
         $(ctx.getDOMNode).on("click", (e: Element, ev: Any) =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -175,7 +175,7 @@ object SeqexecWebClient extends ModelBooPicklers {
   /**
     * Log record
     */
-  def log(record: LogRecord): Future[Unit] =
+  def log(record: LogRecord): Future[String] =
     Ajax.post(
       url = s"$baseUrl/log",
       responseType = "arraybuffer",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/log.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/log.scala
@@ -27,6 +27,7 @@ object log {
 
     override def publish(record: LogRecord): Unit = {
       SeqexecWebClient.log(record)
+      ()
     }
 
     override def flush(): Unit = {}

--- a/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUI.scala
+++ b/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUI.scala
@@ -1,4 +1,4 @@
-package edu.gemini.seqexec.web.client.semanticui
+package edu.gemini.web.client.facades.semanticui
 
 import org.querki.jquery.JQuery
 import org.querki.jsext.{JSOptionBuilder, _}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,6 +1,6 @@
 import Settings.Libraries._
 import sbt.Keys._
-import sbt.{file, ModuleID, project}
+import sbt.{file, Compile, ModuleID, project}
 
 /**
   * Define tasks and settings used by module definitions
@@ -10,6 +10,10 @@ object Common {
     scalaOrganization := "org.typelevel",
     scalaVersion := Settings.LibraryVersions.scalaVersion,
     scalacOptions ++= Settings.Definitions.scalacOptions,
+    scalacOptions in (Compile, console) ~= (_.filterNot(Set(
+      "-Xfatal-warnings",
+      "-Ywarn-unused:imports"
+    ))),
 
     // Common libraries
     libraryDependencies ++= Seq(ScalaZCore.value) ++ TestLibs.value,
@@ -25,6 +29,13 @@ object Common {
     // scalaOrganization := "org.typelevel",
     scalaVersion := Settings.LibraryVersions.scalaJSVersion,
     scalacOptions ++= Settings.Definitions.scalacOptions,
+    scalacOptions ~= (_.filterNot(Set(
+      // typelevel option not supported on js
+      "-Yinduction-heuristics",
+      "-Yliteral-types",
+      "-Xstrict-patmat-analysis",
+      "-Xlint:strict-unsealed-patmat"
+    ))),
 
     // Common libraries
     libraryDependencies ++= Seq(ScalaZCore.value) ++ TestLibs.value

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,18 +10,56 @@ object Settings {
 
     /** Options for the scala compiler */
     val scalacOptions = Seq(
-      "-unchecked",
-      "-deprecation",
-      "-encoding", "UTF-8", // Keep on the same line
-      "-feature",
-      "-language:existentials",
-      "-language:higherKinds",
-      "-language:implicitConversions",
-      "-target:jvm-1.8",
-      "-Xlint",
-      "-Xlint:-stars-align",
-      "-Xfatal-warnings",
-      "-Ywarn-unused-import"
+      "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
+      "-encoding", "utf-8",                // Specify character encoding used by source files.
+      "-explaintypes",                     // Explain type errors in more detail.
+      "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
+      "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+      "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
+      "-language:higherKinds",             // Allow higher-kinded types
+      "-language:implicitConversions",     // Allow definition of implicit functions called views
+      "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
+      "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+      "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+      "-Xfuture",                          // Turn on future language features.
+      "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+      "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+      "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+      "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
+      "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
+      "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
+      "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
+      "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+      "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
+      "-Xlint:option-implicit",            // Option.apply used implicit view.
+      "-Xlint:package-object-classes",     // Class or object defined in package object.
+      "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
+      "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
+      "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
+      "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+      "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+      "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+      "-Ypartial-unification",             // Enable partial unification in type constructor inference
+      "-Ywarn-dead-code",                  // Warn when dead code is identified.
+      "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+      "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
+      "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
+      "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+      "-Ywarn-numeric-widen",              // Warn when numerics are widened.
+      "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+      "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+      "-Ywarn-unused:locals",              // Warn if a local definition is unused.
+      "-Ywarn-unused:params",              // Warn if a value parameter is unused.
+      // "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+      "-Ywarn-unused:privates",            // Warn if a private member is unused.
+      "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
+      "-Yinduction-heuristics",            // speeds up the compilation of inductive implicit resolution
+      // "-Ykind-polymorphism",               // type and method definitions with type parameters of arbitrary kinds
+      "-Yliteral-types",                   // literals can appear in type position
+      "-Xstrict-patmat-analysis",          // more accurate reporting of failures of match exhaustivity
+      "-Xlint:strict-unsealed-patmat"      // warn on inexhaustive matches against unsealed traits
     )
   }
 


### PR DESCRIPTION
This PR updates the scalac params to match the `gem` project. This revealed several cases where the code was either not in the correct style (e.g. unused params) or suspicious (many cases of unused non-Unit return values)

I had to separate the scala.js facades into its own project to give them a special set of scalac params that would make it fail otherwise

It is probably good idea to review the changes carefully. In some cases they highlight code that may not be fully correct