### PR TITLE
SEQNG-335: Unify the models for Instrument

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Resource.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Resource.scala
@@ -2,33 +2,3 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package edu.gemini.seqexec.engine
-
-/**
-  * A Seqexec resource represents any system that can be only used by one single agent.
-  *
-  */
-sealed trait Resource
-
-object Resource {
-
-  case object P1 extends Resource
-  case object OI extends Resource
-  // Mount and science fold cannot be controlled independently. Maybe in the future.
-  // For now, I replaced them with TCS
-//  case object Mount extends Resource
-//  case object ScienceFold extends Resource
-  case object TCS extends Resource
-  case object Gcal extends Resource
-  case object Gems extends Resource
-  case object Altair extends Resource
-  trait Instrument extends Resource
-  case object GMOS_S extends Instrument
-  case object GMOS_N extends Instrument
-  case object F2 extends Instrument
-  case object GSAOI extends Instrument
-  case object GPI extends Instrument
-  case object NIRI extends Instrument
-  case object NIFS extends Instrument
-  case object GNIRS extends Instrument
-
-}

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -3,7 +3,7 @@
 
 package edu.gemini.seqexec.engine
 
-import edu.gemini.seqexec.model.Model.{SequenceMetadata, SequenceState, StepState}
+import edu.gemini.seqexec.model.Model.{Resource, SequenceMetadata, SequenceState, StepState}
 import edu.gemini.seqexec.engine.Step._
 
 import scalaz._

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Step.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Step.scala
@@ -3,7 +3,7 @@
 
 package edu.gemini.seqexec.engine
 
-import edu.gemini.seqexec.model.Model.{StepConfig, StepState}
+import edu.gemini.seqexec.model.Model.{Resource, StepConfig, StepState}
 
 import scalaz._
 import Scalaz._

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -6,6 +6,7 @@ package edu.gemini.seqexec
 import edu.gemini.seqexec.engine.Event._
 import edu.gemini.seqexec.engine.Result.{PartialVal, RetVal}
 import edu.gemini.seqexec.model.Model.{CloudCover, Conditions, ImageQuality, SequenceState, SkyBackground, WaterVapor, Operator, Observer}
+import edu.gemini.seqexec.model.Model.Resource
 import org.log4s.getLogger
 
 import scalaz._

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -5,7 +5,7 @@ package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.engine.Event.start
 import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig}
-import edu.gemini.seqexec.model.Model.F2
+import edu.gemini.seqexec.model.Model.Instrument.F2
 import edu.gemini.seqexec.model.UserDetails
 
 import scala.Function.const
@@ -195,4 +195,3 @@ class SequenceSpec extends FlatSpec {
   }
 
 }
-

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -4,7 +4,7 @@
 package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig, StepState}
-import edu.gemini.seqexec.model.Model.F2
+import edu.gemini.seqexec.model.Model.Instrument.F2
 
 import scalaz.syntax.either._
 import org.scalatest._

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -8,7 +8,8 @@ import java.util.concurrent.Semaphore
 import Event._
 import org.scalatest.{FlatSpec, NonImplicitAssertions}
 import edu.gemini.seqexec.model.Model.{Conditions, SequenceMetadata, SequenceState, StepConfig}
-import edu.gemini.seqexec.model.Model.{F2, GmosS}
+import edu.gemini.seqexec.model.Model.Resource
+import edu.gemini.seqexec.model.Model.Instrument.{F2, GmosS}
 import edu.gemini.seqexec.model.UserDetails
 
 import scala.concurrent.duration._
@@ -65,7 +66,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
                  1,
                  None,
                  config,
-                 Set(Resource.TCS, Resource.F2),
+                 Set(Resource.TCS, F2),
                  breakpoint = false,
                  skip = false,
                  List(
@@ -77,7 +78,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
                  2,
                  None,
                  config,
-                 Set(Resource.TCS, Resource.OI, Resource.F2),
+                 Set(Resource.TCS, Resource.OI, F2),
                  breakpoint = false,
                  skip = false,
                  List(
@@ -102,7 +103,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
             1,
             None,
             config,
-            Set(Resource.GMOS_S),
+            Set(GmosS),
             breakpoint = false,
             skip = false,
             List(
@@ -194,7 +195,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
             1,
             None,
             config,
-            Set(Resource.GMOS_S),
+            Set(GmosS),
             breakpoint = false,
             skip = false,
             List(
@@ -231,7 +232,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
             1,
             None,
             config,
-            Set(Resource.GMOS_S),
+            Set(GmosS),
             breakpoint = false,
             skip = false,
             List(
@@ -264,7 +265,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
             1,
             None,
             config,
-            Set(Resource.GMOS_S),
+            Set(GmosS),
             breakpoint = false,
             skip = false,
             List(

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -136,17 +136,37 @@ object Model {
   // TODO This should be a richer type
   type SequenceId = String
   type StepId = Int
-  sealed trait Instrument
-  case object F2 extends Instrument
-  case object GmosS extends Instrument
-  case object GmosN extends Instrument
-  case object GNIRS extends Instrument
-  case object GPI extends Instrument
-  case object GSAOI extends Instrument
-  case object NIRI extends Instrument
-  case object NIFS extends Instrument
+  /**
+    * A Seqexec resource represents any system that can be only used by one single agent.
+    *
+    */
+  sealed trait Resource
 
+  object Resource {
+
+    case object P1 extends Resource
+    case object OI extends Resource
+    // Mount and science fold cannot be controlled independently. Maybe in the future.
+    // For now, I replaced them with TCS
+  //  case object Mount extends Resource
+  //  case object ScienceFold extends Resource
+    case object TCS extends Resource
+    case object Gcal extends Resource
+    case object Gems extends Resource
+    case object Altair extends Resource
+
+  }
+  sealed trait Instrument extends Resource
   object Instrument {
+    case object F2 extends Instrument
+    case object GmosS extends Instrument
+    case object GmosN extends Instrument
+    case object GNIRS extends Instrument
+    case object GPI extends Instrument
+    case object GSAOI extends Instrument
+    case object NIRI extends Instrument
+    case object NIFS extends Instrument
+
     implicit val equal: Equal[Instrument] = Equal.equalA[Instrument]
     implicit val show: Show[Instrument] = Show.shows({
       case F2    => "Flamingos2"

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration.Duration
 import scalaz.concurrent.Task
 import scalaz._
 
-final case class Flamingos2(f2Controller: Flamingos2Controller) extends Instrument {
+final case class Flamingos2(f2Controller: Flamingos2Controller) extends InstrumentSystem {
 
   import Flamingos2._
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Gmos.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Gmos.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 /**
   * Created by jluhrs on 8/3/17.
   */
-abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosController[T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends Instrument {
+abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosController[T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends InstrumentSystem {
   import Gmos._
 
   override val sfName: String = "gmos"

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/InstrumentSystem.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/InstrumentSystem.scala
@@ -9,7 +9,7 @@ import edu.gemini.spModel.config2.Config
 import scalaz.{EitherT, Reader}
 import scalaz.concurrent.Task
 
-trait Instrument extends System {
+trait InstrumentSystem extends System {
   // The name used for this instrument in the science fold configuration
   val sfName: String
   val contributorName: String
@@ -20,7 +20,7 @@ trait Instrument extends System {
 //Placeholder for observe response
 case class ObserveResult(dataId: ImageFileId)
 
-object UnknownInstrument extends Instrument {
+object UnknownInstrument extends InstrumentSystem {
 
   override val name: String = "UNKNOWN"
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsController.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsController.scala
@@ -3,8 +3,8 @@
 
 package edu.gemini.seqexec.server
 
-import edu.gemini.seqexec.engine.Resource
 import edu.gemini.spModel.core.Wavelength
+import edu.gemini.seqexec.model.Model.Instrument
 
 import scalaz._
 import Scalaz._
@@ -178,7 +178,7 @@ object TcsController {
   sealed trait ScienceFoldPosition
   object ScienceFoldPosition {
     case object Parked extends ScienceFoldPosition
-    final case class Position(source: LightSource, sink: Resource.Instrument) extends ScienceFoldPosition
+    final case class Position(source: LightSource, sink: Instrument) extends ScienceFoldPosition
   }
 
   /** Enumerated type for offloading of tip/tilt corrections from M2 to mount. */

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -38,7 +38,7 @@ case class SequenceTab(instrument: Instrument, currentSequence: RefTo[Option[Seq
 }
 
 object SequenceTab {
-  val empty = SequenceTab(F2, RefTo(new RootModelR(None)), None, None)
+  val empty = SequenceTab(Instrument.F2, RefTo(new RootModelR(None)), None, None)
 }
 
 // Model for the tabbed area of sequences


### PR DESCRIPTION
I noted that we have 3 trait/classes called `Instrument` in ocs3. This is an attempt to have only one. I've merged two definitions on the engine and model and renamed one to `InstrumentSystem`

I tried to convert `InstrumentSystem` to a typeclass to augment the `Instrument` enum instance but I failed 😢 , but this is an improvement nonetheless