### PR TITLE
SEQNG-347: Use a structured table to display results

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,7 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
     npmDependencies in Compile ++= Seq(
       "react" -> LibraryVersions.reactJS,
       "react-dom" -> LibraryVersions.reactJS,
+      "react-virtualized" -> LibraryVersions.reactVirtualized,
       "jquery" -> LibraryVersions.jQuery,
       "semantic-ui-dropdown" -> LibraryVersions.semanticUI,
       "semantic-ui-modal" -> LibraryVersions.semanticUI,
@@ -162,7 +163,8 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
       ScalaCSS.value,
       ScalaJSDom.value,
       JavaTimeJS.value,
-      JavaLogJS.value
+      JavaLogJS.value,
+      ScalaJSReactVirtualized.value
     ) ++ ReactScalaJS.value ++ Diode.value,
     // And add a custom one
     addCompilerPlugin("org.scala-js" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.patch)

--- a/build.sbt
+++ b/build.sbt
@@ -166,7 +166,7 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
       JavaLogJS.value,
       ScalaJSReactVirtualized.value
     ) ++ ReactScalaJS.value ++ Diode.value,
-    // And add a custom one
+    // Specify the scalajs-compiler to make it compatbile with TLS
     addCompilerPlugin("org.scala-js" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.patch)
   )
   .settings(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -65,11 +65,11 @@ object LogArea {
         overscanRowCount = 10,
         height = 300,
         rowCount = p.log().log.size,
-        rowHeight = 40,
+        rowHeight = 30,
         width = size.width.toInt,
         rowGetter = p.rowGetter _,
-        headerClassName = "headerColumn",
-        headerHeight = 30),
+        headerClassName = SeqexecStyles.logTableHeader.htmlClass,
+        headerHeight = 47),
       columns: _*).vdomElement
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -49,14 +49,19 @@ object LogArea {
   def table(p: Props)(size: Size): VdomNode = {
     val columns = List(
       Column(Column.props(200, "timestamp", label = "Timestamp", disableSort = true)),
-      Column(Column.props(100, "level", label = "Level", disableSort = true)),
-      Column(Column.props(size.width.toInt - 200 - 100, "msg", label = "Message", disableSort = true, flexGrow = 1))
+      Column(Column.props(80, "level", label = "Level", disableSort = true)),
+      Column(Column.props(size.width.toInt - 200 - 80, "msg", label = "Message", disableSort = true, flexGrow = 1))
     )
 
     Table(
       Table.props(
         disableHeader = false,
-        noRowsRenderer = () => <.div(^.cls := "noRows", "No entries"),
+        noRowsRenderer = () =>
+          <.div(
+            ^.cls := "ui center aligned segment noRows",
+            ^.height := 270.px,
+            "No log entries"
+          ),
         overscanRowCount = 10,
         height = 300,
         rowCount = p.log().log.size,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -49,6 +49,9 @@ object LogArea {
     }.getOrElse(LogRow.Zero)
   }
 
+  /**
+   * Build the table log
+   */
   def table(p: Props)(size: Size): VdomNode = {
     val rowCount = p.log().log.size
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -43,7 +43,8 @@ object LogArea {
     val Zero: LogRow = apply("", "", "")
   }
   final case class Props(log: ModelProxy[GlobalLog]) {
-    def rowGetter(i: Int): LogRow = log().log.index(i).map { l =>
+    private val reverseLog = log().log.reverse
+    def rowGetter(i: Int): LogRow = reverseLog.index(i).map { l =>
       LogRow(l.timestamp.shows, l.level.shows, l.msg)
     }.getOrElse(LogRow.Zero)
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -66,10 +66,11 @@ object LogArea {
         height = 300,
         rowCount = p.log().log.size,
         rowHeight = 30,
+        rowClassName = SeqexecStyles.logRow.htmlClass,
         width = size.width.toInt,
         rowGetter = p.rowGetter _,
         headerClassName = SeqexecStyles.logTableHeader.htmlClass,
-        headerHeight = 47),
+        headerHeight = 37),
       columns: _*).vdomElement
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -24,11 +24,13 @@ object LogArea {
   implicit val showLevel: Show[ServerLogLevel] = Show.showFromToString
   implicit val showInstant: Show[Instant] = Show.showFromToString
   // ScalaJS defined trait
+  // scalastyle:off
   trait LogRow extends js.Object {
     var timestamp: String
     var level: String
     var msg: String
   }
+  // scalastyle:on
   object LogRow {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     def apply(timestamp: String, level: String, msg: String): LogRow = {
@@ -47,6 +49,8 @@ object LogArea {
   }
 
   def table(p: Props)(size: Size): VdomNode = {
+    val rowCount = p.log().log.size
+
     val columns = List(
       Column(Column.props(200, "timestamp", label = "Timestamp", disableSort = true)),
       Column(Column.props(80, "level", label = "Level", disableSort = true)),
@@ -64,7 +68,7 @@ object LogArea {
           ),
         overscanRowCount = 10,
         height = 300,
-        rowCount = p.log().log.size,
+        rowCount = rowCount,
         rowHeight = 30,
         rowClassName = SeqexecStyles.logRow.htmlClass,
         width = size.width.toInt,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -64,19 +64,22 @@ object LogArea {
             <.div(
               ^.cls := "field",
               <.label("Log"),
-              Table(
-                Table.props(
-                  disableHeader = false,
-                  noRowsRenderer = () => <.div(^.cls := "noRows", "No entries"),
-                  overscanRowCount = 10,
-                  height = 500,
-                  rowCount = p.log().log.size,
-                  rowHeight = 40,
-                  width = 1500,
-                  rowGetter = p.rowGetter _,
-                  headerClassName = "headerColumn",
-                  headerHeight = 30),
-                columns: _*)
+              AutoSizer(AutoSizer.props(
+                (s: Size) =>
+                  Table(
+                    Table.props(
+                      disableHeader = false,
+                      noRowsRenderer = () => <.div(^.cls := "noRows", "No entries"),
+                      overscanRowCount = 10,
+                      height = 300,
+                      rowCount = p.log().log.size,
+                      rowHeight = 40,
+                      width = s.width.toInt,
+                      rowGetter = p.rowGetter _,
+                      headerClassName = "headerColumn",
+                      headerHeight = 30),
+                    columns: _*).vdomElement
+              , disableHeight = true))
             )
           )
         )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -46,11 +46,27 @@ object LogArea {
     }.getOrElse(LogRow.Zero)
   }
 
-  private val columns = List(
-    Column(Column.props(60, "timestamp", label = "Timestamp", disableSort = true)),
-    Column(Column.props(90, "level", label = "Level", disableSort = true)),
-    Column(Column.props(210, "msg", label = "Message", disableSort = true, flexGrow = 1))
-  )
+  def table(p: Props)(size: Size): VdomNode = {
+    val columns = List(
+      Column(Column.props(200, "timestamp", label = "Timestamp", disableSort = true)),
+      Column(Column.props(100, "level", label = "Level", disableSort = true)),
+      Column(Column.props(size.width.toInt - 200 - 100, "msg", label = "Message", disableSort = true, flexGrow = 1))
+    )
+
+    Table(
+      Table.props(
+        disableHeader = false,
+        noRowsRenderer = () => <.div(^.cls := "noRows", "No entries"),
+        overscanRowCount = 10,
+        height = 300,
+        rowCount = p.log().log.size,
+        rowHeight = 40,
+        width = size.width.toInt,
+        rowGetter = p.rowGetter _,
+        headerClassName = "headerColumn",
+        headerHeight = 30),
+      columns: _*).vdomElement
+  }
 
   private val component = ScalaComponent.builder[Props]("LogArea")
     .stateless
@@ -63,23 +79,7 @@ object LogArea {
             ^.cls := "ui form",
             <.div(
               ^.cls := "field",
-              <.label("Log"),
-              AutoSizer(AutoSizer.props(
-                (s: Size) =>
-                  Table(
-                    Table.props(
-                      disableHeader = false,
-                      noRowsRenderer = () => <.div(^.cls := "noRows", "No entries"),
-                      overscanRowCount = 10,
-                      height = 300,
-                      rowCount = p.log().log.size,
-                      rowHeight = 40,
-                      width = s.width.toInt,
-                      rowGetter = p.rowGetter _,
-                      headerClassName = "headerColumn",
-                      headerHeight = 30),
-                    columns: _*).vdomElement
-              , disableHeight = true))
+              AutoSizer(AutoSizer.props(table(p), disableHeight = true))
             )
           )
         )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -3,23 +3,58 @@
 
 package edu.gemini.seqexec.web.client.components
 
+import scala.scalajs.js
 import diode.react.ModelProxy
+import edu.gemini.seqexec.model.Model.ServerLogLevel
 import edu.gemini.seqexec.web.client.model.GlobalLog
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
+import react.virtualized._
+import java.time.Instant
 
-import scalaz.syntax.functor._
+import scalaz.Show
+import scalaz.syntax.foldable._
+import scalaz.syntax.show._
 
 /**
   * Area to display a sequence's log
   */
 object LogArea {
-  final case class Props(log: GlobalLog)
+  implicit val showLevel: Show[ServerLogLevel] = Show.showFromToString
+  implicit val showInstant: Show[Instant] = Show.showFromToString
+  // ScalaJS defined trait
+  trait LogRow extends js.Object {
+    var timestamp: String
+    var level: String
+    var msg: String
+  }
+  object LogRow {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    def apply(timestamp: String, level: String, msg: String): LogRow = {
+      val p = (new js.Object).asInstanceOf[LogRow]
+      p.timestamp = timestamp
+      p.level = level
+      p.msg = msg
+      p
+    }
+    val Zero: LogRow = apply("", "", "")
+  }
+  final case class Props(log: ModelProxy[GlobalLog]) {
+    def rowGetter(i: Int): LogRow = log().log.index(i).map { l =>
+      LogRow(l.timestamp.shows, l.level.shows, l.msg)
+    }.getOrElse(LogRow.Zero)
+  }
+
+  private val columns = List(
+    Column(Column.props(60, "timestamp", label = "Timestamp", disableSort = true)),
+    Column(Column.props(90, "level", label = "Level", disableSort = true)),
+    Column(Column.props(210, "msg", label = "Message", disableSort = true, flexGrow = 1))
+  )
 
   private val component = ScalaComponent.builder[Props]("LogArea")
     .stateless
-    .render_P(p =>
+    .render_P { p =>
       <.div(
         ^.cls := "ui sixteen wide column",
         <.div(
@@ -29,16 +64,25 @@ object LogArea {
             <.div(
               ^.cls := "field",
               <.label("Log"),
-              <.textarea(
-                ^.readOnly := true,
-                ^.value := p.log.log.map(e => s"${e.timestamp} ${e.msg}").toVector.mkString("\n")
-              )
+              Table(
+                Table.props(
+                  disableHeader = false,
+                  noRowsRenderer = () => <.div(^.cls := "noRows", "No entries"),
+                  overscanRowCount = 10,
+                  height = 500,
+                  rowCount = p.log().log.size,
+                  rowHeight = 40,
+                  width = 1500,
+                  rowGetter = p.rowGetter _,
+                  headerClassName = "headerColumn",
+                  headerHeight = 30),
+                columns: _*)
             )
           )
         )
       )
-    )
+    }
     .build
 
-  def apply(p: ModelProxy[GlobalLog]): Unmounted[Props, Unit, Unit] = component(Props(p()))
+  def apply(p: ModelProxy[GlobalLog]): Unmounted[Props, Unit, Unit] = component(Props(p))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -330,4 +330,21 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     (backgroundImage := s"linear-gradient(to bottom, rgba(249, 0, 1, 0) 0%, rgba(249, 0, 1, 0) 0%), linear-gradient(to right, rgba(34, 36, 38, 0.15) 0px, rgba(34, 36, 38, 0.00001) ${gutterWidth}px)").important,
     backgroundClip.contentBox.paddingBox.important
   )
+
+  // Styles for the log table
+  val logTable: StyleA = style(
+    fontSize(1.em)
+  )
+}
+
+object ReactVirtualizedStyles extends scalacss.StyleSheet.Inline {
+  import dsl._
+
+  val headerRow: StyleA = style("ReactVirtualized__Table__headerRow")(
+    fontWeight._700,
+    textTransform.uppercase,
+    display.flex,
+    flexDirection.row,
+    alignItems.center
+  )
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -335,6 +335,37 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   val logTable: StyleA = style(
     fontSize(1.em)
   )
+
+  val logTableHeader: StyleA = style(
+    fontWeight.bold,
+    paddingLeft(0.7.em),
+    paddingRight(0.7.em),
+    paddingBottom(0.928571.em),
+    paddingTop(0.928571.em),
+    color(black),
+    borderLeftWidth(1.px),
+    borderLeftStyle.solid,
+    borderLeftColor(rgba(34, 36, 38, 0.15)),
+  )
+
+  val headerRow: StyleA = style("ReactVirtualized__Table__headerRow")(
+    fontWeight._700,
+    display.flex,
+    flexDirection.row,
+    alignItems.center,
+    backgroundColor(c"#F9FAFB"),
+    borderWidth(1.px),
+    borderStyle.solid,
+    borderColor(rgba(34, 36, 38, 0.15)),
+    borderTopLeftRadius(0.28571429.rem),
+    borderTopRightRadius(0.28571429.rem)
+  )
+
+  val firstHeaderColumn: StyleA = style("ReactVirtualized__Table__headerColumn:first-of-type")(
+    borderLeft.none
+  )
+  val firstRowColumn: StyleA = style("ReactVirtualized__Table__rowColumn:first-of-type")(
+  )
 }
 
 object ReactVirtualizedStyles extends scalacss.StyleSheet.Inline {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -331,11 +331,13 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     backgroundClip.contentBox.paddingBox.important
   )
 
-  // Styles for the log table
+  // Styles for the log table, These styles will make react-virtualized
+  // match the look of SemanticUI tables
   val logTable: StyleA = style(
     fontSize(1.em)
   )
 
+  // Border color
   private val tableBorderColor = rgba(34, 36, 38, 0.15)
 
   private val logTablePaddingMixin: StyleS = mixin(
@@ -350,21 +352,25 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     borderLeftStyle.solid,
     borderLeftColor(tableBorderColor)
   )
+
   val bottomBorderMixin: StyleS = mixin(
     borderBottomWidth(1.px),
     borderBottomStyle.solid,
     borderBottomColor(tableBorderColor)
   )
+
   val topBorderMixin: StyleS = mixin(
     borderTopWidth(1.px),
     borderTopStyle.solid,
     borderTopColor(tableBorderColor)
   )
+
   val rightBorderMixin: StyleS = mixin(
     borderRightWidth(1.px),
     borderRightStyle.solid,
     borderRightColor(tableBorderColor)
   )
+
   val logTableHeader: StyleA = style(
     leftBorderMixin,
     logTablePaddingMixin,
@@ -373,6 +379,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     backgroundColor(c"#F9FAFB")
   )
 
+  // Override styles used by react-virtualized
   val headerRow: StyleA = style("ReactVirtualized__Table__headerRow")(
     fontWeight._700,
     display.flex,
@@ -383,21 +390,26 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   val firstHeaderColumn: StyleA = style("ReactVirtualized__Table__headerColumn:first-of-type")(
     borderLeft.none
   )
+
   val firstRowColumn: StyleA = style("ReactVirtualized__Table__rowColumn:first-of-type")(
     borderLeft.none
   )
+
   val logRow: StyleA = style(
     leftBorderMixin,
     topBorderMixin,
     rightBorderMixin
   )
+
   val tableGrid: StyleA = style("ReactVirtualized__Table__Grid")(
     topBorderMixin,
     bottomBorderMixin
   )
+
   val innerScroll: StyleA = style("ReactVirtualized__Grid__innerScrollContainer")(
     bottomBorderMixin
   )
+
   val rowColumn: StyleA = style("ReactVirtualized__Table__rowColumn")(
     logTablePaddingMixin,
     leftBorderMixin,
@@ -408,43 +420,5 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     textOverflow := "ellipsis",
     backgroundColor.white,
     whiteSpace.nowrap
-  )
-}
-
-object ReactVirtualizedStyles extends scalacss.StyleSheet.Inline {
-  import dsl._
-
-  val headerRow: StyleA = style("ReactVirtualized__Table__headerRow")(
-    fontWeight._700,
-    textTransform.uppercase,
-    display.flex,
-    flexDirection.row,
-    alignItems.center
-  )
-
-  private val firstColumnMixin = mixin(
-    marginLeft(10.px)
-  )
-  val firstHeaderColumn: StyleA = style("ReactVirtualized__Table__headerColumn:first-of-type")(
-    firstColumnMixin
-  )
-  val firstRowColumn: StyleA = style("ReactVirtualized__Table__rowColumn:first-of-type")(
-    firstColumnMixin
-  )
-  private val columnMixin = mixin(
-    marginRight(10.px),
-    minWidth(0.px)
-  )
-  val headerColumn: StyleA = style("ReactVirtualized__Table__headerColumn")(
-    columnMixin
-  )
-  val rowColumn: StyleA = style("ReactVirtualized__Table__rowColumn")(
-    columnMixin,
-    textOverflow := "ellipsis",
-    whiteSpace.nowrap
-  )
-  val bottomRow: StyleA = style("ReactVirtualized__Table__Grid")(
-  )
-  val innerScroll: StyleA = style("ReactVirtualized__Grid__innerScrollContainer")(
   )
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -336,35 +336,60 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     fontSize(1.em)
   )
 
-  val logTableHeader: StyleA = style(
-    fontWeight.bold,
+  private val tableBorderColor = rgba(34, 36, 38, 0.15)
+
+  private val logTablePaddingMixin: StyleS = mixin(
     paddingLeft(0.7.em),
     paddingRight(0.7.em),
-    paddingBottom(0.928571.em),
-    paddingTop(0.928571.em),
+    paddingBottom(0.7.em),
+    paddingTop(1.em)
+  )
+
+  val logTableHeader: StyleA = style(
+    logTablePaddingMixin,
+    fontWeight.bold,
     color(black),
+    backgroundColor(c"#F9FAFB"),
     borderLeftWidth(1.px),
     borderLeftStyle.solid,
-    borderLeftColor(rgba(34, 36, 38, 0.15)),
+    borderLeftColor(tableBorderColor)
   )
 
   val headerRow: StyleA = style("ReactVirtualized__Table__headerRow")(
     fontWeight._700,
     display.flex,
     flexDirection.row,
-    alignItems.center,
-    backgroundColor(c"#F9FAFB"),
-    borderWidth(1.px),
-    borderStyle.solid,
-    borderColor(rgba(34, 36, 38, 0.15)),
-    borderTopLeftRadius(0.28571429.rem),
-    borderTopRightRadius(0.28571429.rem)
+    alignItems.center
   )
 
   val firstHeaderColumn: StyleA = style("ReactVirtualized__Table__headerColumn:first-of-type")(
     borderLeft.none
   )
   val firstRowColumn: StyleA = style("ReactVirtualized__Table__rowColumn:first-of-type")(
+    borderLeft.none
+  )
+  val logRow: StyleA = style(
+    borderLeftWidth(1.px),
+    borderLeftStyle.solid,
+    borderLeftColor(tableBorderColor),
+    borderRightWidth(1.px),
+    borderRightStyle.solid,
+    borderRightColor(tableBorderColor),
+    borderTopWidth(1.px),
+    borderTopStyle.solid,
+    borderTopColor(tableBorderColor),
+    borderCollapse.collapse
+  )
+  val rowColumn: StyleA = style("ReactVirtualized__Table__rowColumn")(
+    logTablePaddingMixin,
+    minWidth(0.px),
+    backgroundColor.white,
+    textOverflow := "ellipsis",
+    backgroundColor.white,
+    whiteSpace.nowrap,
+    borderLeftWidth(1.px),
+    borderLeftStyle.solid,
+    borderLeftColor(tableBorderColor)
   )
 }
 
@@ -377,5 +402,27 @@ object ReactVirtualizedStyles extends scalacss.StyleSheet.Inline {
     display.flex,
     flexDirection.row,
     alignItems.center
+  )
+
+  private val firstColumnMixin = mixin(
+    marginLeft(10.px)
+  )
+  val firstHeaderColumn: StyleA = style("ReactVirtualized__Table__headerColumn:first-of-type")(
+    firstColumnMixin
+  )
+  val firstRowColumn: StyleA = style("ReactVirtualized__Table__rowColumn:first-of-type")(
+    firstColumnMixin
+  )
+  private val columnMixin = mixin(
+    marginRight(10.px),
+    minWidth(0.px)
+  )
+  val headerColumn: StyleA = style("ReactVirtualized__Table__headerColumn")(
+    columnMixin
+  )
+  val rowColumn: StyleA = style("ReactVirtualized__Table__rowColumn")(
+    columnMixin,
+    textOverflow := "ellipsis",
+    whiteSpace.nowrap
   )
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -345,14 +345,32 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     paddingTop(1.em)
   )
 
-  val logTableHeader: StyleA = style(
-    logTablePaddingMixin,
-    fontWeight.bold,
-    color(black),
-    backgroundColor(c"#F9FAFB"),
+  val leftBorderMixin: StyleS = mixin(
     borderLeftWidth(1.px),
     borderLeftStyle.solid,
     borderLeftColor(tableBorderColor)
+  )
+  val bottomBorderMixin: StyleS = mixin(
+    borderBottomWidth(1.px),
+    borderBottomStyle.solid,
+    borderBottomColor(tableBorderColor)
+  )
+  val topBorderMixin: StyleS = mixin(
+    borderTopWidth(1.px),
+    borderTopStyle.solid,
+    borderTopColor(tableBorderColor)
+  )
+  val rightBorderMixin: StyleS = mixin(
+    borderRightWidth(1.px),
+    borderRightStyle.solid,
+    borderRightColor(tableBorderColor)
+  )
+  val logTableHeader: StyleA = style(
+    leftBorderMixin,
+    logTablePaddingMixin,
+    fontWeight.bold,
+    color(black),
+    backgroundColor(c"#F9FAFB")
   )
 
   val headerRow: StyleA = style("ReactVirtualized__Table__headerRow")(
@@ -369,27 +387,27 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     borderLeft.none
   )
   val logRow: StyleA = style(
-    borderLeftWidth(1.px),
-    borderLeftStyle.solid,
-    borderLeftColor(tableBorderColor),
-    borderRightWidth(1.px),
-    borderRightStyle.solid,
-    borderRightColor(tableBorderColor),
-    borderTopWidth(1.px),
-    borderTopStyle.solid,
-    borderTopColor(tableBorderColor),
-    borderCollapse.collapse
+    leftBorderMixin,
+    topBorderMixin,
+    rightBorderMixin
+  )
+  val tableGrid: StyleA = style("ReactVirtualized__Table__Grid")(
+    topBorderMixin,
+    bottomBorderMixin
+  )
+  val innerScroll: StyleA = style("ReactVirtualized__Grid__innerScrollContainer")(
+    bottomBorderMixin
   )
   val rowColumn: StyleA = style("ReactVirtualized__Table__rowColumn")(
     logTablePaddingMixin,
+    leftBorderMixin,
     minWidth(0.px),
     backgroundColor.white,
+    color(rgba(0, 0, 0, 0.95)),
+    fontSize.small,
     textOverflow := "ellipsis",
     backgroundColor.white,
-    whiteSpace.nowrap,
-    borderLeftWidth(1.px),
-    borderLeftStyle.solid,
-    borderLeftColor(tableBorderColor)
+    whiteSpace.nowrap
   )
 }
 
@@ -424,5 +442,9 @@ object ReactVirtualizedStyles extends scalacss.StyleSheet.Inline {
     columnMixin,
     textOverflow := "ellipsis",
     whiteSpace.nowrap
+  )
+  val bottomRow: StyleA = style("ReactVirtualized__Table__Grid")(
+  )
+  val innerScroll: StyleA = style("ReactVirtualized__Grid__innerScrollContainer")(
   )
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/css/virtualized.css
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/css/virtualized.css
@@ -1,0 +1,78 @@
+/* Collection default theme */
+
+.ReactVirtualized__Collection {
+}
+
+.ReactVirtualized__Collection__innerScrollContainer {
+}
+
+/* Grid default theme */
+
+.ReactVirtualized__Grid {
+}
+
+.ReactVirtualized__Grid__innerScrollContainer {
+}
+
+/* Table default theme */
+
+.ReactVirtualized__Table {
+}
+
+.ReactVirtualized__Table__Grid {
+}
+
+.ReactVirtualized__Table__headerRow {
+  font-weight: 700;
+  text-transform: uppercase;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.ReactVirtualized__Table__row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.ReactVirtualized__Table__headerTruncatedText {
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.ReactVirtualized__Table__headerColumn,
+.ReactVirtualized__Table__rowColumn {
+  margin-right: 10px;
+  min-width: 0px;
+}
+.ReactVirtualized__Table__rowColumn {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ReactVirtualized__Table__headerColumn:first-of-type,
+.ReactVirtualized__Table__rowColumn:first-of-type {
+  margin-left: 10px;
+}
+.ReactVirtualized__Table__sortableHeaderColumn {
+  cursor: pointer;
+}
+
+.ReactVirtualized__Table__sortableHeaderIconContainer {
+  display: flex;
+  align-items: center;
+}
+.ReactVirtualized__Table__sortableHeaderIcon {
+  flex: 0 0 24px;
+  height: 1em;
+  width: 1em;
+  fill: currentColor;
+}
+
+/* List default theme */
+
+.ReactVirtualized__List {
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/css/virtualized.css
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/css/virtualized.css
@@ -1,34 +1,9 @@
-/* Collection default theme */
-
-.ReactVirtualized__Collection {
-}
-
-.ReactVirtualized__Collection__innerScrollContainer {
-}
-
-/* Grid default theme */
-
-.ReactVirtualized__Grid {
-}
-
-.ReactVirtualized__Grid__innerScrollContainer {
-}
-
-/* Table default theme */
-
 .ReactVirtualized__Table {
 }
 
 .ReactVirtualized__Table__Grid {
 }
 
-.ReactVirtualized__Table__headerRow {
-  font-weight: 700;
-  text-transform: uppercase;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
 .ReactVirtualized__Table__row {
   display: flex;
   flex-direction: row;
@@ -43,20 +18,6 @@
   overflow: hidden;
 }
 
-.ReactVirtualized__Table__headerColumn,
-.ReactVirtualized__Table__rowColumn {
-  margin-right: 10px;
-  min-width: 0px;
-}
-.ReactVirtualized__Table__rowColumn {
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ReactVirtualized__Table__headerColumn:first-of-type,
-.ReactVirtualized__Table__rowColumn:first-of-type {
-  margin-left: 10px;
-}
 .ReactVirtualized__Table__sortableHeaderColumn {
   cursor: pointer;
 }
@@ -70,9 +31,4 @@
   height: 1em;
   width: 1em;
   fill: currentColor;
-}
-
-/* List default theme */
-
-.ReactVirtualized__List {
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/package.scala
@@ -38,6 +38,7 @@ package object http4s {
           <title>{s"Seqexec - $site"}</title>
 
           <link rel="stylesheet" href={s"/css/semantic.$builtAtMillis.css"}/>
+          <link rel="stylesheet" href={s"/css/virtualized.$builtAtMillis.css"}/>
           <style>{style.stripMargin}</style>
         </head>
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/FixedLengthBuffer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/FixedLengthBuffer.scala
@@ -3,7 +3,7 @@
 
 package edu.gemini.web.common
 
-import scalaz.{Show, Equal, Functor}
+import scalaz.{Show, Equal, Foldable, IsEmpty, Functor}
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.equal._
 import scalaz.std.AllInstances._
@@ -27,6 +27,10 @@ object FixedLengthBuffer {
 
     def toVector: Vector[A] =
       data
+
+    def size: Int = data.size
+
+    def isEmpty: Boolean = data.isEmpty
   }
 
   def apply[A](maxLength: Int, initial: A*): Option[FixedLengthBuffer[A]] = {
@@ -40,14 +44,41 @@ object FixedLengthBuffer {
   def unsafeFromInt[A](maxLength: Int, initial: A*): FixedLengthBuffer[A] =
     fromInt[A](maxLength, initial: _*).getOrElse(sys.error(s"Invalid max length $maxLength, data length ${initial.length}"))
 
+  def Zero[A]: FixedLengthBuffer[A] = FixedLengthBufferImpl[A](0, Vector.empty[A])
+
   implicit def show[A]: Show[FixedLengthBuffer[A]] = Show.showFromToString
 
   implicit def equal[A]: Equal[FixedLengthBuffer[A]] = Equal.equalA
 
-  implicit def functor[A]: Functor[FixedLengthBuffer] = new Functor[FixedLengthBuffer] {
+  implicit val functor: Functor[FixedLengthBuffer] = new Functor[FixedLengthBuffer] {
     def map[B, C](fa: FixedLengthBuffer[B])(f: B => C): FixedLengthBuffer[C] = fa match {
         case FixedLengthBufferImpl(max, data) => FixedLengthBufferImpl[C](max, data.map(f))
       }
+  }
+
+  implicit val foldable: Foldable[FixedLengthBuffer] with IsEmpty[FixedLengthBuffer] = new Foldable[FixedLengthBuffer] with IsEmpty[FixedLengthBuffer] with Foldable.FromFoldr[FixedLengthBuffer] {
+    override def length[A](fa: FixedLengthBuffer[A]) = fa.size
+    def empty[A] = Zero[A]
+    def plus[A](a: FixedLengthBuffer[A], b: => FixedLengthBuffer[A]) = FixedLengthBufferImpl(a.maxLength + b.maxLength, a.toVector ++ b.toVector)
+    def isEmpty[A](fa: FixedLengthBuffer[A]) = fa.isEmpty
+
+    @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+    def foldRight[A, B](fa: FixedLengthBuffer[A], z: => B)(f: (A, => B) => B) = {
+      import scala.collection.mutable.ArrayStack
+      val s = new ArrayStack[A]
+      fa.toVector.foreach(a => s += a)
+      var r = z
+      while (!s.isEmpty) {
+        // Fixes stack overflow issue (#866)
+        val w = r
+        r = f(s.pop, w)
+      }
+      r
+    }
+    override def all[A](fa: FixedLengthBuffer[A])(f: A => Boolean) =
+      fa.toVector.forall(f)
+    override def any[A](fa: FixedLengthBuffer[A])(f: A => Boolean) =
+      fa.toVector.exists(f)
   }
 
 }
@@ -71,4 +102,11 @@ sealed trait FixedLengthBuffer[A] {
    * Converts the buffer to a list
    */
   def toVector: Vector[A]
+
+  /**
+   * Size of the data
+   */
+  def size: Int
+
+  def isEmpty: Boolean
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/FixedLengthBuffer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/FixedLengthBuffer.scala
@@ -52,12 +52,19 @@ object FixedLengthBuffer {
 
   implicit def equal[A]: Equal[FixedLengthBuffer[A]] = Equal.equalA
 
+  /**
+   * @typeclass Functor
+   */
   implicit val functor: Functor[FixedLengthBuffer] = new Functor[FixedLengthBuffer] {
     def map[B, C](fa: FixedLengthBuffer[B])(f: B => C): FixedLengthBuffer[C] = fa match {
         case FixedLengthBufferImpl(max, data) => FixedLengthBufferImpl[C](max, data.map(f))
       }
   }
 
+  /**
+   * @typeclass Foldable
+   * Based on foldable implementation for Set
+   */
   implicit val foldable: Foldable[FixedLengthBuffer] with IsEmpty[FixedLengthBuffer] = new Foldable[FixedLengthBuffer] with IsEmpty[FixedLengthBuffer] with Foldable.FromFoldr[FixedLengthBuffer] {
     override def length[A](fa: FixedLengthBuffer[A]) = fa.size
     def empty[A] = Zero[A]
@@ -67,11 +74,12 @@ object FixedLengthBuffer {
     @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
     def foldRight[A, B](fa: FixedLengthBuffer[A], z: => B)(f: (A, => B) => B) = {
       import scala.collection.mutable.ArrayStack
+      // Faster using a mutable collection
       val s = new ArrayStack[A]
       fa.toVector.foreach(a => s += a)
       var r = z
       while (!s.isEmpty) {
-        // Fixes stack overflow issue (#866)
+        // Fixes stack overflow issue
         val w = r
         r = f(s.pop, w)
       }
@@ -110,7 +118,13 @@ sealed trait FixedLengthBuffer[A] {
    */
   def size: Int
 
+  /**
+   * Indicates if the buffer is empty
+   */
   def isEmpty: Boolean
 
+  /**
+   * Returns a buffer with the values reversed
+   */
   def reverse: FixedLengthBuffer[A]
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/FixedLengthBuffer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/FixedLengthBuffer.scala
@@ -31,6 +31,8 @@ object FixedLengthBuffer {
     def size: Int = data.size
 
     def isEmpty: Boolean = data.isEmpty
+
+    def reverse: FixedLengthBuffer[A] = FixedLengthBufferImpl(maxLength, data.reverse)
   }
 
   def apply[A](maxLength: Int, initial: A*): Option[FixedLengthBuffer[A]] = {
@@ -109,4 +111,6 @@ sealed trait FixedLengthBuffer[A] {
   def size: Int
 
   def isEmpty: Boolean
+
+  def reverse: FixedLengthBuffer[A]
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -46,7 +46,8 @@ object Common {
   lazy val commonJSSettings = commonSettings ++ Seq(
     // These settings allow to use TLS with scala.js
     // Remove the dependency on the scalajs-compiler
-    libraryDependencies := libraryDependencies.value.filterNot(_.name == "scalajs-compiler")
+    libraryDependencies := libraryDependencies.value.filterNot(_.name == "scalajs-compiler"),
+    scalacOptions += "-P:scalajs:sjsDefinedByDefault"
   )
 
   // This function allows triggered compilation to run only when scala files changes

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -69,14 +69,15 @@ object Settings {
     val scalaVersion       = s"$scalaCommonVersion-bin-typelevel-4"
 
     // ScalaJS libraries
-    val scalaDom     = "0.9.3"
-    val scalajsReact = "1.1.1"
-    val scalaCSS     = "0.5.3"
-    val booPickle    = "1.2.6"
-    val diode        = "1.1.2"
-    val javaTimeJS   = "0.2.2"
-    val javaLogJS    = "0.1.2"
-    val scalaJQuery  = "1.2"
+    val scalaDom                = "0.9.3"
+    val scalajsReact            = "1.1.1"
+    val scalaCSS                = "0.5.3"
+    val booPickle               = "1.2.6"
+    val diode                   = "1.1.2"
+    val javaTimeJS              = "0.2.2"
+    val javaLogJS               = "0.1.2"
+    val scalaJQuery             = "1.2"
+    val scalaJSReactVirtualized = "0.0.1"
 
     // Java libraries
     val scalaZ       = "7.2.16"
@@ -103,11 +104,12 @@ object Settings {
     val discipline            = "0.8"
 
     // Pure JS libraries
-    val reactJS        = "15.6.1"
-    val jQuery         = "3.2.1"
-    val semanticUI     = "2.2.10"
-    val ocsVersion     = "2017101.1.4"
-    val uglifyJs       = "1.0.0-beta.3"
+    val reactJS          = "15.6.1"
+    val jQuery           = "3.2.1"
+    val semanticUI       = "2.2.10"
+    val ocsVersion       = "2017101.1.4"
+    val uglifyJs         = "1.0.0-beta.3"
+    val reactVirtualized = "9.12.0"
 
     //Apache XMLRPC
     val apacheXMLRPC   = "3.1.3"
@@ -181,6 +183,7 @@ object Settings {
     ))
     val ScalaCSS   = Def.setting("com.github.japgolly.scalacss" %%% "core"          % LibraryVersions.scalaCSS)
     val ScalaJSDom = Def.setting("org.scala-js"                 %%% "scalajs-dom"   % LibraryVersions.scalaDom)
+    val ScalaJSReactVirtualized = Def.setting("io.github.cquiroz"                 %%% "scalajs-react-virtualized"   % LibraryVersions.scalaJSReactVirtualized)
     val JQuery     = Def.setting("org.querki"                   %%% "jquery-facade" % LibraryVersions.scalaJQuery)
 
     // OCS Libraries, these should become modules in the future

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -77,7 +77,7 @@ object Settings {
     val javaTimeJS              = "0.2.2"
     val javaLogJS               = "0.1.2"
     val scalaJQuery             = "1.2"
-    val scalaJSReactVirtualized = "0.0.1"
+    val scalaJSReactVirtualized = "0.0.2"
 
     // Java libraries
     val scalaZ       = "7.2.16"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -181,10 +181,10 @@ object Settings {
       "io.suzaku" %%% "diode"       % LibraryVersions.diode,
       "io.suzaku" %%% "diode-react" % LibraryVersions.diode
     ))
-    val ScalaCSS   = Def.setting("com.github.japgolly.scalacss" %%% "core"          % LibraryVersions.scalaCSS)
-    val ScalaJSDom = Def.setting("org.scala-js"                 %%% "scalajs-dom"   % LibraryVersions.scalaDom)
+    val ScalaCSS                = Def.setting("com.github.japgolly.scalacss" %%% "core"          % LibraryVersions.scalaCSS)
+    val ScalaJSDom              = Def.setting("org.scala-js"                 %%% "scalajs-dom"   % LibraryVersions.scalaDom)
     val ScalaJSReactVirtualized = Def.setting("io.github.cquiroz"                 %%% "scalajs-react-virtualized"   % LibraryVersions.scalaJSReactVirtualized)
-    val JQuery     = Def.setting("org.querki"                   %%% "jquery-facade" % LibraryVersions.scalaJQuery)
+    val JQuery                  = Def.setting("org.querki"                   %%% "jquery-facade" % LibraryVersions.scalaJQuery)
 
     // OCS Libraries, these should become modules in the future
     val SpModelCore = "edu.gemini.ocs"    %% "edu-gemini-spmodel-core"        % LibraryVersions.ocsVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // Gives support for Scala.js compilation
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.20")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.21")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 


### PR DESCRIPTION
In this PR we replace the log text area by a table. It uses react-virtualized that allows an efficient rendering of large tables with the style matching the SemanticUI tables

Here's a screenshot
![screenshot 2017-11-24 12 36 10](https://user-images.githubusercontent.com/3615303/33218595-82b7a710-d11c-11e7-9019-4ca1a056f7ae.png)
