### PR TITLE
SEQNG-395A: Reduce user facing logging

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -287,12 +287,17 @@ package object engine {
     /**
       * Log info lifted into Handle.
       */
-    def info(msg: String): HandleP[Unit] = pure((logger.info(msg), None)).void
+    def info(msg: => String): HandleP[Unit] = pure((logger.info(msg), None)).void
 
     /**
       * Log warning lifted into Handle.
       */
-    def warning(msg: String): HandleP[Unit] = pure((logger.warn(msg), None)).void
+    def warning(msg: => String): HandleP[Unit] = pure((logger.warn(msg), None)).void
+
+    /**
+      * Log debug lifted into Handle.
+      */
+    def debug(msg: => String): HandleP[Unit] = pure((logger.debug(msg), None)).void
   }
 
   /**
@@ -305,33 +310,33 @@ package object engine {
     */
   private def run(ev: Event): HandleP[Engine.State] = {
     def handleUserEvent(ue: UserEvent): HandleP[Unit] = ue match {
-      case Start(id, _)                => Logger.info("Engine: Started") *> start(id)
-      case Pause(id, _)                => Logger.info("Engine: Pause requested") *> pause(id)
-      case CancelPause(id, _)          => Logger.info("Engine: Pause canceled") *> cancelPause(id)
-      case Load(id, seq)               => Logger.info("Engine: Sequence loaded") *> load(id, seq)
-      case Unload(id)                  => Logger.info("Engine: Sequence unloaded") *> unload(id)
-      case Breakpoint(id, _, step, v)  => Logger.info("Engine: breakpoint changed") *> modifyS(id)(_.setBreakpoint(step, v))
-      case SetOperator(name, user)     => Logger.info(s"Engine: Setting Operator name to '$name' by ${ue.username}") *> setOperator(name)
-      case SetObserver(id, user, name) => Logger.info(s"Engine: Setting Observer for observation $id to '$name' by ${ue.username}") *> setObserver(id)(name)
-      case SetConditions(conds, user)  => Logger.info("Engine: Setting conditions") *> setConditions(conds)
-      case SetImageQuality(iq, user)   => Logger.info("Engine: Setting image quality") *> setImageQuality(iq)
-      case SetWaterVapor(wv, user)     => Logger.info("Engine: Setting water vapor") *> setWaterVapor(wv)
-      case SetSkyBackground(sb, user)  => Logger.info("Engine: Setting sky background") *> setSkyBackground(sb)
-      case SetCloudCover(cc, user)     => Logger.info("Engine: Setting cloud cover") *> setCloudCover(cc)
-      case Poll                        => Logger.info("Engine: Polling current state")
+      case Start(id, _)                => Logger.debug("Engine: Started") *> start(id)
+      case Pause(id, _)                => Logger.debug("Engine: Pause requested") *> pause(id)
+      case CancelPause(id, _)          => Logger.debug("Engine: Pause canceled") *> cancelPause(id)
+      case Load(id, seq)               => Logger.debug("Engine: Sequence loaded") *> load(id, seq)
+      case Unload(id)                  => Logger.debug("Engine: Sequence unloaded") *> unload(id)
+      case Breakpoint(id, _, step, v)  => Logger.debug("Engine: breakpoint changed") *> modifyS(id)(_.setBreakpoint(step, v))
+      case SetOperator(name, user)     => Logger.debug(s"Engine: Setting Operator name to '$name' by ${ue.username}") *> setOperator(name)
+      case SetObserver(id, user, name) => Logger.debug(s"Engine: Setting Observer for observation $id to '$name' by ${ue.username}") *> setObserver(id)(name)
+      case SetConditions(conds, user)  => Logger.debug("Engine: Setting conditions") *> setConditions(conds)
+      case SetImageQuality(iq, user)   => Logger.debug("Engine: Setting image quality") *> setImageQuality(iq)
+      case SetWaterVapor(wv, user)     => Logger.debug("Engine: Setting water vapor") *> setWaterVapor(wv)
+      case SetSkyBackground(sb, user)  => Logger.debug("Engine: Setting sky background") *> setSkyBackground(sb)
+      case SetCloudCover(cc, user)     => Logger.debug("Engine: Setting cloud cover") *> setCloudCover(cc)
+      case Poll                        => Logger.debug("Engine: Polling current state")
       case GetState(f)                 => getState(f)
-      case ActionStop(id, f)           => Logger.info("Engine: Action stop requested") *> actionStop(id, f)
-      case Log(msg)                    => Logger.info(msg)
+      case ActionStop(id, f)           => Logger.debug("Engine: Action stop requested") *> actionStop(id, f)
+      case Log(msg)                    => Logger.debug(msg)
     }
 
     def handleSystemEvent(se: SystemEvent): HandleP[Unit] = se match {
-      case Completed(id, i, r)     => Logger.info("Engine: Action completed") *> complete(id, i, r)
-      case PartialResult(id, i, r) => Logger.info("Engine: Partial result") *> partialResult(id, i, r)
-      case Failed(id, i, e)        => Logger.info("Engine: Action failed") *> fail(id)(i, e)
-      case Busy(id)                => Logger.info("Engine: Resources needed for this sequence are in use")
-      case Executed(id)            => Logger.info("Engine: Execution completed") *> next(id)
-      case Executing(id)           => Logger.info("Engine: Executing") *> execute(id)
-      case Finished(id)            => Logger.info("Engine: Finished") *> switch(id)(SequenceState.Completed)
+      case Completed(id, i, r)     => Logger.debug("Engine: Action completed") *> complete(id, i, r)
+      case PartialResult(id, i, r) => Logger.debug("Engine: Partial result") *> partialResult(id, i, r)
+      case Failed(id, i, e)        => Logger.debug("Engine: Action failed") *> fail(id)(i, e)
+      case Busy(id)                => Logger.debug("Engine: Resources needed for this sequence are in use")
+      case Executed(id)            => Logger.debug("Engine: Execution completed") *> next(id)
+      case Executing(id)           => Logger.debug("Engine: Executing") *> execute(id)
+      case Finished(id)            => Logger.debug("Engine: Finished") *> switch(id)(SequenceState.Completed)
       case Null                    => unit
     }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gcal/GcalControllerSim.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gcal/GcalControllerSim.scala
@@ -27,7 +27,7 @@ object GcalControllerSim extends GcalController {
     s"diffuser = ${config.diffuser}")
 
   override def applyConfig(config: GcalConfig): SeqAction[Unit] = SeqAction.either {
-    Log.info("applyConfig: config is\n" + printConfig(config).mkString("\n"))
+    Log.debug("applyConfig: config is\n" + printConfig(config).mkString("\n"))
     TrySeq(())
   }
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
@@ -40,4 +40,3 @@ package object server {
       }
   }
 }
-

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/Tcs.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/Tcs.scala
@@ -74,7 +74,7 @@ final case class Tcs(tcsController: TcsController, subsystems: NonEmptyList[Subs
     //The desired science fold position is passed as a class parameter
     val tcsConfig = configFromSequence.copy(agc = configFromSequence.agc.copy(sfPos = scienceFoldPosition.some))
 
-    Log.info(s"Applying TCS configuration: ${subsystems.toList.flatMap(subsystemConfig(tcsConfig, _))}")
+    Log.debug(s"Applying TCS configuration: ${subsystems.toList.flatMap(subsystemConfig(tcsConfig, _))}")
 
     if (subsystems.toList.contains(Subsystem.Mount))
       for {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/logging/AppenderForClients.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/logging/AppenderForClients.scala
@@ -23,7 +23,8 @@ import java.time.Instant
  * This is out of the scala/http4s loop
  */
 class AppenderForClients(out: Topic[SeqexecEvent]) extends AppenderBase[ILoggingEvent] {
-  // Remove some loggers. This is a weak for of protection
+  // Remove some loggers. This is a weak form of protection where he don't send some
+  // loggers to the cilent, e.g. security related logs
   private val blackListedLoggers = List(""".*\.security\..*""".r)
 
   override def append(event: ILoggingEvent): Unit = {


### PR DESCRIPTION
This is a partial update to reduce logging that reaches the user. It mostly consist in converting `info` to `debug` and a special case for the `security` logger

There is likely some more work to do in this context but this is a first step