### PR TITLE
SEQNG-440: Show completed steps as disabled

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -195,7 +195,7 @@ object StepsTableContainer {
         case (_, StepState.Completed)                   => <.p(step.status.shows)
         case (_, StepState.Error(msg))                  => stepInError(status.isLogged, isPartiallyExecuted(p), msg)
         // TODO Remove the 2 conditions below when supported by the engine
-        case (_, s) if step.skip                        => <.p(step.status.shows + " - Skipped")
+        case (_, s) if step.skip                        => <.p("Skipped")
         case (_, _)                                     => <.p(step.status.shows)
       }
 
@@ -262,24 +262,23 @@ object StepsTableContainer {
       }
 
     private def classSet(step: Step): List[(String, Boolean)] = List(
-      "positive" -> (step.status === StepState.Completed),
+      "disabled" -> (step.skip || step.status === StepState.Completed),
       "warning"  -> (step.status === StepState.Running),
       "negative" -> (step.status === StepState.Paused),
       "negative" -> step.hasError,
-      "active"   -> (step.status === StepState.Skipped),
-      "disabled" -> step.skip
+      "active"   -> (step.status === StepState.Skipped)
     )
-
 
     private def stepTypeLabel(step: Step): Option[Unmounted[Label.Props, Unit, Unit]] =
       stepTypeO.getOption(step).map { st =>
         val stepTypeColor = st match {
-          case StepType.Object      => "green"
-          case StepType.Arc         => "violet"
-          case StepType.Flat        => "grey"
-          case StepType.Bias        => "teal"
-          case StepType.Dark        => "black"
-          case StepType.Calibration => "blue"
+          case _ if step.status === StepState.Completed => "light gray"
+          case StepType.Object                          => "green"
+          case StepType.Arc                             => "violet"
+          case StepType.Flat                            => "grey"
+          case StepType.Bias                            => "teal"
+          case StepType.Dark                            => "black"
+          case StepType.Calibration                     => "blue"
         }
         Label(Label.Props(st.shows, color = stepTypeColor.some))
       }


### PR DESCRIPTION
It has been requested that completed steps be displayed as grayed out or disabled

A screenshot:
<img width="747" alt="screenshot 2017-12-05 23 26 18" src="https://user-images.githubusercontent.com/3615303/33641537-b0023482-da14-11e7-9c09-b48b51868846.png">
