### PR TITLE
SEQNG-116: Don't display observe controls until exposing

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqexecEngineSpec.scala
@@ -50,10 +50,10 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
       SeqexecEngine.configStatus(executions) shouldBe status
     }
     it should "be some complete and some pending if one will be done in the future" in {
-      val status = List(Resource.TCS -> ActionStatus.Pending, Instrument.GmosN -> ActionStatus.Running)
+      val status = List(Resource.TCS -> ActionStatus.Completed, Instrument.GmosN -> ActionStatus.Running)
       val executions: List[List[Action \/ Result]] = List(
         List(running(Instrument.GmosN)),
-        List(done(Resource.TCS), done(Resource.TCS)))
+        List(done(Resource.TCS), done(Instrument.GmosN)))
       SeqexecEngine.configStatus(executions) shouldBe status
     }
     it should "stop at the first with running steps" in {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -134,13 +134,13 @@ object StepsTableContainer {
             ^.cls := "left column five wide left floated",
             <.div(
               ^.cls := "ui segment basic running",
-              step.status.shows
+              step.shows
             )
           ),
           <.div(
             ^.cls := "right floated right aligned eleven wide computer sixteen wide tablet only",
             SeqexecStyles.buttonsRow,
-            StepsControlButtons(p.id, p.instrument, p.state, step)
+            StepsControlButtons(p.id, p.instrument, p.state, step).when(step.isObserving)
           ).when(loggedIn && p.state === SequenceState.Running)
         )
       )
@@ -258,7 +258,10 @@ object StepsTableContainer {
         ),
         <.td(
           ^.onDoubleClick --> selectRow(step, i),
-          ^.cls := "middle aligned",
+          ^.classSet(
+            "top aligned"    -> step.isObserving,
+            "middle aligned" -> !step.isObserving
+          ),
           stepProgress(state, step)
         ),
         <.td(


### PR DESCRIPTION
This PR updates the UI to display the abort/stop button only when observing. It will also indicate when we are configuring and observing

The video below shows how it works now:

https://www.dropbox.com/s/ll3ay292vazy7n0/screencast%202017-10-30%2014-31-44.mp4?dl=0