### PR TITLE
SEQNG-367A: Show a summary of the configuration for each step

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -105,114 +105,6 @@ object Model {
     final case class ServerLogMessage(level: ServerLogLevel, timestamp: Instant, msg: String) extends SeqexecEvent
     case object NullEvent extends SeqexecEvent
 
-    // Some useful Monocle lenses
-    val obsNameL: Lens[SequenceView, String] = GenLens[SequenceView](_.metadata.name)
-    // From step to standard step
-    val standardStepL: Prism[Step, StandardStep] = GenPrism[Step, StandardStep]
-    val eachStepL: Traversal[List[Step], Step] = Traversal.fromTraverse[List, Step]
-    val obsStepsL: Lens[SequenceView, List[Step]] = GenLens[SequenceView](_.steps)
-    val eachViewL: Traversal[List[SequenceView], SequenceView] = Traversal.fromTraverse[List, SequenceView]
-    val sequencesQueueL: Lens[SequencesQueue[SequenceView], List[SequenceView]] = GenLens[SequencesQueue[SequenceView]](_.queue)
-    val ssLens: Lens[SequenceStart, SequencesQueue[SequenceView]] = GenLens[SequenceStart](_.view)
-    // Required for type correctness
-    val stepConfigRoot: Iso[Map[SystemName, Parameters], Map[SystemName, Parameters]] = Iso.id[Map[SystemName, Parameters]]
-    val parametersRoot: Iso[Map[ParamName, ParamValue], Map[ParamName, ParamValue]] = Iso.id[Map[ParamName, ParamValue]]
-    // Focus on the target name
-    def targetNameL(param: ParamName): Lens[Parameters, Option[TargetName]] =
-      parametersRoot ^|-> // map of parameters
-      at(param)           // parameter containing the name
-    // Possible set of observe parameters
-    def systemConfigL(system: SystemName): Lens[StepConfig, Option[Parameters]] =
-      stepConfigRoot ^|-> // map of systems
-      at(system)          // subsystem name
-    // Target name of a StepConfig
-    def configTargetNameL(system: SystemName, param: String): Optional[StepConfig, TargetName] =
-      systemConfigL(system)                ^<-? // observe paramaters
-      some                                 ^|-> // focus on the option
-      targetNameL(system.withParam(param)) ^<-? // find the target name
-      some                                       // focus on the option
-    // from standard step to config
-    val stepConfigL: Lens[StandardStep, StepConfig] = GenLens[StandardStep](_.config)
-
-    // Prism to focus on only the SeqexecEvents that have a queue
-    val sePrism: Prism[SeqexecEvent, SeqexecModelUpdate] = GenPrism[SeqexecEvent, SeqexecModelUpdate]
-
-    // Focus on the sequence view
-    val seViewL: Lens[SeqexecModelUpdate, SequencesQueue[SequenceView]] = Lens[SeqexecModelUpdate, SequencesQueue[SequenceView]](_.view)(q => {
-        case e @ SequenceStart(_)           => e.copy(view = q)
-        case e @ StepExecuted(_)            => e.copy(view = q)
-        case e @ FileIdStepExecuted(_, _)   => e.copy(view = q)
-        case e @ SequenceCompleted(_)       => e.copy(view = q)
-        case e @ SequenceLoaded(_, v)       => e.copy(view = q)
-        case e @ SequenceUnloaded(_, v)     => e.copy(view = q)
-        case e @ StepBreakpointChanged(_)   => e.copy(view = q)
-        case e @ OperatorUpdated(_)         => e.copy(view = q)
-        case e @ ObserverUpdated(_)         => e.copy(view = q)
-        case e @ ConditionsUpdated(_)       => e.copy(view = q)
-        case e @ StepSkipMarkChanged(_)     => e.copy(view = q)
-        case e @ SequencePauseRequested(_)  => e.copy(view = q)
-        case e @ SequencePauseCanceled(_)   => e.copy(view = q)
-        case e @ SequenceRefreshed(_)       => e.copy(view = q)
-        case e @ ActionStopRequested(_)     => e.copy(view = q)
-        case e @ ResourcesBusy(_, _)        => e.copy(view = q)
-        case e @ SequenceUpdated(_)         => e.copy(view = q)
-        case e                              => e
-      }
-    )
-    // Composite lens to change the sequence name of an event
-    val sequenceNameL: Traversal[SeqexecEvent, ObservationName] =
-      sePrism         ^|->  // Events with model updates
-      seViewL         ^|->  // Find the sequence view
-      sequencesQueueL ^|->> // Find the queue
-      eachViewL       ^|->  // each sequence on the queue
-      obsNameL              // sequence's observation name
-
-    // Composite lens to find the step config
-    val sequenceConfigL: Traversal[SeqexecEvent, StepConfig] =
-      sePrism           ^|->  // Events with model updates
-      seViewL           ^|->  // Find the sequence view
-      sequencesQueueL   ^|->> // Find the queue
-      eachViewL         ^|->  // each sequence on the queue
-      obsStepsL         ^|->> // sequence steps
-      eachStepL         ^<-?  // each step
-      standardStepL     ^|->  // which is a standard step
-      stepConfigL             // configuration of the step
-
-    def filterEntry[K, V](predicate: (K, V) => Boolean): Traversal[Map[K, V], V] =
-      new Traversal[Map[K, V], V]{
-        def modifyF[F[_]: Applicative](f: V => F[V])(s: Map[K, V]): F[Map[K, V]] =
-          s.map { case (k, v) =>
-            k -> (if(predicate(k, v)) f(v) else v.pure[F])
-          }.sequenceU
-      }
-
-    // Find the Parameters of the steps containing science steps
-    val scienceStepL: Traversal[StepConfig, Parameters] = filterEntry[SystemName, Parameters] {
-      case (s, p) => s === SystemName.observe && p.exists {
-        case (k, v) => k === SystemName.observe.withParam("observeType") && v === "OBJECT"
-      }
-    }
-
-    val scienceTargetNameL: Optional[Parameters, TargetName] =
-      targetNameL(SystemName.observe.withParam("object")) ^<-? // find the target name
-      some                                                     // focus on the option
-
-    // Composite lens to find the step config
-    val firstScienceTargetNameL: Traversal[SeqexecEvent, TargetName] =
-      sequenceConfigL     ^|->> // sequence configuration
-      scienceStepL        ^|-?  // science steps
-      scienceTargetNameL        // science target name
-
-    // Composite lens to find the target name on observation
-    val observeTargetNameL: Traversal[SeqexecEvent, TargetName] =
-      sequenceConfigL                                 ^|-?  // configuration of the step
-      configTargetNameL(SystemName.observe, "object")       // on the configuration find the target name
-
-    // Composite lens to find the target name on telescope
-    val telescopeTargetNameL: Traversal[SeqexecEvent, TargetName] =
-      sequenceConfigL                                 ^|-?  // configuration of the step
-      configTargetNameL(SystemName.telescope, "Base:name")       // on the configuration find the target name
-
     implicit val equal: Equal[SeqexecEvent] = Equal.equalA
   }
 
@@ -593,5 +485,133 @@ object Model {
   }
 
   final case class LogMsg(t: LogType, timestamp: Time, msg: String)
+
+}
+
+trait ModelLenses {
+  import Model._
+  import Model.SeqexecEvent._
+
+    // Some useful Monocle lenses
+  val obsNameL: Lens[SequenceView, String] = GenLens[SequenceView](_.metadata.name)
+  // From step to standard step
+  val standardStepP: Prism[Step, StandardStep] = GenPrism[Step, StandardStep]
+  val eachStepT: Traversal[List[Step], Step] = Traversal.fromTraverse[List, Step]
+  val obsStepsL: Lens[SequenceView, List[Step]] = GenLens[SequenceView](_.steps)
+  val eachViewT: Traversal[List[SequenceView], SequenceView] = Traversal.fromTraverse[List, SequenceView]
+  val sequencesQueueL: Lens[SequencesQueue[SequenceView], List[SequenceView]] = GenLens[SequencesQueue[SequenceView]](_.queue)
+  // from standard step to config
+  val stepConfigL: Lens[StandardStep, StepConfig] = GenLens[StandardStep](_.config)
+  // Prism to focus on only the SeqexecEvents that have a queue
+  val sequenceEventsP: Prism[SeqexecEvent, SeqexecModelUpdate] = GenPrism[SeqexecEvent, SeqexecModelUpdate]
+  // Required for type correctness
+  val stepConfigRoot: Iso[Map[SystemName, Parameters], Map[SystemName, Parameters]] = Iso.id[Map[SystemName, Parameters]]
+  val parametersRoot: Iso[Map[ParamName, ParamValue], Map[ParamName, ParamValue]] = Iso.id[Map[ParamName, ParamValue]]
+
+  // Focus on a param value
+  def paramValueL(param: ParamName): Lens[Parameters, Option[String]] =
+    parametersRoot ^|-> // map of parameters
+    at(param)           // parameter containing the name
+
+  // Possible set of observe parameters
+  def systemConfigL(system: SystemName): Lens[StepConfig, Option[Parameters]] =
+    stepConfigRoot ^|-> // map of systems
+    at(system)          // subsystem name
+
+  // Param name of a StepConfig
+  def configParamValueO(system: SystemName, param: String): Optional[StepConfig, String] =
+    systemConfigL(system)                ^<-? // observe paramaters
+    some                                 ^|-> // focus on the option
+    paramValueL(system.withParam(param)) ^<-? // find the target name
+    some                                      // focus on the option
+
+  // Focus on the sequence view
+  val sequenceQueueViewL: Lens[SeqexecModelUpdate, SequencesQueue[SequenceView]] = Lens[SeqexecModelUpdate, SequencesQueue[SequenceView]](_.view)(q => {
+      case e @ SequenceStart(_)           => e.copy(view = q)
+      case e @ StepExecuted(_)            => e.copy(view = q)
+      case e @ FileIdStepExecuted(_, _)   => e.copy(view = q)
+      case e @ SequenceCompleted(_)       => e.copy(view = q)
+      case e @ SequenceLoaded(_, v)       => e.copy(view = q)
+      case e @ SequenceUnloaded(_, v)     => e.copy(view = q)
+      case e @ StepBreakpointChanged(_)   => e.copy(view = q)
+      case e @ OperatorUpdated(_)         => e.copy(view = q)
+      case e @ ObserverUpdated(_)         => e.copy(view = q)
+      case e @ ConditionsUpdated(_)       => e.copy(view = q)
+      case e @ StepSkipMarkChanged(_)     => e.copy(view = q)
+      case e @ SequencePauseRequested(_)  => e.copy(view = q)
+      case e @ SequencePauseCanceled(_)   => e.copy(view = q)
+      case e @ SequenceRefreshed(_)       => e.copy(view = q)
+      case e @ ActionStopRequested(_)     => e.copy(view = q)
+      case e @ ResourcesBusy(_, _)        => e.copy(view = q)
+      case e @ SequenceUpdated(_)         => e.copy(view = q)
+      case e                              => e
+    }
+  )
+  // Composite lens to change the sequence name of an event
+  val sequenceNameT: Traversal[SeqexecEvent, ObservationName] =
+    sequenceEventsP         ^|->  // Events with model updates
+    sequenceQueueViewL         ^|->  // Find the sequence view
+    sequencesQueueL ^|->> // Find the queue
+    eachViewT       ^|->  // each sequence on the queue
+    obsNameL              // sequence's observation name
+
+  // Composite lens to find the step config
+  val sequenceConfigT: Traversal[SeqexecEvent, StepConfig] =
+    sequenceEventsP           ^|->  // Events with model updates
+    sequenceQueueViewL           ^|->  // Find the sequence view
+    sequencesQueueL   ^|->> // Find the queue
+    eachViewT         ^|->  // each sequence on the queue
+    obsStepsL         ^|->> // sequence steps
+    eachStepT         ^<-?  // each step
+    standardStepP     ^|->  // which is a standard step
+    stepConfigL             // configuration of the step
+
+  def filterEntry[K, V](predicate: (K, V) => Boolean): Traversal[Map[K, V], V] =
+    new Traversal[Map[K, V], V]{
+      def modifyF[F[_]: Applicative](f: V => F[V])(s: Map[K, V]): F[Map[K, V]] =
+        s.map { case (k, v) =>
+          k -> (if(predicate(k, v)) f(v) else v.pure[F])
+        }.sequenceU
+    }
+
+  // Find the Parameters of the steps containing science steps
+  val scienceStepT: Traversal[StepConfig, Parameters] = filterEntry[SystemName, Parameters] {
+    case (s, p) => s === SystemName.observe && p.exists {
+      case (k, v) => k === SystemName.observe.withParam("observeType") && v === "OBJECT"
+    }
+  }
+
+  val scienceTargetNameO: Optional[Parameters, TargetName] =
+    paramValueL(SystemName.observe.withParam("object")) ^<-? // find the target name
+    some                                                     // focus on the option
+
+  val stepTypeO: Optional[Parameters, String] =
+    paramValueL(SystemName.observe.withParam("observeType")) ^<-? // find the target name
+    some                                                          // focus on the option
+
+  // Composite lens to find the step config
+  val firstScienceTargetNameT: Traversal[SeqexecEvent, TargetName] =
+    sequenceConfigT     ^|->> // sequence configuration
+    scienceStepT        ^|-?  // science steps
+    scienceTargetNameO        // science target name
+
+  // Composite lens to find the target name on observation
+  val observeTargetNameT: Traversal[SeqexecEvent, TargetName] =
+    sequenceConfigT                                 ^|-?  // configuration of the step
+    configParamValueO(SystemName.observe, "object")       // on the configuration find the target name
+
+  // Composite lens to find the target name on telescope
+  val telescopeTargetNameT: Traversal[SeqexecEvent, TargetName] =
+    sequenceConfigT                                 ^|-?  // configuration of the step
+    configParamValueO(SystemName.telescope, "Base:name")       // on the configuration find the target name
+
+  // Composite lens to find the first science step and from there the target name
+  val firstScienceStepTargetNameT: Traversal[SequenceView, TargetName] =
+    obsStepsL           ^|->> // observation steps
+    eachStepT           ^<-?  // each step
+    standardStepP       ^|->  // only standard steps
+    stepConfigL         ^|->> // get step config
+    scienceStepT        ^|-?  // science steps
+    scienceTargetNameO        // science target name
 
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -6,34 +6,37 @@ package edu.gemini.seqexec.model
 import org.typelevel.discipline.scalatest.Discipline
 import org.scalatest.FunSuite
 import monocle.law.discipline.{LensTests, OptionalTests, PrismTests, TraversalTests}
-import edu.gemini.seqexec.model.Model.{SeqexecEvent, SystemName}
+import edu.gemini.seqexec.model.Model.SystemName
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Arbitrary
 import SharedModelArbitraries._
 
 import scalaz.std.AllInstances._
 
-class ModelLensesSpec extends FunSuite with Discipline {
+class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
 
   // I'm not sure why these are not made available automatically
   implicit def arbF[A]: Arbitrary[A => A] = Arbitrary[A => A]((x: A) => x)
 
-  checkAll("event observer name lens", LensTests(SeqexecEvent.obsNameL))
-  checkAll("each view traversal", TraversalTests(SeqexecEvent.eachViewL))
-  checkAll("sequence queue lens", LensTests(SeqexecEvent.sequencesQueueL))
-  checkAll("queue view lens", LensTests(SeqexecEvent.ssLens))
-  checkAll("events prism", PrismTests(SeqexecEvent.sePrism))
-  checkAll("sequencename traversal", TraversalTests(SeqexecEvent.sequenceNameL))
-  checkAll("steps lens", LensTests(SeqexecEvent.obsStepsL))
-  checkAll("steps traversal", TraversalTests(SeqexecEvent.eachStepL))
-  checkAll("standard step prism", PrismTests(SeqexecEvent.standardStepL))
-  checkAll("standard step config", LensTests(SeqexecEvent.stepConfigL))
-  checkAll("observe step config", LensTests(SeqexecEvent.systemConfigL(SystemName.observe)))
-  checkAll("target name config", LensTests(SeqexecEvent.targetNameL("object")))
-  checkAll("config target name config", OptionalTests(SeqexecEvent.configTargetNameL(SystemName.observe, "object")))
-  checkAll("observe targetname traversal", TraversalTests(SeqexecEvent.observeTargetNameL))
-  checkAll("telescope targetname traversal", TraversalTests(SeqexecEvent.telescopeTargetNameL))
-  checkAll("science step traversal", TraversalTests(SeqexecEvent.scienceStepL))
-  checkAll("science target name optional", OptionalTests(SeqexecEvent.scienceTargetNameL))
-  checkAll("first science target name traversal", TraversalTests(SeqexecEvent.firstScienceTargetNameL))
+  checkAll("event observer name lens", LensTests(obsNameL))
+  checkAll("standard step prism", PrismTests(standardStepP))
+  checkAll("each step traversal", TraversalTests(eachStepT))
+  checkAll("observation steps lens", LensTests(obsStepsL))
+  checkAll("each view traversal", TraversalTests(eachViewT))
+  checkAll("sequence queue lens", LensTests(sequencesQueueL))
+  checkAll("standard step config lens", LensTests(stepConfigL))
+  checkAll("events prism", PrismTests(sequenceEventsP))
+  checkAll("param value lens", LensTests(paramValueL("object")))
+  checkAll("system parameters lens", LensTests(systemConfigL(SystemName.observe)))
+  checkAll("config param value optional", OptionalTests(configParamValueO(SystemName.observe, "object")))
+  checkAll("sequence view Lens", LensTests(sequenceQueueViewL))
+  checkAll("sequencename traversal", TraversalTests(sequenceNameT))
+  checkAll("sequence config traversal", TraversalTests(sequenceConfigT))
+  checkAll("science step traversal", TraversalTests(scienceStepT))
+  checkAll("science target name optional", OptionalTests(scienceTargetNameO))
+  checkAll("step type optional", OptionalTests(stepTypeO))
+  checkAll("first science target name traversal", TraversalTests(firstScienceTargetNameT))
+  checkAll("observe targetname traversal", TraversalTests(observeTargetNameT))
+  checkAll("telescope targetname traversal", TraversalTests(telescopeTargetNameT))
+  checkAll("first science step target name traversal", TraversalTests(firstScienceTargetNameT))
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -39,4 +39,6 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("observe targetname traversal", TraversalTests(observeTargetNameT))
   checkAll("telescope targetname traversal", TraversalTests(telescopeTargetNameT))
   checkAll("first science step target name traversal", TraversalTests(firstScienceTargetNameT))
+  checkAll("step type prism", PrismTests(stringToStepTypeP))
+  checkAll("step step type optional", OptionalTests(stepTypeO))
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
@@ -63,4 +63,5 @@ object SharedModelArbitraries {
   implicit val snArb  = Arbitrary(Gen.oneOf(SystemName.all))
   implicit val steArb = implicitly[Arbitrary[Step]]
   implicit val stsArb = implicitly[Arbitrary[StandardStep]]
+  implicit val styArb = Arbitrary(Gen.oneOf(StepType.all))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -225,12 +225,10 @@ object StepsTableContainer {
       <.tr(
         SeqexecStyles.trNoBorder,
         ^.onMouseOver --> mouseEnter(i),
-        // Available row states: http://semantic-ui.com/collections/table.html#positive--negative
         ^.classSet(
           "positive" -> (step.status === StepState.Completed),
           "warning"  -> (step.status === StepState.Running),
           "negative" -> (step.status === StepState.Paused),
-          // TODO Show error case
           "negative" -> step.hasError,
           "active"   -> (step.status === StepState.Skipped),
           "disabled" -> step.skip

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -16,6 +16,7 @@ import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
 import edu.gemini.seqexec.model.Model._
 import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, ClientStatus, StepsTableFocus}
 import edu.gemini.seqexec.web.client.actions.{FlipSkipStep, FlipBreakpointStep, ShowStep}
+import edu.gemini.seqexec.web.client.lenses._
 import edu.gemini.seqexec.web.client.ModelOps._
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.services.HtmlConstants.iconEmpty
@@ -256,8 +257,8 @@ object StepsTableContainer {
         ),
         <.td(
           ^.onDoubleClick --> selectRow(step, i),
-          ^.cls := "middle aligned",
-          "Settings"
+          ^.cls := "right aligned",
+          StepSettings(StepSettings.Props(step))
         ),
         <.td(
           ^.onDoubleClick --> selectRow(step, i),
@@ -402,4 +403,31 @@ object StepsTableContainer {
     }.build
 
   def apply(p: Props): Unmounted[Props, State, Backend] = component(p)
+}
+
+/**
+ * Component to display the settings of a given step
+ */
+object StepSettings {
+
+  final case class Props(s: Step)
+  private val component = ScalaComponent.builder[Props]("StepSettings")
+    .stateless
+    .render_P { p =>
+      val stepTypeLabel = stepTypeO.getOption(p.s).map { st =>
+        val stepTypeColor = st match {
+          case StepType.Object      => "green"
+          case StepType.Arc         => "violet"
+          case StepType.Flat        => "grey"
+          case StepType.Bias        => "teal"
+          case StepType.Dark        => "black"
+          case StepType.Calibration => "blue"
+        }
+        Label(Label.Props(st.shows, color = stepTypeColor.some, basic = false))
+      }
+      <.div(stepTypeLabel.whenDefined)
+    }
+    .build
+
+  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -258,6 +258,11 @@ object StepsTableContainer {
         ),
         <.td(
           ^.onDoubleClick --> selectRow(step, i),
+          ^.cls := "middle aligned",
+          "Settings"
+        ),
+        <.td(
+          ^.onDoubleClick --> selectRow(step, i),
           ^.classSet(
             "top aligned"    -> step.isObserving,
             "middle aligned" -> !step.isObserving
@@ -279,8 +284,9 @@ object StepsTableContainer {
           <.tr(
             TableHeader(TableHeader.Props(collapsing = true, aligned = Aligned.Center, colSpan = Some(2)), IconSettings),
             TableHeader(TableHeader.Props(collapsing = true), "Step"),
-            TableHeader(TableHeader.Props(width = Width.Eight), "State"),
-            TableHeader(TableHeader.Props(width = Width.Eight), "File"),
+            TableHeader(TableHeader.Props(width = Width.Four), "State"),
+            TableHeader(TableHeader.Props(width = Width.Eight), "Settings"),
+            TableHeader(TableHeader.Props(width = Width.Four), "Progress"),
             TableHeader(TableHeader.Props(collapsing = true), "Config")
           )
         ),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/circuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/circuit.scala
@@ -76,7 +76,7 @@ object circuit {
       zoom { c =>
         val sequencesInQueue = c.uiModel.sequences.queue.map { s =>
           val active = c.uiModel.sequencesOnDisplay.idDisplayed(s.id)
-          val targetName = firstScienceTargetNameL.headOption(s)
+          val targetName = firstScienceStepTargetNameT.headOption(s)
           SequenceInQueue(s.id, s.status, s.metadata.instrument, active, s.metadata.name, targetName, s.runningStep)
         }
         StatusAndLoadedSequencesFocus(c.uiModel.user.isDefined, sequencesInQueue)
@@ -101,7 +101,7 @@ object circuit {
     def sequenceObserverReader(i: Instrument): ModelR[SeqexecAppRootModel, StatusAndObserverFocus] =
       statusReader.zip(instrumentTab(i)).zoom {
         case (status, (tab, _)) =>
-          val targetName = tab.sequence.flatMap(firstScienceTargetNameL.headOption)
+          val targetName = tab.sequence.flatMap(firstScienceStepTargetNameT.headOption)
           StatusAndObserverFocus(status.isLogged, tab.sequence.map(_.metadata.name), i, tab.sequence.map(_.id), tab.sequence.flatMap(_.metadata.observer), tab.sequence.map(_.status), targetName)
       }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/handlers.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/handlers.scala
@@ -388,8 +388,8 @@ object handlers {
         if (value.autoReconnect) {
           // On development mode reload when the connection is broken. This is quite ugly but it helps on development
           if (scala.scalajs.LinkingInfo.developmentMode) {
-            // reload in 4 seconds
-            scala.scalajs.js.timers.setTimeout(6000) (document.location.reload())
+            // reload in 10 seconds
+            scala.scalajs.js.timers.setTimeout(10000) (document.location.reload())
           }
           SeqexecCircuit.dispatch(ConnectionRetry(math.min(60000, math.max(200, value.nextAttempt * 2))))
         }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/lenses.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/lenses.scala
@@ -5,8 +5,6 @@ package edu.gemini.seqexec.web.client
 
 import edu.gemini.seqexec.model.ModelLenses
 
-trait ClientModelLenses extends ModelLenses {
-
-}
+trait ClientModelLenses extends ModelLenses
 
 object lenses extends ClientModelLenses

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/lenses.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/lenses.scala
@@ -3,20 +3,10 @@
 
 package edu.gemini.seqexec.web.client
 
-import monocle.Traversal
-import edu.gemini.seqexec.model.Model.SeqexecEvent._
-import edu.gemini.seqexec.model.Model._
+import edu.gemini.seqexec.model.ModelLenses
 
-trait ModelLenses {
+trait ClientModelLenses extends ModelLenses {
 
-  // Composite lens to find the step config
-  def firstScienceTargetNameL: Traversal[SequenceView, TargetName] =
-    obsStepsL           ^|->> // observation steps
-    eachStepL           ^<-?  // each step
-    standardStepL       ^|->  // only standard steps
-    stepConfigL         ^|->> // get step config
-    scienceStepL        ^|-?  // science steps
-    scienceTargetNameL        // science target name
 }
 
-object lenses extends ModelLenses
+object lenses extends ClientModelLenses

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -32,7 +32,7 @@ import scalaz.stream.{Exchange, Process}
 /**
   * Rest Endpoints under the /api route
   */
-class SeqexecUIApiRoutes(auth: AuthenticationService, events: (server.EventQueue, Topic[SeqexecEvent]), se: SeqexecEngine) extends BooEncoders with ModelBooPicklers {
+class SeqexecUIApiRoutes(auth: AuthenticationService, events: (server.EventQueue, Topic[SeqexecEvent]), se: SeqexecEngine) extends BooEncoders with ModelBooPicklers with ModelLenses {
 
   // Logger for client messages
   private val clientLog = getLogger
@@ -90,7 +90,7 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (server.EventQueue
         // Stream seqexec events to clients and a ping
         def anonymize(e: SeqexecEvent) = {
             // Hide the name and target name for anonymous users
-            (telescopeTargetNameL.set("*****") andThen observeTargetNameL.set("*****") andThen sequenceNameL.set(""))(e)
+            (telescopeTargetNameT.set("*****") andThen observeTargetNameT.set("*****") andThen sequenceNameT.set(""))(e)
         }
         def filterOutNull = (e: SeqexecEvent) => e match {
           case NullEvent => false


### PR DESCRIPTION
This is a first step to add step details. This one includes the object type as a label on the right hand side of the table. I'm sending this to gather opinions, i'm not totally sold on this design. For example what colors would be appropriate? Could we just use a single letter for the object type or an icon?

Here's a screenshot

![screenshot 2017-11-16 14 23 00](https://user-images.githubusercontent.com/3615303/32910016-e9030eb0-cae6-11e7-8d94-f163855bd9b1.png)
