### PR TITLE
SEQNG-404A: Don't display sequences in the queue without steps

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ODBProxy.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ODBProxy.scala
@@ -11,6 +11,8 @@ import edu.gemini.seqexec.model.dhs.ImageFileId
 
 import scalaz.{EitherT, \/}
 import scalaz.syntax.either._
+import scalaz.syntax.equal._
+import scalaz.std.anyVal._
 import scalaz.concurrent.Task
 
 /**
@@ -57,6 +59,12 @@ object ODBProxy {
     override def obsPause(obsId: SPObservationID, reason: String): SeqAction[Boolean] = SeqAction(false)
     override def obsStop(obsId: SPObservationID, reason: String): SeqAction[Boolean] = SeqAction(false)
     override def queuedSequences(): SeqAction[Seq[SPObservationID]] = SeqAction(List.empty)
+  }
+
+  implicit class SeqexecSequenceOps(val s: SeqexecSequence) extends AnyVal {
+    def stepsCount: Int = Option(s.config.getAllSteps).map(_.length).getOrElse(0)
+    def executedCount: Int = s.datasets.size
+    def unExecutedSteps: Boolean = stepsCount =/= executedCount
   }
 
   final case class OdbCommandsImpl(host: Peer) extends OdbCommands {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -13,6 +13,7 @@ import edu.gemini.seqexec.engine
 import edu.gemini.seqexec.engine.{Action, Engine, Event, EventSystem, Executed, Failed, Result, Sequence}
 import edu.gemini.seqexec.engine.Result.{FileIdAllocated, Partial}
 import edu.gemini.seqexec.server.ConfigUtilOps._
+import edu.gemini.seqexec.server.SeqexecFailure.EmptySequence
 import edu.gemini.seqexec.odb.SmartGcal
 import edu.gemini.seqexec.model.Model._
 import edu.gemini.seqexec.model.Model.SeqexecEvent._
@@ -22,6 +23,7 @@ import edu.gemini.seqexec.server.gcal.{GcalControllerEpics, GcalControllerSim, G
 import edu.gemini.seqexec.server.gmos.{GmosControllerSim, GmosEpics, GmosNorthControllerEpics, GmosSouthControllerEpics}
 import edu.gemini.seqexec.server.gws.GwsEpics
 import edu.gemini.seqexec.server.tcs.{TcsControllerEpics, TcsControllerSim, TcsEpics}
+import edu.gemini.seqexec.server.ODBProxy._
 import edu.gemini.spModel.core.Peer
 import edu.gemini.spModel.seqcomp.SeqConfigNames.OCS_KEY
 import edu.gemini.spModel.obscomp.InstConstants
@@ -160,6 +162,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
   private def loadEvents(seqId: SPObservationID): SeqAction[List[Event]] = {
     val t: EitherT[Task, SeqexecFailure, (List[SeqexecFailure], Option[Sequence[Action \/ Result]])] = for {
       odbSeq       <- EitherT(Task.delay(odbProxy.read(seqId)))
+      _            <- EitherT(Task.delay(odbSeq.unExecutedSteps.fold(().right[SeqexecFailure], EmptySequence(odbSeq.title).left)))
       progIdString <- EitherT(Task.delay(odbSeq.config.extract(OCS_KEY / InstConstants.PROGRAMID_PROP).as[String].leftMap(ConfigUtilOps.explainExtractError)))
       progId       <- EitherT.fromTryCatchNonFatal(Task.now(SPProgramID.toProgramID(progIdString))).leftMap(e => SeqexecFailure.SeqexecException(e): SeqexecFailure)
     } yield translator.sequence(seqId, odbSeq)
@@ -328,7 +331,7 @@ object SeqexecEngine {
     }.flatMap {
       x => x._1.strengthR(ActionStatus.Pending) ::: x._2.strengthR(ActionStatus.Completed)
     }.filter {
-      case (a, b) => !presentSystems.contains(a)
+      case (a, _) => !presentSystems.contains(a)
     }.distinct
 
     (configStatus ++ systemsPending).toList.sortBy(_._1)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecFailure.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecFailure.scala
@@ -24,6 +24,9 @@ object SeqexecFailure {
   /** Indicates an unexpected problem while performing a Seqexec operation. */
   final case class Unexpected(msg: String) extends SeqexecFailure
 
+  /** Indicates an attempt to enqueue an empty sequence */
+  final case class EmptySequence(title: String) extends SeqexecFailure
+
   /** Timeout */
   final case class Timeout(msg: String) extends SeqexecFailure
 
@@ -37,7 +40,8 @@ object SeqexecFailure {
     case InvalidOp(msg)               => s"Invalid operation: $msg"
     case Unexpected(msg)              => s"Unexpected error: $msg"
     case Timeout(msg)                 => s"Timeout while waiting for $msg"
-    case ODBSeqError(fail)             => SeqFailure.explain(fail)
+    case EmptySequence(title)         => s"Attempt to enqueue empty sequence $title"
+    case ODBSeqError(fail)            => SeqFailure.explain(fail)
   }
 
 }


### PR DESCRIPTION
It is possible to put sequences without steps though they are meaningless to the seqexec. This PR filters those out. This is part of SEQNG-404 but there are several bits pending