### PR TITLE
SEQNG-359: ODB doesn't send engineering parameters for FLAMINGOS-2 observations

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ODBProxy.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ODBProxy.scala
@@ -31,7 +31,7 @@ class ODBProxy(val loc: Peer, cmds: ODBProxy.OdbCommands) {
 
   def host(): Peer = loc
   def read(oid: SPObservationID): SeqexecFailure \/ ConfigSequence =
-    SeqExecService.client(loc).sequence(oid).leftMap(SeqexecFailure.ODBSeqError)
+    SeqExecService.client(loc).sequence(oid).map(_.config).leftMap(SeqexecFailure.ODBSeqError)
 
   val queuedSequences: SeqAction[Seq[SPObservationID]] = cmds.queuedSequences()
   val datasetStart: (SPObservationID, String, ImageFileId) => SeqAction[Boolean] = cmds.datasetStart

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -106,7 +106,7 @@ object Settings {
     val jQuery         = "3.2.1"
     val semanticUI     = "2.2.10"
     val jQueryTerminal = "0.11.2"
-    val ocsVersion     = "2017101.1.3"
+    val ocsVersion     = "2017101.1.4"
 
     //Apache XMLRPC
     val apacheXMLRPC   = "3.1.3"


### PR DESCRIPTION
This PR brings the new ocs library versions done by @swalker2m to fix this on the seqexec client library