### PR TITLE
Fix for a test that fails if the generator bounds are wrong

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/test/scala/edu/gemini/seqexec/web/common/ArbitrariesWebCommon.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/test/scala/edu/gemini/seqexec/web/common/ArbitrariesWebCommon.scala
@@ -24,7 +24,7 @@ trait ArbitrariesWebCommon {
     Arbitrary {
       val maxSize = 1000
       for {
-        l <- Gen.choose(0, maxSize)
+        l <- Gen.choose(1, maxSize)
         s <- Gen.choose(0, l - 1)
         d <- Gen.listOfN(s, arbitrary[A])
       } yield FixedLengthBuffer.unsafeFromInt(l, d: _*)


### PR DESCRIPTION
Sometimes we have an error on a test happening because the bounds used to generate test cases is bogus