### PR TITLE
SEQNG-246: Use scalajs-bundler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,28 +122,6 @@ lazy val edu_gemini_seqexec_web_server = project.in(file("modules/edu.gemini.seq
   )
   .dependsOn(edu_gemini_seqexec_web_shared_JVM, edu_gemini_seqexec_server, edu_gemini_web_server_common)
 
-// Client side project using Scala.js
-/*lazy val btest = project.in(file("modules/btest"))
-  .enablePlugins(ScalaJSPlugin)
-  .enablePlugins(ScalaJSBundlerPlugin)
-  .settings(commonJSSettings: _*)
-  .settings(
-    // artifactPath in (Compile, fastOptJS) := resourceManaged.value / "seqexec.js",
-    version in webpack := "2.2.1",
-    version in startWebpackDevServer := "2.2.0",
-    webpackBundlingMode := BundlingMode.LibraryOnly(),
-    npmDependencies in Compile ++= Seq(
-      "react" -> LibraryVersions.reactJS,
-      "react-dom" -> LibraryVersions.reactJS,
-      "jquery" -> LibraryVersions.jQuery,
-      "semantic-ui" -> LibraryVersions.semanticUI
-    ),
-    useYarn := true,
-    libraryDependencies ++= ReactScalaJS.value,
-    // And add a custom one
-    addCompilerPlugin("org.scala-js" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.patch)
-  )*/
-
 lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client"))
   .enablePlugins(ScalaJSPlugin)
   .enablePlugins(ScalaJSBundlerPlugin)
@@ -172,13 +150,20 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
     npmDependencies in Compile ++= Seq(
       "react" -> LibraryVersions.reactJS,
       "react-dom" -> LibraryVersions.reactJS,
-      "jquery" -> LibraryVersions.jQuery//,
-      // "semantic-ui-css" -> LibraryVersions.semanticUI
+      "jquery" -> LibraryVersions.jQuery,
+      "semantic-ui-dropdown" -> LibraryVersions.semanticUI,
+      "semantic-ui-modal" -> LibraryVersions.semanticUI,
+      "semantic-ui-progress" -> LibraryVersions.semanticUI,
+      "semantic-ui-tab" -> LibraryVersions.semanticUI,
+      "semantic-ui-visibility" -> LibraryVersions.semanticUI,
+      "semantic-ui-transition" -> LibraryVersions.semanticUI,
+      "semantic-ui-dimmer" -> LibraryVersions.semanticUI
     ),
     // Requires the DOM for tests
     requiresDOM in Test := true,
     // Use yarn as it is faster than npm
     useYarn := true,
+    version in webpack := "3.5.5",
     // crossTarget in (Compile, packageJSDependencies) := (resourceManaged in Compile).value,
     libraryDependencies ++= Seq(
       JQuery.value,

--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val edu_gemini_seqexec_web_server = project.in(file("modules/edu.gemini.seq
   .dependsOn(edu_gemini_seqexec_web_shared_JVM, edu_gemini_seqexec_server, edu_gemini_web_server_common)
 
 // Client side project using Scala.js
-lazy val btest = project.in(file("modules/btest"))
+/*lazy val btest = project.in(file("modules/btest"))
   .enablePlugins(ScalaJSPlugin)
   .enablePlugins(ScalaJSBundlerPlugin)
   .settings(commonJSSettings: _*)
@@ -142,7 +142,7 @@ lazy val btest = project.in(file("modules/btest"))
     libraryDependencies ++= ReactScalaJS.value,
     // And add a custom one
     addCompilerPlugin("org.scala-js" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.patch)
-  )
+  )*/
 
 lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client"))
   .enablePlugins(ScalaJSPlugin)
@@ -167,17 +167,17 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
   // Write the generated js to the filename seqexec.js
     // artifactPath in (Compile, fastOptJS) := (resourceManaged in Compile).value / "seqexec.js",
     // artifactPath in (Compile, fullOptJS) := (resourceManaged in Compile).value / "seqexec-opt.js",
-    // Requires the DOM
-    jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
-    webpackBundlingMode := BundlingMode.LibraryAndApplication(),
+    webpackBundlingMode := BundlingMode.LibraryOnly(),
     // JS dependencies via npm
     npmDependencies in Compile ++= Seq(
       "react" -> LibraryVersions.reactJS,
       "react-dom" -> LibraryVersions.reactJS,
-      "jquery" -> LibraryVersions.jQuery,
-      "semantic-ui-css" -> LibraryVersions.semanticUI
+      "jquery" -> LibraryVersions.jQuery//,
+      // "semantic-ui-css" -> LibraryVersions.semanticUI
     ),
-    // Put the jsdeps file on a place reachable for the server
+    // Requires the DOM for tests
+    requiresDOM in Test := true,
+    // Use yarn as it is faster than npm
     useYarn := true,
     // crossTarget in (Compile, packageJSDependencies) := (resourceManaged in Compile).value,
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -132,19 +132,6 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
   .settings(
     // Needed for Monocle macros
     addCompilerPlugin(Plugins.paradisePlugin),
-    // This is a not very nice trick to remove js files that exist on the scala tools
-    // library and that conflict with the requested on jsDependencies, in particular
-    // with jquery.js
-    // See http://stackoverflow.com/questions/35374131/scala-js-missing-js-library, UPDATE #1
-    // (scalaJSNativeLibraries in Test) := (scalaJSNativeLibraries in Test).map { l =>
-    //   l.map(virtualFiles => virtualFiles.filter(vf => {
-    //     val f = vf.toURI.toString
-    //     !(f.endsWith(".js") && f.contains("scala/tools"))
-    //   }))
-    // }.value,
-  // Write the generated js to the filename seqexec.js
-    // artifactPath in (Compile, fastOptJS) := (resourceManaged in Compile).value / "seqexec.js",
-    // artifactPath in (Compile, fullOptJS) := (resourceManaged in Compile).value / "seqexec-opt.js",
     webpackBundlingMode := BundlingMode.LibraryOnly(),
     // JS dependencies via npm
     npmDependencies in Compile ++= Seq(
@@ -164,7 +151,6 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
     // Use yarn as it is faster than npm
     useYarn := true,
     version in webpack := "3.5.5",
-    // crossTarget in (Compile, packageJSDependencies) := (resourceManaged in Compile).value,
     libraryDependencies ++= Seq(
       JQuery.value,
       ScalaCSS.value,
@@ -281,8 +267,7 @@ lazy val seqexecCommonSettings = Seq(
   // This is important to keep the file generation order correctly
   parallelExecution in Universal := false,
   // Run full opt js on the javascript. They will be placed on the "seqexec" jar
-  resources in Compile += (fullOptJS in (edu_gemini_seqexec_web_client, Compile)).value.data,
-  resources in Compile += (packageMinifiedJSDependencies in (edu_gemini_seqexec_web_client, Compile)).value,
+  resources in Compile ++= (webpack in (edu_gemini_seqexec_web_client, Compile, fullOptJS)).value.map(_.data),
   test := {},
   // Name of the launch script
   executableScriptName := "seqexec-server",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LoginBox.scala
@@ -7,7 +7,6 @@ import diode.react.ModelProxy
 import edu.gemini.seqexec.model.UserDetails
 import japgolly.scalajs.react.{BackendScope, Callback, CallbackTo, ReactEventFromInput, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
-import edu.gemini.web.client.facades.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.model._
 import edu.gemini.seqexec.web.client.actions.{CloseLoginBox, LoggedIn}
@@ -153,6 +152,7 @@ object LoginBox {
         // the Semantic UI javascript library
         // The calls below use a custom scala.js facade for SemanticUI
         import org.querki.jquery.$
+        import edu.gemini.web.client.facades.semanticui.SemanticUIModal._
 
         // Close the modal box if the model changes
         if (ctx.currentProps.visible() === SectionClosed) {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/NavBar.scala
@@ -5,7 +5,6 @@ package edu.gemini.seqexec.web.client.components
 
 import diode.react.ModelProxy
 import diode.react.ReactPot._
-import edu.gemini.web.client.facades.semanticui.SemanticUI._
 import edu.gemini.seqexec.model.Model.SeqexecSite
 import edu.gemini.seqexec.web.client.actions.NavigateTo
 import edu.gemini.seqexec.web.client.circuit.SeqexecCircuit
@@ -67,6 +66,7 @@ object NavBar {
       Callback {
         // Mount the Semantic component using jQuery
         import org.querki.jquery.$
+        import edu.gemini.web.client.facades.semanticui.SemanticUIVisibility._
 
         // Pick the top bar and make it stay visible regardless of scrolling
         $(ctx.getDOMNode).visibility(JsVisiblityOptions.visibilityType("fixed").offset(0))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/ResourcesBox.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/ResourcesBox.scala
@@ -6,7 +6,6 @@ package edu.gemini.seqexec.web.client.components
 import diode.react.ModelProxy
 import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
-import edu.gemini.web.client.facades.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconCheckmark
 import edu.gemini.seqexec.web.client.semanticui.elements.modal.{Content, Header}
 import edu.gemini.seqexec.web.client.model._
@@ -49,6 +48,7 @@ object ResourcesBox {
         // the Semantic UI javascript library
         // The calls below use a custom scala.js facade for SemanticUI
         import org.querki.jquery.$
+        import edu.gemini.web.client.facades.semanticui.SemanticUIModal._
 
         // Close the modal box if the model changes
         ctx.currentProps.visible() match {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -40,8 +40,6 @@ object SeqexecMain {
       )
     ).build
 
-
-
   def apply(site: SeqexecSite, ctl: RouterCtl[SeqexecPages]): Unmounted[Props, Unit, Unit] = component(Props(site, ctl))
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -40,6 +40,8 @@ object SeqexecMain {
       )
     ).build
 
+
+
   def apply(site: SeqexecSite, ctl: RouterCtl[SeqexecPages]): Unmounted[Props, Unit, Unit] = component(Props(site, ctl))
 }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -9,7 +9,6 @@ import edu.gemini.seqexec.web.client.actions.{NavigateTo, SelectInstrumentToDisp
 import edu.gemini.seqexec.web.client.model.Pages.InstrumentPage
 import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, InstrumentStatusFocus}
 import edu.gemini.seqexec.web.client.semanticui._
-import edu.gemini.web.client.facades.semanticui.SemanticUI._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
@@ -67,6 +66,7 @@ object InstrumentTab {
       Callback {
         // Enable menu on Semantic UI
         import org.querki.jquery.$
+        import edu.gemini.web.client.facades.semanticui.SemanticUITab._
 
         $(ctx.getDOMNode).tab(
           JsTabOptions

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/dropdown/DropdownMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/dropdown/DropdownMenu.scala
@@ -13,9 +13,11 @@ import scalaz.Show
 import scalaz.syntax.show._
 import scalaz.syntax.equal._
 import scalaz.std.string._
+
 /**
   * Produces a dropdown menu, similar to a combobox
   */
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object DropdownMenu {
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   final case class Props[A](label: String,
@@ -55,9 +57,9 @@ object DropdownMenu {
       Callback {
         // Enable menu on Semantic UI
         import org.querki.jquery.$
-        import edu.gemini.web.client.facades.semanticui.SemanticUI._
+        import edu.gemini.web.client.facades.semanticui.SemanticUIDropDown._
 
-        $(ctx.getDOMNode).find(".ui.dropdown").dropdown(
+        $(ctx.getDOMNode).find(".ui.dropdown1").dropdown(
           JsDropdownOptions
             .onChange { (value: String, text: String) =>
               // The text comes wrapped on react tags

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/message/CloseableMessage.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/message/CloseableMessage.scala
@@ -45,7 +45,7 @@ object CloseableMessage extends Message {
       Callback {
         // Need to go into jQuery and semantic to enable the close button
         import org.querki.jquery.$
-        import edu.gemini.web.client.facades.semanticui.SemanticUI._
+        import edu.gemini.web.client.facades.semanticui.SemanticUITransition._
         import org.scalajs.dom.Element
 
         $(ctx.getDOMNode).on("click", (e: Element, ev: Any) =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/index-dev.html
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/index-dev.html
@@ -34,7 +34,7 @@
     <div id="content">
     </div>
 
-    <script src="edu_gemini_seqexec_web_client-jsdeps.js"></script>
+    <script src="edu_gemini_seqexec_web_client-fastopt-library.js"></script>
     <script src="seqexec.js"></script>
     <script type="text/javascript">
       edu.gemini.seqexec.web.client.SeqexecApp().main();

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
@@ -15,8 +15,8 @@ package object http4s {
                   |        }
                   |      }
                   |"""
-    val deps = if (devMode) "edu_gemini_seqexec_web_client-fastopt-library.js" else s"edu_gemini_seqexec_web_client-jsdeps.min.$builtAtMillis.js"
-    val loaderScript = if (devMode) s"edu_gemini_seqexec_web_client-fastopt-loader.js" else s"edu_gemini_seqexec_web_client-fastopt-loader-opt.$builtAtMillis.js"
+    val deps = if (devMode) "edu_gemini_seqexec_web_client-fastopt-library.js" else s"edu_gemini_seqexec_web_client-opt-library.$builtAtMillis.js"
+    val loaderScript = if (devMode) s"edu_gemini_seqexec_web_client-fastopt-loader.js" else s"edu_gemini_seqexec_web_client-opt-loader.$builtAtMillis.js"
     val seqexecScript = if (devMode) s"edu_gemini_seqexec_web_client-fastopt.js" else s"edu_gemini_seqexec_web_client-opt.$builtAtMillis.js"
     val xml =
       <html lang="en">

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
@@ -4,6 +4,7 @@
 package edu.gemini.seqexec.web.server
 
 package object http4s {
+  // scalastyle:off
   def index(site: String, devMode: Boolean, builtAtMillis: Long): String = {
     val style = """
                   |   @media screen and (-webkit-min-device-pixel-ratio:0) {
@@ -47,6 +48,18 @@ package object http4s {
 
           <script src={s"/$deps"}></script>
           <script src={s"/$loaderScript"}></script>
+          <script>
+            {"""
+              /* Trick to get semantic ui to talk to jquery loaded via modules */
+              var $ = require('jquery');
+              $.fn.dropdown = require('semantic-ui-dropdown');
+              $.fn.visibility = require('semantic-ui-visibility');
+              $.fn.tab = require('semantic-ui-tab');
+              $.fn.progress = require('semantic-ui-progress');
+              $.fn.dimmer = require('semantic-ui-dimmer');
+              $.fn.transition = require('semantic-ui-transition');
+              $.fn.modal = require('semantic-ui-modal');
+              """} </script>
           <script src={s"/$seqexecScript"}></script>
           <script>
             {s"""SeqexecApp.start('$site');"""}
@@ -55,5 +68,6 @@ package object http4s {
       </html>
     s"<!DOCTYPE html>$xml"
   }
+  // scalastyle:on
 
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
@@ -14,8 +14,9 @@ package object http4s {
                   |        }
                   |      }
                   |"""
-    val deps = if (devMode) "edu_gemini_seqexec_web_client-jsdeps.js" else s"edu_gemini_seqexec_web_client-jsdeps.min.$builtAtMillis.js"
-    val seqexecScript = if (devMode) s"seqexec.js" else s"seqexec-opt.$builtAtMillis.js"
+    val deps = if (devMode) "edu_gemini_seqexec_web_client-fastopt-library.js" else s"edu_gemini_seqexec_web_client-jsdeps.min.$builtAtMillis.js"
+    val loaderScript = if (devMode) s"edu_gemini_seqexec_web_client-fastopt-loader.js" else s"edu_gemini_seqexec_web_client-fastopt-loader-opt.$builtAtMillis.js"
+    val seqexecScript = if (devMode) s"edu_gemini_seqexec_web_client-fastopt.js" else s"edu_gemini_seqexec_web_client-opt.$builtAtMillis.js"
     val xml =
       <html lang="en">
         <head>
@@ -45,6 +46,7 @@ package object http4s {
           </div>
 
           <script src={s"/$deps"}></script>
+          <script src={s"/$loaderScript"}></script>
           <script src={s"/$seqexecScript"}></script>
           <script>
             {s"""SeqexecApp.start('$site');"""}

--- a/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUI.scala
+++ b/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUI.scala
@@ -7,44 +7,19 @@ import org.querki.jquery.JQuery
 import org.querki.jsext.{JSOptionBuilder, _}
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
 
 /**
-  * Facade for the SemanticUI javascript. Note that there are extensions to JQuery
+  * Facades for the SemanticUI javascript. Note that there are extensions to JQuery
   */
-object SemanticUI {
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object SemanticUIDropDown {
 
   @js.native
-  trait JsVisiblityOptions extends js.Object
+  @JSImport("semantic-ui-dropdown", JSImport.Default)
+  private object SemanticDropDownModule extends js.Any
 
-  object JsVisiblityOptions extends JsVisiblityOptionBuilder(noOpts)
-
-  class JsVisiblityOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsVisiblityOptions, JsVisiblityOptionBuilder](new JsVisiblityOptionBuilder(_)) {
-    def visibilityType(t: String): JsVisiblityOptionBuilder = jsOpt("type", t)
-    def offset(t: Int): JsVisiblityOptionBuilder = jsOpt("offset", t)
-  }
-
-  @js.native
-  trait JsModalOptions extends js.Object
-
-  object JsModalOptions extends JsModalOptionBuilder(noOpts)
-
-  class JsModalOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsModalOptions, JsModalOptionBuilder](new JsModalOptionBuilder(_)) {
-    def autofocus(t: Boolean): JsModalOptionBuilder = jsOpt("autofocus", t)
-    def onDeny[A](t: js.Function0[A]): JsModalOptionBuilder = jsOpt("onDeny", t)
-    def onHide[A](t: js.Function0[A]): JsModalOptionBuilder = jsOpt("onHide", t)
-    def onHidden[A](t: js.Function0[A]): JsModalOptionBuilder = jsOpt("onHidden", t)
-    def onApprove[A](t: js.Function0[A]): JsModalOptionBuilder = jsOpt("onApprove", t)
-  }
-
-  @js.native
-  trait JsProgressOptions extends js.Object
-
-  object JsProgressOptions extends JsProgressOptionBuilder(noOpts)
-
-  class JsProgressOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsProgressOptions, JsProgressOptionBuilder](new JsProgressOptionBuilder(_)) {
-    def total(v: Int): JsProgressOptionBuilder = jsOpt("total", v)
-    def value(v: Int): JsProgressOptionBuilder = jsOpt("value", v)
-  }
+  SemanticDropDownModule
 
   @js.native
   trait JsDropdownOptions extends js.Object
@@ -54,6 +29,30 @@ object SemanticUI {
   class JsDropdownOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsDropdownOptions, JsDropdownOptionBuilder](new JsDropdownOptionBuilder(_)) {
     def onChange[A, B, C](t: js.Function2[A, B, C]): JsDropdownOptionBuilder = jsOpt("onChange", t)
   }
+
+  @js.native
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  trait SemanticDropDown extends JQuery {
+    def dropdown(): this.type = js.native
+    def dropdown(cmd: String): this.type = js.native
+    def dropdown(o: JsDropdownOptions): this.type = js.native
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def jq2Semantic($: JQuery): SemanticDropDown = {
+    $.asInstanceOf[SemanticDropDown]
+  }
+
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object SemanticUITab {
+
+  @js.native
+  @JSImport("semantic-ui-tab", JSImport.Default)
+  private object SemanticTabModule extends js.Any
+
+  SemanticTabModule
 
   @js.native
   trait JsTabOptions extends js.Object
@@ -66,25 +65,77 @@ object SemanticUI {
 
   @js.native
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  trait SemanticCommands extends JQuery {
-    def visibility(o: JsVisiblityOptions): this.type = js.native
-
-    def dropdown(): this.type = js.native
-    def dropdown(cmd: String): this.type = js.native
-    def dropdown(o: JsDropdownOptions): this.type = js.native
-
-    def tab(o: JsTabOptions): this.type = js.native
-
-    def transition(s: String): this.type = js.native
-
-    def modal(s: String): this.type = js.native
-
-    def modal(o: JsModalOptions): this.type = js.native
-
-    def progress(o: JsProgressOptions): this.type = js.native
+  trait SemanticTab extends JQuery {
+    def tab(o: JsTabOptions): this.type
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  implicit def jq2Semantic(jq: JQuery): SemanticCommands = jq.asInstanceOf[SemanticCommands]
+  implicit def jq2Semantic($: JQuery): SemanticTab = {
+    $.asInstanceOf[SemanticTab]
+  }
+
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object SemanticUIVisibility {
+
+  @js.native
+  @JSImport("semantic-ui-visibility", JSImport.Namespace)
+  private object SemanticVisibilityModule extends js.Any
+
+  SemanticVisibilityModule
+
+  @js.native
+  trait JsVisiblityOptions extends js.Object
+
+  object JsVisiblityOptions extends JsVisiblityOptionBuilder(noOpts)
+
+  class JsVisiblityOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsVisiblityOptions, JsVisiblityOptionBuilder](new JsVisiblityOptionBuilder(_)) {
+    def visibilityType(t: String): JsVisiblityOptionBuilder = jsOpt("type", t)
+    def offset(t: Int): JsVisiblityOptionBuilder = jsOpt("offset", t)
+  }
+
+  @js.native
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  trait SemanticVisibility extends JQuery {
+    def visibility(o: JsVisiblityOptions): this.type
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def jq2Semantic($: JQuery): SemanticVisibility = {
+    $.asInstanceOf[SemanticVisibility]
+  }
+
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object SemanticUIProgress {
+
+  @js.native
+  @JSImport("semantic-ui-progress", JSImport.Namespace)
+  private object SemanticProgressModule extends js.Any
+
+  SemanticProgressModule
+
+  @js.native
+  trait JsProgressOptions extends js.Object
+
+  object JsProgressOptions extends JsProgressOptionBuilder(noOpts)
+
+  class JsProgressOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsProgressOptions, JsProgressOptionBuilder](new JsProgressOptionBuilder(_)) {
+    def total(v: Int): JsProgressOptionBuilder = jsOpt("total", v)
+    def value(v: Int): JsProgressOptionBuilder = jsOpt("value", v)
+  }
+
+  @js.native
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  trait SemanticProgress extends JQuery {
+    def progress(o: JsProgressOptions): this.type
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def jq2Semantic($: JQuery): SemanticProgress = {
+    $.asInstanceOf[SemanticProgress]
+  }
 
 }

--- a/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUIModal.scala
+++ b/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUIModal.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.web.client.facades.semanticui
+
+import org.querki.jquery.JQuery
+import org.querki.jsext.{JSOptionBuilder, _}
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+/**
+  * Facades for the SemanticUI javascript modal
+  */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object SemanticUITransition {
+
+  @js.native
+  @JSImport("semantic-ui-dimmer", JSImport.Default)
+  private object SemanticDimmerModule extends js.Any
+
+  SemanticDimmerModule
+
+  @js.native
+  @JSImport("semantic-ui-transition", JSImport.Default)
+  private object SemanticTransitionModule extends js.Any
+
+  SemanticTransitionModule
+
+  @js.native
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  trait SemanticTransition extends JQuery {
+    def transition(s: String): this.type
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def jq2Semantic($: JQuery): SemanticTransition = {
+    $.asInstanceOf[SemanticTransition]
+  }
+
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object SemanticUIModal {
+
+  @js.native
+  @JSImport("semantic-ui-modal", JSImport.Default)
+  private object SemanticModalModule extends js.Any
+
+  SemanticModalModule
+
+  @js.native
+  trait JsModalOptions extends js.Object
+
+  object JsModalOptions extends JsModalOptionBuilder(noOpts)
+
+  class JsModalOptionBuilder(val dict: OptMap) extends JSOptionBuilder[JsModalOptions, JsModalOptionBuilder](new JsModalOptionBuilder(_)) {
+    def autofocus(t: Boolean): JsModalOptionBuilder = jsOpt("autofocus", t)
+    def onDeny[A](t: js.Function0[A]): JsModalOptionBuilder = jsOpt("onDeny", t)
+    def onHide[A](t: js.Function0[A]): JsModalOptionBuilder = jsOpt("onHide", t)
+    def onHidden[A](t: js.Function0[A]): JsModalOptionBuilder = jsOpt("onHidden", t)
+    def onApprove[A](t: js.Function0[A]): JsModalOptionBuilder = jsOpt("onApprove", t)
+  }
+
+  @js.native
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  trait SemanticModal extends js.Object {
+    def modal(s: String): this.type
+    def modal(o: JsModalOptions): this.type
+
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def jq2Semantic(jQuery: JQuery): SemanticModal = jQuery.asInstanceOf[SemanticModal]
+}

--- a/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUIModal.scala
+++ b/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/SemanticUIModal.scala
@@ -16,12 +16,6 @@ import scala.scalajs.js.annotation.JSImport
 object SemanticUITransition {
 
   @js.native
-  @JSImport("semantic-ui-dimmer", JSImport.Default)
-  private object SemanticDimmerModule extends js.Any
-
-  SemanticDimmerModule
-
-  @js.native
   @JSImport("semantic-ui-transition", JSImport.Default)
   private object SemanticTransitionModule extends js.Any
 
@@ -42,6 +36,17 @@ object SemanticUITransition {
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object SemanticUIModal {
+  @js.native
+  @JSImport("semantic-ui-transition", JSImport.Default)
+  private object SemanticTransitionModule extends js.Any
+
+  SemanticTransitionModule
+
+  @js.native
+  @JSImport("semantic-ui-dimmer", JSImport.Default)
+  private object SemanticDimmerModule extends js.Any
+
+  SemanticDimmerModule
 
   @js.native
   @JSImport("semantic-ui-modal", JSImport.Default)
@@ -67,7 +72,6 @@ object SemanticUIModal {
   trait SemanticModal extends js.Object {
     def modal(s: String): this.type
     def modal(o: JsModalOptions): this.type
-
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -106,7 +106,6 @@ object Settings {
     val reactJS        = "15.6.1"
     val jQuery         = "3.2.1"
     val semanticUI     = "2.2.10"
-    val jQueryTerminal = "0.11.2"
     val ocsVersion     = "2017101.1.4"
 
     //Apache XMLRPC

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -76,7 +76,7 @@ object Settings {
     val diode        = "1.1.2"
     val javaTimeJS   = "0.2.2"
     val javaLogJS    = "0.1.2"
-    val scalaJQuery  = "1.0"
+    val scalaJQuery  = "1.2"
 
     // Java libraries
     val scalaZ       = "7.2.15"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,8 +22,10 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header"             % "3.0.1")
 // Built the version out of git
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"                % "0.9.3")
 
-
 addSbtPlugin("org.wartremover"   % "sbt-wartremover"        % "2.2.1")
+
+// Use NPM modules rather than webjars
+addSbtPlugin("ch.epfl.scala"     % "sbt-scalajs-bundler"    % "0.8.0")
 
 // Avoids a warning message when starting sbt-git
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"


### PR DESCRIPTION
We have been loading javascript dependencies using `webjars` instead of directly from `npm`. This method is being deprecated in favor of using `scalajs-bundler` to load `npm` modules.

This has several benefits:
* Direct access to the latest versions
* Better downstream management of dependencies
* We can get a reduced version of semantic-ui modules

And the most important of all, this lets us use `react` components directly. They are only supported via `npm` modules

This PR has been very long as the intersection of `sbt` and `npm` is complicated. There are some possible improvements but they will be done later on when possible

The interaction with `semantic/jquery` took quite a bit of effort and this leads me to attempt to use `semantic/react` instead in the future

as a result of this PR several other PRs were sent to upstream projects so this could be considered a win for OSS 😄 