### PR TITLE
SEQNG-308: Failure to set observer and operator to the empty string

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -273,7 +273,7 @@ object Sequence {
 
       // I put a guard against blank values, although Observer is forced to have
       // a default value at an upper level.
-      override def setObserver(name: String): State = observerL.set(self, if(name.isEmpty || name.forall(_.isSpaceChar)) None else Some(name))
+      override def setObserver(name: String): State = observerL.set(self, Some(name))
 
       override val done: List[Step[Result]] = zipper.done
 
@@ -325,9 +325,7 @@ object Sequence {
 
       override def getCurrentBreakpoint: Boolean = false
 
-      // I put a guard against blank values, although Observer is forced to have
-      // a default value at an upper level.
-      override def setObserver(name: String): State = observerL.set(self, if(name.isEmpty || name.forall(_.isSpaceChar)) None else Some(name))
+      override def setObserver(name: String): State = observerL.set(self, Some(name))
 
       override val done: List[Step[Result]] = seq.steps
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -118,7 +118,7 @@ package object engine {
 
   // A blank value is regarded as a None
   def setOperator(name: String): HandleP[Unit] =
-    modify(_.copy(operator = if(name.isEmpty || name.forall(_.isSpaceChar)) None else name.some))
+    modify(_.copy(operator = name.some))
 
   def setObserver(id: Sequence.Id)(name: String): HandleP[Unit] =
     modifyS(id)(_.setObserver(name))

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
@@ -199,8 +199,8 @@ case class StateKeywordsReader(conditions: Conditions, operator: Option[Operator
   def encodeCondition(c: Int): String = if(c == 100) "Any" else s"$c-percentile"
 
   // TODO: "observer" should be the default when not set in state
-  def getObserverName: SeqAction[String] = SeqAction(observer.getOrElse("observer"))
-  def getOperatorName: SeqAction[String] = SeqAction(operator.getOrElse("ssa"))
+  def getObserverName: SeqAction[String] = SeqAction(observer.filter(_.nonEmpty).getOrElse("observer"))
+  def getOperatorName: SeqAction[String] = SeqAction(operator.filter(_.nonEmpty).getOrElse("ssa"))
   def getRawImageQuality: SeqAction[String] = SeqAction(encodeCondition(conditions.iq.toInt))
   def getRawCloudCover: SeqAction[String] = SeqAction(encodeCondition(conditions.cc.toInt))
   def getRawWaterVapor: SeqAction[String] = SeqAction(encodeCondition(conditions.wv.toInt))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -46,7 +46,7 @@ object HeadersSideBar {
 
     def submitIfChanged: Callback =
       ($.state zip $.props) >>= {
-        case (s, p) => Callback.when(p.model().operator.fold(s.currentText.forall(_.nonEmpty))(o => s.currentText.forall(_ =/= o)))(updateOperator(~s.currentText))
+        case (s, p) => Callback.when(p.model().operator =/= s.currentText)(updateOperator(~s.currentText))
       }
 
     def iqChanged(iq: ImageQuality): Callback =

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
@@ -77,7 +77,7 @@ object SequenceObserverField {
 
     def submitIfChanged: Callback =
       ($.state zip $.props) >>= {
-        case (s, p) => Callback.when(p.p().isLogged && p.p().observer.fold(s.currentText.forall(_.nonEmpty))(o => s.currentText.forall(_ =/= o)))(p.p().id.map(updateObserver(_, s.currentText.getOrElse(""))).getOrEmpty)
+        case (s, p) => Callback.when(p.p().isLogged && p.p().observer =/= s.currentText)(p.p().id.map(updateObserver(_, s.currentText.getOrElse(""))).getOrEmpty)
       }
 
     def setupTimer: Callback =


### PR DESCRIPTION
This is a small change to let users set the operator as the empty string unlike the current situation where the empty string is set as `None`