### PR TITLE
SEQNG-309 Fixed ordering of some GMOS keywords.

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosHeader.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosHeader.scala
@@ -19,8 +19,8 @@ case class GmosHeader(hs: DhsClient, gmosObsReader: GmosHeader.ObsKeywordsReader
     sendKeywords(id, inst, hs, List(
       buildInt32(tcsKeywordsReader.getGmosInstPort.orDefault, "INPORT"),
       buildString(gmosReader.ccName, "GMOSCC"),
-      buildBoolean(gmosObsReader.preimage.map(_.toBoolean), "PREIMAGE"),
-      buildString(tcsKeywordsReader.getUT.orDefault, "TIME-OBS"))
+      buildString(tcsKeywordsReader.getUT.orDefault, "TIME-OBS"),
+      buildBoolean(gmosObsReader.preimage.map(_.toBoolean), "PREIMAGE"))
       // TODO NOD*
     )
   }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -42,7 +42,6 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
       d <- dataId
       _ <- systems.odb.datasetStart(obsId, d, imageFileId)
     } yield ()
-
     def sendDataEnd(imageFileId: ImageFileId): SeqAction[Unit] = for {
       d <- dataId
       _ <- systems.odb.datasetComplete(obsId, d, imageFileId)
@@ -56,7 +55,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
       _ <- sendDataStart(id)
       _ <- headers(ctx).map(_.sendBefore(id, inst.dhsInstrumentName)).sequenceU
       _ <- inst.observe(config)(id)
-      _ <- headers(ctx).map(_.sendAfter(id, inst.dhsInstrumentName)).sequenceU
+      _ <- headers(ctx).reverseMap(_.sendAfter(id, inst.dhsInstrumentName)).sequenceU
       _ <- closeImage(id, systems.dhs)
       _ <- sendDataEnd(id)
     } yield ObserveResult(id)
@@ -109,6 +108,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
       headers   <- calcHeaders(config, stepType)
       resources <- calcResources(stepType)
     } yield buildStep(inst, systems, headers, resources)
+
   }
 
   private def extractInstrumentName(config: Config): SeqexecFailure \/ edu.gemini.seqexec.model.Model.Instrument =


### PR DESCRIPTION
There is one change affects all instruments. The "after" keywords are now send in the reverse order, which means the late instrument keywords sent by Seqexec will go before the TCS keywords. That is the same ordering for keywords sent by the instrument itself.