### PR TITLE
SEQNG-272: Use scalastyle to match the gem project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_script:
   - sudo apt-get install -y rpm
 script:
   - sudo chmod +x /usr/local/bin/sbt
-  - sbt -J-Xmx3G -J-XX:-UseGCOverheadLimit test
+  - sbt -J-Xmx3G -J-XX:-UseGCOverheadLimit scalastyle test

--- a/modules/edu.gemini.p1backend/edu.gemini.p1backend.client/src/main/scala/edu/gemini/p1backend/client/P1BackendApp.scala
+++ b/modules/edu.gemini.p1backend/edu.gemini.p1backend.client/src/main/scala/edu/gemini/p1backend/client/P1BackendApp.scala
@@ -8,6 +8,6 @@ import scala.scalajs.js.JSApp
 object P1BackendApp extends JSApp {
 
   def main(): Unit = {
-    println("Phase1 Backend")
+    // Launch the application
   }
 }

--- a/modules/edu.gemini.p1backend/edu.gemini.p1backend.server/src/main/scala/edu/gemini/p1backend/server/http4s/package.scala
+++ b/modules/edu.gemini.p1backend/edu.gemini.p1backend.server/src/main/scala/edu/gemini/p1backend/server/http4s/package.scala
@@ -1,9 +1,9 @@
 package edu.gemini.p1backend.server
 
 package object http4s {
-  def index(devMode: Boolean, builtAtMillis: Long) = {
-    val deps = if (devMode) "edu_gemini_p1backend_client-jsdeps.js" else s"edu_gemini_p1backend_client-jsdeps.min.${builtAtMillis}.js"
-    val scalajsScript = if (devMode) s"p1backend.js" else s"p1backend-opt.${builtAtMillis}.js"
+  def index(devMode: Boolean, builtAtMillis: Long): String = {
+    val deps = if (devMode) "edu_gemini_p1backend_client-jsdeps.js" else s"edu_gemini_p1backend_client-jsdeps.min.$builtAtMillis.js"
+    val scalajsScript = if (devMode) s"p1backend.js" else s"p1backend-opt.$builtAtMillis.js"
     val xml = <html lang="en">
       <head>
         <meta charset="utf-8"/>
@@ -12,17 +12,17 @@ package object http4s {
         <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
         <meta name="description" content="Phase1 Backend"/>
         <meta name="author" content="Gemini Software Group"/>
-        <link rel="icon" href={s"images/launcher.${builtAtMillis}.ico"}/>
+        <link rel="icon" href={s"images/launcher.$builtAtMillis.ico"}/>
 
         <!-- Add to homescreen for Safari on iOS -->
         <meta name="apple-mobile-web-app-capable" content="yes"/>
         <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
         <meta name="apple-mobile-web-app-title" content="Phase1 Backend"/>
-        <link rel="apple-touch-icon-precomposed" href={s"images/launcher.${builtAtMillis}.png"}/>
+        <link rel="apple-touch-icon-precomposed" href={s"images/launcher.$builtAtMillis.png"}/>
 
         <title>Phase1 Backend</title>
 
-        <link rel="stylesheet" href={s"css/semantic.${builtAtMillis}.css"}/>
+        <link rel="stylesheet" href={s"css/semantic.$builtAtMillis.css"}/>
       </head>
 
       <body>

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -31,7 +31,7 @@ case class Load(id: Sequence.Id, sequence: Sequence[Action \/ Result]) extends U
   val user = None
 }
 case class Unload(id: Sequence.Id) extends UserEvent {
-  var user = None
+  val user = None
 }
 case class Breakpoint(id: Sequence.Id, user: Option[UserDetails], step: Step.Id, v: Boolean) extends UserEvent
 case class SetOperator(name: String, user: Option[UserDetails]) extends UserEvent

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -387,7 +387,7 @@ package object engine {
 
   // For debugging
   def printSequenceState(id: Sequence.Id): HandleP[Unit] =
-    getSs(id)((qs: Sequence.State) => Task.now(println(qs)).liftM[HandleStateT]).void
+    getSs(id)((qs: Sequence.State) => Task.now(println(qs)).liftM[HandleStateT]).void // scalastyle:ignore
 
   // The `Catchable` instance of `Handle`` needs to be manually written.
   // Without it it's not possible to use `Handle` as a scalaz-stream process effects.

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Commands.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Commands.scala
@@ -61,6 +61,7 @@ object Commands {
       |    -> shows dynamic instrument values for dataset 4 of obs 355
     """.stripMargin
 
+  // scalastyle:off
   def apply(odbProxy: ODBProxy): Commands = new Commands {
 
     override def host(): CommandResult =
@@ -125,6 +126,7 @@ object Commands {
         case i                   => \/.right(i)
       })
   }
+  // scalastyle:on
 
   def parseId(s: String): CommandError \/ SPObservationID =
     \/.fromTryCatchNonFatal {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -1,20 +1,6 @@
 package edu.gemini.seqexec.server
 
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.concurrent.atomic.AtomicInteger
-
-import argonaut._
-import Argonaut._
 import edu.gemini.seqexec.model.dhs.ImageFileId
-import edu.gemini.seqexec.server.DhsClient.{ImageParameters, KeywordBag}
-import org.apache.commons.httpclient.HttpClient
-import org.apache.commons.httpclient.methods.{EntityEnclosingMethod, PostMethod, PutMethod}
-
-import scala.io.Source
-import scalaz.concurrent.Task
-import scalaz.EitherT
-import scalaz._
 
 /**
   * Defines the interface for dhs client, with methods, e.g. to request image creation
@@ -32,7 +18,6 @@ trait DhsClient {
 
 }
 
-// scalastyle:off
 object DhsClient {
 
   type Contributor = String
@@ -97,131 +82,4 @@ object DhsClient {
         internalKeywordConvert(k4), internalKeywordConvert(k5), internalKeywordConvert(k6)))
   }
 
-}
-// scalastyle:on
-
-/**
-  * Implementation of DhsClient that interfaces with the real DHS over the http interface
-  */
-class DhsClientHttp(val baseURI: String) extends DhsClient {
-  import DhsClientHttp._
-
-  // Connection timeout, im milliseconds
-  val timeout = 10000
-
-  implicit def errorDecode: DecodeJson[Error] = DecodeJson[Error]( c => for {
-      t   <- (c --\ "type").as[ErrorType]
-      msg <- (c --\ "message").as[String]
-    } yield Error(t, msg)
-  )
-
-  implicit def obsIdDecode: DecodeJson[TrySeq[ImageFileId]] = DecodeJson[TrySeq[ImageFileId]](c => {
-    val r = c --\ "response"
-    val s = (r --\ "status").as[String]
-    s.flatMap {
-      case "success" =>
-        (r --\ "result").as[String].map(TrySeq(_))
-      case "error"   =>
-        (r --\ "errors").as[List[Error]].map(l =>
-          TrySeq.fail[ImageFileId](SeqexecFailure.Unexpected(l.mkString(", ")))
-        )
-      case r         =>
-        DecodeResult.fail(s"Unknown response: $r", s.history.getOrElse(CursorHistory.empty))
-    }
-  } )
-
-  implicit def unitDecode: DecodeJson[TrySeq[Unit]] = DecodeJson[TrySeq[Unit]]( c => {
-    val r = c --\ "response"
-    val s = (r --\ "status").as[String]
-    s flatMap {
-      case "success" =>
-        DecodeResult.ok(TrySeq(()))
-      case "error"   =>
-        (r --\ "errors").as[List[Error]].map(
-          l => TrySeq.fail[Unit](SeqexecFailure.Unexpected(l.mkString(", "))))
-      case r         =>
-        DecodeResult.fail(s"Unknown response: $r", s.history.getOrElse(CursorHistory.empty))
-    }
-  } )
-
-  implicit def imageParametersEncode: EncodeJson[DhsClient.ImageParameters] = EncodeJson[DhsClient.ImageParameters]( p =>
-    ("lifetime" := p.lifetime.str) ->: ("contributors" := p.contributors) ->: Json.jEmptyObject )
-
-  implicit def keywordEncode: EncodeJson[DhsClient.InternalKeyword] = EncodeJson[DhsClient.InternalKeyword]( k =>
-    ("name" := k.name) ->: ("type" := k.keywordType.str) ->: ("value" := k.value) ->: Json.jEmptyObject )
-
-  private def sendRequest[T](method: EntityEnclosingMethod, body: Json, errMsg: String)(implicit decoder: argonaut.DecodeJson[TrySeq[T]]): SeqAction[T] = EitherT ( Task.delay {
-      val client = new HttpClient()
-
-      client.setConnectionTimeout(timeout)
-
-      method.addRequestHeader("Content-Type", "application/json")
-      method.setRequestBody(body.nospaces)
-
-      client.executeMethod(method)
-
-      val r = Source.fromInputStream(method.getResponseBodyAsStream).getLines().mkString.decodeOption[TrySeq[T]](decoder)
-
-      method.releaseConnection()
-
-      r.getOrElse(TrySeq.fail[T](SeqexecFailure.Execution(errMsg)))
-    } )
-
-  private def createImage(reqBody: Json): SeqAction[ImageFileId] =
-    sendRequest[ImageFileId](new PostMethod(baseURI), Json.jSingleObject("createImage", reqBody), "Unable to get label")
-
-  def createImage: SeqAction[ImageFileId] = createImage(Json.jEmptyObject)
-
-  override def createImage(p: ImageParameters): SeqAction[ImageFileId] = createImage(p.asJson)
-
-  def setParameters(id: ImageFileId, p: ImageParameters): SeqAction[Unit] =
-    sendRequest[Unit](new PutMethod(baseURI + "/" + id), Json.jSingleObject("setParameters", p.asJson), "Unable to set parameters for image " + id)
-
-  override def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean = false): SeqAction[Unit] =
-    sendRequest[Unit](new PutMethod(baseURI + "/" + id + "/keywords"),
-      Json.jSingleObject("setKeywords", ("final" := finalFlag) ->: ("keywords" := keywords.keywords) ->: Json.jEmptyObject ),
-      "Unable to write keywords for image " + id)
-}
-
-object DhsClientHttp {
-
-  sealed case class ErrorType(str: String)
-  object BadRequest extends ErrorType("BAD_REQUEST")
-  object DhsError extends ErrorType("DHS_ERROR")
-  object InternalServerError extends ErrorType("INTERNAL_SERVER_ERROR")
-
-  implicit def errorTypeDecode: DecodeJson[ErrorType] = DecodeJson[ErrorType]( c =>  c.as[String].map {
-      case BadRequest.str          => BadRequest
-      case DhsError.str            => DhsError
-      case InternalServerError.str => InternalServerError
-      case _                       => InternalServerError
-    }
-  )
-
-  final case class Error(t: ErrorType, msg: String) {
-    override def toString = s"(${t.str}) $msg"
-  }
-
-  def apply(uri: String): DhsClient = new DhsClientHttp(uri)
-}
-
-/**
-  * Implementation of the Dhs client that simulates a dhs without external dependencies
-  */
-class DhsClientSim(date: LocalDate) extends DhsClient {
-  private val counter = new AtomicInteger(0)
-
-  val format: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
-
-  override def createImage(p: ImageParameters): SeqAction[ImageFileId] =
-    EitherT(Task.delay{
-      TrySeq(f"S${date.format(format)}S${counter.incrementAndGet()}%04d")
-    })
-
-  override def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): SeqAction[Unit] = SeqAction(())
-
-}
-
-object DhsClientSim {
-  def apply(date: LocalDate): DhsClient = new DhsClientSim(date)
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -32,6 +32,7 @@ trait DhsClient {
 
 }
 
+// scalastyle:off
 object DhsClient {
 
   type Contributor = String
@@ -97,6 +98,7 @@ object DhsClient {
   }
 
 }
+// scalastyle:on
 
 /**
   * Implementation of DhsClient that interfaces with the real DHS over the http interface
@@ -200,7 +202,7 @@ object DhsClientHttp {
     override def toString = s"(${t.str}) $msg"
   }
 
-  def apply(uri: String) = new DhsClientHttp(uri)
+  def apply(uri: String): DhsClient = new DhsClientHttp(uri)
 }
 
 /**
@@ -209,7 +211,7 @@ object DhsClientHttp {
 class DhsClientSim(date: LocalDate) extends DhsClient {
   private val counter = new AtomicInteger(0)
 
-  val format = DateTimeFormatter.ofPattern("yyyyMMdd")
+  val format: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
 
   override def createImage(p: ImageParameters): SeqAction[ImageFileId] =
     EitherT(Task.delay{
@@ -221,5 +223,5 @@ class DhsClientSim(date: LocalDate) extends DhsClient {
 }
 
 object DhsClientSim {
-  def apply(date: LocalDate) = new DhsClientSim(date)
+  def apply(date: LocalDate): DhsClient = new DhsClientSim(date)
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClientHttp.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClientHttp.scala
@@ -1,0 +1,143 @@
+package edu.gemini.seqexec.server
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.atomic.AtomicInteger
+
+import argonaut._
+import Argonaut._
+import edu.gemini.seqexec.model.dhs.ImageFileId
+import edu.gemini.seqexec.server.DhsClient.{ImageParameters, KeywordBag}
+import org.apache.commons.httpclient.HttpClient
+import org.apache.commons.httpclient.methods.{EntityEnclosingMethod, PostMethod, PutMethod}
+
+import scala.io.Source
+import scalaz.concurrent.Task
+import scalaz.EitherT
+import scalaz._
+
+/**
+  * Implementation of DhsClient that interfaces with the real DHS over the http interface
+  */
+class DhsClientHttp(val baseURI: String) extends DhsClient {
+  import DhsClientHttp._
+
+  // Connection timeout, im milliseconds
+  val timeout = 10000
+
+  implicit def errorDecode: DecodeJson[Error] = DecodeJson[Error]( c => for {
+      t   <- (c --\ "type").as[ErrorType]
+      msg <- (c --\ "message").as[String]
+    } yield Error(t, msg)
+  )
+
+  implicit def obsIdDecode: DecodeJson[TrySeq[ImageFileId]] = DecodeJson[TrySeq[ImageFileId]](c => {
+    val r = c --\ "response"
+    val s = (r --\ "status").as[String]
+    s.flatMap {
+      case "success" =>
+        (r --\ "result").as[String].map(TrySeq(_))
+      case "error"   =>
+        (r --\ "errors").as[List[Error]].map(l =>
+          TrySeq.fail[ImageFileId](SeqexecFailure.Unexpected(l.mkString(", ")))
+        )
+      case r         =>
+        DecodeResult.fail(s"Unknown response: $r", s.history.getOrElse(CursorHistory.empty))
+    }
+  } )
+
+  implicit def unitDecode: DecodeJson[TrySeq[Unit]] = DecodeJson[TrySeq[Unit]]( c => {
+    val r = c --\ "response"
+    val s = (r --\ "status").as[String]
+    s flatMap {
+      case "success" =>
+        DecodeResult.ok(TrySeq(()))
+      case "error"   =>
+        (r --\ "errors").as[List[Error]].map(
+          l => TrySeq.fail[Unit](SeqexecFailure.Unexpected(l.mkString(", "))))
+      case r         =>
+        DecodeResult.fail(s"Unknown response: $r", s.history.getOrElse(CursorHistory.empty))
+    }
+  } )
+
+  implicit def imageParametersEncode: EncodeJson[DhsClient.ImageParameters] = EncodeJson[DhsClient.ImageParameters]( p =>
+    ("lifetime" := p.lifetime.str) ->: ("contributors" := p.contributors) ->: Json.jEmptyObject )
+
+  implicit def keywordEncode: EncodeJson[DhsClient.InternalKeyword] = EncodeJson[DhsClient.InternalKeyword]( k =>
+    ("name" := k.name) ->: ("type" := k.keywordType.str) ->: ("value" := k.value) ->: Json.jEmptyObject )
+
+  private def sendRequest[T](method: EntityEnclosingMethod, body: Json, errMsg: String)(implicit decoder: argonaut.DecodeJson[TrySeq[T]]): SeqAction[T] = EitherT ( Task.delay {
+      val client = new HttpClient()
+
+      client.setConnectionTimeout(timeout)
+
+      method.addRequestHeader("Content-Type", "application/json")
+      method.setRequestBody(body.nospaces)
+
+      client.executeMethod(method)
+
+      val r = Source.fromInputStream(method.getResponseBodyAsStream).getLines().mkString.decodeOption[TrySeq[T]](decoder)
+
+      method.releaseConnection()
+
+      r.getOrElse(TrySeq.fail[T](SeqexecFailure.Execution(errMsg)))
+    } )
+
+  private def createImage(reqBody: Json): SeqAction[ImageFileId] =
+    sendRequest[ImageFileId](new PostMethod(baseURI), Json.jSingleObject("createImage", reqBody), "Unable to get label")
+
+  def createImage: SeqAction[ImageFileId] = createImage(Json.jEmptyObject)
+
+  override def createImage(p: ImageParameters): SeqAction[ImageFileId] = createImage(p.asJson)
+
+  def setParameters(id: ImageFileId, p: ImageParameters): SeqAction[Unit] =
+    sendRequest[Unit](new PutMethod(baseURI + "/" + id), Json.jSingleObject("setParameters", p.asJson), "Unable to set parameters for image " + id)
+
+  override def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean = false): SeqAction[Unit] =
+    sendRequest[Unit](new PutMethod(baseURI + "/" + id + "/keywords"),
+      Json.jSingleObject("setKeywords", ("final" := finalFlag) ->: ("keywords" := keywords.keywords) ->: Json.jEmptyObject ),
+      "Unable to write keywords for image " + id)
+}
+
+object DhsClientHttp {
+
+  sealed case class ErrorType(str: String)
+  object BadRequest extends ErrorType("BAD_REQUEST")
+  object DhsError extends ErrorType("DHS_ERROR")
+  object InternalServerError extends ErrorType("INTERNAL_SERVER_ERROR")
+
+  implicit def errorTypeDecode: DecodeJson[ErrorType] = DecodeJson[ErrorType]( c =>  c.as[String].map {
+      case BadRequest.str          => BadRequest
+      case DhsError.str            => DhsError
+      case InternalServerError.str => InternalServerError
+      case _                       => InternalServerError
+    }
+  )
+
+  final case class Error(t: ErrorType, msg: String) {
+    override def toString = s"(${t.str}) $msg"
+  }
+
+  def apply(uri: String): DhsClient = new DhsClientHttp(uri)
+}
+
+/**
+  * Implementation of the Dhs client that simulates a dhs without external dependencies
+  */
+class DhsClientSim(date: LocalDate) extends DhsClient {
+  private val counter = new AtomicInteger(0)
+
+  val format: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+
+  override def createImage(p: ImageParameters): SeqAction[ImageFileId] =
+    EitherT(Task.delay{
+      TrySeq(f"S${date.format(format)}S${counter.incrementAndGet()}%04d")
+    })
+
+  override def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): SeqAction[Unit] = SeqAction(())
+
+}
+
+object DhsClientSim {
+  def apply(date: LocalDate): DhsClient = new DhsClientSim(date)
+}

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
@@ -50,7 +50,7 @@ trait EpicsSystem[T] {
 
   // Still using a var, but at least now it's hidden. Attempts to access the single instance will
   // now result in an Exception with a meaningful message, instead of a NullPointerException
-  private var instanceInternal = Option.empty[T]
+  private var instanceInternal = Option.empty[T] // scalastyle:ignore
   lazy val instance: T = instanceInternal.getOrElse(
     throw new Exception(s"Attempt to reference $className single instance before initialization."))
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Controller.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Controller.scala
@@ -65,24 +65,24 @@ object Flamingos2Controller {
   }
 
   final case class CCConfig(w: WindowCover, d: Decker, fpu: FocalPlaneUnit, f: Filter, l: Lyot, g: Grism) {
-    def setWindowCover(windowCover: WindowCover) = this.copy(w = windowCover)
-    def setDecker(decker: Decker) = this.copy(d = decker)
-    def setFPU(focalPlaneUnit: FocalPlaneUnit) = this.copy(fpu = focalPlaneUnit)
-    def setFilter(filter: Filter) = this.copy(f = filter)
-    def setLyot(lyot: Lyot) = this.copy(l = lyot)
-    def setGrism(grism: Grism) = this.copy(g = grism)
+    def setWindowCover(windowCover: WindowCover): CCConfig = this.copy(w = windowCover)
+    def setDecker(decker: Decker): CCConfig = this.copy(d = decker)
+    def setFPU(focalPlaneUnit: FocalPlaneUnit): CCConfig = this.copy(fpu = focalPlaneUnit)
+    def setFilter(filter: Filter): CCConfig = this.copy(f = filter)
+    def setLyot(lyot: Lyot): CCConfig = this.copy(l = lyot)
+    def setGrism(grism: Grism): CCConfig = this.copy(g = grism)
   }
 
   final case class DCConfig(t: ExposureTime, n: Reads, r: ReadoutMode, b: BiasMode) {
-    def setExposureTime(exposureTime: ExposureTime) = this.copy(t = exposureTime)
-    def setNumReads(numReads: Reads) =  this.copy(n = numReads)
-    def setReadoutMode(readoutMode: ReadoutMode) = this.copy(r = readoutMode)
-    def setBiasMode(biasMode: BiasMode) = this.copy(b = biasMode)
+    def setExposureTime(exposureTime: ExposureTime): DCConfig = this.copy(t = exposureTime)
+    def setNumReads(numReads: Reads): DCConfig =  this.copy(n = numReads)
+    def setReadoutMode(readoutMode: ReadoutMode): DCConfig = this.copy(r = readoutMode)
+    def setBiasMode(biasMode: BiasMode): DCConfig = this.copy(b = biasMode)
   }
 
   final case class Flamingos2Config(cc: CCConfig, dc: DCConfig) {
-    def setCCConfig(ccConfig: CCConfig) = this.copy(cc = ccConfig)
-    def setDCConfig(dcConfig: DCConfig) = this.copy(dc = dcConfig)
+    def setCCConfig(ccConfig: CCConfig): Flamingos2Config = this.copy(cc = ccConfig)
+    def setDCConfig(dcConfig: DCConfig): Flamingos2Config = this.copy(dc = dcConfig)
   }
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerEpics.scala
@@ -19,7 +19,7 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
 
   import EpicsCodex._
 
-  override def getConfig: SeqAction[Flamingos2Config] = ???
+  override def getConfig: SeqAction[Flamingos2Config] = ??? // scalastyle:ignore
 
   implicit val encodeReadoutMode: EncodeEpicsValue[ReadoutMode, String] = EncodeEpicsValue((a: ReadoutMode)
     => a match {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerSim.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerSim.scala
@@ -12,7 +12,7 @@ import scalaz.concurrent.Task
 object Flamingos2ControllerSim extends Flamingos2Controller {
   private val Log = Logger.getLogger(getClass.getName)
 
-  override def getConfig: SeqAction[Flamingos2Config] = ???
+  override def getConfig: SeqAction[Flamingos2Config] = ??? // scalastyle:ignore
 
   override def observe(obsid: ImageFileId): SeqAction[ImageFileId] = EitherT( Task {
     Log.info("Taking Flamingos-2 observation with label " + obsid)
@@ -30,7 +30,7 @@ object Flamingos2ControllerSim extends Flamingos2Controller {
 object Flamingos2ControllerSimBad extends Flamingos2Controller {
   private val Log = Logger.getLogger(getClass.getName)
 
-  override def getConfig: SeqAction[Flamingos2Config] = ???
+  override def getConfig: SeqAction[Flamingos2Config] = ??? // scalastyle:ignore
 
   override def observe(obsid: ImageFileId): SeqAction[ImageFileId] = EitherT( Task {
     Log.info("Taking Flamingos-2 observation with label " + obsid)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Header.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Header.scala
@@ -44,7 +44,7 @@ class Flamingos2Header(hs: DhsClient, f2ObsReader: Flamingos2Header.ObsKeywordsR
 object Flamingos2Header {
   import Header.Implicits._
 
-  def apply(hs: DhsClient, f2ObsReader: ObsKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) =
+  def apply(hs: DhsClient, f2ObsReader: ObsKeywordsReader, tcsKeywordsReader: TcsKeywordsReader): Flamingos2Header =
     new Flamingos2Header(hs, f2ObsReader, tcsKeywordsReader)
 
   trait ObsKeywordsReader {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosController.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosController.scala
@@ -46,6 +46,7 @@ object GmosController {
 
   }
 
+  // scalastyle:off
   object Config {
     type DTAX = edu.gemini.spModel.gemini.gmos.GmosCommonType.DTAX
     type ADC = edu.gemini.spModel.gemini.gmos.GmosCommonType.ADC
@@ -119,6 +120,7 @@ object GmosController {
     )
 
   }
+  // scalastyle:on
 
   sealed trait SiteDependentTypes {
     type Filter

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosControllerEpics.scala
@@ -28,7 +28,7 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
   val CC = GmosEpics.instance.configCmd
   val DC = GmosEpics.instance.configDCCmd
 
-  override def getConfig: SeqAction[GmosController.GmosConfig[T]] = ???
+  override def getConfig: SeqAction[GmosController.GmosConfig[T]] = ??? // scalastyle:ignore
 
   implicit val ampReadModeEncoder: EncodeEpicsValue[AmpReadMode, String] = EncodeEpicsValue {
     case AmpReadMode.SLOW => "SLOW"

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosControllerSim.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosControllerSim.scala
@@ -11,7 +11,7 @@ import scalaz.concurrent.Task
 private class GmosControllerSim[T<:SiteDependentTypes](name: String) extends GmosController[T] {
   private val Log = Logger.getLogger(getClass.getName)
 
-  override def getConfig: SeqAction[GmosConfig[T]] = ???
+  override def getConfig: SeqAction[GmosConfig[T]] = ??? // scalastyle:ignore
 
   override def observe(obsid: ImageFileId): SeqAction[ImageFileId] = EitherT( Task {
     Log.info(s"Simulate taking Gmos $name observation with label " + obsid)
@@ -30,4 +30,3 @@ object GmosControllerSim {
   val south: GmosController[SouthTypes] = new GmosControllerSim[SouthTypes]("South")
   val north: GmosController[NorthTypes] = new GmosControllerSim[NorthTypes]("North")
 }
-

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosHeader.scala
@@ -25,33 +25,31 @@ case class GmosHeader(hs: DhsClient, gmosObsReader: GmosHeader.ObsKeywordsReader
     )
   }
 
-  // scalastyle:off
+  private val adcKeywords =
+    if (gmosReader.isADCInUse) {
+      List(
+        buildDouble(gmosReader.adcPrismEntSt, "ADCENPST"),
+        buildDouble(gmosReader.adcPrismEntEnd, "ADCENPEN"),
+        buildDouble(gmosReader.adcPrismEntMe, "ADCENPME"),
+        buildDouble(gmosReader.adcPrismExtSt, "ADCEXPST"),
+        buildDouble(gmosReader.adcPrismExtEnd, "ADCEXPEN"),
+        buildDouble(gmosReader.adcPrismExtMe, "ADCEXPME"),
+        buildDouble(gmosReader.adcWavelength1, "ADCWLEN1"),
+        buildDouble(gmosReader.adcWavelength2, "ADCWLEN2")
+      )
+    } else Nil
+
+  private val roiKeywords = gmosReader.roiValues.map {
+    case (i, rv) =>
+      List(
+        buildInt32(rv.xStart, s"DETRO${i}X"),
+        buildInt32(rv.xSize, s"DETRO${i}XS"),
+        buildInt32(rv.yStart, s"DETRO${i}Y"),
+        buildInt32(rv.ySize, s"DETRO${i}YS")
+      )
+  }.toList
+
   override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] = {
-    val adcKeywords = {
-      if (gmosReader.isADCInUse) {
-        List(
-          buildDouble(gmosReader.adcPrismEntSt, "ADCENPST"),
-          buildDouble(gmosReader.adcPrismEntEnd, "ADCENPEN"),
-          buildDouble(gmosReader.adcPrismEntMe, "ADCENPME"),
-          buildDouble(gmosReader.adcPrismExtSt, "ADCEXPST"),
-          buildDouble(gmosReader.adcPrismExtEnd, "ADCEXPEN"),
-          buildDouble(gmosReader.adcPrismExtMe, "ADCEXPME"),
-          buildDouble(gmosReader.adcWavelength1, "ADCWLEN1"),
-          buildDouble(gmosReader.adcWavelength2, "ADCWLEN2")
-        )
-      } else Nil
-    }
-
-    val roiKeywords = gmosReader.roiValues.map {
-      case (i, rv) =>
-        List(
-          buildInt32(rv.xStart, s"DETRO${i}X"),
-          buildInt32(rv.xSize, s"DETRO${i}XS"),
-          buildInt32(rv.yStart, s"DETRO${i}Y"),
-          buildInt32(rv.ySize, s"DETRO${i}YS")
-        )
-    }.toList
-
     sendKeywords(id, inst, hs, List(
       buildInt32(gmosReader.maskId, "MASKID"),
       buildString(gmosReader.maskName, "MASKNAME"),
@@ -88,7 +86,6 @@ case class GmosHeader(hs: DhsClient, gmosObsReader: GmosHeader.ObsKeywordsReader
       buildInt32(gmosReader.exposureTime, "SUBINT")*/
     ) ::: adcKeywords ::: roiKeywords.flatten)
   }
-  // scalastyle:on
 
 }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosHeader.scala
@@ -25,6 +25,7 @@ case class GmosHeader(hs: DhsClient, gmosObsReader: GmosHeader.ObsKeywordsReader
     )
   }
 
+  // scalastyle:off
   override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] = {
     val adcKeywords = {
       if (gmosReader.isADCInUse) {
@@ -87,6 +88,7 @@ case class GmosHeader(hs: DhsClient, gmosObsReader: GmosHeader.ObsKeywordsReader
       buildInt32(gmosReader.exposureTime, "SUBINT")*/
     ) ::: adcKeywords ::: roiKeywords.flatten)
   }
+  // scalastyle:on
 
 }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosNorthControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosNorthControllerEpics.scala
@@ -91,5 +91,4 @@ object GmosNorthEncoders extends GmosControllerEpics.Encoders[NorthTypes] {
   }
 }
 
-object GmosNorthControllerEpics extends GmosControllerEpics[NorthTypes](GmosNorthEncoders)(northConfigTypes) {
-}
+object GmosNorthControllerEpics extends GmosControllerEpics[NorthTypes](GmosNorthEncoders)(northConfigTypes)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouthControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouthControllerEpics.scala
@@ -93,5 +93,4 @@ object GmosSouthEncoders extends GmosControllerEpics.Encoders[SouthTypes] {
 
 }
 
-object GmosSouthControllerEpics extends GmosControllerEpics[SouthTypes](GmosSouthEncoders)(southConfigTypes) {
-}
+object GmosSouthControllerEpics extends GmosControllerEpics[SouthTypes](GmosSouthEncoders)(southConfigTypes)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Instrument.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Instrument.scala
@@ -26,7 +26,7 @@ object UnknownInstrument extends Instrument {
   override val contributorName: String = "unknown"
   override val dhsInstrumentName: String = "UNKNOWN"
 
-  var imageCount = 0
+  private var imageCount = 0 // scalastyle:ignore
 
   override def configure(config: Config): SeqAction[ConfigResult] = EitherT ( Task {
     TrySeq(ConfigResult(this))

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -51,6 +51,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
           d <- dataId
           _ <- systems.odb.datasetStart(obsId, d, imageFileId)
         } yield ()
+
         def sendDataEnd(imageFileId: ImageFileId): SeqAction[Unit] = for {
           d <- dataId
           _ <- systems.odb.datasetComplete(obsId, d, imageFileId)
@@ -238,7 +239,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 }
 
 object SeqTranslate {
-  def apply(site: Site, systems: Systems, settings: Settings) = new SeqTranslate(site, systems, settings)
+  def apply(site: Site, systems: Systems, settings: Settings): SeqTranslate = new SeqTranslate(site, systems, settings)
 
   case class Systems(
                       odb: ODBProxy,

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -34,6 +34,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   def toAction(x: SeqAction[Result.Response]): Action = fromTask(x.run.map(toResult))
 
+  // scalastyle:off
   private def step(
     obsId: SPObservationID,
     i: Int,
@@ -118,6 +119,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     } yield buildStep(inst, systems, headers, resources)
 
   }
+  // scalastyle:on
 
   private def extractInstrumentName(config: Config): SeqexecFailure \/ edu.gemini.seqexec.model.Model.Instrument =
     // This is too weak. We may want to use the extractors used in ITC

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -34,44 +34,36 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   def toAction(x: SeqAction[Result.Response]): Action = fromTask(x.run.map(toResult))
 
-  // scalastyle:off
-  private def step(
-    obsId: SPObservationID,
-    i: Int,
-    config: Config,
-    last: Boolean
-  ): TrySeq[Step[Action \/ Result]] = {
+  private def observe(config: Config, obsId: SPObservationID, inst: Instrument, headers: Reader[ActionMetadata,List[Header]])(ctx: ActionMetadata): SeqAction[ObserveResult] = {
+    val dataId: SeqAction[String] = EitherT(Task(config.extract(OBSERVE_KEY / DATA_LABEL_PROP).as[String].leftMap(e =>
+      SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
 
+    def sendDataStart(imageFileId: ImageFileId): SeqAction[Unit] = for {
+      d <- dataId
+      _ <- systems.odb.datasetStart(obsId, d, imageFileId)
+    } yield ()
+
+    def sendDataEnd(imageFileId: ImageFileId): SeqAction[Unit] = for {
+      d <- dataId
+      _ <- systems.odb.datasetComplete(obsId, d, imageFileId)
+    } yield ()
+
+    def closeImage(id: ImageFileId, client: DhsClient): SeqAction[Unit] =
+      client.setKeywords(id, KeywordBag(StringKeyword("instrument", inst.dhsInstrumentName)), finalFlag = true)
+
+    for {
+      id <- systems.dhs.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List(inst.contributorName, "dhs-http")))
+      _ <- sendDataStart(id)
+      _ <- headers(ctx).map(_.sendBefore(id, inst.dhsInstrumentName)).sequenceU
+      _ <- inst.observe(config)(id)
+      _ <- headers(ctx).map(_.sendAfter(id, inst.dhsInstrumentName)).sequenceU
+      _ <- closeImage(id, systems.dhs)
+      _ <- sendDataEnd(id)
+    } yield ObserveResult(id)
+  }
+
+  private def step(obsId: SPObservationID, i: Int, config: Config, last: Boolean): TrySeq[Step[Action \/ Result]] = {
     def buildStep(inst: Instrument, sys: List[System], headers: Reader[ActionMetadata,List[Header]], resources: Set[Resource]): Step[Action \/ Result] = {
-
-      def observe(config: Config)(ctx: ActionMetadata): SeqAction[ObserveResult] = {
-        val dataId: SeqAction[String] = EitherT(Task(config.extract(OBSERVE_KEY / DATA_LABEL_PROP).as[String].leftMap(e =>
-          SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
-
-        def sendDataStart(imageFileId: ImageFileId): SeqAction[Unit] = for {
-          d <- dataId
-          _ <- systems.odb.datasetStart(obsId, d, imageFileId)
-        } yield ()
-
-        def sendDataEnd(imageFileId: ImageFileId): SeqAction[Unit] = for {
-          d <- dataId
-          _ <- systems.odb.datasetComplete(obsId, d, imageFileId)
-        } yield ()
-
-        def closeImage(id: ImageFileId, client: DhsClient): SeqAction[Unit] =
-          client.setKeywords(id, KeywordBag(StringKeyword("instrument", inst.dhsInstrumentName)), finalFlag = true)
-
-        for {
-          id <- systems.dhs.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List(inst.contributorName, "dhs-http")))
-          _ <- sendDataStart(id)
-          _ <- headers(ctx).map(_.sendBefore(id, inst.dhsInstrumentName)).sequenceU
-          _ <- inst.observe(config)(id)
-          _ <- headers(ctx).map(_.sendAfter(id, inst.dhsInstrumentName)).sequenceU
-          _ <- closeImage(id, systems.dhs)
-          _ <- sendDataEnd(id)
-        } yield ObserveResult(id)
-      }
-
       extractStatus(config) match {
         case StepState.Pending =>
           Step(
@@ -86,7 +78,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
             ++
             List(
               sys.map(x => toAction(x.configure(config).map(y => Result.Configured(y.sys.name)))),
-              List(new Action(ctx => observe(config)(ctx).map(x => Result.Observed(x.dataId)).run.map(toResult)))
+              List(new Action(ctx => observe(config, obsId, inst, headers)(ctx).map(x => Result.Observed(x.dataId)).run.map(toResult)))
             )
             ++
             (if(last) List(List(toAction(systems.odb.sequenceEnd(obsId).map(_ => Result.Ignored))))
@@ -117,9 +109,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
       headers   <- calcHeaders(config, stepType)
       resources <- calcResources(stepType)
     } yield buildStep(inst, systems, headers, resources)
-
   }
-  // scalastyle:on
 
   private def extractInstrumentName(config: Config): SeqexecFailure \/ edu.gemini.seqexec.model.Model.Instrument =
     // This is too weak. We may want to use the extractors used in ITC

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -99,7 +99,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
   def setCloudCover(q: EventQueue, cc: CloudCover, user: UserDetails): Task[SeqexecFailure \/ Unit] =
     q.enqueueOne(Event.setCloudCover(cc, user)).map(_.right)
 
-  def setSkipMark: Task[SeqexecFailure \/ Unit] = ???
+  def setSkipMark: Task[SeqexecFailure \/ Unit] = ??? // scalastyle:ignore
 
   def requestRefresh(q: EventQueue): Task[Unit] = q.enqueueOne(Event.poll)
 
@@ -244,7 +244,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
 
     val x = odbProxy.queuedSequences.flatMapF(seqs => loads(seqs).map(ee => (ee ++ unloads(seqs)).right)).run
     val y = x.map(_.valueOr(r => List(Event.logMsg(SeqexecFailure.explain(r)))))
-    y.map { ee => !ee.isEmpty option Process.emitAll(ee).evalMap(Task.delay(_)) }
+    y.map { ee => ee.nonEmpty option Process.emitAll(ee).evalMap(Task.delay(_)) }
   }
 
 }
@@ -285,7 +285,7 @@ object SeqexecEngine {
     instForceError = false,
     10.seconds)
 
-  def apply(settings: Settings) = new SeqexecEngine(settings)
+  def apply(settings: Settings): SeqexecEngine = new SeqexecEngine(settings)
 
   private def decodeTops(s: String): Map[String, String] =
     s.split("=|,").grouped(2).collect {
@@ -298,6 +298,7 @@ object SeqexecEngine {
     Task.delay(Paths.get(smartGCalLocation)).map { p => SmartGcal.initialize(peer, p) }
   }
 
+  // scalastyle:off
   def seqexecConfiguration: Kleisli[Task, Config, Settings] = Kleisli { cfg: Config => {
     val site = cfg.require[String]("seqexec-engine.site") match {
       case "GS" => Site.GS
@@ -380,5 +381,6 @@ object SeqexecEngine {
 
     }
   }
+  // scalastyle:on
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -298,6 +298,8 @@ object SeqexecEngine {
     Task.delay(Paths.get(smartGCalLocation)).map { p => SmartGcal.initialize(peer, p) }
   }
 
+  private val taskUnit = Task.now(())
+
   // scalastyle:off
   def seqexecConfiguration: Kleisli[Task, Config, Settings] = Kleisli { cfg: Config => {
     val site = cfg.require[String]("seqexec-engine.site") match {
@@ -323,8 +325,6 @@ object SeqexecEngine {
     val caAddrList              = cfg.lookup[String]("seqexec-engine.epics_ca_addr_list")
     val smartGCalHost           = cfg.require[String]("seqexec-engine.smartGCalHost")
     val smartGCalDir            = cfg.require[String]("seqexec-engine.smartGCalDir")
-
-    val taskUnit = Task.now(())
 
     // TODO: Review initialization of EPICS systems
     def initEpicsSystem[T](sys: EpicsSystem[T], tops: Map[String, String]): Task[Unit] =

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
@@ -216,49 +216,170 @@ class StandardHeader(
   import Header._
   import Header.Implicits._
 
-  // scalastyle:off
+  val p: SeqAction[Option[Double]] = for {
+    xoffOpt <- tcsReader.getXOffset
+    yoffOpt <- tcsReader.getYOffset
+    iaaOpt <- tcsReader.getInstrumentAA
+  } yield for {
+    xoff <- xoffOpt
+    yoff <- yoffOpt
+    iaa <- iaaOpt
+  } yield -xoff * Math.cos(Math.toRadians(iaa)) + yoff * Math.sin(Math.toRadians(iaa))
+
+  val q: SeqAction[Option[Double]] = for {
+    xoffOpt <- tcsReader.getXOffset
+    yoffOpt <- tcsReader.getYOffset
+    iaaOpt  <- tcsReader.getInstrumentAA
+  } yield for {
+    xoff <- xoffOpt
+    yoff <- yoffOpt
+    iaa  <- iaaOpt
+  } yield -xoff * Math.sin(Math.toRadians(iaa)) - yoff * Math.cos(Math.toRadians(iaa))
+
+  val raoff: SeqAction[Option[Double]] = for {
+    poffOpt <- p
+    qoffOpt <- q
+    ipaOpt  <- tcsReader.getInstrumentPA
+  } yield for {
+    poff <- poffOpt
+    qoff <- qoffOpt
+    ipa  <- ipaOpt
+  } yield poff * Math.cos(Math.toRadians(ipa)) + qoff * Math.sin(Math.toRadians(ipa))
+
+  val decoff: SeqAction[Option[Double]] = for {
+    poffOpt <- p
+    qoffOpt <- q
+    ipaOpt  <- tcsReader.getInstrumentPA
+  } yield for {
+    poff <- poffOpt
+    qoff <- qoffOpt
+    ipa  <- ipaOpt
+  } yield poff * Math.cos(Math.toRadians(ipa)) + qoff * Math.sin(Math.toRadians(ipa))
+
+
+  val obsObject: SeqAction[Option[String]] = for {
+    obsType   <- obsReader.getObsType
+    obsObject <- obsReader.getObsObject
+    tcsObject <- tcsReader.getSourceATarget.getObjectName
+  } yield if (obsType == "OBJECT" && obsObject != "Twilight" && obsObject != "Domeflat") tcsObject
+          else Some(obsObject)
+
+  private def decodeGuide(v: StandardGuideOptions.Value): String = v match {
+    case StandardGuideOptions.Value.park   => "parked"
+    case StandardGuideOptions.Value.guide  => "guiding"
+    case StandardGuideOptions.Value.freeze => "frozen"
+  }
+
+  val baseKeywords = List(
+    buildString(obsObject.orDefault, "OBJECT"),
+    buildString(obsReader.getObsType, "OBSTYPE"),
+    buildString(obsReader.getObsClass, "OBSCLASS"),
+    buildString(obsReader.getGemPrgId, "GEMPRGID"),
+    buildString(obsReader.getObsId, "obsid"),
+    buildString(obsReader.getDataLabel, "DATALAB"),
+    buildString(stateReader.getObserverName, "OBSERVER"),
+    buildString(obsReader.getObservatory, "OBSERVAT"),
+    buildString(obsReader.getTelescope, "telescope"),
+    buildDouble(tcsReader.getSourceATarget.getParallax.orDefault, "PARALLAX"),
+    buildDouble(tcsReader.getSourceATarget.getRadialVelocity.orDefault, "RADVEL"),
+    buildDouble(tcsReader.getSourceATarget.getEpoch.orDefault, "EPOCH"),
+    buildDouble(tcsReader.getSourceATarget.getEquinox.orDefault, "EQUINOX"),
+    buildDouble(tcsReader.getTrackingEquinox.orDefault, "TRKEQUIN"),
+    buildString(stateReader.getOperatorName, "SSA"),
+    buildDouble(tcsReader.getSourceATarget.getRA.orDefault, "RA"),
+    buildDouble(tcsReader.getSourceATarget.getDec.orDefault, "DEC"),
+    buildDouble(tcsReader.getElevation.orDefault, "ELEVATIO"),
+    buildDouble(tcsReader.getAzimuth.orDefault, "AZIMUTH"),
+    buildDouble(tcsReader.getCRPositionAngle.orDefault, "CRPA"),
+    buildString(tcsReader.getHourAngle.orDefault, "HA"),
+    buildString(tcsReader.getLocalTime.orDefault, "LT"),
+    buildString(tcsReader.getTrackingFrame.orDefault, "TRKFRAME"),
+    buildDouble(tcsReader.getTrackingDec.orDefault, "DECTRACK"),
+    buildDouble(tcsReader.getTrackingEpoch.orDefault, "TRKEPOCH"),
+    buildDouble(tcsReader.getTrackingRA.orDefault, "RATRACK"),
+    buildString(tcsReader.getSourceATarget.getFrame.orDefault, "FRAME"),
+    buildDouble(tcsReader.getSourceATarget.getProperMotionDec.orDefault, "PMDEC"),
+    buildDouble(tcsReader.getSourceATarget.getProperMotionRA.orDefault, "PMRA"),
+    {
+      val x = tcsReader.getSourceATarget.getWavelength.map(_.map(_.length.toAngstroms))
+      buildDouble(x.orDefault, "WAVELENG")
+    },
+    buildString(stateReader.getRawImageQuality, "RAWIQ"),
+    buildString(stateReader.getRawCloudCover, "RAWCC"),
+    buildString(stateReader.getRawWaterVapor, "RAWWV"),
+    buildString(stateReader.getRawBackgroundLight, "RAWBG"),
+    buildString(obsReader.getPIReq, "RAWPIREQ"),
+    buildString(obsReader.getGeminiQA, "RAWGEMQA"),
+    buildString(tcsReader.getCarouselMode.orDefault, "CGUIDMOD"),
+    buildString(tcsReader.getUT.orDefault, "UT"),
+    buildString(tcsReader.getDate.orDefault, "DATE"),
+    buildString(tcsReader.getM2Baffle.orDefault, "M2BAFFLE"),
+    buildString(tcsReader.getM2CentralBaffle.orDefault, "M2CENBAF"),
+    buildString(tcsReader.getST.orDefault, "ST"),
+    buildDouble(tcsReader.getXOffset.orDefault, "XOFFSET"),
+    buildDouble(tcsReader.getYOffset.orDefault, "YOFFSET"),
+    buildDouble(p.orDefault, "POFFSET"),
+    buildDouble(q.orDefault, "QOFFSET"),
+    buildDouble(raoff.orDefault, "RAOFFSET"),
+    buildDouble(decoff.orDefault, "DECOFFSE"),
+    buildDouble(tcsReader.getTrackingRAOffset.orDefault, "RATRGOFF"),
+    buildDouble(tcsReader.getTrackingDecOffset.orDefault, "DECTRGOF"),
+    buildDouble(tcsReader.getInstrumentPA.orDefault, "PA"),
+    buildDouble(tcsReader.getInstrumentAA.orDefault, "IAA"),
+    buildDouble(tcsReader.getSFRotation.orDefault, "SFRT2"),
+    buildDouble(tcsReader.getSFTilt.orDefault, "SFTILT"),
+    buildDouble(tcsReader.getSFLinear.orDefault, "SFLINEAR"),
+    buildString(tcsReader.getAOFoldName.orDefault, "AOFOLD"),
+    buildString(obsReader.getPwfs1Guide.map(decodeGuide), "PWFS1_ST"),
+    buildString(obsReader.getPwfs2Guide.map(decodeGuide), "PWFS2_ST"),
+    buildString(obsReader.getOiwfsGuide.map(decodeGuide), "OIWFS_ST"),
+    buildString(obsReader.getAowfsGuide.map(decodeGuide), "AOWFS_ST"),
+    buildInt32(obsReader.getSciBand.orDefault, "SCIBAND")
+  )
+
+  def timinigWindows(id: ImageFileId, inst: String): SeqAction[Unit] = {
+    val timingWindows = obsReader.getTimingWindows
+    val windows = timingWindows.flatMap {
+      case (i, tw) =>
+        List(
+          buildString(tw.start,    f"REQTWS${i + 1}%02d"),
+          buildDouble(tw.duration, f"REQTWD${i + 1}%02d"),
+          buildInt32(tw.repeat,    f"REQTWN${i + 1}%02d"),
+          buildDouble(tw.period,   f"REQTWP${i + 1}%02d"))
+    }
+    val windowsCount = buildInt32(SeqAction(timingWindows.length), "NUMREQTW")
+    sendKeywords(id, inst, hs, windowsCount :: windows)
+  }
+
+  def requestedConditions(id: ImageFileId, inst: String): SeqAction[Unit] = {
+    import ObsKeywordsReader._
+    val keys = List(
+      "REQIQ" -> IQ,
+      "REQCC" -> CC,
+      "REQBG" -> SB,
+      "REQWV" -> WV)
+    val requested = keys.flatMap {
+      case (keyword, value) => obsReader.getRequestedConditions.get(value).map(buildString(_, keyword))
+    }
+    sendKeywords(id, inst, hs, requested)
+  }
+
+  def requestedAirMassAngle(id: ImageFileId, inst: String): SeqAction[Unit] = {
+    import ObsKeywordsReader._
+    val keys = List(
+      "REQMAXAM" -> MAX_AIRMASS,
+      "REQMAXHA" -> MAX_HOUR_ANGLE,
+      "REQMINAM" -> MIN_AIRMASS,
+      "REQMINHA" -> MIN_HOUR_ANGLE)
+    val requested = keys.flatMap {
+      case (keyword, value) => obsReader.getRequestedAirMassAngle.get(value).map(buildDouble(_, keyword))
+    }
+    if (!requested.isEmpty) sendKeywords(id, inst, hs, requested)
+    else SeqAction(())
+  }
+
+  // scalastyle:of
   override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] = {
-
-    val p: SeqAction[Option[Double]] = for {
-      xoffOpt <- tcsReader.getXOffset
-      yoffOpt <- tcsReader.getYOffset
-      iaaOpt <- tcsReader.getInstrumentAA
-    } yield for {
-      xoff <- xoffOpt
-      yoff <- yoffOpt
-      iaa <- iaaOpt
-    } yield -xoff * Math.cos(Math.toRadians(iaa)) + yoff * Math.sin(Math.toRadians(iaa))
-
-    val q: SeqAction[Option[Double]] = for {
-      xoffOpt <- tcsReader.getXOffset
-      yoffOpt <- tcsReader.getYOffset
-      iaaOpt <- tcsReader.getInstrumentAA
-    } yield for {
-      xoff <- xoffOpt
-      yoff <- yoffOpt
-      iaa <- iaaOpt
-    } yield -xoff * Math.sin(Math.toRadians(iaa)) - yoff * Math.cos(Math.toRadians(iaa))
-
-    val raoff: SeqAction[Option[Double]] = for {
-      poffOpt <- p
-      qoffOpt <- q
-      ipaOpt <- tcsReader.getInstrumentPA
-    } yield for {
-      poff <- poffOpt
-      qoff <- qoffOpt
-      ipa <- ipaOpt
-    } yield poff * Math.cos(Math.toRadians(ipa)) + qoff * Math.sin(Math.toRadians(ipa))
-
-    val decoff: SeqAction[Option[Double]] = for {
-      poffOpt <- p
-      qoffOpt <- q
-      ipaOpt <- tcsReader.getInstrumentPA
-    } yield for {
-      poff <- poffOpt
-      qoff <- qoffOpt
-      ipa <- ipaOpt
-    } yield poff * Math.cos(Math.toRadians(ipa)) + qoff * Math.sin(Math.toRadians(ipa))
-
     def guiderKeywords(guideWith: SeqAction[StandardGuideOptions.Value], baseName: String, target: TargetKeywordsReader,
                        extras: List[KeywordBag => SeqAction[KeywordBag]]): SeqAction[Unit] = guideWith.flatMap { g =>
       if (g == StandardGuideOptions.Value.guide) sendKeywords(id, inst, hs, List(
@@ -283,6 +404,9 @@ class StandardHeader(
                                target: TargetKeywordsReader, extras: List[KeywordBag => SeqAction[KeywordBag]]): SeqAction[Unit] =
       guiderKeywords(guideWith, baseName, target, List(buildDouble(tcsReader.getM2UserFocusOffset.orDefault, baseName + "FOCUS")) ++ extras)
 
+    val oiwfsKeywords = guiderKeywords(obsReader.getOiwfsGuide, "OI", tcsReader.getOiwfsTarget,
+      List(buildDouble(tcsReader.getOiwfsFreq.orDefault, "OIFREQ")))
+
     val pwfs1Keywords = standardGuiderKeywords(obsReader.getPwfs1Guide, "P1", tcsReader.getPwfs1Target,
       List(buildDouble(tcsReader.getPwfs1Freq.orDefault, "P1FREQ")))
 
@@ -291,132 +415,10 @@ class StandardHeader(
 
     val aowfsKeywords = standardGuiderKeywords(obsReader.getAowfsGuide, "AO", tcsReader.getAowfsTarget, List())
 
-    val oiwfsKeywords = guiderKeywords(obsReader.getOiwfsGuide, "OI", tcsReader.getOiwfsTarget,
-      List(buildDouble(tcsReader.getOiwfsFreq.orDefault, "OIFREQ")))
-
-    val obsObject: SeqAction[Option[String]] = for {
-      obsType   <- obsReader.getObsType
-      obsObject <- obsReader.getObsObject
-      tcsObject <- tcsReader.getSourceATarget.getObjectName
-    } yield if (obsType == "OBJECT" && obsObject != "Twilight" && obsObject != "Domeflat") tcsObject
-            else Some(obsObject)
-
-    val requestedAirMassAngle: SeqAction[Unit] = {
-      import ObsKeywordsReader._
-      val keys = List(
-        "REQMAXAM" -> MAX_AIRMASS,
-        "REQMAXHA" -> MAX_HOUR_ANGLE,
-        "REQMINAM" -> MIN_AIRMASS,
-        "REQMINHA" -> MIN_HOUR_ANGLE)
-      val requested = keys.flatMap {
-        case (keyword, value) => obsReader.getRequestedAirMassAngle.get(value).map(buildDouble(_, keyword))
-      }
-      if(!requested.isEmpty) sendKeywords(id, inst, hs, requested)
-      else SeqAction(())
-    }
-
-    val requestedConditions: SeqAction[Unit] = {
-      import ObsKeywordsReader._
-      val keys = List(
-        "REQIQ" -> IQ,
-        "REQCC" -> CC,
-        "REQBG" -> SB,
-        "REQWV" -> WV)
-      val requested = keys.flatMap {
-        case (keyword, value) => obsReader.getRequestedConditions.get(value).map(buildString(_, keyword))
-      }
-      sendKeywords(id, inst, hs, requested)
-    }
-
-    val timinigWindows: SeqAction[Unit] = {
-      val timingWindows = obsReader.getTimingWindows
-      val windows = timingWindows.flatMap {
-        case (i, tw) =>
-          List(
-            buildString(tw.start,    f"REQTWS${i + 1}%02d"),
-            buildDouble(tw.duration, f"REQTWD${i + 1}%02d"),
-            buildInt32(tw.repeat,    f"REQTWN${i + 1}%02d"),
-            buildDouble(tw.period,   f"REQTWP${i + 1}%02d"))
-      }
-      val windowsCount = buildInt32(SeqAction(timingWindows.length), "NUMREQTW")
-      sendKeywords(id, inst, hs, windowsCount :: windows)
-    }
-
-    def decodeGuide(v: StandardGuideOptions.Value): String = v match {
-      case StandardGuideOptions.Value.park   => "parked"
-      case StandardGuideOptions.Value.guide  => "guiding"
-      case StandardGuideOptions.Value.freeze => "frozen"
-    }
-
-    sendKeywords(id, inst, hs, List(
-      buildString(obsObject.orDefault, "OBJECT"),
-      buildString(obsReader.getObsType, "OBSTYPE"),
-      buildString(obsReader.getObsClass, "OBSCLASS"),
-      buildString(obsReader.getGemPrgId, "GEMPRGID"),
-      buildString(obsReader.getObsId, "obsid"),
-      buildString(obsReader.getDataLabel, "DATALAB"),
-      buildString(stateReader.getObserverName, "OBSERVER"),
-      buildString(obsReader.getObservatory, "OBSERVAT"),
-      buildString(obsReader.getTelescope, "telescope"),
-      buildDouble(tcsReader.getSourceATarget.getParallax.orDefault, "PARALLAX"),
-      buildDouble(tcsReader.getSourceATarget.getRadialVelocity.orDefault, "RADVEL"),
-      buildDouble(tcsReader.getSourceATarget.getEpoch.orDefault, "EPOCH"),
-      buildDouble(tcsReader.getSourceATarget.getEquinox.orDefault, "EQUINOX"),
-      buildDouble(tcsReader.getTrackingEquinox.orDefault, "TRKEQUIN"),
-      buildString(stateReader.getOperatorName, "SSA"),
-      buildDouble(tcsReader.getSourceATarget.getRA.orDefault, "RA"),
-      buildDouble(tcsReader.getSourceATarget.getDec.orDefault, "DEC"),
-      buildDouble(tcsReader.getElevation.orDefault, "ELEVATIO"),
-      buildDouble(tcsReader.getAzimuth.orDefault, "AZIMUTH"),
-      buildDouble(tcsReader.getCRPositionAngle.orDefault, "CRPA"),
-      buildString(tcsReader.getHourAngle.orDefault, "HA"),
-      buildString(tcsReader.getLocalTime.orDefault, "LT"),
-      buildString(tcsReader.getTrackingFrame.orDefault, "TRKFRAME"),
-      buildDouble(tcsReader.getTrackingDec.orDefault, "DECTRACK"),
-      buildDouble(tcsReader.getTrackingEpoch.orDefault, "TRKEPOCH"),
-      buildDouble(tcsReader.getTrackingRA.orDefault, "RATRACK"),
-      buildString(tcsReader.getSourceATarget.getFrame.orDefault, "FRAME"),
-      buildDouble(tcsReader.getSourceATarget.getProperMotionDec.orDefault, "PMDEC"),
-      buildDouble(tcsReader.getSourceATarget.getProperMotionRA.orDefault, "PMRA"),
-      {
-        val x = tcsReader.getSourceATarget.getWavelength.map(_.map(_.length.toAngstroms))
-        buildDouble(x.orDefault, "WAVELENG")
-      },
-      buildString(stateReader.getRawImageQuality, "RAWIQ"),
-      buildString(stateReader.getRawCloudCover, "RAWCC"),
-      buildString(stateReader.getRawWaterVapor, "RAWWV"),
-      buildString(stateReader.getRawBackgroundLight, "RAWBG"),
-      buildString(obsReader.getPIReq, "RAWPIREQ"),
-      buildString(obsReader.getGeminiQA, "RAWGEMQA"),
-      buildString(tcsReader.getCarouselMode.orDefault, "CGUIDMOD"),
-      buildString(tcsReader.getUT.orDefault, "UT"),
-      buildString(tcsReader.getDate.orDefault, "DATE"),
-      buildString(tcsReader.getM2Baffle.orDefault, "M2BAFFLE"),
-      buildString(tcsReader.getM2CentralBaffle.orDefault, "M2CENBAF"),
-      buildString(tcsReader.getST.orDefault, "ST"),
-      buildDouble(tcsReader.getXOffset.orDefault, "XOFFSET"),
-      buildDouble(tcsReader.getYOffset.orDefault, "YOFFSET"),
-      buildDouble(p.orDefault, "POFFSET"),
-      buildDouble(q.orDefault, "QOFFSET"),
-      buildDouble(raoff.orDefault, "RAOFFSET"),
-      buildDouble(decoff.orDefault, "DECOFFSE"),
-      buildDouble(tcsReader.getTrackingRAOffset.orDefault, "RATRGOFF"),
-      buildDouble(tcsReader.getTrackingDecOffset.orDefault, "DECTRGOF"),
-      buildDouble(tcsReader.getInstrumentPA.orDefault, "PA"),
-      buildDouble(tcsReader.getInstrumentAA.orDefault, "IAA"),
-      buildDouble(tcsReader.getSFRotation.orDefault, "SFRT2"),
-      buildDouble(tcsReader.getSFTilt.orDefault, "SFTILT"),
-      buildDouble(tcsReader.getSFLinear.orDefault, "SFLINEAR"),
-      buildString(tcsReader.getAOFoldName.orDefault, "AOFOLD"),
-      buildString(obsReader.getPwfs1Guide.map(decodeGuide), "PWFS1_ST"),
-      buildString(obsReader.getPwfs2Guide.map(decodeGuide), "PWFS2_ST"),
-      buildString(obsReader.getOiwfsGuide.map(decodeGuide), "OIWFS_ST"),
-      buildString(obsReader.getAowfsGuide.map(decodeGuide), "AOWFS_ST"),
-      buildInt32(obsReader.getSciBand.orDefault, "SCIBAND")
-    )) *>
-    requestedConditions *>
-    requestedAirMassAngle *>
-    timinigWindows *>
+    sendKeywords(id, inst, hs, baseKeywords) *>
+    requestedConditions(id, inst) *>
+    requestedAirMassAngle(id, inst) *>
+    timinigWindows(id, inst) *>
     pwfs1Keywords *>
     pwfs2Keywords *>
     oiwfsKeywords *>

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/StandardHeader.scala
@@ -216,6 +216,7 @@ class StandardHeader(
   import Header._
   import Header.Implicits._
 
+  // scalastyle:off
   override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] = {
 
     val p: SeqAction[Option[Double]] = for {
@@ -421,6 +422,7 @@ class StandardHeader(
     oiwfsKeywords *>
     aowfsKeywords
   }
+  // scalastyle:on
 
   override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] = sendKeywords(id, inst, hs,
     List(

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TaskRef.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TaskRef.scala
@@ -7,12 +7,12 @@ sealed trait TaskRef[A] {
 
   /** Atomic modification. */
   def modify(f: A => A): Task[Unit]
-  
+
   /** Return the current value. */
   def get: Task[A]
 
   /** Replace the current value. */
-  def put(a: A): Task[Unit] = 
+  def put(a: A): Task[Unit] =
     modify(_ => a)
 
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsController.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsController.scala
@@ -58,8 +58,8 @@ object TcsController {
   sealed trait M2GuideConfig
   case object M2GuideOff extends M2GuideConfig
   final case class M2GuideOn(coma: ComaOption, source: Set[TipTiltSource]) extends M2GuideConfig {
-    def setComa(v: ComaOption) = M2GuideOn(v, source)
-    def setSource(v: Set[TipTiltSource]) = M2GuideOn(coma, v)
+    def setComa(v: ComaOption): M2GuideConfig = M2GuideOn(v, source)
+    def setSource(v: Set[TipTiltSource]): M2GuideConfig = M2GuideOn(coma, v)
   }
 
   /** Data type for M2 guide config. */
@@ -183,9 +183,9 @@ object TcsController {
 
   /** Data type for guide config. */
   final case class GuideConfig(mountGuide: MountGuideOption, m1Guide: M1GuideConfig, m2Guide: M2GuideConfig) {
-    def setMountGuide(v: MountGuideOption) = GuideConfig(v, m1Guide, m2Guide)
-    def setM1Guide(v: M1GuideConfig) = GuideConfig(mountGuide, v, m2Guide)
-    def setM2Guide(v: M2GuideConfig) = GuideConfig(mountGuide, m1Guide, v)
+    def setMountGuide(v: MountGuideOption): GuideConfig = GuideConfig(v, m1Guide, m2Guide)
+    def setM1Guide(v: M1GuideConfig): GuideConfig = GuideConfig(mountGuide, v, m2Guide)
+    def setM2Guide(v: M2GuideConfig): GuideConfig = GuideConfig(mountGuide, m1Guide, v)
   }
 
   // TCS expects offsets as two length quantities (in millimeters) in the focal plane
@@ -238,13 +238,13 @@ object TcsController {
   ) {
 
     // TODO: these in terms of .copy
-    def setOffsetA(v: FocalPlaneOffset) = TelescopeConfig(OffsetA(v), offsetB, offsetC, wavelA, wavelB, wavelC, m2beam)
-    def setOffsetB(v: FocalPlaneOffset) = TelescopeConfig(offsetA, OffsetB(v), offsetC, wavelA, wavelB, wavelC, m2beam)
-    def setOffsetC(v: FocalPlaneOffset) = TelescopeConfig(offsetA, offsetB, OffsetC(v), wavelA, wavelB, wavelC, m2beam)
-    def setWavelengthA(v: Wavelength) = TelescopeConfig(offsetA, offsetB, offsetC, WavelengthA(v), wavelB, wavelC, m2beam)
-    def setWavelengthB(v: Wavelength) = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, WavelengthB(v), wavelC, m2beam)
-    def setWavelengthC(v: Wavelength) = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, wavelB, WavelengthC(v), m2beam)
-    def setBeam(v: Beam) = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, wavelB, wavelC, v)
+    def setOffsetA(v: FocalPlaneOffset): TelescopeConfig = TelescopeConfig(OffsetA(v), offsetB, offsetC, wavelA, wavelB, wavelC, m2beam)
+    def setOffsetB(v: FocalPlaneOffset): TelescopeConfig = TelescopeConfig(offsetA, OffsetB(v), offsetC, wavelA, wavelB, wavelC, m2beam)
+    def setOffsetC(v: FocalPlaneOffset): TelescopeConfig = TelescopeConfig(offsetA, offsetB, OffsetC(v), wavelA, wavelB, wavelC, m2beam)
+    def setWavelengthA(v: Wavelength): TelescopeConfig = TelescopeConfig(offsetA, offsetB, offsetC, WavelengthA(v), wavelB, wavelC, m2beam)
+    def setWavelengthB(v: Wavelength): TelescopeConfig = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, WavelengthB(v), wavelC, m2beam)
+    def setWavelengthC(v: Wavelength): TelescopeConfig = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, wavelB, WavelengthC(v), m2beam)
+    def setBeam(v: Beam): TelescopeConfig = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, wavelB, wavelC, v)
   }
 
   final case class ProbeTrackingConfigP1(self: ProbeTrackingConfig) extends AnyVal
@@ -258,10 +258,10 @@ object TcsController {
     oiwfs: ProbeTrackingConfigOI,
     aowfs: ProbeTrackingConfigAO
   ) {
-    def setPwfs1TrackingConfig(v: ProbeTrackingConfig) = GuidersTrackingConfig(ProbeTrackingConfigP1(v), pwfs2, oiwfs, aowfs)
-    def setPwfs2TrackingConfig(v: ProbeTrackingConfig) = GuidersTrackingConfig(pwfs1, ProbeTrackingConfigP2(v), oiwfs, aowfs)
-    def setOiwfsTrackingConfig(v: ProbeTrackingConfig) = GuidersTrackingConfig(pwfs1, pwfs2, ProbeTrackingConfigOI(v), aowfs)
-    def setAowfsTrackingConfig(v: ProbeTrackingConfig) = GuidersTrackingConfig(pwfs1, pwfs2, oiwfs, ProbeTrackingConfigAO(v))
+    def setPwfs1TrackingConfig(v: ProbeTrackingConfig): GuidersTrackingConfig = GuidersTrackingConfig(ProbeTrackingConfigP1(v), pwfs2, oiwfs, aowfs)
+    def setPwfs2TrackingConfig(v: ProbeTrackingConfig): GuidersTrackingConfig = GuidersTrackingConfig(pwfs1, ProbeTrackingConfigP2(v), oiwfs, aowfs)
+    def setOiwfsTrackingConfig(v: ProbeTrackingConfig): GuidersTrackingConfig = GuidersTrackingConfig(pwfs1, pwfs2, ProbeTrackingConfigOI(v), aowfs)
+    def setAowfsTrackingConfig(v: ProbeTrackingConfig): GuidersTrackingConfig = GuidersTrackingConfig(pwfs1, pwfs2, oiwfs, ProbeTrackingConfigAO(v))
   }
 
   sealed trait GuiderSensorOption
@@ -279,9 +279,9 @@ object TcsController {
     pwfs2: GuiderSensorOptionP2,
     oiwfs: GuiderSensorOptionOI
   ) {
-    def setPwfs1GuiderSensorOption(v: GuiderSensorOption) = this.copy(pwfs1 = GuiderSensorOptionP1(v))
-    def setPwfs2GuiderSensorOption(v: GuiderSensorOption) = this.copy(pwfs2 = GuiderSensorOptionP2(v))
-    def setOiwfsGuiderSensorOption(v: GuiderSensorOption) = this.copy(oiwfs = GuiderSensorOptionOI(v))
+    def setPwfs1GuiderSensorOption(v: GuiderSensorOption): GuidersEnabled = this.copy(pwfs1 = GuiderSensorOptionP1(v))
+    def setPwfs2GuiderSensorOption(v: GuiderSensorOption): GuidersEnabled = this.copy(pwfs2 = GuiderSensorOptionP2(v))
+    def setOiwfsGuiderSensorOption(v: GuiderSensorOption): GuidersEnabled = this.copy(oiwfs = GuiderSensorOptionOI(v))
   }
 
   final case class AGConfig(sfPos: Option[ScienceFoldPosition], hrwfsPos: Option[HrwfsPickupPosition])
@@ -296,12 +296,12 @@ object TcsController {
     agc: AGConfig,
     iaa: InstrumentAlignAngle
   ) {
-    def setGuideConfig(v: GuideConfig) = TcsConfig(v, tc, gtc, ge, agc, iaa)
-    def setTelescopeConfig(v: TelescopeConfig) = TcsConfig(gc, v, gtc, ge, agc, iaa)
-    def setGuidersTrackingConfig(v: GuidersTrackingConfig) = TcsConfig(gc, tc, v, ge, agc, iaa)
-    def setGuidersEnabled(v: GuidersEnabled) = TcsConfig(gc, tc, gtc, v, agc, iaa)
-    def setAGConfig(v: AGConfig) = TcsConfig(gc, tc, gtc, ge, v, iaa)
-    def setIAA(v: InstrumentAlignAngle) = TcsConfig(gc, tc, gtc, ge, agc, v)
+    def setGuideConfig(v: GuideConfig): TcsConfig = TcsConfig(v, tc, gtc, ge, agc, iaa)
+    def setTelescopeConfig(v: TelescopeConfig): TcsConfig = TcsConfig(gc, v, gtc, ge, agc, iaa)
+    def setGuidersTrackingConfig(v: GuidersTrackingConfig): TcsConfig = TcsConfig(gc, tc, v, ge, agc, iaa)
+    def setGuidersEnabled(v: GuidersEnabled): TcsConfig = TcsConfig(gc, tc, gtc, v, agc, iaa)
+    def setAGConfig(v: AGConfig): TcsConfig = TcsConfig(gc, tc, gtc, ge, v, iaa)
+    def setIAA(v: InstrumentAlignAngle): TcsConfig = TcsConfig(gc, tc, gtc, ge, agc, v)
   }
 
   sealed trait Subsystem

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsController.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsController.scala
@@ -24,6 +24,7 @@ trait TcsController {
   def applyConfig(subsystems: NonEmptyList[Subsystem], tc: TcsConfig): SeqAction[Unit]
 }
 
+// scalastyle:off
 object TcsController {
 
   case class Requested[T](self: T) extends AnyVal
@@ -102,12 +103,11 @@ object TcsController {
   sealed trait NodChopTrackingConfig {
     def get(nodchop: NodChop): NodChopTrackingOption
   }
-  sealed trait ActiveNodChopTracking extends NodChopTrackingConfig {
+  sealed trait ActiveNodChopTracking extends NodChopTrackingConfig
 
     // If x is of type ActiveNodChopTracking then ∃ a:NodChop ∍ x.get(a) == NodChopTrackingOn
     // How could I reflect that in the code?
 
-  }
   object NodChopTrackingConfig {
 
     object None extends NodChopTrackingConfig {
@@ -318,5 +318,5 @@ object TcsController {
     val all = NonEmptyList(OIWFS, P1WFS, P2WFS, ScienceFold, HRProbe, Mount, M1, M2)
   }
 
-
 }
+// scalastyle:on

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
@@ -113,7 +113,7 @@ object TcsControllerEpics extends TcsController {
       cc <- g.nodcchopc.map(decodeNodChopOption)
 
       // This last production is slightly tricky.
-      o  <- if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).exists(_ == true)) {
+      o  <- if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).contais(true)) {
               if (List(aa, bb, cc).forall(_ == true) && List(ab, ac, ba, bc, ca, cb).forall(_ == false)) {
                 Some(NodChopTrackingConfig.Normal)
               } else {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
@@ -113,7 +113,7 @@ object TcsControllerEpics extends TcsController {
       cc <- g.nodcchopc.map(decodeNodChopOption)
 
       // This last production is slightly tricky.
-      o  <- if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).contais(true)) {
+      o  <- if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).contains(true)) {
               if (List(aa, bb, cc).forall(_ == true) && List(ab, ac, ba, bc, ca, cb).forall(_ == false)) {
                 Some(NodChopTrackingConfig.Normal)
               } else {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
@@ -24,6 +24,7 @@ import scalaz.concurrent.Task
  * Created by jluhrs on 10/1/15.
  */
 
+// scalastyle:off
 final class TcsEpics(epicsService: CaService, tops: Map[String, String]) {
 
   import TcsEpics._
@@ -617,3 +618,4 @@ object TcsEpics extends EpicsSystem[TcsEpics] {
   }
 
 }
+// scalastyle:on

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
@@ -26,7 +26,7 @@ package object server {
     def apply[A](a: => A): SeqAction[A]          = EitherT(Task.delay(TrySeq(a)))
     def either[A](a: => TrySeq[A]): SeqAction[A] = EitherT(Task.delay(a))
     def fail[A](p: SeqexecFailure): SeqAction[A] = EitherT(Task.delay(TrySeq.fail(p)))
-    def void = SeqAction.apply(())
+    def void: SeqAction[Unit] = SeqAction.apply(())
   }
 
   implicit class MoreDisjunctionOps[A,B](ab: A \/ B) {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -60,6 +60,7 @@ object LoginBox {
       )
     }
 
+    // scalastyle:off
     def render(s: State): TagOf[Div] =
       <.div(
         ^.cls := "ui modal",
@@ -137,6 +138,7 @@ object LoginBox {
           )
         )
       )
+    // scalastyle:on
   }
 
   private val component = ScalaComponent.builder[Props]("Login")
@@ -146,7 +148,7 @@ object LoginBox {
       Callback {
         // To properly handle the model we need to do updates with jQuery and
         // the Semantic UI javascript library
-        // The calls below use a custom scala.js facade for SemantiUI
+        // The calls below use a custom scala.js facade for SemanticUI
         import org.querki.jquery.$
 
         // Close the modal box if the model changes
@@ -154,7 +156,7 @@ object LoginBox {
           $(ctx.getDOMNode).modal("hide")
         }
         if (ctx.currentProps.visible() === SectionOpen) {
-          // Configure the modal to autofoucs and to act properly on closing
+          // Configure the modal to autofocus and to act properly on closing
           $(ctx.getDOMNode).modal(
             JsModalOptions
               .autofocus(true)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -60,7 +60,36 @@ object LoginBox {
       )
     }
 
-    // scalastyle:off
+    private def toolbar(s: State) =
+      <.div(
+        ^.cls := "ui actions",
+        <.div(
+          ^.cls := "ui grid",
+          <.div(
+            ^.cls := "middle aligned row",
+            s.progressMsg.map( m =>
+              <.div(
+                ^.cls := "left floated left aligned six wide column",
+                IconCircleNotched.copyIcon(loading = true),
+                m
+              )
+            ).whenDefined,
+            s.errorMsg.map( m =>
+              <.div(
+                ^.cls := "left floated left aligned six wide column red",
+                IconAttention,
+                m
+              )
+            ).whenDefined,
+            <.div(
+              ^.cls := "right floated right aligned ten wide column",
+              Button(Button.Props(onClick = closeBox), "Cancel"),
+              Button(Button.Props(onClick = attemptLogin, buttonType = Button.SubmitType, form = Some(formId)), "Login")
+            )
+          )
+        )
+      )
+
     def render(s: State): TagOf[Div] =
       <.div(
         ^.cls := "ui modal",
@@ -109,36 +138,8 @@ object LoginBox {
             )
           )
         ),
-        <.div(
-          ^.cls := "ui actions",
-          <.div(
-            ^.cls := "ui grid",
-            <.div(
-              ^.cls := "middle aligned row",
-              s.progressMsg.map( m =>
-                <.div(
-                  ^.cls := "left floated left aligned six wide column",
-                  IconCircleNotched.copyIcon(loading = true),
-                  m
-                )
-              ).whenDefined,
-              s.errorMsg.map( m =>
-                <.div(
-                  ^.cls := "left floated left aligned six wide column red",
-                  IconAttention,
-                  m
-                )
-              ).whenDefined,
-              <.div(
-                ^.cls := "right floated right aligned ten wide column",
-                Button(Button.Props(onClick = closeBox), "Cancel"),
-                Button(Button.Props(onClick = attemptLogin, buttonType = Button.SubmitType, form = Some(formId)), "Login")
-              )
-            )
-          )
-        )
+        toolbar(s)
       )
-    // scalastyle:on
   }
 
   private val component = ScalaComponent.builder[Props]("Login")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
@@ -103,5 +103,5 @@ object ConnectionState {
     )
     .build
 
-  def apply(u: ModelProxy[WebSocketConnection]) = component(Props(u()))
+  def apply(u: ModelProxy[WebSocketConnection]): Unmounted[Props, Unit, Unit] = component(Props(u()))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -9,9 +9,9 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.{Callback, ScalaComponent}
 import diode.ModelRO
+import japgolly.scalajs.react.component.Scala.Unmounted
 
 import scala.scalajs.js.timers.SetTimeoutHandle
-
 import scalaz._
 import Scalaz._
 
@@ -33,7 +33,7 @@ object SeqexecMain {
       )
     ).build
 
-  def apply(site: SeqexecSite, ctl: RouterCtl[SeqexecPages]) = component(Props(site, ctl))
+  def apply(site: SeqexecSite, ctl: RouterCtl[SeqexecPages]): Unmounted[Props, Unit, Unit] = component(Props(site, ctl))
 }
 
 /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/TopMenu.scala
@@ -6,7 +6,7 @@ import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconSignOut
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
 
 import scalacss.ScalaCssReact._
@@ -18,13 +18,13 @@ object TopMenu {
 
   case class Props(status: ModelProxy[ClientStatus])
 
-  def openLogin[A](proxy: ModelProxy[A]) = japgolly.scalajs.react.Callback.log("Login")>>proxy.dispatchCB(OpenLoginBox)
-  def logout[A](proxy: ModelProxy[A]) = proxy.dispatchCB(Logout)
+  def openLogin[A](proxy: ModelProxy[A]): Callback = japgolly.scalajs.react.Callback.log("Login") >> proxy.dispatchCB(OpenLoginBox)
+  def logout[A](proxy: ModelProxy[A]): Callback = proxy.dispatchCB(Logout)
 
-  def loginButton[A](proxy: ModelProxy[A], enabled: Boolean) =
+  private def loginButton[A](proxy: ModelProxy[A], enabled: Boolean) =
     Button(Button.Props(size = Size.Medium, onClick = openLogin(proxy), disabled = !enabled), "Login")
 
-  def logoutButton[A](proxy: ModelProxy[A], text: String, enabled: Boolean) =
+  private def logoutButton[A](proxy: ModelProxy[A], text: String, enabled: Boolean) =
     Button(Button.Props(size = Size.Medium, onClick = logout(proxy), icon = Some(IconSignOut), disabled = !enabled), text)
 
   private val component = ScalaComponent.builder[Props]("SeqexecTopMenu")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -31,7 +31,7 @@ object InstrumentTab {
       val tab = p.t()
       val active = tab.active
       val status = tab.idState.map(_._2)
-      val hasError = status.map(SequenceState.isError).getOrElse(false)
+      val hasError = status.exists(SequenceState.isError)
       val sequenceId = tab.idState.map(_._1)
       val instrument = tab.instrument
       val icon = status.flatMap {
@@ -80,7 +80,7 @@ object InstrumentTab {
       }
     ).build
 
-  def apply(site: SeqexecSite, p: ModelProxy[InstrumentStatusFocus]) = component(Props(site, p))
+  def apply(site: SeqexecSite, p: ModelProxy[InstrumentStatusFocus]): Unmounted[Props, Unit, Unit] = component(Props(site, p))
 }
 /**
   * Menu with tabs

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
@@ -147,6 +147,7 @@ object SequenceControl {
   def requestPause(s: SequenceId): ScalazReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(Callback(SeqexecCircuit.dispatch(RequestPause(s)))) >> ST.mod(_.copy(runRequested = false, pauseRequested = true, syncRequested = false)).liftCB
 
+  // scalastyle:off
   private def component = ScalaComponent.builder[Props]("SequencesDefaultToolbar")
     .initialState(State(runRequested = false, pauseRequested = false, syncRequested = false))
     .renderPS { ($, p, s) =>
@@ -218,6 +219,7 @@ object SequenceControl {
       // Update state of run requested depending on the run state
       Callback.when(f.nextProps.p().control.map(_.status).contains(SequenceState.Running) && f.state.runRequested)(f.modState(_.copy(runRequested = false)))
     }.build
+  // scalastyle:on
 
   def apply(p: ModelProxy[SequenceControlFocus]): Unmounted[Props, State, Unit] = component(Props(p))
 }
@@ -243,7 +245,7 @@ object SequenceDefaultToolbar {
           <.div(
             ^.cls := "ui left column eight wide computer sixteen wide tablet only",
             SeqexecStyles.controlColumn,
-            p.sequenceControlConnects.get(p.instrument).whenDefined(c => c(SequenceControl.apply)),
+            p.sequenceControlConnects.get(p.instrument).whenDefined(c => c(SequenceControl.apply))
           ),
           <.div(
             ^.cls := "ui right column eight wide computer eight wide tablet sixteen wide mobile",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -170,6 +170,7 @@ object StepsTableContainer {
     def breakpointAt(id: SequenceId, step: Step): Callback =
       $.props >>= { p => Callback.when(p.status.isLogged)(p.stepsTable.dispatchCB(FlipBreakpointStep(id, step))) }
 
+    // scalastyle:off
     def stepsTable(status: ClientStatus, p: StepsTableFocus, s: State): TagMod =
       <.table(
         ^.cls := "ui selectable compact celled table unstackable",
@@ -266,6 +267,7 @@ object StepsTableContainer {
           }.toTagMod
         )
       )
+    // scalastyle:on
 
     def render(p: Props, s: State): VdomTagOf[Div] = {
       <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -299,8 +299,8 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
     def onMessage(e: MessageEvent): Unit = {
       val byteBuffer = TypedArrayBuffer.wrap(e.data.asInstanceOf[ArrayBuffer])
       \/.fromTryCatchNonFatal(Unpickle[SeqexecEvent].fromBytes(byteBuffer)) match {
-        case \/-(event) => println(s"Decoding event: ${event.getClass}"); SeqexecCircuit.dispatch(ServerMessage(event))
-        case -\/(t)     => println(s"Error decoding event ${t.getMessage}")
+        case \/-(event) => logger.info(s"Decoding event: ${event.getClass}"); SeqexecCircuit.dispatch(ServerMessage(event))
+        case -\/(t)     => logger.warning(s"Error decoding event ${t.getMessage}")
       }
     }
 
@@ -462,9 +462,6 @@ case class SequenceControlFocus(isLogged: Boolean, isConnected: Boolean, control
 object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[SeqexecAppRootModel] {
   type SearchResults = SequencesQueue[SequenceId]
   private val logger = Logger.getLogger(SeqexecCircuit.getClass.getSimpleName)
-
-  def appendToLogE(s: String) =
-    Effect(Future(AppendToLog(s)))
 
   // Model read-writers
   val webSocketFocusRW: ModelRW[SeqexecAppRootModel, WebSocketsFocus] =

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -362,6 +362,7 @@ class WebSocketEventsHandler[M](modelRW: ModelRW[M, WebSocketsFocus]) extends Ac
       case SequenceView(_, metadata, _, _, _) => value.site.instruments.list.toList.contains(metadata.instrument)
     })
 
+  // scalastyle:off
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(ConnectionOpenEvent(u)) =>
       updated(value.copy(user = u))
@@ -422,6 +423,7 @@ class WebSocketEventsHandler[M](modelRW: ModelRW[M, WebSocketsFocus]) extends Ac
       // Ignore unknown events
       noChange
   }
+  // scalastyle:on
 }
 
 /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
@@ -12,6 +12,9 @@ import org.scalajs.dom.WebSocket
 case class NavigateTo(page: Pages.SeqexecPages) extends Action
 case class NavigateSilentTo(page: Pages.SeqexecPages) extends Action
 case class SyncToPage(view: SequenceView) extends Action
+case class SyncToRunning(view: SequenceView) extends Action
+case class SyncPageToRemovedSequence(id: SequenceId) extends Action
+case class SyncPageToAddedSequence(i: Instrument, id: SequenceId) extends Action
 case class Initialize(site: SeqexecSite) extends Action
 
 // Actions to close and/open the login box

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
@@ -1,0 +1,63 @@
+package edu.gemini.seqexec.web.client.model
+
+
+import diode.Action
+import edu.gemini.seqexec.model.UserDetails
+import edu.gemini.seqexec.model.Model._
+import org.scalajs.dom.WebSocket
+
+
+// scalastyle:off
+// Actions
+case class NavigateTo(page: Pages.SeqexecPages) extends Action
+case class NavigateSilentTo(page: Pages.SeqexecPages) extends Action
+case class SyncToPage(view: SequenceView) extends Action
+case class Initialize(site: SeqexecSite) extends Action
+
+// Actions to close and/open the login box
+case object OpenLoginBox extends Action
+case object CloseLoginBox extends Action
+
+case class LoggedIn(u: UserDetails) extends Action
+case object Logout extends Action
+
+// Action to select a sequence for display
+case class SelectToDisplay(s: SequenceView) extends Action
+case class SelectIdToDisplay(id: SequenceId) extends Action
+case class SelectInstrumentToDisplay(i: Instrument) extends Action
+
+// Actions related to executing sequences
+case class RequestRun(s: SequenceId) extends Action
+case class RequestSync(s: SequenceId) extends Action
+case class RequestPause(s: SequenceId) extends Action
+case class RunStarted(s: SequenceId) extends Action
+case class RunPaused(s: SequenceId) extends Action
+case class RunSync(s: SequenceId) extends Action
+case class RunStartFailed(s: SequenceId) extends Action
+case class RunPauseFailed(s: SequenceId) extends Action
+case class RunSyncFailed(s: SequenceId) extends Action
+
+case class ShowStep(s: SequenceId, i: Int) extends Action
+case class UnShowStep(i: Instrument) extends Action
+
+case class AppendToLog(s: String) extends Action
+
+// Actions related to web sockets
+case class WSConnect(delay: Int) extends Action
+case object Connecting extends Action
+case class Connected(ws: WebSocket, delay: Int) extends Action
+case class ConnectionClosed(delay: Int) extends Action
+case class ConnectionError(s: String) extends Action
+case class ServerMessage(e: SeqexecEvent) extends Action
+
+// Temporal actions for UI prototyping
+case class FlipSkipStep(id: SequenceId, step: Step) extends Action
+case class FlipBreakpointStep(id: SequenceId, step: Step) extends Action
+case class UpdateObserver(id: SequenceId, name: String) extends Action
+case class UpdateOperator(name: String) extends Action
+case class UpdateImageQuality(iq: ImageQuality) extends Action
+case class UpdateCloudCover(cc: CloudCover) extends Action
+case class UpdateSkyBackground(sb: SkyBackground) extends Action
+case class UpdateWaterVapor(wv: WaterVapor) extends Action
+
+// scalastyle:on

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -2,7 +2,7 @@ package edu.gemini.seqexec.web.client.model
 
 import java.time.LocalTime
 
-import diode.{Action, RootModelR}
+import diode.RootModelR
 import diode.data.{Empty, Pot, RefTo}
 import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.model.Model._
@@ -18,63 +18,6 @@ object Pages {
   case object Root extends SeqexecPages
   case class InstrumentPage(instrument: Instrument, obsId: Option[SequenceId]) extends SeqexecPages
 }
-
-// Actions
-case class NavigateTo(page: Pages.SeqexecPages) extends Action
-case class NavigateSilentTo(page: Pages.SeqexecPages) extends Action
-case class SyncToPage(view: SequenceView) extends Action
-case class SyncToRunning(view: SequenceView) extends Action
-case class SyncPageToRemovedSequence(id: SequenceId) extends Action
-case class SyncPageToAddedSequence(i: Instrument, id: SequenceId) extends Action
-case class Initialize(site: SeqexecSite) extends Action
-
-// Actions to close and/open the login box
-case object OpenLoginBox extends Action
-case object CloseLoginBox extends Action
-
-case class LoggedIn(u: UserDetails) extends Action
-case object Logout extends Action
-
-// Action to select a sequence for display
-case class SelectToDisplay(s: SequenceView) extends Action
-case class SelectIdToDisplay(id: SequenceId) extends Action
-case class SelectInstrumentToDisplay(i: Instrument) extends Action
-
-// Actions related to executing sequences
-case class RequestRun(s: SequenceId) extends Action
-case class RequestSync(s: SequenceId) extends Action
-case class RequestPause(s: SequenceId) extends Action
-case class RunStarted(s: SequenceId) extends Action
-case class RunPaused(s: SequenceId) extends Action
-case class RunSync(s: SequenceId) extends Action
-case class RunStartFailed(s: SequenceId) extends Action
-case class RunPauseFailed(s: SequenceId) extends Action
-case class RunSyncFailed(s: SequenceId) extends Action
-
-case class ShowStep(s: SequenceId, i: Int) extends Action
-case class UnShowStep(i: Instrument) extends Action
-
-case class AppendToLog(s: String) extends Action
-
-// Actions related to web sockets
-case class WSConnect(delay: Int) extends Action
-case object Connecting extends Action
-case class Connected(ws: WebSocket, delay: Int) extends Action
-case class ConnectionClosed(delay: Int) extends Action
-case class ConnectionError(s: String) extends Action
-case class ServerMessage(e: SeqexecEvent) extends Action
-
-// Temporal actions for UI prototyping
-case class FlipSkipStep(id: SequenceId, step: Step) extends Action
-case class FlipBreakpointStep(id: SequenceId, step: Step) extends Action
-case class UpdateObserver(id: SequenceId, name: String) extends Action
-case class UpdateOperator(name: String) extends Action
-case class UpdateImageQuality(iq: ImageQuality) extends Action
-case class UpdateCloudCover(cc: CloudCover) extends Action
-case class UpdateSkyBackground(sb: SkyBackground) extends Action
-case class UpdateWaterVapor(wv: WaterVapor) extends Action
-
-// End Actions
 
 // UI model
 sealed trait SectionVisibilityState

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/align.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/align.scala
@@ -1,0 +1,16 @@
+package edu.gemini.seqexec.web.client.semanticui
+
+import scalaz.Equal
+
+sealed trait Aligned
+
+object Aligned {
+  case object None extends Aligned
+  case object Left extends Aligned
+  case object Center extends Aligned
+  case object Right extends Aligned
+
+  implicit val equal: Equal[Aligned] = Equal.equalA[Aligned]
+}
+
+trait SemanticUIAlign extends Aligned

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/message/CloseableMessage.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/message/CloseableMessage.scala
@@ -1,6 +1,7 @@
 package edu.gemini.seqexec.web.client.semanticui.elements.message
 
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconClose
+import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
 
@@ -47,5 +48,5 @@ object CloseableMessage extends Message {
     )
     .build
 
-  def apply(p: Props, children: VdomNode*) = component(p)(children: _*)
+  def apply(p: Props, children: VdomNode*): Unmounted[Props, Unit, Unit] = component(p)(children: _*)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/table/TableHeader.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/table/TableHeader.scala
@@ -16,7 +16,7 @@ object TableHeader {
   )
 
   object Props {
-    def zero = Props()
+    def zero: Props = Props()
   }
 
   private val component = ScalaComponent.builder[Props]("th")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/package.scala
@@ -2,7 +2,7 @@ package edu.gemini.seqexec.web.client
 
 import japgolly.scalajs.react.vdom.html_<^.VdomAttr
 
-package object semanticui {
+package object semanticui extends SemanticUISize with SemanticUIWidth with SemanticUIAlign {
   // Custom attributes used by SemanticUI
   val dataTab     = VdomAttr("data-tab")
   val dataTooltip = VdomAttr("data-tooltip")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/size.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/size.scala
@@ -1,0 +1,21 @@
+package edu.gemini.seqexec.web.client.semanticui
+
+import scalaz.Equal
+
+sealed trait Size
+
+object Size {
+  case object NotSized extends Size
+  case object Tiny extends Size
+  case object Mini extends Size
+  case object Medium extends Size
+  case object Small extends Size
+  case object Large extends Size
+  case object Big extends Size
+  case object Huge extends Size
+  case object Massive extends Size
+
+  implicit val equal: Equal[Size] = Equal.equalA[Size]
+}
+
+trait SemanticUISize extends Size

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/width.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/width.scala
@@ -1,20 +1,6 @@
 package edu.gemini.seqexec.web.client.semanticui
 
-import scalaz._
-
-sealed trait Size
-
-object Size {
-  case object NotSized extends Size
-  case object Tiny extends Size
-  case object Mini extends Size
-  case object Medium extends Size
-  case object Small extends Size
-  case object Large extends Size
-  case object Big extends Size
-  case object Huge extends Size
-  case object Massive extends Size
-}
+import scalaz.Equal
 
 sealed trait Width
 
@@ -40,13 +26,4 @@ object Width {
   implicit val equal: Equal[Width] = Equal.equalA[Width]
 }
 
-sealed trait Aligned
-
-object Aligned {
-  case object None extends Aligned
-  case object Left extends Aligned
-  case object Center extends Aligned
-  case object Right extends Aligned
-
-  implicit val equal: Equal[Aligned] = Equal.equalA[Aligned]
-}
+trait SemanticUIWidth extends Width

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/log.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/log.scala
@@ -10,9 +10,9 @@ object log {
 
     override def publish(record: LogRecord): Unit = {
       if (record.getLevel == Level.SEVERE) {
-        System.err.println(getFormatter.format(record))
+        System.err.println(getFormatter.format(record)) // scalastyle:ignore
       } else {
-        println(getFormatter.format(record))
+        println(getFormatter.format(record)) // scalastyle:ignore
       }
     }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -42,7 +42,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (server.EventQueue
   /**
     * Creates a process that sends a ping every second to keep the connection alive
     */
-  def pingProcess = {
+  private def pingProcess: Process[Task, Ping] = {
     import scalaz.stream.DefaultScheduler
     import scalaz.stream.time.awakeEvery
     import scalaz.concurrent.Strategy

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
@@ -1,7 +1,7 @@
 package edu.gemini.seqexec.web.server
 
 package object http4s {
-  def index(site: String, devMode: Boolean, builtAtMillis: Long) = {
+  def index(site: String, devMode: Boolean, builtAtMillis: Long): String = {
     val style = """
                   |   @media screen and (-webkit-min-device-pixel-ratio:0) {
                   |        select,
@@ -11,8 +11,8 @@ package object http4s {
                   |        }
                   |      }
                   |"""
-    val deps = if (devMode) "edu_gemini_seqexec_web_client-jsdeps.js" else s"edu_gemini_seqexec_web_client-jsdeps.min.${builtAtMillis}.js"
-    val seqexecScript = if (devMode) s"seqexec.js" else s"seqexec-opt.${builtAtMillis}.js"
+    val deps = if (devMode) "edu_gemini_seqexec_web_client-jsdeps.js" else s"edu_gemini_seqexec_web_client-jsdeps.min.$builtAtMillis.js"
+    val seqexecScript = if (devMode) s"seqexec.js" else s"seqexec-opt.$builtAtMillis.js"
     val xml =
       <html lang="en">
         <head>
@@ -22,17 +22,17 @@ package object http4s {
           <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
           <meta name="description" content={s"Seqexec - $site"}/>
           <meta name="author" content="Gemini Software Group"/>
-          <link rel="icon" href={s"/images/launcher.${builtAtMillis}.ico"}/>
+          <link rel="icon" href={s"/images/launcher.$builtAtMillis.ico"}/>
 
           <!-- Add to homescreen for Safari on iOS -->
           <meta name="apple-mobile-web-app-capable" content="yes"/>
           <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
           <meta name="apple-mobile-web-app-title" content="Seqexec"/>
-          <link rel="apple-touch-icon-precomposed" href={s"/images/launcher.${builtAtMillis}.png"}/>
+          <link rel="apple-touch-icon-precomposed" href={s"/images/launcher.$builtAtMillis.png"}/>
 
           <title>{s"Seqexec - $site"}</title>
 
-          <link rel="stylesheet" href={s"/css/semantic.${builtAtMillis}.css"}/>
+          <link rel="stylesheet" href={s"/css/semantic.$builtAtMillis.css"}/>
           <style>{style.stripMargin}</style>
         </head>
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/security/authentication.scala
@@ -50,7 +50,7 @@ case class AuthenticationConfig(devMode: Boolean, sessionLifeHrs: Time, cookieNa
 
 // Intermediate class to decode the claim stored in the JWT token
 case class JwtUserClaim(exp: Int, iat: Int, username: String, displayName: String) {
-  def toUserDetails = UserDetails(username, displayName)
+  def toUserDetails: UserDetails = UserDetails(username, displayName)
 }
 
 case class AuthenticationService(config: AuthenticationConfig) extends AuthService {

--- a/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUI.scala
+++ b/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUI.scala
@@ -58,7 +58,7 @@ object SemanticUI {
   object JsTabOptions extends JsTabOptionBuilder(noOpts)
 
   class JsTabOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsTabOptions, JsTabOptionBuilder](new JsTabOptionBuilder(_)) {
-    def onVisible[A, B](t: js.Function1[A, B]) = jsOpt("onVisible", t)
+    def onVisible[A, B](t: js.Function1[A, B]): JsTabOptionBuilder = jsOpt("onVisible", t)
   }
 
   @js.native

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 
 // Support making distributions
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M7")
+
+// Check the style with scalastyle
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,75 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Za-z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][a-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+ <!-- <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check> -->
+ <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <parameters>
+   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <!-- <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check> -->
+ <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <!-- <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check> -->
+ <!-- <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check> -->
+ <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+  <parameters>
+   <parameter name="ignoreOverride">true</parameter>
+  </parameters>
+ </check>
+
+  <check level="error" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"/>
+  <!-- <check level="error" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"/> -->
+  <!-- <check level="error" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true"/> -->
+  <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+  <!-- <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/> -->
+  <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"/>
+  <!-- <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/> -->
+  <!-- <check level="error" class="org.scalastyle.scalariform.TodoCommentChecker" enabled="true"/> -->
+  <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+  <check level="error" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"/>
+
+</scalastyle>


### PR DESCRIPTION
This PR establish the use of scalastyle along the settings used on the gem project. There are some refactorings (mostly breaking up large methods/files) to be able to pass as much of the rules as possible

In a few places a scalastyle ignore annotation has been used for example for large objects containing many type definitions