### PR TITLE
SEQNG-425: Show coadds x exptime

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
@@ -129,6 +129,7 @@ trait ModelLenses {
   private[model] def telescopeOffsetQI: Iso[Double, TelescopeOffset.Q] = Iso(TelescopeOffset.Q.apply)(_.value)
   val stringToDoubleP: Prism[String, Double] = Prism((x: String) => x.parseDouble.toOption)(_.shows)
   val stringToGuidingP: Prism[String, Guiding] = Prism(Guiding.fromString)(_.configValue)
+  val stringToIntP: Prism[String, Int] = Prism((x: String) => x.parseInt.toOption)(_.shows)
 
   def stepObserveOptional[A](systemName: SystemName, param: String, prism: Prism[String, A]): Optional[Step, A] =
     standardStepP                            ^|-> // which is a standard step
@@ -145,6 +146,10 @@ trait ModelLenses {
   // Composite lens to find the observe exposure time
   val observeExposureTimeO: Optional[Step, Double] =
     stepObserveOptional(SystemName.observe, "exposureTime", stringToDoubleP)
+
+  // Composite lens to find the observe coadds
+  val observeCoaddsO: Optional[Step, Int] =
+    stepObserveOptional(SystemName.observe, "coadds", stringToIntP)
 
   // Lens to find p offset
   def telescopeOffsetO(x: OffsetAxis): Optional[Step, Double] =

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
@@ -130,24 +130,25 @@ trait ModelLenses {
   val stringToDoubleP: Prism[String, Double] = Prism((x: String) => x.parseDouble.toOption)(_.shows)
   val stringToGuidingP: Prism[String, Guiding] = Prism(Guiding.fromString)(_.configValue)
 
+  def stepObserveOptional[A](systemName: SystemName, param: String, prism: Prism[String, A]): Optional[Step, A] =
+    standardStepP                            ^|-> // which is a standard step
+    stepConfigL                              ^|-> // configuration of the step
+    systemConfigL(systemName)                ^<-? // Observe config
+    some                                     ^|-> // some
+    paramValueL(systemName.withParam(param)) ^<-? // find the target name
+    some                                     ^<-? // focus on the option
+    prism                                         // step type
+
   val stepTypeO: Optional[Step, StepType] =
-    standardStepP                                            ^|-> // which is a standard step
-    stepConfigL                                              ^|-> // configuration of the step
-    systemConfigL(SystemName.observe)                        ^<-? // Observe config
-    some                                                     ^|-> // some
-    paramValueL(SystemName.observe.withParam("observeType")) ^<-? // find the target name
-    some                                                     ^<-? // focus on the option
-    stringToStepTypeP                                             // step type
+    stepObserveOptional(SystemName.observe, "observeType", stringToStepTypeP)
+
+  // Composite lens to find the observe exposure time
+  val observeExposureTimeO: Optional[Step, Double] =
+    stepObserveOptional(SystemName.observe, "exposureTime", stringToDoubleP)
 
   // Lens to find p offset
   def telescopeOffsetO(x: OffsetAxis): Optional[Step, Double] =
-    standardStepP                                             ^|-> // which is a standard step
-    stepConfigL                                               ^|-> // configuration of the step
-    systemConfigL(SystemName.telescope)                       ^<-? // Observe config
-    some                                                      ^|-> // some
-    paramValueL(SystemName.telescope.withParam(x.configItem)) ^<-? // find the offset
-    some                                                      ^<-? // focus on the option
-    stringToDoubleP                                                // double value
+    stepObserveOptional(SystemName.telescope, x.configItem, stringToDoubleP)
 
   val telescopeOffsetPO: Optional[Step, TelescopeOffset.P] = telescopeOffsetO(OffsetAxis.AxisP) ^<-> telescopeOffsetPI
   val telescopeOffsetQO: Optional[Step, TelescopeOffset.Q] = telescopeOffsetO(OffsetAxis.AxisQ) ^<-> telescopeOffsetQI

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -47,4 +47,5 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("step double prism", PrismTests(stringToDoubleP))
   checkAll("param guiding prism", PrismTests(stringToGuidingP))
   checkAll("telescope guiding traversal", TraversalTests(telescopeGuidingWithT))
+  checkAll("observe exposure time O", OptionalTests(observeExposureTimeO))
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -47,5 +47,6 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("step double prism", PrismTests(stringToDoubleP))
   checkAll("param guiding prism", PrismTests(stringToGuidingP))
   checkAll("telescope guiding traversal", TraversalTests(telescopeGuidingWithT))
-  checkAll("observe exposure time O", OptionalTests(observeExposureTimeO))
+  checkAll("observe exposure time Optional", OptionalTests(observeExposureTimeO))
+  checkAll("observe coadds Optional", OptionalTests(observeCoaddsO))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -6,7 +6,7 @@ package edu.gemini.seqexec.web.client.components.sequence.steps
 import edu.gemini.seqexec.model.Model.{Guiding, OffsetAxis, Step, TelescopeOffset}
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.components.sequence.steps.OffsetFns._
-import edu.gemini.seqexec.web.client.lenses.{telescopeOffsetPO, telescopeOffsetQO, telescopeGuidingWithT}
+import edu.gemini.seqexec.web.client.lenses.{observeCoaddsO, observeExposureTimeO, telescopeOffsetPO, telescopeOffsetQO, telescopeGuidingWithT}
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconBan, IconCrosshairs}
 import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.web.client.utils._
@@ -131,6 +131,31 @@ object OffsetBlock {
     .build
 
   def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+}
+
+/**
+ * Component to display the exposure time and coadds
+ */
+object ExposureTime {
+  private val component = ScalaComponent.builder[Step]("ExposureTime")
+    .stateless
+    .render_P { p =>
+      val exposureTime = observeExposureTimeO.getOption(p)
+      val coadds = observeCoaddsO.getOption(p)
+
+      val displayedText: String = (coadds, exposureTime) match {
+        case (Some(c), Some(e)) => s"$c \u2A2F $e [s]"
+        case (None, Some(e)) => s"$e [s]"
+        case _ => ""
+      }
+
+      <.div(
+        displayedText
+      )
+    }
+    .build
+
+  def apply(p: Step): Unmounted[Step, Unit, Unit] = component(p)
 }
 
 /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -19,7 +19,9 @@ import org.scalajs.dom.html.Canvas
 
 import scalacss.ScalaCssReact._
 import scalaz.syntax.order._
+import scalaz.syntax.show._
 import scalaz.syntax.std.option._
+import scalaz.std.anyVal._
 
 /**
   * Component to draw a grid for the offsets using canvas
@@ -143,13 +145,17 @@ object ExposureTime {
       val exposureTime = observeExposureTimeO.getOption(p)
       val coadds = observeCoaddsO.getOption(p)
 
-      val displayedText: String = (coadds, exposureTime) match {
-        case (Some(c), Some(e)) => s"$c \u2A2F $e [s]"
-        case (None, Some(e)) => s"$e [s]"
-        case _ => ""
+      // TODO Find a better way to output math-style text
+      val seconds = List(<.span(^.display := "inline-block", ^.marginLeft := 5.px, "["), <.span(^.display := "inline-block", ^.verticalAlign := "text-bottom", ^.fontStyle := "italic", "s"), <.span(^.display := "inline-block", "]"))
+
+      val displayedText: TagMod = (coadds, exposureTime) match {
+        case (Some(c), Some(e)) => (List(<.span(^.display := "inline-block", s"${c.shows} "), <.span(^.display := "inline-block", ^.verticalAlign := "text-bottom", "\u2A2F"), <.span(^.display := "inline-block", s"$e")) ::: seconds).toTagMod
+        case (None, Some(e))    => ((s"$e": VdomNode) :: seconds).toTagMod
+        case _                  => EmptyVdom
       }
 
       <.div(
+        ^.cls := "center aligned",
         displayedText
       )
     }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -145,9 +145,9 @@ object ExposureTime {
     .stateless
     .render_P { p =>
       def formatExposureTime(e: Double): String = p.i match {
-        case Instrument.GmosN | Instrument.GmosS => f"$e%.0f"
-        case Instrument.F2                       => f"$e%.1f"
-        case _                                   => f"$e%.1f"
+        case Instrument.GmosN | Instrument.GmosS                => f"$e%.0f"
+        case Instrument.F2 | Instrument.GNIRS | Instrument.NIFS => f"$e%.1f"
+        case _                                                  => f"$e%.2f"
       }
 
       def supportCoadds: Boolean = p.i match {
@@ -165,7 +165,7 @@ object ExposureTime {
         case (_, Some(e)) if !supportCoadds => ((s"${formatExposureTime(e)}": VdomNode) :: seconds).toTagMod
         case (None, Some(e))                => ((s"${formatExposureTime(e)}": VdomNode) :: seconds).toTagMod
         case (Some(c), Some(e))             => (List(<.span(^.display := "inline-block", s"${c.shows} "), <.span(^.display := "inline-block", ^.verticalAlign := "text-bottom", "\u2A2F"), <.span(^.display := "inline-block", s"${formatExposureTime(e)}")) ::: seconds).toTagMod
-        case _                  => EmptyVdom
+        case _                              => EmptyVdom
       }
 
       <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -318,7 +318,7 @@ object StepsTableContainer {
         ),
         <.td( // Column exposure time
           ^.onDoubleClick --> selectRow(step, i),
-          ExposureTime(step)
+          ExposureTime(ExposureTime.Props(step, p.instrument))
         ),
         <.td( // Column object type
           ^.onDoubleClick --> selectRow(step, i),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -72,6 +72,7 @@ object StepsTableHeader {
           TableHeader(TableHeader.Props(width = stateWidth), "State"),
           TableHeader(TableHeader.Props(width = Width.Three), "Offset").unless(displayOffsets),
           TableHeader(TableHeader.Props(width = Width.One), "Guiding"),
+          TableHeader(TableHeader.Props(width = Width.One), "Exposure"),
           TableHeader(TableHeader.Props(width = Width.Two, aligned = Aligned.Right), "Type"),
           TableHeader(TableHeader.Props(collapsing = true, width = Width.Eight), "Progress"),
           TableHeader(TableHeader.Props(collapsing = true), "Config")
@@ -313,6 +314,11 @@ object StepsTableContainer {
         <.td( // Column step guiding
           ^.onDoubleClick --> selectRow(step, i),
           GuidingBlock(GuidingBlock.Props(step))
+        ),
+        <.td( // Column exposure time
+          ^.onDoubleClick --> selectRow(step, i),
+          ^.cls := "middle aligned",
+          ExposureTime(step)
         ),
         <.td( // Column object type
           ^.onDoubleClick --> selectRow(step, i),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -317,7 +317,6 @@ object StepsTableContainer {
         ),
         <.td( // Column exposure time
           ^.onDoubleClick --> selectRow(step, i),
-          ^.cls := "middle aligned",
           ExposureTime(step)
         ),
         <.td( // Column object type

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -284,6 +284,7 @@ object StepsTableContainer {
         Label(Label.Props(st.shows, color = stepTypeColor.some))
       }
 
+    // scalastyle:off
     private def stepCols(status: ClientStatus, p: StepsTableFocus, i: Int, state: SequenceState, step: Step, offsetsDisplay: OffsetsDisplay) =
       <.tr(
         SeqexecStyles.trNoBorder,
@@ -337,6 +338,7 @@ object StepsTableContainer {
           IconCaretRight.copyIcon(onClick = displayStepDetails(p.id, i))
         )
       )
+      // scalastyle:on
 
     def stepsTable(status: ClientStatus, p: StepsTableFocus, s: State, offsetsDisplay: OffsetsDisplay): TagMod =
       <.table(


### PR DESCRIPTION
This PR adds a column with coadds and exposure time. The formatting depends on the instrument with Gmos using no decimals, F2, GNIRS and NIFS with 1 decimal and the rest with 2 decimals

coadds is shown only for instrument supporting it

Some screenshots:

F2
<img width="1034" alt="screenshot 2017-12-04 21 15 00" src="https://user-images.githubusercontent.com/3615303/33583330-8d2ef8c8-d938-11e7-9bce-82258c6714ca.png">

GMOS:
<img width="1054" alt="screenshot 2017-12-04 21 15 08" src="https://user-images.githubusercontent.com/3615303/33583339-9a070c48-d938-11e7-95a3-79ba04229461.png">

and finally an example with coadds. This is to demonstrate the code only, GMOS won't show the coadds in general
Fake GMOS with coadds:
<img width="1105" alt="screenshot 2017-12-04 20 56 18" src="https://user-images.githubusercontent.com/3615303/33583356-b15c74d2-d938-11e7-9f7f-176877f04da7.png">
