### PR TITLE
SEQNG-296: Fix smart gcal exposure times

### DIFF
--- a/app/seqexec-server-gs/src/main/resources/app.conf
+++ b/app/seqexec-server-gs/src/main/resources/app.conf
@@ -36,6 +36,7 @@ seqexec-engine {
     odbQueuePollingInterval = "3 seconds"
     tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gws=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"
     epics_ca_addr_list = "172.17.2.255 172.17.3.255 172.17.102.130 172.17.105.20 172.16.102.130 172.17.106.111 172.17.105.37 172.17.107.50 172.17.55.101 172.17.101.101 172.17.65.255 172.17.102.139 172.17.102.138"
+    smartGCalHost = "gsodb.gemini.edu"
     # Location of the csv files
     smartGCalDir = "/home/software/.seqexec/smartgcal"
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -56,7 +56,7 @@ seqexec-engine {
     tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gw=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"
     epics_ca_addr_list = "127.0.0.1"
     # We normally always use GS for smartGCalDir
-    smartGCalHost = "gsodb.gemini.edu"
+    smartGCalHost = "gsodbtest.gemini.edu"
     # Tmp file for development
     smartGCalDir = "/tmp/smartgcal"
 }


### PR DESCRIPTION
Change the default smartGCal host to be the test odb. Only the production seqexec is configured for the production smartGCal instance