### PR TITLE
SEQNG-439: Give a placeholder target name for calibrations

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -96,6 +96,7 @@ object Model {
   type StepId = Int
   type ObservationName = String
   type TargetName = String
+  val DaytimeCalibrationTargetName = "Daytime calibration"
   /**
     * A Seqexec resource represents any system that can be only used by one single agent.
     *

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -4,7 +4,7 @@
 package edu.gemini.seqexec.web.client.components
 
 import diode.react.ModelProxy
-import edu.gemini.seqexec.model.Model.SequenceState
+import edu.gemini.seqexec.model.Model.{DaytimeCalibrationTargetName, SequenceState}
 import edu.gemini.seqexec.web.client.circuit._
 import edu.gemini.seqexec.web.client.actions._
 import edu.gemini.seqexec.web.client.model.Pages._
@@ -82,7 +82,11 @@ object QueueTableBody {
               val stepAtText = s.status.shows + s.runningStep.map(u => s" ${u._1 + 1}/${u._2}").getOrElse("")
               val inProcess = s.status.isInProcess
               // Let's assume if the target name is not found, we are doing a calibration
-              val targetName = s.targetName.getOrElse("DAYCAL")
+              val daytimeCalibrationTargetName: TagMod =
+                <.span(
+                  SeqexecStyles.daytimeCal,
+                  DaytimeCalibrationTargetName)
+              val targetName = s.targetName.fold(daytimeCalibrationTargetName)(x => x: TagMod)
               val selectableRowCls = List(
                   ^.classSet(
                     "selectable" -> !inProcess

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -81,7 +81,8 @@ object QueueTableBody {
                 }
               val stepAtText = s.status.shows + s.runningStep.map(u => s" ${u._1 + 1}/${u._2}").getOrElse("")
               val inProcess = s.status.isInProcess
-              val targetName = s.targetName.getOrElse("*****")
+              // Let's assume if the target name is not found, we are doing a calibration
+              val targetName = s.targetName.getOrElse("DAYCAL")
               val selectableRowCls = List(
                   ^.classSet(
                     "selectable" -> !inProcess

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -331,6 +331,11 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     backgroundClip.contentBox.paddingBox.important
   )
 
+  val daytimeCal: StyleA = style(
+    fontWeight.bold,
+    fontStyle.italic
+  )
+
   // Styles for the log table, These styles will make react-virtualized
   // match the look of SemanticUI tables
   val logTable: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceAnonymousToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceAnonymousToolbar.scala
@@ -16,7 +16,8 @@ import scalacss.ScalaCssReact._
   */
 object SequenceAnonymousToolbar {
   final case class Props(site: SeqexecSite, instrument: Instrument) {
-    protected[sequence] val instrumentConnects = site.instruments.list.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i)))).toMap
+    protected[sequence] val instrumentConnects =
+     site.instruments.list.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i)))).toMap
   }
 
   private def component = ScalaComponent.builder[Props]("SequencesDefaultToolbar")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
@@ -8,7 +8,7 @@ import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.semanticui.elements.label.Label
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.IconCheckmark
 import edu.gemini.seqexec.web.client.semanticui.Size
-import edu.gemini.seqexec.model.Model.SequenceState
+import edu.gemini.seqexec.model.Model.{DaytimeCalibrationTargetName, SequenceState}
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
@@ -29,7 +29,9 @@ object SequenceInfo {
     .render_P { p =>
       val StatusAndObserverFocus(isLogged, name, _, _, observer, status, tName) = p.p()
       val obsName = name.filter(_.nonEmpty).getOrElse("Unknown.")
-      val targetName = tName.filter(_.nonEmpty).getOrElse("DAYCAL")
+      val daytimeCalibrationTargetName: TagMod =
+        Label(Label.Props(DaytimeCalibrationTargetName, basic = true, extraStyles = List(SeqexecStyles.daytimeCal)))
+      val targetName = tName.filter(_.nonEmpty).fold(daytimeCalibrationTargetName)(t => Label(Label.Props(t, basic = true)))
       <.div(
         ^.cls := "ui form",
         <.div(
@@ -45,7 +47,7 @@ object SequenceInfo {
           ).when(isLogged),
           <.div(
             ^.cls := "field",
-            Label(Label.Props(targetName, basic = true))
+            targetName
           ).when(isLogged),
           <.div(
             ^.cls := "field",

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
@@ -29,7 +29,7 @@ object SequenceInfo {
     .render_P { p =>
       val StatusAndObserverFocus(isLogged, name, _, _, observer, status, tName) = p.p()
       val obsName = name.filter(_.nonEmpty).getOrElse("Unknown.")
-      val targetName = tName.filter(_.nonEmpty).getOrElse("Unknown.")
+      val targetName = tName.filter(_.nonEmpty).getOrElse("DAYCAL")
       <.div(
         ^.cls := "ui form",
         <.div(


### PR DESCRIPTION
We are reading the target name from the target value of the first science step of a sequence. This makes daycalibrations to look like they don't have a target. Which normally doesn't matter but it looks a bit strange.

This PR changes that to use the word `DAYCAL` for those cases

Here's a screenshot:
![screenshot 2017-12-05 14 34 10](https://user-images.githubusercontent.com/3615303/33621521-bd2699c8-d9c9-11e7-95b1-d417734cb9a9.png)
