### PR TITLE
SEQNG-322: Add an appender to forward messages to the client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,6 +204,7 @@ lazy val edu_gemini_seqexec_model = crossProject.crossType(CrossType.Pure)
   .jsSettings(commonJSSettings)
   .jsSettings(
     // And add a custom one
+    libraryDependencies += JavaTimeJS.value,
     addCompilerPlugin("org.scala-js" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.patch)
   )
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -10,6 +10,8 @@ import monocle.{Lens, Prism}
 import monocle.macros.GenLens
 import monocle.Traversal
 
+import java.time.Instant
+
 object Model {
   // We use this to avoid a dependency on spModel, should be replaced by gem
   sealed trait SeqexecSite {
@@ -28,6 +30,13 @@ object Model {
       case SeqexecGN => "GN"
       case SeqexecGS => "GS"
     })
+  }
+
+  sealed trait ServerLogLevel
+  object ServerLogLevel {
+    case object INFO extends ServerLogLevel
+    case object WARN extends ServerLogLevel
+    case object ERROR extends ServerLogLevel
   }
 
   sealed trait SeqexecEvent
@@ -66,9 +75,10 @@ object Model {
     // Generic update. It will probably become useless if we have a special Event for every case.
     case class SequenceUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
-    // TODO: msg should be LogMsg bit it does IO when getting a timestamp, it
+    // TODO: msg should be LogMsg but it does IO when getting a timestamp, it
     // has to be embedded in a `Task`
     case class NewLogMessage(msg: String) extends SeqexecEvent
+    case class ServerLogMessage(level: ServerLogLevel, timestamp: Instant, msg: String) extends SeqexecEvent
     case object NullEvent extends SeqexecEvent
 
     // Some useful Monocle lenses

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -7,6 +7,8 @@ import boopickle.Default._
 import edu.gemini.seqexec.model.Model._
 import edu.gemini.seqexec.model.Model.SeqexecEvent._
 
+import java.time.Instant
+
 /**
   * Contains boopickle implicit picklers of model objects
   * Boopickle can auto derived encoders but it is preferred to make
@@ -42,6 +44,13 @@ trait ModelBooPicklers {
 
   implicit val stepConfigPickler = generatePickler[SequenceView]
 
+  implicit val datePickler = transformPickler((t: Long) => Instant.ofEpochMilli(t))(_.toEpochMilli)
+
+  implicit val serverLogLevelPickler = compositePickler[ServerLogLevel]
+    .addConcreteType[ServerLogLevel.INFO.type]
+    .addConcreteType[ServerLogLevel.WARN.type]
+    .addConcreteType[ServerLogLevel.ERROR.type]
+
   implicit val sequenceQueueIdPickler = generatePickler[SequencesQueue[SequenceId]]
 
   // Composite pickler for the seqexec event hierarchy
@@ -59,6 +68,7 @@ trait ModelBooPicklers {
     .addConcreteType[SequenceUpdated]
     .addConcreteType[SequenceRefreshed]
     .addConcreteType[NewLogMessage]
+    .addConcreteType[ServerLogMessage]
     .addConcreteType[NullEvent.type]
     .addConcreteType[ObserverUpdated]
     .addConcreteType[OperatorUpdated]

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SeqexecEventPrismSpec.scala
@@ -24,6 +24,7 @@ class SeqexecEventPrismSpec extends FlatSpec with Matchers with PropertyChecks {
           case e: SeqexecModelUpdate if e.view.queue.isEmpty =>
           case e: ConnectionOpenEvent                        =>
           case e: NewLogMessage                              =>
+          case e: ServerLogMessage                           =>
           case NullEvent                                     =>
         }
       }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
@@ -7,6 +7,7 @@ import Model._
 import Model.SeqexecEvent._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
+import java.time.Instant
 
 // Keep the arbitraries in a separate trait to improve caching
 object SharedModelArbitraries {
@@ -21,6 +22,13 @@ object SharedModelArbitraries {
       // Let's reduce the test space by only testing the list of items
     } yield SequencesQueue(Conditions.default, Some("operator"), b)
   }
+
+  implicit val instArb: Arbitrary[Instant] = Arbitrary {
+    for {
+      i <- Gen.choose(0L, Long.MaxValue)
+    } yield Instant.ofEpochMilli(i)
+  }
+  implicit val levArb = Arbitrary(Gen.oneOf(ServerLogLevel.INFO, ServerLogLevel.WARN, ServerLogLevel.ERROR))
 
   implicit val udArb  = implicitly[Arbitrary[UserDetails]]
   implicit val svArb  = implicitly[Arbitrary[SequenceView]]
@@ -37,6 +45,7 @@ object SharedModelArbitraries {
   implicit val smeArb = implicitly[Arbitrary[StepSkipMarkChanged]]
   implicit val speArb = implicitly[Arbitrary[SequencePauseRequested]]
   implicit val lmArb  = implicitly[Arbitrary[NewLogMessage]]
+  implicit val slmArb = implicitly[Arbitrary[ServerLogMessage]]
   implicit val neArb  = implicitly[Arbitrary[NullEvent.type]]
   implicit val opArb  = implicitly[Arbitrary[OperatorUpdated]]
   implicit val obArb  = implicitly[Arbitrary[ObserverUpdated]]

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/logback.xml
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/logback.xml
@@ -9,6 +9,7 @@
  It supports auto reloading scanning every 60s
 -->
 <configuration scan="true" scanPeriod="60 seconds">
+  <logger name="org.http4s" level="INFO"/>
 
   <if condition='property("HOSTNAME").contains("seqexec")'>
     <!-- Configuration when running on the test or production servers -->

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -4,6 +4,8 @@
 package edu.gemini.seqexec.web.server.http4s
 
 import org.log4s._
+import ch.qos.logback.core.Appender
+import ch.qos.logback.classic.spi.ILoggingEvent
 
 import edu.gemini.seqexec.engine
 import edu.gemini.seqexec.server
@@ -128,23 +130,30 @@ object WebServerLauncher extends ProcessApp with LogInitialization {
 
   // We need to manually update the configuration of the logging subsystem
   // to support capturing log messages and forward them to the clients
-  def logToClients(out: Topic[SeqexecEvent]): Task[AppenderForClients] = Task.delay {
+  def logToClients(out: Topic[SeqexecEvent]): Task[Appender[ILoggingEvent]] = Task.delay {
     import org.slf4j.LoggerFactory
     import ch.qos.logback.classic.LoggerContext
     import ch.qos.logback.classic.Logger
+    import ch.qos.logback.classic.AsyncAppender
 
+    val asyncAppender = new AsyncAppender
     val appender = new AppenderForClients(out)
     Option(LoggerFactory.getILoggerFactory()).collect {
       case lc: LoggerContext => lc
-    }.foreach(appender.setContext)
+    }.foreach { ctx =>
+      asyncAppender.setContext(ctx)
+      appender.setContext(ctx)
+      asyncAppender.addAppender(appender)
+    }
 
     Option(LoggerFactory.getLogger("edu.gemini.seqexec")).collect {
       case l: Logger => l
     }.foreach { l =>
-      l.addAppender(appender)
+      l.addAppender(asyncAppender)
+      asyncAppender.start()
       appender.start()
     }
-    appender
+    asyncAppender
   }
 
   /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/logging/AppenderForClients.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/logging/AppenderForClients.scala
@@ -1,14 +1,37 @@
 package edu.gemini.seqexec.web.server.logging
 
 import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.Level
 import ch.qos.logback.core.AppenderBase
+import edu.gemini.seqexec.model.Model.{ServerLogLevel, SeqexecEvent}
+import edu.gemini.seqexec.model.Model.SeqexecEvent.ServerLogMessage
+import scalaz.stream.async.mutable.Topic
+
+import scalaz._
+import Scalaz._
+import scalaz.concurrent.Task
+
+import java.time.Instant
 
 /**
  * Custom appender that can take log events from logback and send them
  * to clients via the common pipe/WebSockets
+ *
+ * This is out of the scala/http4s loop
  */
-class AppenderForClients extends AppenderBase[ILoggingEvent] {
+class AppenderForClients(out: Topic[SeqexecEvent]) extends AppenderBase[ILoggingEvent] {
   override def append(event: ILoggingEvent): Unit = {
-    println("Event " + event)
+    // Convert to a seqexec model to send to clients
+    val level = event.getLevel match {
+      case Level.INFO  => ServerLogLevel.INFO.some
+      case Level.WARN  => ServerLogLevel.WARN.some
+      case Level.ERROR => ServerLogLevel.ERROR.some
+      case _           => none
+    }
+    val timestamp = Instant.ofEpochMilli(event.getTimeStamp)
+
+    // Send a message to the clients if level is INFO or higher
+    // We are outside the normal execution loop, thus we need to call unsafePerformSync directly
+    level.fold(Task.now(()))(l => out.publishOne(ServerLogMessage(l, timestamp, event.getMessage))).unsafePerformSync
   }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/logging/AppenderForClients.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/logging/AppenderForClients.scala
@@ -1,0 +1,14 @@
+package edu.gemini.seqexec.web.server.logging
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+
+/**
+ * Custom appender that can take log events from logback and send them
+ * to clients via the common pipe/WebSockets
+ */
+class AppenderForClients extends AppenderBase[ILoggingEvent] {
+  override def append(event: ILoggingEvent): Unit = {
+    println("Event " + event)
+  }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/logging/AppenderForClients.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/logging/AppenderForClients.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package edu.gemini.seqexec.web.server.logging
 
 import ch.qos.logback.classic.spi.ILoggingEvent


### PR DESCRIPTION
A custom logback appender is created to send some of the log messages of the server to the client. This requires a bit of hackery as this is a java API that doesn't fit too well with the rest of the scala structure

The messages sent to the client have a certain structure (level, timestamp, msg) to eventually let clients to filter and sort messages on the UI