### PR TITLE
SEQNG-401 Fixed value for disperser mode parameter.

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerEpics.scala
@@ -164,7 +164,8 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   def setDisperser(d: GmosController.Config[T]#GmosDisperser): SeqAction[Unit] = {
-    val disperserMode = "Select Grating and Tilt"
+    // TODO: add support for Enum parameters in acm, and then define Enum type for disperserMode
+    val disperserMode = "WLEN"
     CC.setDisperser(encoders.disperser.encode(d.disperser)) *>
       CC.setDisperserMode(disperserMode) *>
       d.order.filter(_ => d.disperser != Disperser.MIRROR).fold(SeqAction.void)(o => CC.setDisperserOrder(encode(o))) *>


### PR DESCRIPTION
Old Seqexec wrote the value to an EPICS menu record (therefore, the user friendly value), which was then converted to values WLEN or SEL for the CAD record. In the new Seqexec I bypassed the menu record.