### PR TITLE
SEQNG-426: Don't show offset column for nil offsets

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/OffsetFns.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/OffsetFns.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.seqexec.web.client.components.sequence.steps
+
+import edu.gemini.seqexec.model.Model.{Offset, OffsetAxis, Step, TelescopeOffset}
+import edu.gemini.seqexec.web.client.lenses.{telescopeOffsetPO, telescopeOffsetQO}
+import edu.gemini.web.client.utils._
+import scalaz.Equal
+import scalaz.syntax.show._
+import scalaz.syntax.equal._
+import scalaz.syntax.std.boolean._
+
+/**
+  * Utility methods to display offsets and calculate their widths
+  */
+object OffsetFns {
+  // Used to decide if the offsets are displayed
+  sealed trait OffsetsDisplay
+
+  object OffsetsDisplay {
+    case object NoDisplay extends OffsetsDisplay
+    final case class DisplayOffsets(offsetsWidth: Int) extends OffsetsDisplay
+    implicit val eq: Equal[OffsetsDisplay] = Equal.equalA
+  }
+
+  def offsetAxis(axis: OffsetAxis): String =
+    f"${axis.shows}:"
+
+  def offsetValueFormat(off: Offset): String =
+    f" ${off.value}%003.2f″"
+
+  def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
+
+  def offsetText(axis: OffsetAxis)(step: Step): String =
+    offsetValueFormat(axis match {
+      case OffsetAxis.AxisP => telescopeOffsetPO.getOption(step).getOrElse(TelescopeOffset.P.Zero)
+      case OffsetAxis.AxisQ => telescopeOffsetQO.getOption(step).getOrElse(TelescopeOffset.Q.Zero)
+    })
+
+  val offsetPText: Step => String = offsetText(OffsetAxis.AxisP) _
+  val offsetQText: Step => String = offsetText(OffsetAxis.AxisQ) _
+
+  val pLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisP))
+  val qLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisQ))
+
+  // Calculate the widest offset step
+  private def sequenceOffsetWidthsF(steps: List[Step]): (Int, Int) =
+    steps.map(s => (tableTextWidth(offsetPText(s)), tableTextWidth(offsetQText(s)))).foldLeft((0, 0)) {
+      case ((p1, q1), (p2, q2)) => (p1.max(p2), q1.max(q2))
+    }
+
+  // Calculate if there are non-zero offsets
+  private def areNonZeroOffsetsF(steps: List[Step]): Boolean = {
+    steps.map(s => telescopeOffsetPO.exist(_ =/= TelescopeOffset.P.Zero)(s) || telescopeOffsetQO.exist(_ =/= TelescopeOffset.Q.Zero)(s)).fold(false)(_ || _)
+  }
+
+  implicit class OffsetFnsOps(val steps: List[Step]) extends AnyVal {
+    def sequenceOffsetWidths: (Int, Int) = sequenceOffsetWidthsF(steps)
+    def areNonZeroOffsets: Boolean = areNonZeroOffsetsF(steps)
+    // Find out if offsets should be displayed
+    def offsetsDisplay: OffsetsDisplay = steps.areNonZeroOffsets.fold( {
+      val (p, q) = steps.sequenceOffsetWidths
+      OffsetsDisplay.DisplayOffsets(scala.math.max(p, q))
+    }, OffsetsDisplay.NoDisplay)
+  }
+}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -3,8 +3,9 @@
 
 package edu.gemini.seqexec.web.client.components.sequence.steps
 
-import edu.gemini.seqexec.model.Model.{Guiding, Offset, OffsetAxis, Step, TelescopeOffset}
+import edu.gemini.seqexec.model.Model.{Guiding, OffsetAxis, Step, TelescopeOffset}
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
+import edu.gemini.seqexec.web.client.components.sequence.steps.OffsetFns._
 import edu.gemini.seqexec.web.client.lenses.{telescopeOffsetPO, telescopeOffsetQO, telescopeGuidingWithT}
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconBan, IconCrosshairs}
 import edu.gemini.seqexec.web.client.semanticui.Size
@@ -18,40 +19,7 @@ import org.scalajs.dom.html.Canvas
 
 import scalacss.ScalaCssReact._
 import scalaz.syntax.order._
-import scalaz.syntax.show._
 import scalaz.syntax.std.option._
-
-/**
-  * Utility methods to display offsets and calculate their widths
-  */
-trait OffsetFns {
-  def offsetAxis(axis: OffsetAxis): String =
-    f"${axis.shows}:"
-
-  def offsetValueFormat(off: Offset): String =
-    f" ${off.value}%003.2f″"
-
-  def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
-
-  def offsetText(axis: OffsetAxis)(step: Step): String =
-    offsetValueFormat(axis match {
-      case OffsetAxis.AxisP => telescopeOffsetPO.getOption(step).getOrElse(TelescopeOffset.P.Zero)
-      case OffsetAxis.AxisQ => telescopeOffsetQO.getOption(step).getOrElse(TelescopeOffset.Q.Zero)
-    })
-
-  private val offsetPText = offsetText(OffsetAxis.AxisP) _
-  private val offsetQText = offsetText(OffsetAxis.AxisQ) _
-
-  val pLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisP))
-  val qLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisQ))
-
-  // Calculate the widest offset step
-  def sequenceOffsetWidths(steps: List[Step]): (Int, Int) = {
-    steps.map(s => (tableTextWidth(offsetPText(s)), tableTextWidth(offsetQText(s)))).foldLeft((0, 0)) {
-      case ((p1, q1), (p2, q2)) => (p1.max(p2), q1.max(q2))
-    }
-  }
-}
 
 /**
   * Component to draw a grid for the offsets using canvas
@@ -115,7 +83,7 @@ object OffsetGrid {
 /**
  * Component to display the offset grid and offset values
  */
-object OffsetBlock extends OffsetFns {
+object OffsetBlock {
   final case class Props(s: Step, offsetWidth: Int)
   private val component = ScalaComponent.builder[Props]("OffsetValues")
     .stateless
@@ -168,8 +136,8 @@ object OffsetBlock extends OffsetFns {
 /**
  * Component to display the Guiding state of the step
  */
-object GuidingBlock extends OffsetFns {
-  final case class Props(s: Step, offsetWidth: Int)
+object GuidingBlock {
+  final case class Props(s: Step)
   private val guidingIcon = IconCrosshairs.copyIcon(color = "green".some, size = Size.Big)
   private val noGuidingIcon = IconBan.copyIcon(size = Size.Big)
   private val component = ScalaComponent.builder[Props]("OffsetValues")


### PR DESCRIPTION
This PR changes the UI hiding the offset columns if all the steps have zero offsets, e.g. when taking darks

With column offsets:
![screenshot 2017-11-30 12 38 39](https://user-images.githubusercontent.com/3615303/33439176-93eac4fa-d5cb-11e7-82bc-847d9bc1d223.png)

Without:
![screenshot 2017-11-30 12 38 31](https://user-images.githubusercontent.com/3615303/33439194-9b849128-d5cb-11e7-8e99-343546c0d14e.png)
