### PR TITLE
SEQNG-422: Split settings into columns

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -10,6 +10,7 @@ import edu.gemini.seqexec.web.client.semanticui._
 import edu.gemini.seqexec.web.client.semanticui.elements.message.IconMessage
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconInbox
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
+import edu.gemini.seqexec.web.client.components.sequence.steps.StepsTableContainer
 import edu.gemini.seqexec.model.Model.SeqexecSite
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.{CallbackTo, ScalaComponent, ScalazReact}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -3,10 +3,9 @@
 
 package edu.gemini.seqexec.web.client.components.sequence.steps
 
-import edu.gemini.seqexec.model.Model.{Offset, OffsetAxis, Step, StepType, TelescopeOffset}
+import edu.gemini.seqexec.model.Model.{Offset, OffsetAxis, Step, TelescopeOffset}
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
-import edu.gemini.seqexec.web.client.lenses.{stepTypeO, telescopeOffsetPO, telescopeOffsetQO}
-import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
+import edu.gemini.seqexec.web.client.lenses.{telescopeOffsetPO, telescopeOffsetQO}
 import edu.gemini.web.client.utils._
 import japgolly.scalajs.react.ScalazReact._
 import japgolly.scalajs.react._
@@ -18,7 +17,6 @@ import org.scalajs.dom.html.Canvas
 import scalacss.ScalaCssReact._
 import scalaz.syntax.order._
 import scalaz.syntax.show._
-import scalaz.syntax.std.option._
 
 /**
   * Utility methods to display offsets and calculate their widths
@@ -164,42 +162,3 @@ object OffsetBlock extends OffsetFns {
   def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }
 
-/**
- * Component to display the settings of a given step
- */
-object StepSettings extends OffsetFns {
-  final case class Props(s: Step, offsetWidth: Int)
-  private val component = ScalaComponent.builder[Props]("StepSettings")
-    .stateless
-    .render_P { p =>
-      val stepTypeLabel = stepTypeO.getOption(p.s).map { st =>
-        val stepTypeColor = st match {
-          case StepType.Object      => "green"
-          case StepType.Arc         => "violet"
-          case StepType.Flat        => "grey"
-          case StepType.Bias        => "teal"
-          case StepType.Dark        => "black"
-          case StepType.Calibration => "blue"
-        }
-        Label(Label.Props(st.shows, color = stepTypeColor.some))
-      }
-
-      <.div(
-        ^.cls := "ui two column grid",
-        <.div(
-          ^.cls := "row",
-          <.div(
-            ^.cls := "middle aligned left aligned left floated column",
-            OffsetBlock(OffsetBlock.Props(p.s, p.offsetWidth))
-          ),
-          <.div(
-            ^.cls := "middle aligned right floated column",
-            <.div(stepTypeLabel.whenDefined)
-          )
-        )
-      )
-    }
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.seqexec.web.client.components.sequence
+package edu.gemini.seqexec.web.client.components.sequence.steps
 
 import edu.gemini.seqexec.model.Model.{Offset, OffsetAxis, Step, StepType, TelescopeOffset}
 import edu.gemini.seqexec.web.client.components.SeqexecStyles

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -3,24 +3,23 @@
 
 package edu.gemini.seqexec.web.client.components.sequence.steps
 
-import japgolly.scalajs.react.{Callback, CallbackTo, ScalaComponent, ScalazReact}
-import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.ScalazReact._
-import edu.gemini.seqexec.web.client.semanticui._
-import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconPause, IconPlay, IconStop, IconTrash}
-import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
-import edu.gemini.seqexec.web.client.components.SeqexecStyles
-import edu.gemini.seqexec.web.client.actions.{RequestAbort, RequestStop}
-import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, StepsTableFocus}
-import edu.gemini.seqexec.web.client.ModelOps._
 import edu.gemini.seqexec.model.Model._
 import edu.gemini.seqexec.model.operations.ObservationOperations._
 import edu.gemini.seqexec.model.operations._
+import edu.gemini.seqexec.web.client.ModelOps._
+import edu.gemini.seqexec.web.client.actions.{RequestAbort, RequestStop}
+import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, StepsTableFocus}
+import edu.gemini.seqexec.web.client.components.SeqexecStyles
+import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
+import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconPause, IconPlay, IconStop, IconTrash}
+import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.{Callback, CallbackTo, ScalaComponent, ScalazReact}
 
+import scalacss.ScalaCssReact._
 import scalaz.syntax.equal._
 import scalaz.syntax.show._
-import scalacss.ScalaCssReact._
 
 /**
  * Component to wrap the steps control buttons


### PR DESCRIPTION
It seems that we have many settings, probably too many to display in a single column. This PR adds some refactoring and puts the offset and type onto their own columns. More columns will be added as part of SEQNG-367

![screenshot 2017-11-27 15 11 17](https://user-images.githubusercontent.com/3615303/33281802-3cde39dc-d385-11e7-987a-60743b45231f.png)
