### PR TITLE
SEQNG-318: Enable debugging on the seqexec JVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -245,15 +245,18 @@ lazy val seqexecCommonSettings = Seq(
     // -J params will be added as jvm parameters
     "-J-Xmx512m",
     "-J-Xms256m",
-    "-J-Xms256m",
+    // Support remote JMX access
     "-J-Dcom.sun.management.jmxremote",
     "-J-Dcom.sun.management.jmxremote.authenticate=false",
     "-J-Dcom.sun.management.jmxremote.port=2407",
     "-J-Dcom.sun.management.jmxremote.ssl=false",
-    "-J-Djava.net.preferIPv4Stack=true",
-    "-J-Dnetworkaddress.cache.ttl=60",
+    // Ensure the local is correctly set
     "-J-Duser.language=en",
-    "-J-Duser.country=US"
+    "-J-Duser.country=US",
+    // Support remote debugging
+    "-J-Xdebug",
+    "-J-Xnoagent",
+    "-J-Xrunjdwp:transport=dt_socket,address=8457,server=y,suspend=n"
   )
 ) ++ commonSettings
 

--- a/build.sbt
+++ b/build.sbt
@@ -245,8 +245,15 @@ lazy val seqexecCommonSettings = Seq(
     // -J params will be added as jvm parameters
     "-J-Xmx512m",
     "-J-Xms256m",
-    // Logging configuration
-    "-Dlogback.configurationFil=${app_home}/../conf/logback.xml"
+    "-J-Xms256m",
+    "-J-Dcom.sun.management.jmxremote",
+    "-J-Dcom.sun.management.jmxremote.authenticate=false",
+    "-J-Dcom.sun.management.jmxremote.port=2407",
+    "-J-Dcom.sun.management.jmxremote.ssl=false",
+    "-J-Djava.net.preferIPv4Stack=true",
+    "-J-Dnetworkaddress.cache.ttl=60",
+    "-J-Duser.language=en",
+    "-J-Duser.country=US"
   )
 ) ++ commonSettings
 


### PR DESCRIPTION
Add jvm configuration properties to support remote monitoring via JMX and remote debugging. This has been already tested on seqexec-gs-test