### PR TITLE
SEQNG-312: Display file id of already executed steps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val edu_gemini_seqexec_server = project
           Knobs,
           OpenCSV,
           Log4s
-      ) ++ SeqexecOdb ++ WDBAClient ++ Http4sClient ++ TestLibs.value
+      ) ++ SeqexecOdb ++ WDBAClient ++ TestLibs.value
   ).settings(
     sources in (Compile,doc) := Seq.empty
   )

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Commands.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Commands.scala
@@ -77,35 +77,35 @@ object Commands {
       for {
         oid <- parseId(obsId)
         seq <- odbProxy.read(oid).leftMap(SeqexecFailureError.apply)
-      } yield CommandResponse(s"$oid sequence has ${seq.size()} steps.")
+      } yield CommandResponse(s"$oid sequence has ${seq.config.size()} steps.")
 
     override def showStatic(obsId: String): CommandResult =
       for {
         oid <- parseId(obsId)
         seq <- odbProxy.read(oid).leftMap(SeqexecFailureError.apply)
-      } yield CommandResponse(s"$oid Static Values", keys(seq, 0, seq.getStaticKeys), Nil)
+      } yield CommandResponse(s"$oid Static Values", keys(seq.config, 0, seq.config.getStaticKeys), Nil)
 
     override def showStatic(obsId: String, system: String): CommandResult =
       for {
         oid <- parseId(obsId)
         seq <- odbProxy.read(oid).leftMap(SeqexecFailureError.apply)
-        ks  = seq.getStaticKeys.filter(sysFilter(system))
-      } yield CommandResponse(s"$oid Static Values ($system only)", keys(seq, 0, ks), Nil)
+        ks  = seq.config.getStaticKeys.filter(sysFilter(system))
+      } yield CommandResponse(s"$oid Static Values ($system only)", keys(seq.config, 0, ks), Nil)
 
     override def showDynamic(obsId: String, step: String): CommandResult =
       for {
         oid <- parseId(obsId)
         seq <- odbProxy.read(oid).leftMap(SeqexecFailureError.apply)
-        s   <- ifStepValid(oid, seq, step)
-      } yield CommandResponse(s"$oid Dynamic Values (Step ${s + 1})", keys(seq, s, seq.getIteratedKeys), Nil)
+        s   <- ifStepValid(oid, seq.config, step)
+      } yield CommandResponse(s"$oid Dynamic Values (Step ${s + 1})", keys(seq.config, s, seq.config.getIteratedKeys), Nil)
 
     override def showDynamic(obsId: String, step: String, system: String): CommandResult =
       for {
         oid <- parseId(obsId)
         seq <- odbProxy.read(oid).leftMap(SeqexecFailureError.apply)
-        s   <- ifStepValid(oid, seq, step)
-        ks  = seq.getStaticKeys.filter(sysFilter(system))
-      } yield CommandResponse(s"$oid Dynamic Values (Step ${s + 1}, $system only)", keys(seq, s, ks), Nil)
+        s   <- ifStepValid(oid, seq.config, step)
+        ks  = seq.config.getStaticKeys.filter(sysFilter(system))
+      } yield CommandResponse(s"$oid Dynamic Values (Step ${s + 1}, $system only)", keys(seq.config, s, ks), Nil)
 
     def seqValue(o: Object): String = o match {
       case s: SequenceableSpType => s.sequenceValue()

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -144,7 +144,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       odbSeq       <- EitherT(Task.delay(odbProxy.read(seqId)))
       progIdString <- EitherT(Task.delay(odbSeq.config.extract(OCS_KEY / InstConstants.PROGRAMID_PROP).as[String].leftMap(ConfigUtilOps.explainExtractError)))
       progId       <- EitherT.fromTryCatchNonFatal(Task.now(SPProgramID.toProgramID(progIdString))).leftMap(e => SeqexecFailure.SeqexecException(e): SeqexecFailure)
-    } yield translator.sequence(seqId, odbSeq.config, odbSeq.title)
+    } yield translator.sequence(seqId, odbSeq)
 
     t.map {
       case (err :: _, None)  => List(Event.logMsg(SeqexecFailure.explain(err)))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -157,10 +157,6 @@ object Settings {
       "org.http4s" %% "http4s-dsl"          % LibraryVersions.http4s,
       "org.http4s" %% "http4s-blaze-server" % LibraryVersions.http4s)
 
-    val Http4sClient  = Seq(
-      "org.http4s" %% "http4s-blaze-client" % LibraryVersions.http4s,
-      "org.http4s" %% "http4s-scala-xml"    % LibraryVersions.http4s)
-
     val Monocle  = Def.setting(Seq(
       "com.github.julien-truffaut" %%% "monocle-core"  % LibraryVersions.monocle,
       "com.github.julien-truffaut" %%% "monocle-macro" % LibraryVersions.monocle))


### PR DESCRIPTION
Thanks to #322 we are extracting more information about a sequence from the ODB. In this PR we use this to obtain the title of the sequence (thus avoiding an extra call to the odb browser) and we also read the file names of previously executed steps

Thus we can display de file id of previous executions when loading a sequence like

![screenshot 2017-09-05 15 43 03](https://user-images.githubusercontent.com/3615303/30078961-0ca52710-9255-11e7-864d-23826abea16d.png)
