### PR TITLE
SEQNG-367B: Offset display

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val edu_gemini_web_client_facades = project
       // By necessity facades will have unused params
       "-Ywarn-unused:params"
     ))),
-    libraryDependencies += JQuery.value,
+    libraryDependencies ++= Seq(ScalaJSDom.value, JQuery.value),
     // And add a custom one
     addCompilerPlugin("org.scala-js" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.patch)
   )

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -14,6 +14,7 @@ import scalaz.{Applicative, Equal, Show, Order, NonEmptyList}
 import scalaz.std.list._
 import scalaz.std.anyVal._
 import scalaz.std.map._
+import scalaz.syntax.std.string._
 import scalaz.syntax.equal._
 import scalaz.syntax.show._
 import scalaz.syntax.applicative._
@@ -366,6 +367,23 @@ object Model {
 
     def fromString(s: String): Option[StepType] = names.get(s)
   }
+  sealed trait OffsetAxis {
+    val configItem: String
+  }
+  object OffsetAxis {
+    case object AxisP extends OffsetAxis {
+      val configItem = "p"
+    }
+    case object AxisQ extends OffsetAxis {
+      val configItem = "q"
+    }
+  }
+
+  final case class TelescopeOffset(value: Double, axis: OffsetAxis)
+  object TelescopeOffset {
+    implicit val eq: Equal[TelescopeOffset] = Equal.equalA[TelescopeOffset]
+    implicit val show: Show[TelescopeOffset] = Show.showFromToString
+  }
 
   // Ported from OCS' SPSiteQuality.java
 
@@ -612,6 +630,9 @@ trait ModelLenses {
     some                                                     // focus on the option
 
   val stringToStepTypeP: Prism[String, StepType] = Prism(StepType.fromString)(_.shows)
+  // Unlawful but useful prism
+  private[model] def telescopeOffsetP(axis: OffsetAxis): Prism[Double, TelescopeOffset] = Prism((d: Double) => Some(TelescopeOffset(d, axis)))(_.value)
+  val stringToDoubleP: Prism[String, Double] = Prism((x: String) => x.parseDouble.toOption)(_.shows)
 
   val stepTypeO: Optional[Step, StepType] =
     standardStepP                                            ^|-> // which is a standard step
@@ -621,6 +642,17 @@ trait ModelLenses {
     paramValueL(SystemName.observe.withParam("observeType")) ^<-? // find the target name
     some                                                     ^<-? // focus on the option
     stringToStepTypeP                                             // step type
+
+  // Lens to find p offset
+  def telescopeOffsetO(x: OffsetAxis): Optional[Step, TelescopeOffset] =
+    standardStepP                                            ^|-> // which is a standard step
+    stepConfigL                                              ^|-> // configuration of the step
+    systemConfigL(SystemName.telescope)                      ^<-? // Observe config
+    some                                                     ^|-> // some
+    paramValueL(SystemName.telescope.withParam(x.configItem))         ^<-? // find the offset
+    some                                                     ^<-? // focus on the option
+    stringToDoubleP  ^<-?                                    // double value
+    telescopeOffsetP(x)
 
   // Composite lens to find the step config
   val firstScienceTargetNameT: Traversal[SeqexecEvent, TargetName] =
@@ -635,8 +667,9 @@ trait ModelLenses {
 
   // Composite lens to find the target name on telescope
   val telescopeTargetNameT: Traversal[SeqexecEvent, TargetName] =
-    sequenceConfigT                                 ^|-?  // configuration of the step
-    configParamValueO(SystemName.telescope, "Base:name")       // on the configuration find the target name
+    sequenceConfigT                                       ^|-?  // configuration of the step
+    configParamValueO(SystemName.telescope, "Base:name")        // on the configuration find the target name
+
 
   // Composite lens to find the first science step and from there the target name
   val firstScienceStepTargetNameT: Traversal[SequenceView, TargetName] =

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -385,6 +385,7 @@ object Model {
 
   final case class TelescopeOffset(value: Double, axis: OffsetAxis)
   object TelescopeOffset {
+    def Zero(axis: OffsetAxis): TelescopeOffset = TelescopeOffset(0.0, axis)
     implicit val eq: Equal[TelescopeOffset] = Equal.equalA[TelescopeOffset]
     implicit val show: Show[TelescopeOffset] = Show.showFromToString
   }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -377,6 +377,10 @@ object Model {
     case object AxisQ extends OffsetAxis {
       val configItem = "q"
     }
+    implicit val show: Show[OffsetAxis] = Show.shows {
+      case AxisP => "p"
+      case AxisQ => "q"
+    }
   }
 
   final case class TelescopeOffset(value: Double, axis: OffsetAxis)

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -5,7 +5,7 @@ package edu.gemini.seqexec.model
 
 import org.typelevel.discipline.scalatest.Discipline
 import org.scalatest.FunSuite
-import monocle.law.discipline.{LensTests, OptionalTests, PrismTests, TraversalTests}
+import monocle.law.discipline.{IsoTests, LensTests, OptionalTests, PrismTests, TraversalTests}
 import edu.gemini.seqexec.model.Model.{OffsetAxis, SystemName}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Arbitrary
@@ -17,7 +17,6 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
 
   // I'm not sure why these are not made available automatically
   implicit def arbF[A]: Arbitrary[A => A] = Arbitrary[A => A]((x: A) => x)
-  private implicit val telescopeOffsetArb = teoArb(OffsetAxis.AxisP)
 
   checkAll("event observer name lens", LensTests(obsNameL))
   checkAll("standard step prism", PrismTests(standardStepP))
@@ -42,7 +41,8 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("first science step target name traversal", TraversalTests(firstScienceTargetNameT))
   checkAll("step type prism", PrismTests(stringToStepTypeP))
   checkAll("step step type optional", OptionalTests(stepTypeO))
-  checkAll("telescope offset prism", PrismTests(telescopeOffsetP(OffsetAxis.AxisP)))
+  checkAll("telescope p offset iso", IsoTests(telescopeOffsetPI))
+  checkAll("telescope q offset iso", IsoTests(telescopeOffsetQI))
   checkAll("telescope offset optional", OptionalTests(telescopeOffsetO(OffsetAxis.AxisP)))
   checkAll("step double prism", PrismTests(stringToDoubleP))
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -6,7 +6,7 @@ package edu.gemini.seqexec.model
 import org.typelevel.discipline.scalatest.Discipline
 import org.scalatest.FunSuite
 import monocle.law.discipline.{LensTests, OptionalTests, PrismTests, TraversalTests}
-import edu.gemini.seqexec.model.Model.SystemName
+import edu.gemini.seqexec.model.Model.{OffsetAxis, SystemName}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Arbitrary
 import SharedModelArbitraries._
@@ -17,6 +17,7 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
 
   // I'm not sure why these are not made available automatically
   implicit def arbF[A]: Arbitrary[A => A] = Arbitrary[A => A]((x: A) => x)
+  private implicit val telescopeOffsetArb = teoArb(OffsetAxis.AxisP)
 
   checkAll("event observer name lens", LensTests(obsNameL))
   checkAll("standard step prism", PrismTests(standardStepP))
@@ -41,4 +42,7 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("first science step target name traversal", TraversalTests(firstScienceTargetNameT))
   checkAll("step type prism", PrismTests(stringToStepTypeP))
   checkAll("step step type optional", OptionalTests(stepTypeO))
+  checkAll("telescope offset prism", PrismTests(telescopeOffsetP(OffsetAxis.AxisP)))
+  checkAll("telescope offset optional", OptionalTests(telescopeOffsetO(OffsetAxis.AxisP)))
+  checkAll("step double prism", PrismTests(stringToDoubleP))
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
@@ -64,4 +64,7 @@ object SharedModelArbitraries {
   implicit val steArb = implicitly[Arbitrary[Step]]
   implicit val stsArb = implicitly[Arbitrary[StandardStep]]
   implicit val styArb = Arbitrary(Gen.oneOf(StepType.all))
+  def teoArb(axis: OffsetAxis) = Arbitrary {
+    arbitrary[Double].map(x => TelescopeOffset(x, axis))
+  }
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
@@ -64,7 +64,6 @@ object SharedModelArbitraries {
   implicit val steArb = implicitly[Arbitrary[Step]]
   implicit val stsArb = implicitly[Arbitrary[StandardStep]]
   implicit val styArb = Arbitrary(Gen.oneOf(StepType.all))
-  def teoArb(axis: OffsetAxis) = Arbitrary {
-    arbitrary[Double].map(x => TelescopeOffset(x, axis))
-  }
+  implicit val ofpArb = implicitly[Arbitrary[TelescopeOffset.P]]
+  implicit val ofqArb = implicitly[Arbitrary[TelescopeOffset.Q]]
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -54,6 +54,11 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     textAlign.center
   )
 
+  val tdNoUpDownPadding: StyleA = style(
+    paddingBottom(0.em).important,
+    paddingTop(0.em).important
+  )
+
   val activeInstrumentContent: StyleA = style(
     padding(0.6.em, 0.9.em),
     backgroundColor(rgb(243, 244, 245)).important

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -103,6 +103,10 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     display.inline
   }
 
+  val inlineBlock: StyleA = style {
+    display.inlineBlock
+  }
+
   val observerField: StyleA = style {
     paddingRight(0.px).important
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -111,6 +111,10 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     paddingRight(0.px).important
   }
 
+  val offsetGrid: StyleA = style {
+    marginRight(1.em).important
+  }
+
   val noPadding: StyleS = mixin(
     padding(0.px).important
   )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepSettings.scala
@@ -1,0 +1,182 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.seqexec.web.client.components.sequence
+
+import edu.gemini.seqexec.model.Model.{Offset, OffsetAxis, Step, StepType, TelescopeOffset}
+import edu.gemini.seqexec.web.client.components.SeqexecStyles
+import edu.gemini.seqexec.web.client.lenses.{stepTypeO, telescopeOffsetPO, telescopeOffsetQO}
+import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
+import edu.gemini.web.client.utils._
+import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import org.scalajs.dom.CanvasRenderingContext2D
+import org.scalajs.dom.html.Canvas
+
+import scalacss.ScalaCssReact._
+import scalaz.syntax.order._
+import scalaz.syntax.show._
+import scalaz.syntax.std.option._
+
+/**
+  * Utility methods to display offsets and calculate their widths
+  */
+trait OffsetFns {
+  def offsetAxis(axis: OffsetAxis): String =
+    f"${axis.shows}:"
+
+  def offsetValueFormat(off: Offset): String =
+    f" ${off.value}%003.2f″"
+
+  def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
+
+  def offsetText(axis: OffsetAxis)(step: Step): String =
+    offsetValueFormat(axis match {
+      case OffsetAxis.AxisP => telescopeOffsetPO.getOption(step).getOrElse(TelescopeOffset.P.Zero)
+      case OffsetAxis.AxisQ => telescopeOffsetQO.getOption(step).getOrElse(TelescopeOffset.Q.Zero)
+    })
+
+  private val offsetPText = offsetText(OffsetAxis.AxisP) _
+  private val offsetQText = offsetText(OffsetAxis.AxisQ) _
+
+  val pLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisP))
+  val qLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisQ))
+
+  // Calculate the widest offset step
+  def sequenceOffsetWidths(steps: List[Step]): (Int, Int) = {
+    steps.map(s => (tableTextWidth(offsetPText(s)), tableTextWidth(offsetQText(s)))).foldLeft((0, 0)) {
+      case ((p1, q1), (p2, q2)) => (p1.max(p2), q1.max(q2))
+    }
+  }
+}
+
+/**
+  * Component to draw a grid for the offsets using canvas
+  */
+object OffsetGrid {
+  private val Size = 33.0
+  final case class Props(p: TelescopeOffset.P, q: TelescopeOffset.Q)
+  final case class State(canvas: Option[Canvas])
+
+  private val ST = ReactS.Fix[State]
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def render(props: Props, state: State): Callback = state.canvas.fold(Callback.empty) { c => Callback {
+    // The canvas API is very imperative and stateful but we are inside a Callback!
+    val ctx = c.getContext("2d").asInstanceOf[CanvasRenderingContext2D]
+    c.width = Size.toInt
+    c.height = Size.toInt
+    // First quadrant
+    ctx.fillStyle = if (props.p > TelescopeOffset.P.Zero && props.q > TelescopeOffset.Q.Zero) "darkgray" else "white"
+    ctx.fillRect(0, 0, Size / 2, Size / 2)
+    // Second quadrant
+    ctx.fillStyle = if (props.p < TelescopeOffset.P.Zero && props.q > TelescopeOffset.Q.Zero) "darkgray" else "white"
+    ctx.fillRect(Size / 2, 0, Size / 2, Size / 2)
+    // Third quadrant
+    ctx.fillStyle = if (props.p < TelescopeOffset.P.Zero && props.q < TelescopeOffset.Q.Zero) "darkgray" else "white"
+    ctx.fillRect(Size / 2, Size / 2, Size / 2, Size / 2)
+    // Fourth quadrant
+    ctx.fillStyle = if (props.p > TelescopeOffset.P.Zero && props.q < TelescopeOffset.Q.Zero) "darkgray" else "white"
+    ctx.fillRect(0, Size / 2, Size / 2, Size / 2)
+    // Grid
+    ctx.fillStyle = "black"
+    // Outer border
+    ctx.strokeRect(0, 0, Size, Size)
+    // Inner borders
+    ctx.strokeRect(0, 0, Size / 2, Size / 2)
+    ctx.strokeRect(Size / 2, 0, Size / 2, Size / 2)
+    ctx.strokeRect(0, Size / 2, Size / 2, Size / 2)
+    ctx.strokeRect(Size/2, Size / 2, Size / 2, Size / 2)
+  }}
+
+  private val component = ScalaComponent.builder[Props]("OffsetGrid")
+    .initialState(State(None))
+    .render_P ( p =>
+      <.canvas(
+        ^.cls := "middle aligned",
+        ^.width := Size.toInt.px,
+        ^.height := Size.toInt.px
+      )
+    ).componentWillReceiveProps { ctx =>
+    render(ctx.nextProps, ctx.state)
+  }.componentDidMount { ctx =>
+    // Grab a copy of the canvas
+    val state = State(Some(ctx.getDOMNode.domCast[Canvas]))
+    ctx.runState(ST.set(state)) >> render(ctx.props, state)
+  }.build
+
+  def apply(p: Props): Unmounted[Props, State, Unit] = component(p)
+
+}
+
+/**
+ * Component to display the settings of a given step
+ */
+object StepSettings extends OffsetFns {
+  final case class Props(s: Step, offsetWidth: Int)
+  private val component = ScalaComponent.builder[Props]("StepSettings")
+    .stateless
+    .render_P { p =>
+      val offsetP = telescopeOffsetPO.getOption(p.s).getOrElse(TelescopeOffset.P.Zero)
+      val offsetQ = telescopeOffsetQO.getOption(p.s).getOrElse(TelescopeOffset.Q.Zero)
+      val stepTypeLabel = stepTypeO.getOption(p.s).map { st =>
+        val stepTypeColor = st match {
+          case StepType.Object      => "green"
+          case StepType.Arc         => "violet"
+          case StepType.Flat        => "grey"
+          case StepType.Bias        => "teal"
+          case StepType.Dark        => "black"
+          case StepType.Calibration => "blue"
+        }
+        Label(Label.Props(st.shows, color = stepTypeColor.some))
+      }
+      <.div(
+        ^.cls := "ui two column grid",
+        <.div(
+          ^.cls := "row",
+          <.div(
+            ^.cls := "left floated middle aligned one wide column",
+            OffsetGrid(OffsetGrid.Props(offsetP, offsetQ))
+          ),
+          <.div(
+            ^.cls := "left floated four wide column",
+            <.div(
+              ^.cls := "right aligned",
+              <.div(
+                ^.width := pLabelWidth.px,
+                SeqexecStyles.inlineBlock,
+                offsetAxis(OffsetAxis.AxisP)
+              ),
+              <.div(
+                ^.width := p.offsetWidth.px,
+                SeqexecStyles.inlineBlock,
+                offsetValueFormat(offsetP)
+              )
+            ),
+            <.div(
+              ^.cls := "right aligned",
+              <.div(
+                ^.width := qLabelWidth.px,
+                SeqexecStyles.inlineBlock,
+                offsetAxis(OffsetAxis.AxisQ)
+              ),
+              <.div(
+                ^.width := p.offsetWidth.px,
+                SeqexecStyles.inlineBlock,
+                offsetValueFormat(offsetQ)
+              )
+            )
+          ),
+          <.div(
+            ^.cls := "middle aligned right floated four wide column",
+            <.div(stepTypeLabel.whenDefined)
+          )
+        )
+      )
+    }
+    .build
+
+  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepSettings.scala
@@ -95,7 +95,7 @@ object OffsetGrid {
     .initialState(State(None))
     .render_P ( p =>
       <.canvas(
-        ^.cls := "middle aligned",
+        SeqexecStyles.offsetGrid,
         ^.width := Size.toInt.px,
         ^.height := Size.toInt.px
       )
@@ -112,6 +112,59 @@ object OffsetGrid {
 }
 
 /**
+ * Component to display the offset grid and offset values
+ */
+object OffsetBlock extends OffsetFns {
+  final case class Props(s: Step, offsetWidth: Int)
+  private val component = ScalaComponent.builder[Props]("OffsetValues")
+    .stateless
+    .render_P { p =>
+      val offsetP = telescopeOffsetPO.getOption(p.s).getOrElse(TelescopeOffset.P.Zero)
+      val offsetQ = telescopeOffsetQO.getOption(p.s).getOrElse(TelescopeOffset.Q.Zero)
+
+      <.div(
+        <.div(
+          SeqexecStyles.inlineBlock,
+          OffsetGrid(OffsetGrid.Props(offsetP, offsetQ))
+        ),
+        <.div(
+          SeqexecStyles.inlineBlock,
+          <.div(
+            ^.cls := "right aligned",
+            <.div(
+              ^.width := pLabelWidth.px,
+              SeqexecStyles.inlineBlock,
+              offsetAxis(OffsetAxis.AxisP)
+            ),
+            <.div(
+              ^.width := p.offsetWidth.px,
+              SeqexecStyles.inlineBlock,
+              offsetValueFormat(offsetP)
+            )
+          ),
+          <.div(
+            ^.cls := "right aligned",
+              SeqexecStyles.inlineBlock,
+            <.div(
+              ^.width := qLabelWidth.px,
+              SeqexecStyles.inlineBlock,
+              offsetAxis(OffsetAxis.AxisQ)
+            ),
+            <.div(
+              ^.width := p.offsetWidth.px,
+              SeqexecStyles.inlineBlock,
+              offsetValueFormat(offsetQ)
+            )
+          )
+        )
+      )
+    }
+    .build
+
+  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+}
+
+/**
  * Component to display the settings of a given step
  */
 object StepSettings extends OffsetFns {
@@ -119,8 +172,6 @@ object StepSettings extends OffsetFns {
   private val component = ScalaComponent.builder[Props]("StepSettings")
     .stateless
     .render_P { p =>
-      val offsetP = telescopeOffsetPO.getOption(p.s).getOrElse(TelescopeOffset.P.Zero)
-      val offsetQ = telescopeOffsetQO.getOption(p.s).getOrElse(TelescopeOffset.Q.Zero)
       val stepTypeLabel = stepTypeO.getOption(p.s).map { st =>
         val stepTypeColor = st match {
           case StepType.Object      => "green"
@@ -132,45 +183,17 @@ object StepSettings extends OffsetFns {
         }
         Label(Label.Props(st.shows, color = stepTypeColor.some))
       }
+
       <.div(
         ^.cls := "ui two column grid",
         <.div(
           ^.cls := "row",
           <.div(
-            ^.cls := "left floated middle aligned one wide column",
-            OffsetGrid(OffsetGrid.Props(offsetP, offsetQ))
+            ^.cls := "middle aligned left aligned left floated column",
+            OffsetBlock(OffsetBlock.Props(p.s, p.offsetWidth))
           ),
           <.div(
-            ^.cls := "left floated four wide column",
-            <.div(
-              ^.cls := "right aligned",
-              <.div(
-                ^.width := pLabelWidth.px,
-                SeqexecStyles.inlineBlock,
-                offsetAxis(OffsetAxis.AxisP)
-              ),
-              <.div(
-                ^.width := p.offsetWidth.px,
-                SeqexecStyles.inlineBlock,
-                offsetValueFormat(offsetP)
-              )
-            ),
-            <.div(
-              ^.cls := "right aligned",
-              <.div(
-                ^.width := qLabelWidth.px,
-                SeqexecStyles.inlineBlock,
-                offsetAxis(OffsetAxis.AxisQ)
-              ),
-              <.div(
-                ^.width := p.offsetWidth.px,
-                SeqexecStyles.inlineBlock,
-                offsetValueFormat(offsetQ)
-              )
-            )
-          ),
-          <.div(
-            ^.cls := "middle aligned right floated four wide column",
+            ^.cls := "middle aligned right floated column",
             <.div(stepTypeLabel.whenDefined)
           )
         )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -258,6 +258,7 @@ object StepsTableContainer {
         <.td(
           ^.onDoubleClick --> selectRow(step, i),
           ^.cls := "right aligned",
+          SeqexecStyles.tdNoUpDownPadding,
           StepSettings(StepSettings.Props(step))
         ),
         <.td(
@@ -411,9 +412,13 @@ object StepsTableContainer {
 object StepSettings {
 
   final case class Props(s: Step)
+  def offsetFormat(off: TelescopeOffset): String =
+    f"${off.axis.shows}: ${off.value}%003.1f″"
   private val component = ScalaComponent.builder[Props]("StepSettings")
     .stateless
     .render_P { p =>
+      val offsetP = telescopeOffsetO(OffsetAxis.AxisP).getOption(p.s).map(offsetFormat)
+      val offsetQ = telescopeOffsetO(OffsetAxis.AxisQ).getOption(p.s).map(offsetFormat)
       val stepTypeLabel = stepTypeO.getOption(p.s).map { st =>
         val stepTypeColor = st match {
           case StepType.Object      => "green"
@@ -425,7 +430,21 @@ object StepSettings {
         }
         Label(Label.Props(st.shows, color = stepTypeColor.some, basic = false))
       }
-      <.div(stepTypeLabel.whenDefined)
+      <.div(
+        ^.cls := "ui two column grid",
+        <.div(
+          ^.cls := "stretched row",
+          <.div(
+            ^.cls := "left floated column",
+            <.div(^.cls := "left aligned", ~offsetP),
+            <.div(^.cls := "left aligned", ~offsetQ),
+          ),
+          <.div(
+            ^.cls := "middle aligned right floated column",
+            <.div(stepTypeLabel.whenDefined)
+          )
+        )
+      )
     }
     .build
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -222,6 +222,16 @@ object StepsTableContainer {
         )
       )
 
+    private def stepIcon(p: StepsTableFocus, step: Step, i: Int): VdomNode =
+      step.status match {
+        case StepState.Completed                  => IconCheckmark
+        case StepState.Running                    => IconCircleNotched.copyIcon(loading = true)
+        case StepState.Error(_)                   => IconAttention
+        case _ if p.nextStepToRun.forall(_ === i) => IconChevronRight
+        case _ if step.skip                       => IconReply.copyIcon(rotated = Icon.Rotated.CounterClockwise)
+        case _                                    => iconEmpty
+      }
+
     private def stepCols(status: ClientStatus, p: StepsTableFocus, i: Int, state: SequenceState, step: Step) =
       <.tr(
         SeqexecStyles.trNoBorder,
@@ -237,14 +247,7 @@ object StepsTableContainer {
         SeqexecStyles.stepRunning.when(step.status === StepState.Running),
         <.td(
           ^.onDoubleClick --> selectRow(step, i),
-          step.status match {
-            case StepState.Completed                  => IconCheckmark
-            case StepState.Running                    => IconCircleNotched.copyIcon(loading = true)
-            case StepState.Error(_)                   => IconAttention
-            case _ if p.nextStepToRun.forall(_ === i) => IconChevronRight
-            case _ if step.skip                       => IconReply.copyIcon(rotated = Icon.Rotated.CounterClockwise)
-            case _                                    => iconEmpty
-          }
+          stepIcon(p, step, i)
         ),
         <.td(
           ^.onDoubleClick --> selectRow(step, i),
@@ -435,9 +438,9 @@ object StepSettings {
         <.div(
           ^.cls := "stretched row",
           <.div(
-            ^.cls := "left floated column",
-            <.div(^.cls := "left aligned", ~offsetP),
-            <.div(^.cls := "left aligned", ~offsetQ),
+            ^.cls := "left floated three wide column",
+            <.span(^.cls := "right aligned", ~offsetP),
+            <.span(^.cls := "right aligned", ~offsetQ)
           ),
           <.div(
             ^.cls := "middle aligned right floated column",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -449,7 +449,7 @@ object StepsTableContainer extends OffsetFns {
 }
 
 object OffsetGrid {
-  private val Size = 40.0
+  private val Size = 33.0
   final case class Props(p: TelescopeOffset.P, q: TelescopeOffset.Q)
   final case class State(canvas: Option[Canvas])
 
@@ -457,22 +457,38 @@ object OffsetGrid {
 
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def render(props: Props, state: State): Callback = state.canvas.fold(Callback.empty) { c => Callback {
+    // The canvas API is very imperative and stateful but we are inside a Callback!
     val ctx = c.getContext("2d").asInstanceOf[CanvasRenderingContext2D]
     c.width = Size.toInt
     c.height = Size.toInt
+    // First quadrant
+    ctx.fillStyle = if (props.p > TelescopeOffset.P.Zero && props.q > TelescopeOffset.Q.Zero) "darkgray" else "white"
+    ctx.fillRect(0, 0, Size / 2, Size / 2)
+    // Second quadrant
+    ctx.fillStyle = if (props.p < TelescopeOffset.P.Zero && props.q > TelescopeOffset.Q.Zero) "darkgray" else "white"
+    ctx.fillRect(Size / 2, 0, Size / 2, Size / 2)
+    // Third quadrant
+    ctx.fillStyle = if (props.p < TelescopeOffset.P.Zero && props.q < TelescopeOffset.Q.Zero) "darkgray" else "white"
+    ctx.fillRect(Size / 2, Size / 2, Size / 2, Size / 2)
+    // Fourth quadrant
+    ctx.fillStyle = if (props.p > TelescopeOffset.P.Zero && props.q < TelescopeOffset.Q.Zero) "darkgray" else "white"
+    ctx.fillRect(0, Size / 2, Size / 2, Size / 2)
+    // Grid
+    ctx.fillStyle = "black"
     // Outer border
     ctx.strokeRect(0, 0, Size, Size)
-    // First quadrant
-    ctx.fillStyle = if (props.p > TelescopeOffset.P.Zero) "black" else "white"
-    ctx.fillRect(0, 0, Size/2-1, Size/2-1)
-    ctx.fillStyle = "yellow"
-    ctx.fillRect(Size/2+1, Size/2+1, Size/2-1, Size/2-1)
+    // Inner borders
+    ctx.strokeRect(0, 0, Size / 2, Size / 2)
+    ctx.strokeRect(Size / 2, 0, Size / 2, Size / 2)
+    ctx.strokeRect(0, Size / 2, Size / 2, Size / 2)
+    ctx.strokeRect(Size/2, Size / 2, Size / 2, Size / 2)
   }}
 
   private val component = ScalaComponent.builder[Props]("OffsetGrid")
     .initialState(State(None))
     .render_P ( p =>
       <.canvas(
+        ^.cls := "middle aligned",
         ^.width := Size.toInt.px,
         ^.height := Size.toInt.px
       )
@@ -512,9 +528,9 @@ object StepSettings extends OffsetFns {
       <.div(
         ^.cls := "ui two column grid",
         <.div(
-          ^.cls := "stretched row",
+          ^.cls := "row",
           <.div(
-            ^.cls := "left floated one wide column",
+            ^.cls := "left floated middle aligned one wide column",
             OffsetGrid(OffsetGrid.Props(offsetP, offsetQ))
           ),
           <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -3,9 +3,10 @@
 
 package edu.gemini.seqexec.web.client.components.sequence
 
-import japgolly.scalajs.react.{BackendScope, Callback, ScalaComponent}
+import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.ScalazReact._
 import diode.react.ModelProxy
 import edu.gemini.seqexec.web.client.semanticui._
 import edu.gemini.seqexec.web.client.semanticui.elements.table.TableHeader
@@ -38,7 +39,7 @@ trait OffsetFns {
     f"${axis.shows}:"
 
   def offsetValueFormat(off: TelescopeOffset): String =
-    f" ${off.value}%003.1f″"
+    f" ${off.value}%003.2f″"
 
   def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
 
@@ -442,6 +443,36 @@ object StepsTableContainer extends OffsetFns {
   def apply(p: Props): Unmounted[Props, State, Backend] = component(p)
 }
 
+object OffsetGrid {
+  final case class State(canvas: Option[Canvas])
+
+  private val ST = ReactS.Fix[State]
+
+  def render(state: State): Callback = Callback.log(s"$state")
+
+  private val component = ScalaComponent.builder[Unit]("OffsetGrid")
+    .initialState(State(None))
+    .render_P ( p =>
+      <.canvas(
+        ^.width := 40.px,
+        ^.height := 40.px
+      )
+    ).componentWillReceiveProps { ctx =>
+    println(ctx.state)
+    render(ctx.state)
+//      ctx.runState(ST.callbacksT(State(None), render))
+}.componentWillMount { ctx =>
+      println("Will mount")
+      render(ctx.state)
+    }.componentDidMount { ctx =>
+      // Grab a copy of the canvas
+      ctx.runState(ST.set(State(Some(ctx.getDOMNode.domCast[Canvas]))))
+    }.build
+
+  def apply(): Unmounted[Unit, State, Unit] = component()
+
+}
+
 /**
  * Component to display the settings of a given step
  */
@@ -468,16 +499,20 @@ object StepSettings extends OffsetFns {
         <.div(
           ^.cls := "stretched row",
           <.div(
-            ^.cls := "left floated three wide column",
+            ^.cls := "left floated one wide column",
+            OffsetGrid()
+          ),
+          <.div(
+            ^.cls := "left floated four wide column",
             <.div(
               ^.cls := "right aligned",
               <.div(
-                ^.width := s"${pLabelWidth}px",
+                ^.width := pLabelWidth.px,
                 SeqexecStyles.inlineBlock,
                 offsetAxis(OffsetAxis.AxisP)
               ),
               <.div(
-                ^.width := s"${p.offsetWidth}px",
+                ^.width := p.offsetWidth.px,
                 SeqexecStyles.inlineBlock,
                 offsetValueFormat(offsetP)
               )
@@ -485,19 +520,19 @@ object StepSettings extends OffsetFns {
             <.div(
               ^.cls := "right aligned",
               <.div(
-                ^.width := s"${qLabelWidth}px",
+                ^.width := qLabelWidth.px,
                 SeqexecStyles.inlineBlock,
                 offsetAxis(OffsetAxis.AxisQ)
               ),
               <.div(
-                ^.width := s"${p.offsetWidth}px",
+                ^.width := p.offsetWidth.px,
                 SeqexecStyles.inlineBlock,
                 offsetValueFormat(offsetQ)
               )
             )
           ),
           <.div(
-            ^.cls := "middle aligned right floated column",
+            ^.cls := "middle aligned right floated four wide column",
             <.div(stepTypeLabel.whenDefined)
           )
         )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -42,7 +42,7 @@ trait OffsetFns {
 
   def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
 
-  def offsetText(axis: OffsetAxis)(step: Step): String = ~telescopeOffsetO(axis).getOption(step).map(offsetValueFormat)
+  def offsetText(axis: OffsetAxis)(step: Step): String = offsetValueFormat(telescopeOffsetO(axis).getOption(step).getOrElse(TelescopeOffset.Zero(axis)))
 
   private val offsetPText = offsetText(OffsetAxis.AxisP) _
   private val offsetQText = offsetText(OffsetAxis.AxisQ) _
@@ -450,8 +450,8 @@ object StepSettings extends OffsetFns {
   private val component = ScalaComponent.builder[Props]("StepSettings")
     .stateless
     .render_P { p =>
-      val offsetP = telescopeOffsetO(OffsetAxis.AxisP).getOption(p.s)
-      val offsetQ = telescopeOffsetO(OffsetAxis.AxisQ).getOption(p.s)
+      val offsetP = telescopeOffsetO(OffsetAxis.AxisP).getOption(p.s).getOrElse(TelescopeOffset.Zero(OffsetAxis.AxisP))
+      val offsetQ = telescopeOffsetO(OffsetAxis.AxisQ).getOption(p.s).getOrElse(TelescopeOffset.Zero(OffsetAxis.AxisQ))
       val stepTypeLabel = stepTypeO.getOption(p.s).map { st =>
         val stepTypeColor = st match {
           case StepType.Object      => "green"
@@ -463,7 +463,6 @@ object StepSettings extends OffsetFns {
         }
         Label(Label.Props(st.shows, color = stepTypeColor.some, basic = false))
       }
-      println(p.offsetWidth)
       <.div(
         ^.cls := "ui two column grid",
         <.div(
@@ -475,12 +474,12 @@ object StepSettings extends OffsetFns {
               <.div(
                 ^.width := s"${pLabelWidth}px",
                 SeqexecStyles.inlineBlock,
-                offsetAxis(OffsetAxis.AxisP)),
+                offsetAxis(OffsetAxis.AxisP)
+              ),
               <.div(
                 ^.width := s"${p.offsetWidth}px",
-                // ^.width := s"50",
                 SeqexecStyles.inlineBlock,
-                offsetP.map(offsetValueFormat).whenDefined
+                offsetValueFormat(offsetP)
               )
             ),
             <.div(
@@ -488,14 +487,14 @@ object StepSettings extends OffsetFns {
               <.div(
                 ^.width := s"${qLabelWidth}px",
                 SeqexecStyles.inlineBlock,
-                offsetAxis(OffsetAxis.AxisQ)),
+                offsetAxis(OffsetAxis.AxisQ)
+              ),
               <.div(
                 ^.width := s"${p.offsetWidth}px",
-                // ^.width := s"50",
                 SeqexecStyles.inlineBlock,
-                offsetQ.map(offsetValueFormat).whenDefined
+                offsetValueFormat(offsetQ)
               )
-            ),
+            )
           ),
           <.div(
             ^.cls := "middle aligned right floated column",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/StepsTableContainer.scala
@@ -3,66 +3,31 @@
 
 package edu.gemini.seqexec.web.client.components.sequence
 
-import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.ScalazReact._
 import diode.react.ModelProxy
-import edu.gemini.seqexec.web.client.semanticui._
-import edu.gemini.seqexec.web.client.semanticui.elements.table.TableHeader
-import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
-import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
-import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
-import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
 import edu.gemini.seqexec.model.Model._
-import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, ClientStatus, StepsTableFocus}
-import edu.gemini.seqexec.web.client.actions.{FlipSkipStep, FlipBreakpointStep, ShowStep}
-import edu.gemini.seqexec.web.client.lenses._
 import edu.gemini.seqexec.web.client.ModelOps._
+import edu.gemini.seqexec.web.client.actions.{FlipBreakpointStep, FlipSkipStep, ShowStep}
+import edu.gemini.seqexec.web.client.circuit.{ClientStatus, SeqexecCircuit, StepsTableFocus}
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
+import edu.gemini.seqexec.web.client.semanticui._
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon._
+import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
+import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
+import edu.gemini.seqexec.web.client.semanticui.elements.table.TableHeader
 import edu.gemini.seqexec.web.client.services.HtmlConstants.iconEmpty
-import edu.gemini.web.client.utils._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import org.scalajs.dom.html.Div
 
 import scalacss.ScalaCssReact._
+import scalaz.std.AllInstances._
+import scalaz.syntax.equal._
 import scalaz.syntax.show._
-import scalaz.syntax.order._
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.std.option._
-import scalaz.std.AllInstances._
-import org.scalajs.dom.html.Div
-import org.scalajs.dom.CanvasRenderingContext2D
 
-/**
- * Utility methods to display offsets and calculate their widths
- */
-trait OffsetFns {
-  def offsetAxis(axis: OffsetAxis): String =
-    f"${axis.shows}:"
-
-  def offsetValueFormat(off: Offset): String =
-    f" ${off.value}%003.2f″"
-
-  def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
-
-  def offsetText(axis: OffsetAxis)(step: Step): String =
-    offsetValueFormat(axis match {
-      case OffsetAxis.AxisP => telescopeOffsetPO.getOption(step).getOrElse(TelescopeOffset.P.Zero)
-      case OffsetAxis.AxisQ => telescopeOffsetQO.getOption(step).getOrElse(TelescopeOffset.Q.Zero)
-    })
-
-  private val offsetPText = offsetText(OffsetAxis.AxisP) _
-  private val offsetQText = offsetText(OffsetAxis.AxisQ) _
-
-  val pLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisP))
-  val qLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisQ))
-
-  // Calculate the widest offset step
-  def sequenceOffsetWidths(steps: List[Step]): (Int, Int) = {
-    steps.map(s => (tableTextWidth(offsetPText(s)), tableTextWidth(offsetQText(s)))).foldLeft((0, 0)) {
-      case ((p1, q1), (p2, q2)) => (p1.max(p2), q1.max(q2))
-    }
-  }
-}
 
 /**
   * Container for a table with the steps
@@ -448,128 +413,3 @@ object StepsTableContainer extends OffsetFns {
   def apply(p: Props): Unmounted[Props, State, Backend] = component(p)
 }
 
-object OffsetGrid {
-  private val Size = 33.0
-  final case class Props(p: TelescopeOffset.P, q: TelescopeOffset.Q)
-  final case class State(canvas: Option[Canvas])
-
-  private val ST = ReactS.Fix[State]
-
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def render(props: Props, state: State): Callback = state.canvas.fold(Callback.empty) { c => Callback {
-    // The canvas API is very imperative and stateful but we are inside a Callback!
-    val ctx = c.getContext("2d").asInstanceOf[CanvasRenderingContext2D]
-    c.width = Size.toInt
-    c.height = Size.toInt
-    // First quadrant
-    ctx.fillStyle = if (props.p > TelescopeOffset.P.Zero && props.q > TelescopeOffset.Q.Zero) "darkgray" else "white"
-    ctx.fillRect(0, 0, Size / 2, Size / 2)
-    // Second quadrant
-    ctx.fillStyle = if (props.p < TelescopeOffset.P.Zero && props.q > TelescopeOffset.Q.Zero) "darkgray" else "white"
-    ctx.fillRect(Size / 2, 0, Size / 2, Size / 2)
-    // Third quadrant
-    ctx.fillStyle = if (props.p < TelescopeOffset.P.Zero && props.q < TelescopeOffset.Q.Zero) "darkgray" else "white"
-    ctx.fillRect(Size / 2, Size / 2, Size / 2, Size / 2)
-    // Fourth quadrant
-    ctx.fillStyle = if (props.p > TelescopeOffset.P.Zero && props.q < TelescopeOffset.Q.Zero) "darkgray" else "white"
-    ctx.fillRect(0, Size / 2, Size / 2, Size / 2)
-    // Grid
-    ctx.fillStyle = "black"
-    // Outer border
-    ctx.strokeRect(0, 0, Size, Size)
-    // Inner borders
-    ctx.strokeRect(0, 0, Size / 2, Size / 2)
-    ctx.strokeRect(Size / 2, 0, Size / 2, Size / 2)
-    ctx.strokeRect(0, Size / 2, Size / 2, Size / 2)
-    ctx.strokeRect(Size/2, Size / 2, Size / 2, Size / 2)
-  }}
-
-  private val component = ScalaComponent.builder[Props]("OffsetGrid")
-    .initialState(State(None))
-    .render_P ( p =>
-      <.canvas(
-        ^.cls := "middle aligned",
-        ^.width := Size.toInt.px,
-        ^.height := Size.toInt.px
-      )
-    ).componentWillReceiveProps { ctx =>
-      render(ctx.nextProps, ctx.state)
-    }.componentDidMount { ctx =>
-      // Grab a copy of the canvas
-      val state = State(Some(ctx.getDOMNode.domCast[Canvas]))
-      ctx.runState(ST.set(state)) >> render(ctx.props, state)
-    }.build
-
-  def apply(p: Props): Unmounted[Props, State, Unit] = component(p)
-
-}
-
-/**
- * Component to display the settings of a given step
- */
-object StepSettings extends OffsetFns {
-  final case class Props(s: Step, offsetWidth: Int)
-  private val component = ScalaComponent.builder[Props]("StepSettings")
-    .stateless
-    .render_P { p =>
-      val offsetP = telescopeOffsetPO.getOption(p.s).getOrElse(TelescopeOffset.P.Zero)
-      val offsetQ = telescopeOffsetQO.getOption(p.s).getOrElse(TelescopeOffset.Q.Zero)
-      val stepTypeLabel = stepTypeO.getOption(p.s).map { st =>
-        val stepTypeColor = st match {
-          case StepType.Object      => "green"
-          case StepType.Arc         => "violet"
-          case StepType.Flat        => "grey"
-          case StepType.Bias        => "teal"
-          case StepType.Dark        => "black"
-          case StepType.Calibration => "blue"
-        }
-        Label(Label.Props(st.shows, color = stepTypeColor.some))
-      }
-      <.div(
-        ^.cls := "ui two column grid",
-        <.div(
-          ^.cls := "row",
-          <.div(
-            ^.cls := "left floated middle aligned one wide column",
-            OffsetGrid(OffsetGrid.Props(offsetP, offsetQ))
-          ),
-          <.div(
-            ^.cls := "left floated four wide column",
-            <.div(
-              ^.cls := "right aligned",
-              <.div(
-                ^.width := pLabelWidth.px,
-                SeqexecStyles.inlineBlock,
-                offsetAxis(OffsetAxis.AxisP)
-              ),
-              <.div(
-                ^.width := p.offsetWidth.px,
-                SeqexecStyles.inlineBlock,
-                offsetValueFormat(offsetP)
-              )
-            ),
-            <.div(
-              ^.cls := "right aligned",
-              <.div(
-                ^.width := qLabelWidth.px,
-                SeqexecStyles.inlineBlock,
-                offsetAxis(OffsetAxis.AxisQ)
-              ),
-              <.div(
-                ^.width := p.offsetWidth.px,
-                SeqexecStyles.inlineBlock,
-                offsetValueFormat(offsetQ)
-              )
-            )
-          ),
-          <.div(
-            ^.cls := "middle aligned right floated four wide column",
-            <.div(stepTypeLabel.whenDefined)
-          )
-        )
-      )
-    }
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}

--- a/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/utils.scala
+++ b/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/utils.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.web.client
+
+import org.scalajs.dom
+import org.scalajs.dom.html
+import scala.math
+
+trait utils {
+  type Canvas = html.Canvas
+  type Ctx2D = dom.CanvasRenderingContext2D
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def textWidth(text: String, font: String): Int = {
+    val canvas = dom.document.createElement("canvas").asInstanceOf[Canvas]
+    val ctx = canvas.getContext("2d").asInstanceOf[Ctx2D]
+    ctx.font = font
+    val metrics = ctx.measureText(text)
+    println(text)
+    println(metrics.width)
+    math.round(metrics.width.toFloat)
+  }
+}
+
+object utils extends utils

--- a/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/utils.scala
+++ b/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/utils.scala
@@ -17,8 +17,6 @@ trait utils {
     val ctx = canvas.getContext("2d").asInstanceOf[Ctx2D]
     ctx.font = font
     val metrics = ctx.measureText(text)
-    println(text)
-    println(metrics.width)
     math.round(metrics.width.toFloat)
   }
 }


### PR DESCRIPTION
As part of SEQNG-367 this PR includes a display for the offsets. it displays it numerically and with a graphical widget showing in which quadrant the offset is placed. This PR required getting deeper into JS functions to get the numbers to align properly and to use the canvas. This will be useful in the future

Should we display this for 0 offsets?

Here's a screenshot

![screenshot 2017-11-22 17 35 42](https://user-images.githubusercontent.com/3615303/33148706-97d2665c-cfab-11e7-8d04-06bfca18f165.png)
