### PR TITLE
SEQNG-122: Get fileId in the engine state as soon as the observation starts

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
@@ -111,4 +111,5 @@ object Result {
   final case class Observed(fileId: FileId) extends Response
   object Ignored extends Response
 
+  final case class FileIdAllocated(fileId: FileId) extends PartialVal
 }

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -297,8 +297,8 @@ object Sequence {
           zipperL >=> Sequence.Zipper.focus >=> Step.Zipper.fileId
 
         val z: Zipper = r match {
-            case Result.OK(Result.Observed(fileId)) => currentFileIdL.set(self, fileId.some)
-            case _                                  => self
+            case Result.Partial(Result.FileIdAllocated(fileId), _) => currentFileIdL.set(self, fileId.some)
+            case _                                                 => self
           }
 
         currentExecutionL.mod(_.mark(i)(r), z)

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Sequence.scala
@@ -266,7 +266,7 @@ object Sequence {
 
       override val pending: List[Step[Action]] = zipper.pending
 
-      override def rollback = self.copy(zipper = zipper.rollback)
+      override def rollback: Zipper = self.copy(zipper = zipper.rollback)
 
       override def setBreakpoint(stepId: Step.Id, v: Boolean): State = self.copy(zipper =
         zipper.copy(pending =
@@ -276,7 +276,7 @@ object Sequence {
 
       // I put a guard against blank values, although Observer is forced to have
       // a default value at an upper level.
-      override def setObserver(name: String): State = observerL.set(self, Some(name))
+      override def setObserver(name: String): State = observerL.set(self, name.some)
 
       override val done: List[Step[Result]] = zipper.done
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Step.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Step.scala
@@ -45,6 +45,10 @@ object Step {
     *
     */
   def status(step: Step[Action \/ Result]): StepState = {
+    def stepCompleted(s: Action \/ Result): Boolean = s match {
+      case \/-(Result.OK(_)) => true
+      case _                 => false
+    }
 
     // Find an error in the Step
     step.findLeft(Execution.errored).flatMap(
@@ -58,7 +62,7 @@ object Step {
       // All actions in this Step are pending.
       else if (step.all(_.isLeft)) StepState.Pending
       // All actions in this Step were completed successfully.
-      else if (step.all(_.isRight)) StepState.Completed
+      else if (step.all(stepCompleted)) StepState.Completed
       // Not all actions are completed or pending.
       else StepState.Running
     )

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -94,6 +94,7 @@ object Model {
     // Prism to focus on only the SeqexecEvents that have a queue
     // Unfortunately it doesn't seem to exist a more generic form to build this one
     val sePrism: Prism[SeqexecEvent, (SeqexecEvent, SequencesQueue[SequenceView])] = Prism.partial[SeqexecEvent, (SeqexecEvent, SequencesQueue[SequenceView])]{
+      case e @ FileIdStepExecuted(i, v)  => (e, v)
       case e @ StepExecuted(v)           => (e, v)
       case e @ SequenceStart(v)          => (e, v)
       case e @ SequenceCompleted(v)      => (e, v)
@@ -112,6 +113,7 @@ object Model {
       e match {
         case SequenceStart(_)           => SequenceStart(q)
         case StepExecuted(_)            => StepExecuted(q)
+        case FileIdStepExecuted(i, _)   => FileIdStepExecuted(i, q)
         case SequenceCompleted(_)       => SequenceCompleted(q)
         case e @ SequenceLoaded(_, v)   => e.copy(view = q)
         case e @ SequenceUnloaded(_, v) => e.copy(view = q)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -12,6 +12,8 @@ import monocle.Traversal
 
 import java.time.Instant
 
+import dhs.ImageFileId
+
 object Model {
   // We use this to avoid a dependency on spModel, should be replaced by gem
   sealed trait SeqexecSite {
@@ -49,6 +51,8 @@ object Model {
     final case class SequenceStart(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
     final case class StepExecuted(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+
+    final case class FileIdStepExecuted(fileId: ImageFileId, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
     final case class SequenceCompleted(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -60,6 +60,7 @@ trait ModelBooPicklers {
     .addConcreteType[ConnectionOpenEvent]
     .addConcreteType[SequenceStart]
     .addConcreteType[StepExecuted]
+    .addConcreteType[FileIdStepExecuted]
     .addConcreteType[SequenceCompleted]
     .addConcreteType[SequenceLoaded]
     .addConcreteType[SequenceUnloaded]

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -90,8 +90,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
       val regularStepExecutions: List[List[Action]] =
         List(
           sys.map(x => x.configure(config).map(y => Result.Configured(y.sys.name)).toAction),
-          List(new Action(ctx => observe(config, obsId, inst, sys.filterNot(inst.equals), headers)(ctx).run.map(_.toResult)))
-        )
+          List(new Action(ctx => observe(config, obsId, inst, sys.filterNot(inst.equals), headers)(ctx).run.map(_.toResult))))
 
       extractStatus(config) match {
         case StepState.Pending =>

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -33,8 +33,6 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   import SeqTranslate._
 
-
-
   private def dhsFileId(inst: InstrumentSystem): SeqAction[ImageFileId] =
     systems.dhs.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List(inst.contributorName, "dhs-http")))
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -11,6 +11,7 @@ import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.spModel.core.Site
 import edu.gemini.seqexec.engine
 import edu.gemini.seqexec.engine.{Action, Engine, Event, EventSystem, Executed, Failed, Result, Sequence}
+import edu.gemini.seqexec.engine.Result.{FileIdAllocated, Partial}
 import edu.gemini.seqexec.server.ConfigUtilOps._
 import edu.gemini.seqexec.odb.SmartGcal
 
@@ -175,13 +176,14 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
     }
     case engine.EventSystem(se) => se match {
       // TODO: Sequence completed event not emited by engine.
-      case engine.Completed(_, _, _)     => NewLogMessage("Action completed")
-      case engine.PartialResult(_, _, _) => SequenceUpdated(svs)
-      case engine.Failed(_, _, _)        => NewLogMessage("Action failed")
-      case engine.Busy(_)                => ResourcesBusy(svs)
-      case engine.Executed(_)            => StepExecuted(svs)
-      case engine.Executing(_)           => NewLogMessage("Executing")
-      case engine.Finished(_)            => SequenceCompleted(svs)
+      case engine.Completed(_, _, _)                                        => NewLogMessage("Action completed")
+      case engine.PartialResult(id, _, Partial(FileIdAllocated(fileId), _)) => FileIdStepExecuted(fileId, svs)
+      case engine.PartialResult(_, _, _)                                    => SequenceUpdated(svs)
+      case engine.Failed(_, _, _)                                           => NewLogMessage("Action failed")
+      case engine.Busy(_)                                                   => ResourcesBusy(svs)
+      case engine.Executed(_)                                               => StepExecuted(svs)
+      case engine.Executing(_)                                              => NewLogMessage("Executing")
+      case engine.Finished(_)                                               => SequenceCompleted(svs)
     }
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -72,13 +72,21 @@ object StepsTableContainer {
 
     def stepProgress(step: Step): VdomNode =
       step.status match {
+        case StepState.Pending =>
+          step.fileId.fold(<.div("Pending"))(_ => <.div("Configuring"))
         case StepState.Running =>
-          <.div(
-            ^.cls := "ui progress vcentered",
+          step.fileId.fold(<.div("Configuring..."))(fileId =>
             <.div(
-              ^.cls := "bar",
+              ^.cls := "ui small progress vcentered",
               <.div(
-                ^.cls := "progress")
+                ^.cls := "bar",
+                <.div(
+                  ^.cls := "progress")
+              ),
+              <.div(
+                ^.cls := "label",
+                fileId
+              )
             )
           )
         case StepState.Completed =>


### PR DESCRIPTION
This PR is to request comments as this is not properly working right now

The idea on this PR is to change the engine to read the file id at the beginning of the observation, and then send an extra event to the client at the start of the observation
