### PR TITLE
SEQNG-311: Set the observer for newly scheduled observations

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -25,6 +25,7 @@ case class NavigateSilentTo(page: Pages.SeqexecPages) extends Action
 case class SyncToPage(view: SequenceView) extends Action
 case class SyncToRunning(view: SequenceView) extends Action
 case class SyncPageToRemovedSequence(id: SequenceId) extends Action
+case class SyncPageToAddedSequence(i: Instrument, id: SequenceId) extends Action
 case class Initialize(site: SeqexecSite) extends Action
 
 // Actions to close and/open the login box


### PR DESCRIPTION
This fixes a small bug where the operator is set for the first set of sequences but not for newly queued sequences