### PR TITLE
SEQNG-310: Sync action not refreshing

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
@@ -180,7 +180,7 @@ object SequenceControl {
                 color = Some("purple"),
                 dataTooltip = Some(s"Sync sequence"),
                 disabled = !isLogged || !isConnected || s.runRequested || s.syncRequested),
-              s" Synkeys"
+              s"Sync"
             ).when(status === SequenceState.Idle),
             Button(
               Button.Props(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -428,8 +428,8 @@ case class InstrumentStatusFocus(instrument: Instrument, active: Boolean, idStat
 case class StatusAndObserverFocus(isLogged: Boolean, name: Option[String], instrument: Instrument, id: Option[SequenceId], observer: Option[Observer]) extends UseValueEq
 case class StatusAndStepFocus(isLogged: Boolean, instrument: Instrument, stepConfigDisplayed: Option[Int]) extends UseValueEq
 case class StepsTableFocus(id: SequenceId, instrument: Instrument, steps: List[Step], stepConfigDisplayed: Option[Int], nextStepToRun: Option[Int]) extends UseValueEq
-case class ControlModel(id: SequenceId, isPartiallyExecuted: Boolean, nextStepToRun: Option[Int], status: SequenceState) extends UseValueEq
-case class SequenceControlFocus(isLogged: Boolean, isConnected: Boolean, control: Option[ControlModel]) extends UseValueEq
+case class ControlModel(id: SequenceId, isPartiallyExecuted: Boolean, nextStepToRun: Option[Int], status: SequenceState)
+case class SequenceControlFocus(isLogged: Boolean, isConnected: Boolean, control: Option[ControlModel])
 
 /**
   * Contains the model for Diode


### PR DESCRIPTION
This is a small change that will make the sequence buttons to re-render every time there is a change on the top model. While this maybe slower in practice there is no appreciable difference and it makes it update e.g. in the case there is a sync and there are no changes on the remote side