### PR TITLE
SEQNG-398: Update layout

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/ControlMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/ControlMenu.scala
@@ -16,9 +16,9 @@ import japgolly.scalajs.react.vdom.html_<^._
 import scalacss.ScalaCssReact._
 
 /**
-  * Menu at the top bar
+  * Menu with options
   */
-object TopMenu {
+object ControlMenu {
 
   final case class Props(status: ModelProxy[ClientStatus])
 
@@ -26,7 +26,7 @@ object TopMenu {
   def logout[A](proxy: ModelProxy[A]): Callback = proxy.dispatchCB(Logout)
 
   private def loginButton[A](proxy: ModelProxy[A], enabled: Boolean) =
-    Button(Button.Props(size = Size.Medium, onClick = openLogin(proxy), disabled = !enabled), "Login")
+    Button(Button.Props(size = Size.Medium, onClick = openLogin(proxy), disabled = !enabled, inverted = true), "Login")
 
   private def logoutButton[A](proxy: ModelProxy[A], text: String, enabled: Boolean) =
     Button(Button.Props(size = Size.Medium, onClick = logout(proxy), icon = Some(IconSignOut), disabled = !enabled), text)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/ControlMenu.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/ControlMenu.scala
@@ -29,7 +29,7 @@ object ControlMenu {
     Button(Button.Props(size = Size.Medium, onClick = openLogin(proxy), disabled = !enabled, inverted = true), "Login")
 
   private def logoutButton[A](proxy: ModelProxy[A], text: String, enabled: Boolean) =
-    Button(Button.Props(size = Size.Medium, onClick = logout(proxy), icon = Some(IconSignOut), disabled = !enabled), text)
+    Button(Button.Props(size = Size.Medium, onClick = logout(proxy), icon = Some(IconSignOut), disabled = !enabled, inverted = true), text)
 
   private val component = ScalaComponent.builder[Props]("SeqexecTopMenu")
     .stateless

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/Footer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/Footer.scala
@@ -27,7 +27,7 @@ import scalaz.syntax.show._
   */
 object Footer {
   private val userConnect = SeqexecCircuit.connect(SeqexecCircuit.statusReader)
-  // private val wsConnect = SeqexecCircuit.connect(_.ws)
+  private val wsConnect = SeqexecCircuit.connect(_.ws)
 
   private def goHome(e: ReactEvent): Callback = {
     e.preventDefault
@@ -45,6 +45,7 @@ object Footer {
           s"Seqexec - ${p.show}"
         ),
         HeaderItem(HeaderItem.Props(OcsBuildInfo.version, sub = true)),
+        wsConnect(ConnectionState.apply),
         userConnect(ControlMenu.apply)
       )
     )
@@ -80,10 +81,10 @@ object ConnectionState {
     .stateless
     .render_P( p =>
       <.div(
-        ^.cls := "header item",
+        ^.cls := "ui header item sub",
         p.u.ws.renderPending(t =>
           <.div(
-            IconAttention.copyIcon(size = Size.Large, color = Option("red")),
+            IconAttention.copyIcon(color = Option("red")),
             <.span(
               SeqexecStyles.errorText,
               s"Connection lost, retrying in ${formatTime(p.u.nextAttempt)} [s] ..."

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/Footer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/Footer.scala
@@ -11,7 +11,6 @@ import edu.gemini.seqexec.web.client.circuit.SeqexecCircuit
 import edu.gemini.seqexec.web.client.model.WebSocketConnection
 import edu.gemini.seqexec.web.client.model.Pages.Root
 import edu.gemini.seqexec.web.client.OcsBuildInfo
-import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
 import edu.gemini.seqexec.web.client.semanticui.elements.menu.HeaderItem
 import japgolly.scalajs.react._

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/Footer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/Footer.scala
@@ -25,9 +25,9 @@ import scalaz.syntax.show._
 /**
   * Component for the bar at the top of the page
   */
-object NavBar {
+object Footer {
   private val userConnect = SeqexecCircuit.connect(SeqexecCircuit.statusReader)
-  private val wsConnect = SeqexecCircuit.connect(_.ws)
+  // private val wsConnect = SeqexecCircuit.connect(_.ws)
 
   private def goHome(e: ReactEvent): Callback = {
     e.preventDefault
@@ -38,28 +38,14 @@ object NavBar {
     .stateless
     .render_P(p =>
       <.div(
-        SeqexecStyles.mainContainer,
-        <.div(
-          ^.cls := "ui container five column stackable grid",
-          <.div(
-            ^.cls := "ui row",
-            HeaderItem(HeaderItem.Props(name = ""),
-              <.a(
-                ^.href := "/#",
-                <.img(
-                  ^.cls := "ui mini image logo",
-                  SeqexecStyles.logo,
-                  ^.src :="/images/launcher.png"
-                ),
-                ^.onClick ==> goHome
-              ),
-              s"Seqexec - ${p.show}"
-            ),
-            HeaderItem(HeaderItem.Props(OcsBuildInfo.version, sub = true)),
-            wsConnect(ConnectionState.apply),
-            userConnect(TopMenu.apply)
-          )
-        )
+        ^.cls := "ui footer inverted menu",
+        <.a(
+          ^.cls := "header item",
+          ^.onClick ==> goHome,
+          s"Seqexec - ${p.show}"
+        ),
+        HeaderItem(HeaderItem.Props(OcsBuildInfo.version, sub = true)),
+        userConnect(ControlMenu.apply)
       )
     )
     .componentDidMount(ctx =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -21,7 +21,7 @@ object LogArea {
     .stateless
     .render_P(p =>
       <.div(
-        // ^.cls := "ui raised segments container",
+        ^.cls := "ui raised segments container",
         // TextMenuSegment("Log", "key.log.menu"),
         <.div(
           ^.cls := "ui sixteen wide column",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -21,10 +21,10 @@ object LogArea {
     .stateless
     .render_P(p =>
       <.div(
-        ^.cls := "ui raised segments container",
-        TextMenuSegment("Log", "key.log.menu"),
+        // ^.cls := "ui raised segments container",
+        // TextMenuSegment("Log", "key.log.menu"),
         <.div(
-          ^.cls := "ui secondary segment",
+          ^.cls := "ui sixteen wide column",
           <.div(
             ^.cls := "ui form",
             <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -23,7 +23,7 @@ object LogArea {
       <.div(
         ^.cls := "ui sixteen wide column",
         <.div(
-          ^.cls := "ui raised secondary segment",
+          ^.cls := "ui secondary segment",
           <.div(
             ^.cls := "ui form",
             <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -21,14 +21,14 @@ object LogArea {
     .stateless
     .render_P(p =>
       <.div(
-        ^.cls := "ui raised segments container",
-        // TextMenuSegment("Log", "key.log.menu"),
+        ^.cls := "ui sixteen wide column",
         <.div(
-          ^.cls := "ui sixteen wide column",
+          ^.cls := "ui raised secondary segment",
           <.div(
             ^.cls := "ui form",
             <.div(
               ^.cls := "field",
+              <.label("Log"),
               <.textarea(
                 ^.readOnly := true,
                 ^.value := p.log.log.map(e => s"${e.timestamp} ${e.msg}").toVector.mkString("\n")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -163,21 +163,8 @@ object QueueArea {
     .stateless
     .render_P(p =>
       <.div(
-        ^.cls := "ui raised segments container",
-        TextMenuSegment("Night Queue", "key.queue.menu"),
-        <.div(
-          ^.cls := "ui attached segment",
-          <.div(
-            ^.cls := "ui grid",
-            <.div(
-              ^.cls := "stretched row",
-              <.div(
-                ^.cls := "sixteen wide column",
-                QueueTableSection(p)
-              )
-            )
-          )
-        )
+        ^.cls := "sixteen wide column",
+        QueueTableSection(p)
       )
     )
     .build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -163,7 +163,7 @@ object QueueArea {
     .stateless
     .render_P(p =>
       <.div(
-        ^.cls := "sixteen wide column",
+        ^.cls := "twelve wide column",
         QueueTableSection(p)
       )
     )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -77,8 +77,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val queueListPane: StyleA = style (
-    maxHeight(13.5.em),
-    minHeight(13.5.em),
+    maxHeight(15.45.em),
+    minHeight(15.45.em),
     marginTop(0.px).important
   )
 
@@ -307,8 +307,6 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val stepsTable: StyleA = style(
-    maxHeight(24.3.em),
-    minHeight(24.3.em),
     // CSS Dark magic to get the gutter background, see
     // http://stackoverflow.com/questions/14628601/can-i-add-background-color-only-for-padding
     (backgroundImage := s"linear-gradient(to bottom, rgba(249, 0, 1, 0) 0%, rgba(249, 0, 1, 0) 0%), linear-gradient(to right, rgba(34, 36, 38, 0.15) 0px, rgba(34, 36, 38, 0.00001) ${gutterWidth}px)").important,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -126,7 +126,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val shorterFields: StyleA = style(
-    marginBottom(-0.2.em).important
+    marginBottom(0.2.em).important
   )
 
   val hidden: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -125,6 +125,10 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     marginTop(-1.em).important
   )
 
+  val shorterFields: StyleA = style(
+    marginBottom(-0.2.em).important
+  )
+
   val hidden: StyleA = style(
     display.none
   )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -96,8 +96,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     display.inline
   }
 
-  val controlColumn: StyleA = style {
-    paddingBottom(0.px).important
+  val observerField: StyleA = style {
+    paddingRight(0.px).important
   }
 
   val noPadding: StyleS = mixin(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -80,12 +80,9 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     marginTop(0.px).important
   )
 
-  val searchResultListPane: StyleA = style {
-    maxHeight(10.3.em)
-  }
-
   val stepsListPane: StyleA = style (
-    maxHeight(24.3.em)
+    maxHeight(24.3.em),
+    minHeight(24.3.em)
   )
 
   val stepsListBody: StyleA = style() // Marker css
@@ -121,6 +118,19 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
 
   val shorterRow: StyleA = style(
     marginBottom(-1.em).important
+  )
+
+  val emptyInstrumentTab: StyleA = style(
+    minHeight(31.8.em)
+  )
+
+  val instrumentTab: StyleA = style(
+    minWidth(20.%%),
+    textAlign.center
+  )
+
+  val instrumentTabLabel: StyleA = style(
+    width(100.%%)
   )
 
   val lowerRow: StyleA = style(
@@ -279,6 +289,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val stepsTable: StyleA = style(
+    maxHeight(24.3.em),
+    minHeight(24.3.em),
     // CSS Dark magic to get the gutter background, see
     // http://stackoverflow.com/questions/14628601/can-i-add-background-color-only-for-padding
     (backgroundImage := s"linear-gradient(to bottom, rgba(249, 0, 1, 0) 0%, rgba(249, 0, 1, 0) 0%), linear-gradient(to right, rgba(34, 36, 38, 0.15) 0px, rgba(34, 36, 38, 0.00001) ${gutterWidth}px)").important,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -51,7 +51,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val activeInstrumentContent: StyleA = style(
-    padding(0.6.em, 0.9.em)
+    padding(0.6.em, 0.9.em),
+    backgroundColor(rgb(243, 244, 245)).important
   )
 
   val fieldsNoBottom: StyleA = style(
@@ -117,7 +118,11 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val shorterRow: StyleA = style(
-    marginBottom(-1.em)
+    marginBottom(-1.em).important
+  )
+
+  val lowerRow: StyleA = style(
+    marginTop(-1.em).important
   )
 
   val hidden: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -16,7 +16,9 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   private val iconWidth = 16.5
 
   val body: StyleA = style(unsafeRoot("body")(
-    backgroundColor(white)
+    backgroundColor(white),
+    display.flex,
+    flexDirection.column
   ))
 
   val mainContainer: StyleA = style(
@@ -266,6 +268,14 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
         )
       )
     )
+  )
+
+  val footerSegment: StyleA = style("ui.footer")(
+    position.fixed,
+    bottom(0.px),
+    width(100.%%),
+    marginBottom(0.px),
+    backgroundColor(c"#F5F5F5")
   )
 
   val stepsTable: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -4,6 +4,8 @@
 package edu.gemini.seqexec.web.client.components
 
 import scalacss.DevDefaults._
+import scalacss.internal.Keyframes
+import scala.concurrent.duration._
 
 /**
   * Custom CSS for the Seqexec UI
@@ -151,6 +153,22 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
 
   val errorTab: StyleA = style(
     borderTop(3.px, red, solid).important
+  )
+
+  val noOpacity: StyleA = style(
+    opacity(0)
+  )
+
+  val blink: Keyframes = keyframes(
+    50.%% -> noOpacity
+  )
+
+  val blinking: StyleA = style(
+    animationName(blink),
+    animationDuration(1.7.seconds),
+    animationIterationCount.infinite,
+    animationTimingFunction.cubicBezier(0.5, 0, 1, 1),
+    animationDirection.alternate
   )
 
   val buttonsRow: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -116,6 +116,10 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     )
   )
 
+  val shorterRow: StyleA = style(
+    marginBottom(-1.em)
+  )
+
   val hidden: StyleA = style(
     display.none
   )
@@ -184,6 +188,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   val gutterIconVisible: StyleA = style(
     visibility.visible
   )
+
   val gutterIconHidden: StyleA = style(
     visibility.hidden
   )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -14,6 +14,7 @@ import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.{Callback, ScalaComponent}
 import diode.ModelRO
 import japgolly.scalajs.react.component.Scala.Unmounted
+import scalacss.ScalaCssReact._
 
 import scala.scalajs.js.timers.SetTimeoutHandle
 import scalaz.syntax.show._
@@ -37,20 +38,24 @@ object SeqexecMain {
           ^.cls := "ui horizontally padded grid",
           <.div(
             ^.cls := "ui row",
-          QueueArea(p.ctl)
-        ),
+            SeqexecStyles.shorterRow,
+            QueueArea(p.ctl)
+          ),
           <.div(
             ^.cls := "ui row",
-          SequenceArea(p.site)
-        ),
+            SeqexecStyles.shorterRow,
+            SequenceArea(p.site)
+          ),
           <.div(
             ^.cls := "ui row",
-          HeadersArea(p.site)
-        ),
+            SeqexecStyles.shorterRow,
+            HeadersArea(p.site)
+          ),
           <.div(
             ^.cls := "ui row",
-          logConnect(LogArea.apply)
-        ),
+            SeqexecStyles.shorterRow,
+            logConnect(LogArea.apply)
+          )
         ),
         lbConnect(LoginBox.apply),
         resourcesBusyConnect(ResourcesBox.apply)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -16,8 +16,9 @@ import diode.ModelRO
 import japgolly.scalajs.react.component.Scala.Unmounted
 
 import scala.scalajs.js.timers.SetTimeoutHandle
-import scalaz._
-import Scalaz._
+import scalaz.syntax.show._
+import scalaz.syntax.equal._
+import scalaz.syntax.std.option._
 import scalaz.effect.IO
 
 object SeqexecMain {
@@ -32,10 +33,25 @@ object SeqexecMain {
     .render_P(p =>
       <.div(
         NavBar(p.site),
-        QueueArea(p.ctl),
-        SequenceArea(p.site),
-        HeadersArea(p.site),
-        logConnect(LogArea.apply),
+        <.div(
+          ^.cls := "ui horizontally padded grid",
+          <.div(
+            ^.cls := "ui row",
+          QueueArea(p.ctl)
+        ),
+          <.div(
+            ^.cls := "ui row",
+          SequenceArea(p.site)
+        ),
+          <.div(
+            ^.cls := "ui row",
+          HeadersArea(p.site)
+        ),
+          <.div(
+            ^.cls := "ui row",
+          logConnect(LogArea.apply)
+        ),
+        ),
         lbConnect(LoginBox.apply),
         resourcesBusyConnect(ResourcesBox.apply)
       )
@@ -61,7 +77,7 @@ object SeqexecUI {
       | dynamicRoute(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+").option)
         .pmap {
           case (i, Some(s)) => instrumentNames.get(i).map(InstrumentPage(_, s.some))
-          case (i, None)    => instrumentNames.get(i).map(InstrumentPage(_, none))
+          case (i, None)    => instrumentNames.get(i).map(InstrumentPage(_, None))
         }(p => (p.instrument.shows, p.obsId))) {
           case x @ InstrumentPage(i, _) if site.instruments.list.toList.contains(i) => x
         } ~> dynRenderR((p, r) => SeqexecMain(site, r))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -7,7 +7,7 @@ import edu.gemini.seqexec.web.client.circuit.SeqexecCircuit
 import edu.gemini.seqexec.web.client.actions.WSConnect
 import edu.gemini.seqexec.web.client.model.Pages._
 import edu.gemini.seqexec.web.client.actions.NavigateSilentTo
-import edu.gemini.seqexec.web.client.components.sequence.SequenceArea
+import edu.gemini.seqexec.web.client.components.sequence.{HeadersArea, SequenceArea}
 import edu.gemini.seqexec.model.Model.SeqexecSite
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router._
@@ -34,6 +34,7 @@ object SeqexecMain {
         NavBar(p.site),
         QueueArea(p.ctl),
         SequenceArea(p.site),
+        HeadersArea(p.site),
         logConnect(LogArea.apply),
         lbConnect(LoginBox.apply),
         resourcesBusyConnect(ResourcesBox.apply)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -7,7 +7,7 @@ import edu.gemini.seqexec.web.client.circuit.SeqexecCircuit
 import edu.gemini.seqexec.web.client.actions.WSConnect
 import edu.gemini.seqexec.web.client.model.Pages._
 import edu.gemini.seqexec.web.client.actions.NavigateSilentTo
-import edu.gemini.seqexec.web.client.components.sequence.{HeadersArea, SequenceArea}
+import edu.gemini.seqexec.web.client.components.sequence.{HeadersSideBar, SequenceArea}
 import edu.gemini.seqexec.model.Model.SeqexecSite
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router._
@@ -28,6 +28,7 @@ object SeqexecMain {
   private val lbConnect = SeqexecCircuit.connect(_.uiModel.loginBox)
   private val logConnect = SeqexecCircuit.connect(_.uiModel.globalLog)
   private val resourcesBusyConnect = SeqexecCircuit.connect(_.uiModel.resourceConflict)
+  private val headerSideBarConnect = SeqexecCircuit.connect(SeqexecCircuit.headerSideBarReader)
 
   private val component = ScalaComponent.builder[Props]("SeqexecUI")
     .stateless
@@ -39,17 +40,19 @@ object SeqexecMain {
           <.div(
             ^.cls := "ui row",
             SeqexecStyles.shorterRow,
-            QueueArea(p.ctl)
+            <.div(
+              ^.cls := "ten wide column",
+              QueueTableSection(p.ctl)
+            ),
+            <.div(
+              ^.cls := "six wide column",
+              headerSideBarConnect(HeadersSideBar.apply)
+            )
           ),
           <.div(
             ^.cls := "ui row",
             SeqexecStyles.shorterRow,
             SequenceArea(p.site)
-          ),
-          <.div(
-            ^.cls := "ui row",
-            SeqexecStyles.shorterRow,
-            HeadersArea(p.site)
           ),
           <.div(
             ^.cls := "ui row",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -34,9 +34,20 @@ object SeqexecMain {
     .stateless
     .render_P(p =>
       <.div(
-        NavBar(p.site),
         <.div(
           ^.cls := "ui horizontally padded grid",
+          <.div(
+            ^.cls := "ui row",
+            SeqexecStyles.shorterRow
+          ),
+          <.div(
+            ^.cls := "ui row",
+            SeqexecStyles.shorterRow,
+            <.h4(
+              ^.cls := "ui horizontal divider header",
+              s"Seqexec ${p.site.show}"
+            )
+          ),
           <.div(
             ^.cls := "ui row",
             SeqexecStyles.shorterRow,
@@ -61,7 +72,8 @@ object SeqexecMain {
           )
         ),
         lbConnect(LoginBox.apply),
-        resourcesBusyConnect(ResourcesBox.apply)
+        resourcesBusyConnect(ResourcesBox.apply),
+        Footer(p.site)
       )
     ).build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -82,28 +82,30 @@ object HeadersSideBar {
                 <.div(
                   ^.cls := "required field",
                   FormLabel(FormLabel.Props("Operator", Some("operator"))),
-                  InputEV(InputEV.Props("operator", "operator",
-                    operatorEV,
-                    placeholder = "Operator...",
-                    disabled = !enabled,
-                    onBlur = _ => submitIfChanged
-                  ))
+                  InputEV(
+                    InputEV.Props("operator", "operator",
+                      operatorEV,
+                      placeholder = "Operator...",
+                      disabled = !enabled,
+                      onBlur = _ => submitIfChanged
+                    )
+                  )
                 )
-              ),
+              )
             ),
             <.div(
               ^.cls := "row",
               <.div(
                 ^.cls := "four wide column",
-                DropdownMenu(DropdownMenu.Props("Image Quality", p.model().conditions.iq.some, "Select", ImageQuality.all, disabled = !enabled, iqChanged)),
+                DropdownMenu(DropdownMenu.Props("Image Quality", p.model().conditions.iq.some, "Select", ImageQuality.all, disabled = !enabled, iqChanged))
               ),
               <.div(
                 ^.cls := "four wide column",
-                DropdownMenu(DropdownMenu.Props("Cloud Cover", p.model().conditions.cc.some, "Select", CloudCover.all, disabled = !enabled, ccChanged)),
+                DropdownMenu(DropdownMenu.Props("Cloud Cover", p.model().conditions.cc.some, "Select", CloudCover.all, disabled = !enabled, ccChanged))
               ),
               <.div(
                 ^.cls := "four wide column",
-                DropdownMenu(DropdownMenu.Props("Water Vapor", p.model().conditions.wv.some, "Select", WaterVapor.all, disabled = !enabled, wvChanged)),
+                DropdownMenu(DropdownMenu.Props("Water Vapor", p.model().conditions.wv.some, "Select", WaterVapor.all, disabled = !enabled, wvChanged))
               ),
               <.div(
                 ^.cls := "four wide column",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -10,11 +10,13 @@ import edu.gemini.seqexec.web.client.semanticui.elements.label.FormLabel
 import edu.gemini.seqexec.web.client.semanticui.elements.input.InputEV
 import edu.gemini.seqexec.web.client.circuit.{HeaderSideBarFocus, SeqexecCircuit}
 import edu.gemini.seqexec.web.client.actions.{UpdateOperator, UpdateCloudCover, UpdateWaterVapor, UpdateImageQuality, UpdateSkyBackground}
+import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.{BackendScope, Callback, ScalaComponent}
 import japgolly.scalajs.react.extra.{StateSnapshot, TimerSupport}
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom.html.Div
+import scalacss.ScalaCssReact._
 
 import scalaz.syntax.equal._
 import scalaz.std.string._
@@ -70,48 +72,36 @@ object HeadersSideBar {
 
       val operatorEV = StateSnapshot(~s.currentText)(updateState)
       <.div(
-        ^.cls := "ui raised secondary segment",
+        ^.cls := "ui secondary segment",
         <.div(
           ^.cls := "ui form",
           <.div(
-            ^.cls := "ui grid",
+            ^.cls := "fields",
+            SeqexecStyles.fieldsNoBottom,
             <.div(
-              ^.cls := "row",
-              <.div(
-                ^.cls := "sixteen wide column",
-                <.div(
-                  ^.cls := "required field",
-                  FormLabel(FormLabel.Props("Operator", Some("operator"))),
-                  InputEV(
-                    InputEV.Props("operator", "operator",
-                      operatorEV,
-                      placeholder = "Operator...",
-                      disabled = !enabled,
-                      onBlur = _ => submitIfChanged
-                    )
-                  )
+              ^.cls := "sixteen wide field",
+              FormLabel(FormLabel.Props("Operator", Some("operator"))),
+              InputEV(
+                InputEV.Props("operator", "operator",
+                  operatorEV,
+                  placeholder = "Operator...",
+                  disabled = !enabled,
+                  onBlur = _ => submitIfChanged
                 )
               )
-            ),
-            <.div(
-              ^.cls := "row",
-              <.div(
-                ^.cls := "four wide column",
-                DropdownMenu(DropdownMenu.Props("Image Quality", p.model().conditions.iq.some, "Select", ImageQuality.all, disabled = !enabled, iqChanged))
-              ),
-              <.div(
-                ^.cls := "four wide column",
-                DropdownMenu(DropdownMenu.Props("Cloud Cover", p.model().conditions.cc.some, "Select", CloudCover.all, disabled = !enabled, ccChanged))
-              ),
-              <.div(
-                ^.cls := "four wide column",
-                DropdownMenu(DropdownMenu.Props("Water Vapor", p.model().conditions.wv.some, "Select", WaterVapor.all, disabled = !enabled, wvChanged))
-              ),
-              <.div(
-                ^.cls := "four wide column",
-                DropdownMenu(DropdownMenu.Props("Sky Background", p.model().conditions.sb.some, "Select", SkyBackground.all, disabled = !enabled, sbChanged))
-              )
             )
+          ),
+          <.div(
+            ^.cls := "two fields",
+            SeqexecStyles.fieldsNoBottom,
+            DropdownMenu(DropdownMenu.Props("Image Quality", p.model().conditions.iq.some, "Select", ImageQuality.all, disabled = !enabled, iqChanged)),
+            DropdownMenu(DropdownMenu.Props("Cloud Cover", p.model().conditions.cc.some, "Select", CloudCover.all, disabled = !enabled, ccChanged))
+          ),
+          <.div(
+            ^.cls := "two fields",
+            SeqexecStyles.fieldsNoBottom,
+            DropdownMenu(DropdownMenu.Props("Water Vapor", p.model().conditions.wv.some, "Select", WaterVapor.all, disabled = !enabled, wvChanged)),
+            DropdownMenu(DropdownMenu.Props("Sky Background", p.model().conditions.sb.some, "Select", SkyBackground.all, disabled = !enabled, sbChanged))
           )
         )
       )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -71,24 +71,46 @@ object HeadersSideBar {
       val operatorEV = StateSnapshot(~s.currentText)(updateState)
       <.div(
         ^.cls := "ui raised secondary segment",
-        <.h4("Headers"),
         <.div(
           ^.cls := "ui form",
           <.div(
-            ^.cls := "required field",
-            FormLabel(FormLabel.Props("Operator", Some("operator"))),
-            InputEV(InputEV.Props("operator", "operator",
-              operatorEV,
-              placeholder = "Operator...",
-              disabled = !enabled,
-              onBlur = _ => submitIfChanged
-            ))
-          ),
-
-          DropdownMenu(DropdownMenu.Props("Image Quality", p.model().conditions.iq.some, "Select", ImageQuality.all, disabled = !enabled, iqChanged)),
-          DropdownMenu(DropdownMenu.Props("Cloud Cover", p.model().conditions.cc.some, "Select", CloudCover.all, disabled = !enabled, ccChanged)),
-          DropdownMenu(DropdownMenu.Props("Water Vapor", p.model().conditions.wv.some, "Select", WaterVapor.all, disabled = !enabled, wvChanged)),
-          DropdownMenu(DropdownMenu.Props("Sky Background", p.model().conditions.sb.some, "Select", SkyBackground.all, disabled = !enabled, sbChanged))
+            ^.cls := "ui grid",
+            <.div(
+              ^.cls := "row",
+              <.div(
+                ^.cls := "sixteen wide column",
+                <.div(
+                  ^.cls := "required field",
+                  FormLabel(FormLabel.Props("Operator", Some("operator"))),
+                  InputEV(InputEV.Props("operator", "operator",
+                    operatorEV,
+                    placeholder = "Operator...",
+                    disabled = !enabled,
+                    onBlur = _ => submitIfChanged
+                  ))
+                )
+              ),
+            ),
+            <.div(
+              ^.cls := "row",
+              <.div(
+                ^.cls := "four wide column",
+                DropdownMenu(DropdownMenu.Props("Image Quality", p.model().conditions.iq.some, "Select", ImageQuality.all, disabled = !enabled, iqChanged)),
+              ),
+              <.div(
+                ^.cls := "four wide column",
+                DropdownMenu(DropdownMenu.Props("Cloud Cover", p.model().conditions.cc.some, "Select", CloudCover.all, disabled = !enabled, ccChanged)),
+              ),
+              <.div(
+                ^.cls := "four wide column",
+                DropdownMenu(DropdownMenu.Props("Water Vapor", p.model().conditions.wv.some, "Select", WaterVapor.all, disabled = !enabled, wvChanged)),
+              ),
+              <.div(
+                ^.cls := "four wide column",
+                DropdownMenu(DropdownMenu.Props("Sky Background", p.model().conditions.sb.some, "Select", SkyBackground.all, disabled = !enabled, sbChanged))
+              )
+            )
+          )
         )
       )
     }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -50,17 +50,23 @@ object InstrumentTab {
         case SequenceState.Completed => "green".some
         case _                       => "grey".some
       }
+      val instrumentNoId =
+        <.div(SeqexecStyles.instrumentTabLabel, instrument.shows)
+      val instrumentWithId =
+       <.div(SeqexecStyles.instrumentTabLabel, <.div(SeqexecStyles.activeInstrumentLabel, instrument.shows), Label(Label.Props(tabTitle, color = color, icon = icon)))
+
       <.a(
         ^.cls := "item",
         ^.classSet(
           "active" -> active,
           "error"  -> hasError
         ),
-        SeqexecStyles.activeInstrumentContent.when(sequenceId.isDefined),
+        SeqexecStyles.instrumentTab,
+        SeqexecStyles.activeInstrumentContent.when(active),
         SeqexecStyles.errorTab.when(hasError),
         dataTab := instrument.shows,
         IconAttention.copyIcon(color = Some("red")).when(hasError),
-        sequenceId.fold(instrument.shows: VdomNode){ _ => <.div(<.div(SeqexecStyles.activeInstrumentLabel, instrument.shows), Label(Label.Props(tabTitle, color = color, icon = icon)))}
+        sequenceId.fold(instrumentNoId)(_ => instrumentWithId)
       )
     }.componentDidMount(ctx =>
       Callback {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -48,7 +48,7 @@ object InstrumentTab {
       val color = status.flatMap {
         case SequenceState.Running   => "green".some
         case SequenceState.Completed => "green".some
-        case _                       => none[String]
+        case _                       => "grey".some
       }
       <.a(
         ^.cls := "item",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -66,7 +66,7 @@ object SequenceTabContent {
     .render_P { p =>
       val InstrumentTabContentFocus(instrument, active, sequenceSelected) = p.p()
       <.div(
-        ^.cls := "ui bottom attached tab segment",
+        ^.cls := "ui attached tab segment",
         ^.classSet(
           "active" -> active
         ),
@@ -92,9 +92,17 @@ object SequenceTabsBody {
     .stateless
     .render_P(p =>
       <.div(
-        ^.cls := "twelve wide computer twelve wide tablet sixteen wide mobile column",
-        InstrumentsTabs(p.site),
-        p.instrumentConnects.map(c => c(s => SequenceTabContent(p.site, s))).toList.toTagMod
+        ^.cls := "ui grid",
+        <.div(
+          ^.cls := "stretched row",
+          <.div(
+            ^.cls := "sixteen wide column",
+            <.div(
+              InstrumentsTabs(p.site),
+              p.instrumentConnects.map(c => c(s => SequenceTabContent(p.site, s))).toList.toTagMod
+            )
+          )
+        )
       )
     ).build
 
@@ -110,14 +118,17 @@ object SequenceHeadersAndTable {
   private val component = ScalaComponent.builder[SeqexecSite]("SequenceHeadersAndTable")
     .stateless
     .render_P(p =>
+      <.div(<.div(
+        ^.cls := "row",
+        SequenceTabsBody(p)
+      ),
       <.div(
         ^.cls := "row",
         <.div(
-          ^.cls := "four wide column computer tablet only",
+          ^.cls := "sixteen wide column computer tablet only",
           headerSideBarConnect(HeadersSideBar.apply)
-        ),
-        SequenceTabsBody(p)
-      )
+        )
+      ))
     )
     .build
 
@@ -135,7 +146,7 @@ object SequenceTabs {
       <.div(
         ^.cls := "ui bottom attached segment",
         <.div(
-          ^.cls := "ui two column vertically divided grid",
+          ^.cls := "ui grid",
           SequenceHeadersAndTable(p)
         )
       )
@@ -158,7 +169,10 @@ object SequenceArea {
       <.div(
         ^.cls := "ui raised segments container",
         TextMenuSegment("Running Sequences", "key.sequences.menu"),
-        SequenceTabs(p)
+        <.div(
+          ^.cls := "ui bottom attached segment",
+          SequenceTabsBody(p)
+        )
       )
     ).build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -4,22 +4,26 @@
 package edu.gemini.seqexec.web.client.components.sequence
 
 import diode.react.ModelProxy
-import edu.gemini.seqexec.web.client.components.sequence.toolbars.{SequenceDefaultToolbar, StepConfigToolbar, SequenceAnonymousToolbar}
+import edu.gemini.seqexec.web.client.components.sequence.toolbars.{SequenceInfo, SequenceControl, SequenceObserverField, StepConfigToolbar, SequenceAnonymousToolbar}
 import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, StatusAndStepFocus, InstrumentTabContentFocus}
 import edu.gemini.seqexec.web.client.semanticui._
 import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconInbox
+import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.model.Model.SeqexecSite
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.{CallbackTo, ScalaComponent, ScalazReact}
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.ScalazReact._
+import scalacss.ScalaCssReact._
 
 import scalaz.syntax.show._
 
 object SequenceStepsTableContainer {
   final case class Props(site: SeqexecSite, p: ModelProxy[StatusAndStepFocus]) {
+    protected[sequence] val sequenceControlConnects = site.instruments.list.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceControlReader(i)))).toMap
     private[sequence] val instrumentConnects = site.instruments.list.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.stepsTableReader(i)))).toMap
+    protected[sequence] val sequenceObserverConnects = site.instruments.list.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i)))).toMap
   }
   final case class State(nextStepToRun: Int)
 
@@ -28,22 +32,51 @@ object SequenceStepsTableContainer {
   def updateStepToRun(step: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
     ST.set(State(step)).liftCB
 
+
   private val component = ScalaComponent.builder[Props]("SequenceStepsTableContainer")
     .initialState(State(0))
     .renderP { ($, p) =>
+      <.div(
+        ^.cls := "ui grid",
+        p.p().stepConfigDisplayed.fold{
+          if (p.p().isLogged)
+            List(<.div(
+              ^.cls := "ui row",
+              SeqexecStyles.shorterRow,
+              <.div(
+                ^.cls := "ui sixteen wide column",
+                p.sequenceObserverConnects.get(p.p().instrument).whenDefined(c => c(SequenceInfo.apply))
+              )
+            ),
+            <.div(
+              ^.cls := "ui row",
+              SeqexecStyles.shorterRow,
+              SeqexecStyles.lowerRow,
+              <.div(
+                ^.cls := "ui left column eight wide computer sixteen wide tablet only",
+                SeqexecStyles.controlColumn,
+                p.sequenceControlConnects.get(p.p().instrument).whenDefined(c => c(SequenceControl.apply))
+              ),
+              <.div(
+                ^.cls := "ui right column eight wide computer eight wide tablet sixteen wide mobile",
+                SeqexecStyles.controlColumn,
+                p.sequenceObserverConnects.get(p.p().instrument).whenDefined(c => c(m => SequenceObserverField(m)))
+              )
+            )).toTagMod
+        //          SequenceDefaultToolbar(p.site, p.p().instrument): VdomElement
+          else
+            SequenceAnonymousToolbar(p.site, p.p().instrument): VdomElement
+        }(s => StepConfigToolbar(StepConfigToolbar.Props(p.site, p.p().instrument, p.p().isLogged, s))),
         <.div(
-          ^.cls := "ui raised secondary segment",
-          p.p().stepConfigDisplayed.fold{
-            if (p.p().isLogged)
-              SequenceDefaultToolbar(p.site, p.p().instrument): VdomElement
-            else
-              SequenceAnonymousToolbar(p.site, p.p().instrument): VdomElement
-          }(s => StepConfigToolbar(StepConfigToolbar.Props(p.site, p.p().instrument, p.p().isLogged, s))),
+          ^.cls := "ui row",
+          SeqexecStyles.lowerRow,
           <.div(
-            ^.cls := "ui raised secondary segment",
-            p.instrumentConnects.get(p.p().instrument).whenDefined(x => x(m => StepsTableContainer(StepsTableContainer.Props(m, x => $.runState(updateStepToRun(x))))))
+            ^.cls := "ui sixteen wide column",
+            p.instrumentConnects.get(p.p().instrument).whenDefined(x => x(m =>
+                StepsTableContainer(StepsTableContainer.Props(m, x => $.runState(updateStepToRun(x))))))
           )
         )
+      )
     }.build
 
   def apply(site: SeqexecSite, p: ModelProxy[StatusAndStepFocus]): Unmounted[Props, State, Unit] = component(Props(site, p))
@@ -63,7 +96,7 @@ object SequenceTabContent {
     .render_P { p =>
       val InstrumentTabContentFocus(instrument, active, sequenceSelected) = p.p()
       <.div(
-        ^.cls := "ui attached tab segment",
+        ^.cls := "ui attached secondary segment tab",
         ^.classSet(
           "active" -> active
         ),
@@ -89,17 +122,8 @@ object SequenceTabsBody {
     .stateless
     .render_P(p =>
       <.div(
-        ^.cls := "ui grid",
-        <.div(
-          ^.cls := "stretched row",
-          <.div(
-            ^.cls := "sixteen wide column",
-            <.div(
-              InstrumentsTabs(p.site),
-              p.instrumentConnects.map(c => c(s => SequenceTabContent(p.site, s))).toList.toTagMod
-            )
-          )
-        )
+        InstrumentsTabs(p.site),
+        p.instrumentConnects.map(c => c(s => SequenceTabContent(p.site, s))).toList.toTagMod
       )
     ).build
 
@@ -118,36 +142,12 @@ object SequenceHeadersAndTable {
       <.div(
         ^.cls := "ui grid",
         <.div(
-          ^.cls := "stretched row",
+          ^.cls := "sixteen wide column",
           <.div(
-            ^.cls := "sixteen wide column",
-            <.div(
-              headerSideBarConnect(HeadersSideBar.apply)
-            )
+            headerSideBarConnect(HeadersSideBar.apply)
           )
         )
-      )
     )
-    .build
-
-  def apply(site: SeqexecSite): Unmounted[SeqexecSite, Unit, Unit] = component(site)
-}
-
-/**
- * Contains all the tabs for the sequences available in parallel
- * All connects at this level, be careful about adding connects below here
- */
-object SequenceTabs {
-  private val component = ScalaComponent.builder[SeqexecSite]("SequenceTabs")
-    .stateless
-    .render_P( p =>
-      <.div(
-        ^.cls := "ui bottom attached segment",
-        <.div(
-          ^.cls := "ui grid",
-          SequenceHeadersAndTable(p)
-        )
-      )
     )
     .build
 
@@ -180,7 +180,7 @@ object HeadersArea {
     .render_P( p =>
       <.div(
         ^.cls := "ui sixteen wide column",
-          SequenceHeadersAndTable(p)
+        SequenceHeadersAndTable(p)
       )
     ).build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -131,30 +131,6 @@ object SequenceTabsBody {
 }
 
 /**
-  * Component containing the sidebar on the left and the sequence tabs on the right
-  */
-object SequenceHeadersAndTable {
-  private val headerSideBarConnect = SeqexecCircuit.connect(SeqexecCircuit.headerSideBarReader)
-
-  private val component = ScalaComponent.builder[SeqexecSite]("SequenceHeadersAndTable")
-    .stateless
-    .render_P(p =>
-      <.div(
-        ^.cls := "ui grid",
-        <.div(
-          ^.cls := "sixteen wide column",
-          <.div(
-            headerSideBarConnect(HeadersSideBar.apply)
-          )
-        )
-    )
-    )
-    .build
-
-  def apply(site: SeqexecSite): Unmounted[SeqexecSite, Unit, Unit] = component(site)
-}
-
-/**
  * Top level container of the sequence area
  */
 object SequenceArea {
@@ -165,22 +141,6 @@ object SequenceArea {
       <.div(
         ^.cls := "ui sixteen wide column",
         SequenceTabsBody(p)
-      )
-    ).build
-
-  def apply(site: SeqexecSite): Unmounted[SeqexecSite, Unit, Unit] = component(site)
-}
-
-/**
- * Top level container of the headers area
- */
-object HeadersArea {
-  private val component = ScalaComponent.builder[SeqexecSite]("QueueTableSection")
-    .stateless
-    .render_P( p =>
-      <.div(
-        ^.cls := "ui sixteen wide column",
-        SequenceHeadersAndTable(p)
       )
     ).build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -39,7 +39,7 @@ object SequenceStepsTableContainer {
       <.div(
         ^.cls := "ui grid",
         p.p().stepConfigDisplayed.fold{
-          if (p.p().isLogged)
+          if (p.p().isLogged) {
             List(<.div(
               ^.cls := "ui row",
               SeqexecStyles.shorterRow,
@@ -63,9 +63,9 @@ object SequenceStepsTableContainer {
                 p.sequenceObserverConnects.get(p.p().instrument).whenDefined(c => c(m => SequenceObserverField(m)))
               )
             )).toTagMod
-        //          SequenceDefaultToolbar(p.site, p.p().instrument): VdomElement
-          else
+          } else {
             SequenceAnonymousToolbar(p.site, p.p().instrument): VdomElement
+          }
         }(s => StepConfigToolbar(StepConfigToolbar.Props(p.site, p.p().instrument, p.p().isLogged, s))),
         <.div(
           ^.cls := "ui row",
@@ -101,6 +101,7 @@ object SequenceTabContent {
           "active" -> active
         ),
         dataTab := instrument.shows,
+        SeqexecStyles.emptyInstrumentTab.unless(sequenceSelected),
         IconMessage(IconMessage.Props(IconInbox, Some("No sequence loaded"), IconMessage.Style.Warning)).unless(sequenceSelected),
         p.connect(st => SequenceStepsTableContainer(p.site, st)).when(sequenceSelected)
       )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -3,12 +3,10 @@
 
 package edu.gemini.seqexec.web.client.components.sequence
 
-import diode.ModelR
 import diode.react.ModelProxy
 import edu.gemini.seqexec.web.client.components.TextMenuSegment
 import edu.gemini.seqexec.web.client.components.sequence.toolbars.{SequenceDefaultToolbar, StepConfigToolbar, SequenceAnonymousToolbar}
-import edu.gemini.seqexec.web.client.model._
-import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, StatusAndStepFocus, HeaderSideBarFocus, InstrumentTabContentFocus, ClientStatus}
+import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, StatusAndStepFocus, InstrumentTabContentFocus}
 import edu.gemini.seqexec.web.client.semanticui._
 import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconInbox
@@ -118,17 +116,18 @@ object SequenceHeadersAndTable {
   private val component = ScalaComponent.builder[SeqexecSite]("SequenceHeadersAndTable")
     .stateless
     .render_P(p =>
-      <.div(<.div(
-        ^.cls := "row",
-        SequenceTabsBody(p)
-      ),
       <.div(
-        ^.cls := "row",
+        ^.cls := "ui grid",
         <.div(
-          ^.cls := "sixteen wide column computer tablet only",
-          headerSideBarConnect(HeadersSideBar.apply)
+          ^.cls := "stretched row",
+          <.div(
+            ^.cls := "sixteen wide column",
+            <.div(
+              headerSideBarConnect(HeadersSideBar.apply)
+            )
+          )
         )
-      ))
+      )
     )
     .build
 
@@ -160,8 +159,6 @@ object SequenceTabs {
  * Top level container of the sequence area
  */
 object SequenceArea {
-  type SequencesModel = ModelR[SeqexecAppRootModel, (ClientStatus, SequencesOnDisplay)]
-  type HeadersSideBarModel = ModelR[SeqexecAppRootModel, HeaderSideBarFocus]
 
   private val component = ScalaComponent.builder[SeqexecSite]("QueueTableSection")
     .stateless
@@ -172,6 +169,26 @@ object SequenceArea {
         <.div(
           ^.cls := "ui bottom attached segment",
           SequenceTabsBody(p)
+        )
+      )
+    ).build
+
+  def apply(site: SeqexecSite): Unmounted[SeqexecSite, Unit, Unit] = component(site)
+}
+
+/**
+ * Top level container of the headers area
+ */
+object HeadersArea {
+  private val component = ScalaComponent.builder[SeqexecSite]("QueueTableSection")
+    .stateless
+    .render_P( p =>
+      <.div(
+        ^.cls := "ui raised segments container",
+        TextMenuSegment("Headers", "key.headers.menu"),
+        <.div(
+          ^.cls := "ui bottom attached segment",
+          SequenceHeadersAndTable(p)
         )
       )
     ).build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -53,13 +53,12 @@ object SequenceStepsTableContainer {
               SeqexecStyles.shorterRow,
               SeqexecStyles.lowerRow,
               <.div(
-                ^.cls := "ui left column eight wide computer sixteen wide tablet only",
-                SeqexecStyles.controlColumn,
+                ^.cls := "ui left floated column eight wide computer eight wide tablet only",
                 p.sequenceControlConnects.get(p.p().instrument).whenDefined(c => c(SequenceControl.apply))
               ),
               <.div(
-                ^.cls := "ui right column eight wide computer eight wide tablet sixteen wide mobile",
-                SeqexecStyles.controlColumn,
+                ^.cls := "ui right floated column eight wide computer eight wide tablet sixteen wide mobile",
+                SeqexecStyles.observerField.when(p.p().isLogged),
                 p.sequenceObserverConnects.get(p.p().instrument).whenDefined(c => c(m => SequenceObserverField(m)))
               )
             )).toTagMod

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -4,7 +4,6 @@
 package edu.gemini.seqexec.web.client.components.sequence
 
 import diode.react.ModelProxy
-import edu.gemini.seqexec.web.client.components.TextMenuSegment
 import edu.gemini.seqexec.web.client.components.sequence.toolbars.{SequenceDefaultToolbar, StepConfigToolbar, SequenceAnonymousToolbar}
 import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, StatusAndStepFocus, InstrumentTabContentFocus}
 import edu.gemini.seqexec.web.client.semanticui._
@@ -164,12 +163,8 @@ object SequenceArea {
     .stateless
     .render_P( p =>
       <.div(
-        ^.cls := "ui raised segments container",
-        TextMenuSegment("Running Sequences", "key.sequences.menu"),
-        <.div(
-          ^.cls := "ui bottom attached segment",
-          SequenceTabsBody(p)
-        )
+        ^.cls := "ui sixteen wide column",
+        SequenceTabsBody(p)
       )
     ).build
 
@@ -184,12 +179,8 @@ object HeadersArea {
     .stateless
     .render_P( p =>
       <.div(
-        ^.cls := "ui raised segments container",
-        TextMenuSegment("Headers", "key.headers.menu"),
-        <.div(
-          ^.cls := "ui bottom attached segment",
+        ^.cls := "ui sixteen wide column",
           SequenceHeadersAndTable(p)
-        )
       )
     ).build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -202,7 +202,7 @@ object StepsTableContainer {
             if (step.breakpoint) {
               Icon.IconMinus.copyIcon(link = true, color = Some("brown"), onClick = breakpointAt(id, step))
             } else {
-              Icon.IconCaretDown.copyIcon(link = true, color = Some("gray"), onClick = breakpointAt(id, step))
+              Icon.IconCaretDown.copyIcon(link = true, color = Some("grey"), onClick = breakpointAt(id, step))
             }
           ),
           <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceAnonymousToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceAnonymousToolbar.scala
@@ -5,9 +5,11 @@ package edu.gemini.seqexec.web.client.components.sequence.toolbars
 
 import edu.gemini.seqexec.model.Model.{Instrument, SeqexecSite}
 import edu.gemini.seqexec.web.client.circuit.SeqexecCircuit
+import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
+import scalacss.ScalaCssReact._
 
 /**
   * Toolbar for anonymous users
@@ -24,6 +26,7 @@ object SequenceAnonymousToolbar {
         ^.cls := "ui column",
         <.div(
           ^.cls := "ui row",
+          SeqexecStyles.shorterRow,
           <.div(
             ^.cls := "left column bottom aligned sixteen wide computer ten wide tablet only",
             p.instrumentConnects.get(p.instrument).whenDefined(_(SequenceInfo.apply))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -3,14 +3,13 @@
 
 package edu.gemini.seqexec.web.client.components.sequence.toolbars
 
-import edu.gemini.seqexec.model.Model.{Instrument, SequenceId, SeqexecSite, SequenceState}
+import edu.gemini.seqexec.model.Model.{SequenceId, SequenceState}
 import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, SequenceControlFocus, ControlModel}
 import edu.gemini.seqexec.web.client.actions.{RequestCancelPause, RequestPause, RequestSync, RequestRun}
 import edu.gemini.seqexec.web.client.ModelOps._
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
-import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.semanticui.Size
-import edu.gemini.seqexec.web.client.semanticui.elements.label.{Label}
+import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconRefresh, IconCheckmark, IconPlay, IconPause, IconBan}
 import japgolly.scalajs.react.vdom.html_<^._
@@ -22,8 +21,6 @@ import diode.react.ModelProxy
 import scalaz.syntax.equal._
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.std.option._
-
-import scalacss.ScalaCssReact._
 
 /**
   * Control buttons for the sequence
@@ -110,41 +107,4 @@ object SequenceControl {
     }.build
 
   def apply(p: ModelProxy[SequenceControlFocus]): Unmounted[Props, State, Unit] = component(Props(p))
-}
-
-/**
-  * Component deciding what tooblar to display
-  */
-object SequenceDefaultToolbar {
-  final case class Props(site: SeqexecSite, instrument: Instrument) {
-    protected[sequence] val sequenceObserverConnects = site.instruments.list.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i)))).toMap
-    protected[sequence] val sequenceControlConnects = site.instruments.list.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceControlReader(i)))).toMap
-  }
-
-  private def component = ScalaComponent.builder[Props]("SequencesDefaultToolbar")
-    .render_P( p =>
-        <.div(
-        ^.cls := "ui row",
-        SeqexecStyles.shorterRow,
-        <.div(
-          ^.cls := "ui sixteen wide column",
-          p.sequenceObserverConnects.get(p.instrument).whenDefined(c => c(SequenceInfo.apply))
-        ),
-        <.div(
-          ^.cls := "ui sixteen wide column",
-          <.div(
-            ^.cls := "ui left column eight wide computer sixteen wide tablet only",
-            SeqexecStyles.controlColumn,
-            p.sequenceControlConnects.get(p.instrument).whenDefined(c => c(SequenceControl.apply))
-          ),
-          <.div(
-            ^.cls := "ui right column eight wide computer eight wide tablet sixteen wide mobile",
-            SeqexecStyles.controlColumn,
-            p.sequenceObserverConnects.get(p.instrument).whenDefined(c => c(m => SequenceObserverField(m)))
-          )
-        )
-      )
-    ).build
-
-  def apply(site: SeqexecSite, p: Instrument): Unmounted[Props, Unit, Unit] = component(Props(site, p))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -123,13 +123,15 @@ object SequenceDefaultToolbar {
 
   private def component = ScalaComponent.builder[Props]("SequencesDefaultToolbar")
     .render_P( p =>
-      <.div(
-        ^.cls := "ui row",
         <.div(
+        ^.cls := "ui row",
+        SeqexecStyles.shorterRow,
+        <.div(
+          ^.cls := "ui sixteen wide column",
           p.sequenceObserverConnects.get(p.instrument).whenDefined(c => c(SequenceInfo.apply))
         ),
         <.div(
-          ^.cls := "ui two column grid",
+          ^.cls := "ui sixteen wide column",
           <.div(
             ^.cls := "ui left column eight wide computer sixteen wide tablet only",
             SeqexecStyles.controlColumn,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
@@ -29,8 +29,7 @@ object SequenceInfo {
         ^.cls := "ui form",
         <.div(
           ^.cls := "fields",
-          SeqexecStyles.shorterFields,
-          SeqexecStyles.fieldsNoBottom.unless(isLogged),
+          SeqexecStyles.fieldsNoBottom,
           <.div(
             ^.cls := "field",
             Label(Label.Props(obsName, basic = true))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
@@ -29,6 +29,7 @@ object SequenceInfo {
         ^.cls := "ui form",
         <.div(
           ^.cls := "fields",
+          SeqexecStyles.shorterFields,
           SeqexecStyles.fieldsNoBottom.unless(isLogged),
           <.div(
             ^.cls := "field",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceObserverField.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceObserverField.scala
@@ -8,12 +8,14 @@ import edu.gemini.seqexec.web.client.actions.UpdateObserver
 import edu.gemini.seqexec.web.client.circuit.StatusAndObserverFocus
 import edu.gemini.seqexec.web.client.semanticui.elements.label.FormLabel
 import edu.gemini.seqexec.web.client.semanticui.elements.input.InputEV
+import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.{BackendScope, Callback, ScalaComponent}
 import japgolly.scalajs.react.extra.{StateSnapshot, TimerSupport}
 import japgolly.scalajs.react.component.Scala.Unmounted
 import diode.react.ModelProxy
 import org.scalajs.dom.html.Div
+import scalacss.ScalaCssReact._
 
 import scalaz.syntax.equal._
 import scalaz.syntax.std.option._
@@ -53,6 +55,7 @@ object SequenceObserverField {
         ^.cls := "ui form",
         <.div(
           ^.cls := "ui inline fields",
+          SeqexecStyles.shorterFields,
           <.div(
             ^.cls := "field four wide required",
             FormLabel(FormLabel.Props("Observer"))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
@@ -39,7 +39,7 @@ object Label {
     .stateless
     .renderPC((_, p, c) =>
       <.label(
-        ^.cls := "ui label",
+        ^.cls := p.color.fold("ui label")(u => s"ui $u label"),
         ^.classSet(
           "basic"          -> p.basic,
           "tag"            -> p.tag,
@@ -55,7 +55,6 @@ object Label {
           "left pointing"  -> (p.pointing === Pointing.Left),
           "right pointing" -> (p.pointing === Pointing.Right)
         ),
-        p.color.map(u => ^.cls := u).whenDefined,
         ^.htmlFor :=? p.htmlFor,
         p.icon.whenDefined,
         p.text,


### PR DESCRIPTION
After some discussion we are considering to update the layout of the application. We want to better use the space removing the width restrictions and vertical layers

This PR is not final, it needs a lot of polishing but I wanted to show it to get comments.

The main changes are:
* Use of the full width of the browser
* Removal of titles to gain vertical space
* Reduce nesting of sections
* Move headers section next to the queue area
* Remove top bar and replace it with a status bar at the bottom

Here's a screenshot. Let me know what you think before I can continue

https://monosnap.com/file/JsNR3B1XcpG1T77fzjdKVc0Qg1FSkg