### PR TITLE
SEQNG-319: Use sbt-git to generate the application version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,20 @@ parallelExecution in (ThisBuild, Test) := false
 
 cancelable in Global := true
 
+// Settings to use git to define the version of the project
+enablePlugins(GitVersioning)
+
+git.useGitDescribe := true
+
+git.formattedShaVersion := git.gitHeadCommit.value map { sha => s"v$sha" }
+
+git.uncommittedSignifier in ThisBuild := Some("UNCOMMITTED")
+
+enablePlugins(GitBranchPrompt)
+
+//////////////
+// Projects
+//////////////
 lazy val edu_gemini_web_server_common = project
   .in(file("modules/edu.gemini.web.server.common"))
   .settings(commonSettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,9 @@ addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "0.8.0")
 
 // add and check headers
 addSbtPlugin("de.heikoseeberger" % "sbt-header"             % "2.0.0")
+
+// Built the version out of git
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+
+// Avoids a warning message when starting sbt-git
+libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
With this PR I propose that we use [sbt-git](https://github.com/sbt/sbt-git) to generate the version number. This is based on tags and what is provided by [git-describe](https://git-scm.com/docs/git-describe)

The benefit is that our public version will always match what software version on github as we often forget to update the version number or even release uncommited changes. The UI gets the actual version number too

<img width="338" alt="screenshot 2017-08-18 08 29 12" src="https://user-images.githubusercontent.com/3615303/29458494-e1f49450-83f5-11e7-9a52-a50cac7be67e.png">
