### PR TITLE
SEQNG-288: Completed observations should remain

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -5,7 +5,7 @@ package edu.gemini.seqexec.web.client.components.sequence
 
 import diode.react.ModelProxy
 import edu.gemini.seqexec.model.Model.{SequenceState, SeqexecSite}
-import edu.gemini.seqexec.web.client.model.{InstrumentStatusFocus, NavigateTo, SelectIdToDisplay, SelectInstrumentToDisplay}
+import edu.gemini.seqexec.web.client.model.{InstrumentStatusFocus, NavigateTo, SelectInstrumentToDisplay}
 import edu.gemini.seqexec.web.client.model.Pages.InstrumentPage
 import edu.gemini.seqexec.web.client.model.SeqexecCircuit
 import edu.gemini.seqexec.web.client.semanticui._
@@ -69,8 +69,6 @@ object InstrumentTab {
             .onVisible { (x: String) =>
               val instrument = ctx.props.site.instruments.list.toList.find(_.shows === x)
               val updateModelCB = (ctx.props.t().idState, instrument) match {
-                case (Some((id, _)), Some(i)) =>
-                  ctx.props.t.dispatchCB(NavigateTo(InstrumentPage(i, id.some))) >> ctx.props.t.dispatchCB(SelectIdToDisplay(id))
                 case (_, Some(i))             =>
                   ctx.props.t.dispatchCB(NavigateTo(InstrumentPage(i, none))) >> ctx.props.t.dispatchCB(SelectInstrumentToDisplay(i))
                 case _                        =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -37,6 +37,10 @@ object InstrumentTab {
       val hasError = status.exists(SequenceState.isError)
       val sequenceId = tab.idState.map(_._1)
       val instrument = tab.instrument
+      val tabTitle = tab.runningStep match {
+        case Some((current, total)) => s"${~sequenceId} - ${current + 1}/$total"
+        case _                      => ~sequenceId
+      }
       val icon = status.flatMap {
         case SequenceState.Running   => IconCircleNotched.copyIcon(loading = true).some
         case SequenceState.Completed => IconCheckmark.some
@@ -57,7 +61,7 @@ object InstrumentTab {
         SeqexecStyles.errorTab.when(hasError),
         dataTab := instrument.shows,
         IconAttention.copyIcon(color = Some("red")).when(hasError),
-        sequenceId.map(id => <.div(<.div(SeqexecStyles.activeInstrumentLabel, instrument.shows), Label(Label.Props(id, color = color, icon = icon)))).getOrElse(instrument.shows)
+        sequenceId.fold(instrument.shows: VdomNode){ _ => <.div(<.div(SeqexecStyles.activeInstrumentLabel, instrument.shows), Label(Label.Props(tabTitle, color = color, icon = icon)))}
       )
     }.componentDidMount(ctx =>
       Callback {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -62,7 +62,7 @@ object SequenceTabContent {
   private val component = ScalaComponent.builder[Props]("SequenceTabContent")
     .stateless
     .render_P { p =>
-      val InstrumentStatusFocus(instrument, active, id) = p.p()
+      val InstrumentStatusFocus(instrument, active, id, _) = p.p()
       <.div(
         ^.cls := "ui bottom attached tab segment",
         ^.classSet(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceToolbars.scala
@@ -8,6 +8,7 @@ import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.model.ModelOps._
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
+import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.seqexec.web.client.semanticui.elements.input.InputEV
 import edu.gemini.seqexec.web.client.semanticui.elements.label.{FormLabel, Label}
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
@@ -174,10 +175,7 @@ object SequenceControl {
           val runContinueTooltip = s"${isPartiallyExecuted ? "Continue" | "Run"} the sequence from the step $nextStepToRun"
           val runContinueButton = s"${isPartiallyExecuted ? "Continue" | "Run"} from step $nextStepToRun"
           List(
-            <.h3(
-              ^.cls := "ui green header",
-              "Sequence complete"
-            ).when(status === SequenceState.Completed),
+            Label(Label.Props("Sequence Complete", color = "green".some, icon = IconCheckmark.some, size = Size.Big)).when(status === SequenceState.Completed),
             // Sync button
             controlButton(IconRefresh, "purple", $.runState(requestSync(id)), !isLogged || !isConnected || s.runRequested || s.syncRequested, "Sync sequence", "Sync")
               .when(status === SequenceState.Idle),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -454,7 +454,7 @@ case class WebSocketsFocus(sequences: LoadedSequences, user: Option[UserDetails]
 case class SequenceInQueue(id: SequenceId, status: SequenceState, instrument: Instrument, active: Boolean, name: String, runningStep: Option[(Int, Int)]) extends UseValueEq
 case class StatusAndLoadedSequencesFocus(isLogged: Boolean, sequences: List[SequenceInQueue]) extends UseValueEq
 case class HeaderSideBarFocus(status: ClientStatus, conditions: Conditions, operator: Option[Operator]) extends UseValueEq
-case class InstrumentStatusFocus(instrument: Instrument, active: Boolean, idState: Option[(SequenceId, SequenceState)]) extends UseValueEq
+case class InstrumentStatusFocus(instrument: Instrument, active: Boolean, idState: Option[(SequenceId, SequenceState)], runningStep: Option[(Int, Int)]) extends UseValueEq
 case class StatusAndObserverFocus(isLogged: Boolean, name: Option[String], instrument: Instrument, id: Option[SequenceId], observer: Option[Observer]) extends UseValueEq
 case class StatusAndStepFocus(isLogged: Boolean, instrument: Instrument, stepConfigDisplayed: Option[Int]) extends UseValueEq
 case class StepsTableFocus(id: SequenceId, instrument: Instrument, steps: List[Step], stepConfigDisplayed: Option[Int], nextStepToRun: Option[Int]) extends UseValueEq
@@ -501,7 +501,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
 
   def instrumentStatusReader(i: Instrument): ModelR[SeqexecAppRootModel, InstrumentStatusFocus] =
     zoom(_.uiModel.sequencesOnDisplay.instrument(i)).zoom {
-      case (tab, active) => InstrumentStatusFocus(tab.instrument, active, tab.sequence.map(s => (s.id, s.status)))
+      case (tab, active) => InstrumentStatusFocus(tab.instrument, active, tab.sequence.map(s => (s.id, s.status)), tab.sequence.flatMap(_.runningStep))
     }
 
   private def instrumentTab(i: Instrument): ModelR[SeqexecAppRootModel, (SequenceTab, Boolean)] = zoom(_.uiModel.sequencesOnDisplay.instrument(i))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/SeqexecCircuit.scala
@@ -201,14 +201,14 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, (SequencesOnDisplay, LoadedS
       updated(value.copy(_1 = value._1.withSite(site), _3 = site))
 
     case ShowStep(s, i) =>
-      if (value._1.instrumentSequences.focus.sequence().exists(_.id === s)) {
+      if (value._1.instrumentSequences.focus.sequence.exists(_.id === s)) {
         updated(value.copy(_1 = value._1.showStep(i)))
       } else {
         noChange
       }
 
     case UnShowStep(instrument) =>
-      if (value._1.instrumentSequences.focus.sequence().exists(_.metadata.instrument == instrument)) {
+      if (value._1.instrumentSequences.focus.sequence.exists(_.metadata.instrument == instrument)) {
         updated(value.copy(_1 = value._1.unshowStep))
       } else {
         noChange
@@ -501,14 +501,14 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
 
   def instrumentStatusReader(i: Instrument): ModelR[SeqexecAppRootModel, InstrumentStatusFocus] =
     zoom(_.uiModel.sequencesOnDisplay.instrument(i)).zoom {
-      case (tab, active) => InstrumentStatusFocus(tab.instrument, active, tab.sequence().map(s => (s.id, s.status)))
+      case (tab, active) => InstrumentStatusFocus(tab.instrument, active, tab.sequence.map(s => (s.id, s.status)))
     }
 
   private def instrumentTab(i: Instrument): ModelR[SeqexecAppRootModel, (SequenceTab, Boolean)] = zoom(_.uiModel.sequencesOnDisplay.instrument(i))
 
   def sequenceObserverReader(i: Instrument): ModelR[SeqexecAppRootModel, StatusAndObserverFocus] =
     statusReader.zip(instrumentTab(i)).zoom {
-      case (status, (tab, _)) => StatusAndObserverFocus(status.isLogged, tab.sequence().map(_.metadata.name), i, tab.sequence().map(_.id), tab.sequence().flatMap(_.metadata.observer))
+      case (status, (tab, _)) => StatusAndObserverFocus(status.isLogged, tab.sequence.map(_.metadata.name), i, tab.sequence.map(_.id), tab.sequence.flatMap(_.metadata.observer))
     }
 
   def statusAndStepReader(i: Instrument): ModelR[SeqexecAppRootModel, StatusAndStepFocus] =
@@ -519,7 +519,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   def stepsTableReader(i: Instrument): ModelR[SeqexecAppRootModel, (ClientStatus, Option[StepsTableFocus])] =
     statusReader.zip(instrumentTab(i)).zoom {
       case (status, (tab, _)) =>
-        (status, tab.sequence().map { sequence =>
+        (status, tab.sequence.map { sequence =>
           StepsTableFocus(sequence.id, i, sequence.steps, tab.stepConfigDisplayed, sequence.nextStepToRun)
         })
     }
@@ -527,7 +527,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   def sequenceControlReader(i: Instrument): ModelR[SeqexecAppRootModel, SequenceControlFocus] =
     statusReader.zip(instrumentTab(i)).zoom {
       case (status, (tab, _)) =>
-        SequenceControlFocus(status.isLogged, status.isConnected, tab.sequence().map(s => ControlModel(s.id, s.isPartiallyExecuted, s.nextStepToRun, s.status)))
+        SequenceControlFocus(status.isLogged, status.isConnected, tab.sequence.map(s => ControlModel(s.id, s.isPartiallyExecuted, s.nextStepToRun, s.status)))
     }
 
   // Reader for a specific sequence if available

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
@@ -28,7 +28,6 @@ case class LoggedIn(u: UserDetails) extends Action
 case object Logout extends Action
 
 // Action to select a sequence for display
-case class SelectToDisplay(s: SequenceView) extends Action
 case class SelectIdToDisplay(id: SequenceId) extends Action
 case class SelectInstrumentToDisplay(i: Instrument) extends Action
 
@@ -45,6 +44,7 @@ case class RunSyncFailed(s: SequenceId) extends Action
 
 case class ShowStep(s: SequenceId, i: Int) extends Action
 case class UnShowStep(i: Instrument) extends Action
+case class RememberCompleted(s: SequenceView) extends Action
 
 case class AppendToLog(s: String) extends Action
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -31,16 +31,20 @@ object SectionVisibilityState {
   implicit val eq = Equal.equalA[SectionVisibilityState]
 }
 
-case class SequenceTab(instrument: Instrument, sequence: RefTo[Option[SequenceView]], stepConfigDisplayed: Option[Int])
+case class SequenceTab(instrument: Instrument, currentSequence: RefTo[Option[SequenceView]], completedSequence: Option[SequenceView], stepConfigDisplayed: Option[Int]) {
+  // Returns the current sequence or if empty the last completed one
+  // This must be a def since it calls to deferrence RefTo
+  def sequence: Option[SequenceView] = currentSequence().orElse(completedSequence)
+}
 
 object SequenceTab {
-  val empty = SequenceTab(F2, RefTo(new RootModelR(None)), None)
+  val empty = SequenceTab(F2, RefTo(new RootModelR(None)), None, None)
 }
 
 // Model for the tabbed area of sequences
 case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
   def withSite(site: SeqexecSite): SequencesOnDisplay =
-    SequencesOnDisplay(site.instruments.map(SequenceTab(_, SequencesOnDisplay.emptySeqRef, None)).toZipper)
+    SequencesOnDisplay(site.instruments.map(SequenceTab(_, SequencesOnDisplay.emptySeqRef, None, None)).toZipper)
 
   // Display a given step on the focused sequence
   def showStep(i: Int): SequencesOnDisplay =
@@ -52,7 +56,7 @@ case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
 
   def focusOnSequence(s: RefTo[Option[SequenceView]]): SequencesOnDisplay = {
     // Replace the sequence for the instrument and focus
-    val q = instrumentSequences.findZ(i => s().exists(_.metadata.instrument === i.instrument)).map(_.modify(_.copy(sequence = s)))
+    val q = instrumentSequences.findZ(i => s().exists(_.metadata.instrument === i.instrument)).map(_.modify(_.copy(currentSequence = s)))
     copy(instrumentSequences = q | instrumentSequences)
   }
 
@@ -62,11 +66,11 @@ case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
     copy(instrumentSequences = q | instrumentSequences)
   }
 
-  def isAnySelected: Boolean = instrumentSequences.toStream.exists(_.sequence().isDefined)
+  def isAnySelected: Boolean = instrumentSequences.toStream.exists(_.sequence.isDefined)
 
   // Is the id on the sequences area?
   def idDisplayed(id: SequenceId): Boolean =
-    instrumentSequences.withFocus.toStream.find { case (s, a) => a && s.sequence().exists(_.id === id)}.isDefined
+    instrumentSequences.withFocus.toStream.find { case (s, a) => a && s.sequence.exists(_.id === id)}.isDefined
 
   def instrument(i: Instrument): (SequenceTab, Boolean) =
     // The getOrElse shouldn't be called as we have an element per instrument
@@ -80,7 +84,7 @@ object SequencesOnDisplay {
   val emptySeqRef: RefTo[Option[SequenceView]] = RefTo(new RootModelR(None))
 
   // We need to initialize the model with some instruments but it will be shortly replaced by the actual list
-  val empty = SequencesOnDisplay(Instrument.gsInstruments.map(SequenceTab(_, emptySeqRef, None)).toZipper)
+  val empty = SequencesOnDisplay(Instrument.gsInstruments.map(SequenceTab(_, emptySeqRef, None, None)).toZipper)
 }
 
 case class WebSocketConnection(ws: Pot[WebSocket], nextAttempt: Int)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -55,7 +55,7 @@ case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
     copy(instrumentSequences = instrumentSequences.modify(_.copy(stepConfigDisplayed = None)))
 
   def focusOnSequence(s: RefTo[Option[SequenceView]]): SequencesOnDisplay = {
-    // Replace the sequence for the instrument and focus
+    // Replace the sequence for the instrument or the completed sequence
     val q = instrumentSequences.findZ(i => s().exists(_.metadata.instrument === i.instrument)).map(_.modify(_.copy(currentSequence = s)))
     copy(instrumentSequences = q | instrumentSequences)
   }
@@ -75,6 +75,12 @@ case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
   def instrument(i: Instrument): (SequenceTab, Boolean) =
     // The getOrElse shouldn't be called as we have an element per instrument
     instrumentSequences.withFocus.toStream.find(_._1.instrument === i).getOrElse((SequenceTab.empty, false))
+
+  // We'll set the passed SequenceView as completed for the given instruments
+  def markCompleted(completed: SequenceView): SequencesOnDisplay = {
+    val q = instrumentSequences.findZ(s => s.instrument === completed.metadata.instrument).map(_.modify(_.copy(completedSequence = completed.some)))
+    copy(instrumentSequences = q | instrumentSequences)
+  }
 }
 
 /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -33,7 +33,7 @@ object SectionVisibilityState {
 
 case class SequenceTab(instrument: Instrument, currentSequence: RefTo[Option[SequenceView]], completedSequence: Option[SequenceView], stepConfigDisplayed: Option[Int]) {
   // Returns the current sequence or if empty the last completed one
-  // This must be a def since it calls to deferrence RefTo
+  // This must be a def since it will do a call to dereference a RefTo
   def sequence: Option[SequenceView] = currentSequence().orElse(completedSequence)
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
@@ -3,6 +3,7 @@
 
 package edu.gemini.seqexec.web.client.semanticui.elements.label
 
+import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
@@ -14,6 +15,7 @@ object Label {
     color  : Option[String] = None,
     tag    : Boolean = false,
     basic  : Boolean = false,
+    size   : Size = Size.NotSized,
     icon   : Option[Icon] = None)
 
   private val component = ScalaComponent.builder[Props]("Label")
@@ -22,8 +24,15 @@ object Label {
       <.label(
         ^.cls := "ui label",
         ^.classSet(
-          "basic" -> p.basic,
-          "tag"   -> p.tag
+          "basic"   -> p.basic,
+          "tag"     -> p.tag,
+          "tiny"    -> (p.size == Size.Tiny),
+          "mini"    -> (p.size == Size.Mini),
+          "small"   -> (p.size == Size.Small),
+          "large"   -> (p.size == Size.Large),
+          "big"     -> (p.size == Size.Big),
+          "huge"    -> (p.size == Size.Huge),
+          "massive" -> (p.size == Size.Massive)
         ),
         p.color.map(u => ^.cls := u).whenDefined,
         ^.htmlFor :=? p.htmlFor,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -33,14 +33,14 @@ trait ArbitrariesWebClient extends ArbitrariesWebCommon {
         i   <- arbitrary[Instrument]
         idx <- arbitrary[Option[Int]]
         sv  <- arbitrary[Option[SequenceView]]
-      } yield SequenceTab(i, RefTo(new RootModelR(sv.map(k => k.copy(metadata = k.metadata.copy(instrument = i))))), idx)
+      } yield SequenceTab(i, RefTo(new RootModelR(sv.map(k => k.copy(metadata = k.metadata.copy(instrument = i))))), None, idx)
     }
 
   implicit val arbSequenceOnDisplay: Arbitrary[SequencesOnDisplay] =
     Arbitrary {
       for {
         s <- Gen.nonEmptyListOf(arbitrary[SequenceTab])
-        if s.exists(_.sequence().isDefined)
+        if s.exists(_.sequence.isDefined)
       } yield {
         val sequences = NonEmptyList(s.head, s.tail: _*)
         SequencesOnDisplay(sequences.toZipper)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SequenceDisplayHandlerSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/test/scala/edu/gemini/seqexec/web/client/model/SequenceDisplayHandlerSpec.scala
@@ -18,7 +18,7 @@ class SequenceDisplayHandlerSpec extends FlatSpec with Matchers with PropertyChe
   "SequenceDisplayHandler" should "ignore setting a sequence for an unknown sequence" in {
     forAll { (sequence: SequenceView) =>
       val handler = new SequenceDisplayHandler(new RootModelRW((SequencesOnDisplay.empty, SeqexecUIModel.noSequencesLoaded, SeqexecSite.SeqexecGS)))
-      val result = handler.handle(SelectToDisplay(sequence))
+      val result = handler.handle(SelectIdToDisplay(sequence.id))
       result should matchPattern {
         case ModelUpdate((SequencesOnDisplay(t), _, _)) if t.findNext(_.sequence === SeqexecCircuit.sequenceRef(sequence.id)).isEmpty =>
       }


### PR DESCRIPTION
This PR changes the logic on the UI to keep completed sequences on the sequences table when completed though they get removed from the queue table as seen below

![screenshot 2017-08-16 15 10 28](https://user-images.githubusercontent.com/3615303/29382775-1fd74540-82a4-11e7-805a-6ddfabefd8fa.png)

This was tricky because the state is removed from the server so we have to keep an extra copy on the client. This also mean that the completed sequence will disappear on a page refresh but that's likely ok

I added a small improvement to the tabs displaying the current running step

![screenshot 2017-08-16 16 39 07](https://user-images.githubusercontent.com/3615303/29382855-5f18f3b6-82a4-11e7-921b-f5c149a999eb.png)
