### PR TITLE
SEQNG-397: Send observation state to the clients

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ActionType.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ActionType.scala
@@ -5,6 +5,8 @@ package edu.gemini.seqexec.model
 
 import edu.gemini.seqexec.model.Model.Resource
 
+import scalaz.Equal
+
 /**
   * Created by jluhrs on 10/13/17.
   */
@@ -15,4 +17,6 @@ object ActionType {
   // Used in tests
   object Undefined extends ActionType
   final case class Configure(sys: Resource) extends ActionType
+
+  implicit val eq: Equal[ActionType] = Equal.equalA[ActionType]
 }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -246,6 +246,8 @@ object Model {
     case object Pending extends ActionStatus
     case object Completed extends ActionStatus
     case object Running extends ActionStatus
+
+    implicit val equal: Equal[ActionStatus] = Equal.equalA[ActionStatus]
   }
 
   sealed trait Step {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -297,12 +297,12 @@ object SeqexecEngine {
   def splitAfter[A](l: List[A])(p: (A => Boolean)): (List[A], List[A]) =
     l.splitAt(l.indexWhere(p) + 1)
 
-  def kindToResult(kind: ActionType): List[Resource] = kind match {
+  private def kindToResource(kind: ActionType): List[Resource] = kind match {
     case ActionType.Configure(r) => List(r)
     case _                       => Nil
   }
 
-  def configStatus(executions: List[List[engine.Action \/ engine.Result]]): List[(Resource, ActionStatus)] = {
+  private[server] def configStatus(executions: List[List[engine.Action \/ engine.Result]]): List[(Resource, ActionStatus)] = {
     // Split where at least one is running
     val (current, pending) = splitAfter(executions)(ex => ex.lefts.nonEmpty)
 
@@ -311,15 +311,15 @@ object SeqexecEngine {
       case (s, e) =>
         val (a, r) = e.separate
           .bimap(
-            _.flatMap(a => kindToResult(a.kind).strengthR(ActionStatus.Running)).toMap,
-            _.flatMap(r => kindToResult(r.kind).strengthR(ActionStatus.Completed)).toMap)
+            _.flatMap(a => kindToResource(a.kind).strengthR(ActionStatus.Running)).toMap,
+            _.flatMap(r => kindToResource(r.kind).strengthR(ActionStatus.Completed)).toMap)
         s ++ a ++ r
     }
 
     // Find out systems in the future
     val presentSystems = configStatus.keys
     val systemsPending = pending.map {
-      s => s.separate.bimap(_.map(_.kind).flatMap(kindToResult), _.map(_.kind).flatMap(kindToResult))
+      s => s.separate.bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
     }.flatMap {
       x => x._1 ::: x._2
     }.distinct
@@ -329,20 +329,41 @@ object SeqexecEngine {
     (configStatus ++ pendingConfig).toList.sortBy(_._1)
   }
 
-  def pendingConfigStatus(executions: List[List[engine.Action \/ engine.Result]]): List[(Resource, ActionStatus)] =
+  /**
+   * Calculates the config status for pending steps
+   */
+  private[server] def pendingConfigStatus(executions: List[List[engine.Action \/ engine.Result]]): List[(Resource, ActionStatus)] =
     executions.map {
-      s => s.separate.bimap(_.map(_.kind).flatMap(kindToResult), _.map(_.kind).flatMap(kindToResult))
+      s => s.separate.bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
     }.flatMap {
       x => x._1 ::: x._2
     }.distinct.strengthR(ActionStatus.Pending).sortBy(_._1)
 
-  def stepConfigStatus(step: StepAR): List[(Resource, ActionStatus)] =
+  /**
+   * Overall pending status for a step
+   */
+  private def stepConfigStatus(step: StepAR): List[(Resource, ActionStatus)] =
     engine.Step.status(step) match {
       case StepState.Pending => pendingConfigStatus(step.executions)
       case _                 => configStatus(step.executions)
     }
 
+  protected[server] def observeStatus(executions: List[List[engine.Action \/ engine.Result]], configStatus: List[(Resource, ActionStatus)]): ActionStatus = {
+    if (configStatus.forall(_._2 === ActionStatus.Completed)) {
+      // Find one with kind observe
+      executions.map { e =>
+        e.separate.bimap(_.map(_.kind), _.map(_.kind))
+      }.filter {
+        case (a, r) => a.contains(ActionType.Observe) || r.contains(ActionType.Observe)
+      }.map {
+        case (a, r) if r.contains(ActionType.Observe) => ActionStatus.Completed
+        case _                                        => ActionStatus.Running
+      }.headOption.getOrElse(ActionStatus.Pending)
+    } else ActionStatus.Pending
+  }
+
   def viewStep(step: StepAR): StandardStep = {
+    val configStatus = stepConfigStatus(step)
     StandardStep(
       id = step.id,
       config = step.config,
@@ -351,9 +372,8 @@ object SeqexecEngine {
       breakpoint = step.breakpoint,
       // TODO: Implement skipping at Engine level
       skip = false,
-      configStatus = stepConfigStatus(step),
-      // TODO: Implement standard step at Engine level
-      observeStatus = ActionStatus.Pending,
+      configStatus = configStatus,
+      observeStatus = observeStatus(step.executions, configStatus),
       fileId = step.fileId
     )
   }

--- a/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqexecEngineSpec.scala
@@ -23,6 +23,8 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
     engine.fromTask(ActionType.Observe, dummyTask).left[Result]
   def observed: Action \/ Result =
     Result.OK(Result.Observed("fileId")).right[Action]
+  def fileId: Action \/ Result =
+    Result.Partial(Result.FileIdAllocated("fileId"), engine.fromTask(ActionType.Observe, dummyTask)).right[Action]
 
   "SeqexecEngine configStatus" should
     "build empty without tasks" in {
@@ -125,5 +127,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
       val executions: List[List[Action \/ Result]] = List(
         List(done(Resource.TCS), observed))
       SeqexecEngine.observeStatus(executions, status) shouldBe ActionStatus.Completed
+    }
+    it should "be running if there is a partial result with the file id" in {
+      val status = List(Resource.TCS -> ActionStatus.Completed)
+      val executions: List[List[Action \/ Result]] = List(
+        List(done(Resource.TCS), fileId))
+      SeqexecEngine.observeStatus(executions, status) shouldBe ActionStatus.Running
     }
 }


### PR DESCRIPTION
This PR calculates the current observation status on each step out of the executions and adds it to the state sent to the clients