### PR TITLE
SEQNG-424: Show FPU

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -358,6 +358,20 @@ object Model {
       case _        => none
     }
   }
+  sealed trait FPUMode
+  object FPUMode {
+    case object BuiltIn extends FPUMode
+    case object Custom extends FPUMode
+
+    implicit val equal: Equal[FPUMode] = Equal.equalA
+    implicit val show: Show[FPUMode] = Show.showFromToString
+
+    def fromString(s: String): Option[FPUMode] = s match {
+      case "BUILTIN"     => FPUMode.BuiltIn.some
+      case "CUSTOM_MASK" => FPUMode.Custom.some
+      case _             => none
+    }
+  }
 
   // Telescope offsets, roughly based on gem
   final case class TelescopeOffset(p: TelescopeOffset.P, q: TelescopeOffset.Q)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
@@ -128,7 +128,6 @@ trait ModelLenses {
   private[model] def telescopeOffsetPI: Iso[Double, TelescopeOffset.P] = Iso(TelescopeOffset.P.apply)(_.value)
   private[model] def telescopeOffsetQI: Iso[Double, TelescopeOffset.Q] = Iso(TelescopeOffset.Q.apply)(_.value)
   val stringToDoubleP: Prism[String, Double] = Prism((x: String) => x.parseDouble.toOption)(_.shows)
-  val stringToGuidingP: Prism[String, Guiding] = Prism(Guiding.fromString)(_.configValue)
   val stringToIntP: Prism[String, Int] = Prism((x: String) => x.parseInt.toOption)(_.shows)
 
   def stepObserveOptional[A](systemName: SystemName, param: String, prism: Prism[String, A]): Optional[Step, A] =
@@ -151,9 +150,18 @@ trait ModelLenses {
   val observeCoaddsO: Optional[Step, Int] =
     stepObserveOptional(SystemName.observe, "coadds", stringToIntP)
 
-  // Composite lens to find the observe fpu
+  val stringToFPUModeP: Prism[String, FPUMode] = Prism(FPUMode.fromString)(_.shows)
+  // Composite lens to find the instrument fpu model
+  val instrumentFPUModeO: Optional[Step, FPUMode] =
+    stepObserveOptional(SystemName.instrument, "fpuMode", stringToFPUModeP)
+
+  // Composite lens to find the instrument fpu
   val instrumentFPUO: Optional[Step, String] =
     stepObserveOptional(SystemName.instrument, "fpu", Iso.id[String].asPrism)
+
+  // Composite lens to find the instrument fpu custom mask
+  val instrumentFPUCustomMaskO: Optional[Step, String] =
+    stepObserveOptional(SystemName.instrument, "fpuCustomMask", Iso.id[String].asPrism)
 
   // Lens to find p offset
   def telescopeOffsetO(x: OffsetAxis): Optional[Step, Double] =
@@ -161,6 +169,8 @@ trait ModelLenses {
 
   val telescopeOffsetPO: Optional[Step, TelescopeOffset.P] = telescopeOffsetO(OffsetAxis.AxisP) ^<-> telescopeOffsetPI
   val telescopeOffsetQO: Optional[Step, TelescopeOffset.Q] = telescopeOffsetO(OffsetAxis.AxisQ) ^<-> telescopeOffsetQI
+
+  val stringToGuidingP: Prism[String, Guiding] = Prism(Guiding.fromString)(_.configValue)
 
   // Lens to find guidingWith configurations
   val telescopeGuidingWithT: Traversal[Step, Guiding] =

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
@@ -151,6 +151,10 @@ trait ModelLenses {
   val observeCoaddsO: Optional[Step, Int] =
     stepObserveOptional(SystemName.observe, "coadds", stringToIntP)
 
+  // Composite lens to find the observe fpu
+  val instrumentFPUO: Optional[Step, String] =
+    stepObserveOptional(SystemName.instrument, "fpu", Iso.id[String].asPrism)
+
   // Lens to find p offset
   def telescopeOffsetO(x: OffsetAxis): Optional[Step, Double] =
     stepObserveOptional(SystemName.telescope, x.configItem, stringToDoubleP)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/enumerations.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/enumerations.scala
@@ -1,0 +1,76 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.seqexec.model
+
+/**
+ * Unfortunatly we'll have to store this here too to avoid exposing
+ * spModel to the client
+ * Should be gone when we integrate into gem
+ */
+object enumerations {
+
+  object fpu {
+    val CustomMaskKey = "CUSTOM_MASK"
+
+    val GmosSFPU: Map[String, String] = Map(
+      "FPU_NONE" -> "None",
+      "LONGSLIT_1" -> "Longslit 0.25 arcsec",
+      "LONGSLIT_2" -> "Longslit 0.50 arcsec",
+      "LONGSLIT_3" -> "Longslit 0.75 arcsec",
+      "LONGSLIT_4" -> "Longslit 1.00 arcsec",
+      "LONGSLIT_5" -> "Longslit 1.50 arcsec",
+      "LONGSLIT_6" -> "Longslit 2.00 arcsec",
+      "LONGSLIT_7" -> "Longslit 5.00 arcsec",
+      "IFU_1" -> "IFU 2 Slits",
+      "IFU_2" -> "IFU Left Slit (blue)",
+      "IFU_3" -> "IFU Right Slit (red)",
+      "BHROS" -> "bHROS",
+
+      "IFU_N" -> "IFU N and S 2 Slits",
+      "IFU_N_B" -> "IFU N and S Left Slit (blue)",
+      "IFU_N_R" -> "IFU N and S Right Slit (red)",
+
+      "NS_1" -> "N and S 0.50 arcsec",
+      "NS_2" -> "N and S 0.75 arcsec",
+      "NS_3" -> "N and S 1.00 arcsec",
+      "NS_4" -> "N and S 1.50 arcsec",
+      "NS_5" -> "N and S 2.00 arcsec",
+      "CUSTOM_MASK" -> "Custom Mask"
+    )
+
+    val GmosNFPU: Map[String, String] = Map(
+      "FPU_NONE" -> "None",
+      "LONGSLIT_1" -> "Longslit 0.25 arcsec",
+      "LONGSLIT_2" -> "Longslit 0.50 arcsec",
+      "LONGSLIT_3" -> "Longslit 0.75 arcsec",
+      "LONGSLIT_4" -> "Longslit 1.00 arcsec",
+      "LONGSLIT_5" -> "Longslit 1.50 arcsec",
+      "LONGSLIT_6" -> "Longslit 2.00 arcsec",
+      "LONGSLIT_7" -> "Longslit 5.00 arcsec",
+      "IFU_1" -> "IFU 2 Slits",
+      "IFU_2" -> "IFU Left Slit (blue)",
+      "IFU_3" -> "IFU Right Slit (red)",
+      "NS_0" -> "N and S 0.25 arcsec",
+      "NS_1" -> "N and S 0.50 arcsec",
+      "NS_2" -> "N and S 0.75 arcsec",
+      "NS_3" -> "N and S 1.00 arcsec",
+      "NS_4" -> "N and S 1.50 arcsec",
+      "NS_5" -> "N and S 2.00 arcsec",
+      "CUSTOM_MASK" -> "Custom Mask"
+    )
+
+    val Flamingos2: Map[String, String] = Map(
+      "FPU_NONE" -> "Imaging (none)",
+      "LONGSLIT_1" -> "1-pix longslit",
+      "LONGSLIT_2" -> "2-pix longslit",
+      "LONGSLIT_3" -> "3-pix longslit",
+      "LONGSLIT_4" -> "4-pix longslit",
+      "LONGSLIT_6" -> "6-pix longslit",
+      "LONGSLIT_8" -> "8-pix longslit",
+      "PINHOLE" -> "2-pix pinhole grid",
+      "SUBPIX_PINHOLE" -> "subpix pinhole grid",
+      "CUSTOM_MASK" -> "Custom Mask"
+    )
+  }
+}

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -50,4 +50,6 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("observe exposure time Optional", OptionalTests(observeExposureTimeO))
   checkAll("observe coadds Optional", OptionalTests(observeCoaddsO))
   checkAll("instrument fpu Optional", OptionalTests(instrumentFPUO))
+  checkAll("instrument fpu mode Optional", OptionalTests(instrumentFPUModeO))
+  checkAll("instrument fpu custom mask Optional", OptionalTests(instrumentFPUCustomMaskO))
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -49,4 +49,5 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("telescope guiding traversal", TraversalTests(telescopeGuidingWithT))
   checkAll("observe exposure time Optional", OptionalTests(observeExposureTimeO))
   checkAll("observe coadds Optional", OptionalTests(observeCoaddsO))
+  checkAll("instrument fpu Optional", OptionalTests(instrumentFPUO))
 }

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
@@ -68,4 +68,5 @@ object SharedModelArbitraries {
   implicit val ofpArb = implicitly[Arbitrary[TelescopeOffset.P]]
   implicit val ofqArb = implicitly[Arbitrary[TelescopeOffset.Q]]
   implicit val guiArb = Arbitrary[Guiding](Gen.oneOf(Guiding.Park, Guiding.Guide, Guiding.Freeze))
+  implicit val fpmArb = Arbitrary[FPUMode](Gen.oneOf(FPUMode.BuiltIn, FPUMode.Custom))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -336,6 +336,14 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     fontStyle.italic
   )
 
+  val fpuLabel: StyleA = style(
+    fontSize.smaller,
+    textOverflow := "ellipsis",
+    overflow.hidden,
+    wordWrap.breakWord,
+    whiteSpace.nowrap
+  )
+
   // Styles for the log table, These styles will make react-virtualized
   // match the look of SemanticUI tables
   val logTable: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -3,11 +3,11 @@
 
 package edu.gemini.seqexec.web.client.components.sequence.steps
 
-import edu.gemini.seqexec.model.Model.{Guiding, Instrument, OffsetAxis, Step, TelescopeOffset}
+import edu.gemini.seqexec.model.Model.{FPUMode, Guiding, Instrument, OffsetAxis, Step, TelescopeOffset}
 import edu.gemini.seqexec.model.enumerations
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.components.sequence.steps.OffsetFns._
-import edu.gemini.seqexec.web.client.lenses.{instrumentFPUO, observeCoaddsO, observeExposureTimeO, telescopeOffsetPO, telescopeOffsetQO, telescopeGuidingWithT}
+import edu.gemini.seqexec.web.client.lenses._
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconBan, IconCrosshairs}
 import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.web.client.utils._
@@ -153,11 +153,13 @@ object FPUCell {
         case Instrument.F2    => enumerations.fpu.Flamingos2
         case _                => Map.empty
       }
-      val fpuValue: Option[String] =
-        for {
-          fpuS <- instrumentFPUO.getOption(p.s)
-          fpu <- nameMapper.get(fpuS)
-        } yield fpu
+
+      val fpuValue = for {
+        mode <- instrumentFPUModeO.getOption(p.s).orElse(FPUMode.BuiltIn.some) // If the instrument has no fpu mode default to built in
+        fpuL = if (mode === FPUMode.BuiltIn) instrumentFPUO else instrumentFPUCustomMaskO
+        fpu  <- fpuL.getOption(p.s)
+      } yield nameMapper.getOrElse(fpu, fpu)
+
       <.div(
         ^.cls := "center aligned",
         SeqexecStyles.fpuLabel,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -4,7 +4,7 @@
 package edu.gemini.seqexec.web.client.components.sequence.steps
 
 import edu.gemini.seqexec.model.Model.{Guiding, Instrument, OffsetAxis, Step, TelescopeOffset}
-import edu.gemini.seqexec.model.enumerations._
+import edu.gemini.seqexec.model.enumerations
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.components.sequence.steps.OffsetFns._
 import edu.gemini.seqexec.web.client.lenses.{instrumentFPUO, observeCoaddsO, observeExposureTimeO, telescopeOffsetPO, telescopeOffsetQO, telescopeGuidingWithT}
@@ -147,11 +147,21 @@ object FPUCell {
     .stateless
     .render_P { p =>
 
-      val fpu: Option[String] = instrumentFPUO.getOption(p.s).flatMap(GmosSFPU.get)
+      val nameMapper: Map[String, String] = p.i match {
+        case Instrument.GmosS => enumerations.fpu.GmosSFPU
+        case Instrument.GmosN => enumerations.fpu.GmosNFPU
+        case Instrument.F2    => enumerations.fpu.Flamingos2
+        case _                => Map.empty
+      }
+      val fpuValue: Option[String] =
+        for {
+          fpuS <- instrumentFPUO.getOption(p.s)
+          fpu <- nameMapper.get(fpuS)
+        } yield fpu
       <.div(
         ^.cls := "center aligned",
         SeqexecStyles.fpuLabel,
-        fpu.getOrElse("Unknown"): String
+        fpuValue.getOrElse("Unknown"): String
       )
     }
     .build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -4,9 +4,10 @@
 package edu.gemini.seqexec.web.client.components.sequence.steps
 
 import edu.gemini.seqexec.model.Model.{Guiding, Instrument, OffsetAxis, Step, TelescopeOffset}
+import edu.gemini.seqexec.model.enumerations._
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.components.sequence.steps.OffsetFns._
-import edu.gemini.seqexec.web.client.lenses.{observeCoaddsO, observeExposureTimeO, telescopeOffsetPO, telescopeOffsetQO, telescopeGuidingWithT}
+import edu.gemini.seqexec.web.client.lenses.{instrumentFPUO, observeCoaddsO, observeExposureTimeO, telescopeOffsetPO, telescopeOffsetQO, telescopeGuidingWithT}
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconBan, IconCrosshairs}
 import edu.gemini.seqexec.web.client.semanticui.Size
 import edu.gemini.web.client.utils._
@@ -136,6 +137,27 @@ object OffsetBlock {
   def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }
 
+/**
+ * Component to display the FPU
+ */
+object FPUCell {
+  final case class Props(s: Step, i: Instrument)
+
+  private val component = ScalaComponent.builder[Props]("FPUCell")
+    .stateless
+    .render_P { p =>
+
+      val fpu: Option[String] = instrumentFPUO.getOption(p.s).flatMap(GmosSFPU.get)
+      <.div(
+        ^.cls := "center aligned",
+        SeqexecStyles.fpuLabel,
+        fpu.getOrElse("Unknown"): String
+      )
+    }
+    .build
+
+  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+}
 /**
  * Component to display the exposure time and coadds
  */

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -75,7 +75,7 @@ object StepsTableHeader {
           TableHeader(TableHeader.Props(width = Width.Three), "Offset").unless(displayOffsets),
           TableHeader(TableHeader.Props(width = Width.One), "Guiding"),
           TableHeader(TableHeader.Props(width = Width.One), "Exposure"),
-          TableHeader(TableHeader.Props(width = Width.One), "FPU"),
+          TableHeader(TableHeader.Props(width = Width.Two), "FPU"),
           TableHeader(TableHeader.Props(width = Width.Two, aligned = Aligned.Right), "Type"),
           TableHeader(TableHeader.Props(collapsing = true, width = Width.Eight), "Progress"),
           TableHeader(TableHeader.Props(collapsing = true), "Config")
@@ -335,11 +335,11 @@ object StepsTableContainer {
         ExposureTime(ExposureTime.Props(step, instrument))
       )
 
-    private def stepFPUCell(step: Step, i: Int) =
+    private def stepFPUCell(instrument: Instrument, step: Step, i: Int) =
       <.td( // Column object type
         ^.onDoubleClick --> selectRow(step, i),
         ^.cls := "right aligned",
-        stepTypeLabel(step).whenDefined
+        FPUCell(FPUCell.Props(step, instrument))
       )
 
     private def stepObjectTypeCell(step: Step, i: Int) =
@@ -377,7 +377,7 @@ object StepsTableContainer {
         offsetDisplayCell(offsetsDisplay, step, i),
         stepGuidingCell(step, i),
         stepExposureTimeCell(p.instrument, step, i),
-        stepFPUCell(step, i),
+        stepFPUCell(p.instrument, step, i),
         stepObjectTypeCell(step, i),
         stepProgressCell(step, state, i),
         stepDetailsCell(p.id, i)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -335,6 +335,13 @@ object StepsTableContainer {
         ExposureTime(ExposureTime.Props(step, instrument))
       )
 
+    private def stepFPUCell(step: Step, i: Int) =
+      <.td( // Column object type
+        ^.onDoubleClick --> selectRow(step, i),
+        ^.cls := "right aligned",
+        stepTypeLabel(step).whenDefined
+      )
+
     private def stepObjectTypeCell(step: Step, i: Int) =
       <.td( // Column object type
         ^.onDoubleClick --> selectRow(step, i),
@@ -370,6 +377,7 @@ object StepsTableContainer {
         offsetDisplayCell(offsetsDisplay, step, i),
         stepGuidingCell(step, i),
         stepExposureTimeCell(p.instrument, step, i),
+        stepFPUCell(step, i),
         stepObjectTypeCell(step, i),
         stepProgressCell(step, state, i),
         stepDetailsCell(p.id, i)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -359,13 +359,14 @@ object StepsTableContainer {
         stepProgress(state, step)
       )
 
-    private def stepDetailsCell(id: SequenceId, i: Int) =
+    private def stepDetailsCell(router: RouterCtl[SeqexecPages], instrument: Instrument, id: SequenceId, i: Int) =
       <.td( // Column link to details
         ^.cls := "collapsing right aligned",
-	router.link(SequenceConfigPage(p.instrument, p.id, i + 1))(IconCaretRight.copyIcon(color = "black".some, onClick = displayStepDetails(p.instrument, p.id, i)))
+        router.link(SequenceConfigPage(instrument, id, i + 1))
+          (IconCaretRight.copyIcon(color = "black".some, onClick = displayStepDetails(instrument, id, i)))
       )
 
-    private def stepCols(status: ClientStatus, p: StepsTableFocus, i: Int, state: SequenceState, step: Step, offsetsDisplay: OffsetsDisplay) =
+    private def stepCols(router: RouterCtl[SeqexecPages], status: ClientStatus, p: StepsTableFocus, i: Int, state: SequenceState, step: Step, offsetsDisplay: OffsetsDisplay) =
       <.tr(
         SeqexecStyles.trNoBorder,
         ^.onMouseOver --> mouseEnter(i),
@@ -380,7 +381,7 @@ object StepsTableContainer {
         stepFPUCell(p.instrument, step, i),
         stepObjectTypeCell(step, i),
         stepProgressCell(step, state, i),
-        stepDetailsCell(p.id, i)
+        stepDetailsCell(router, p.instrument, p.id, i)
       )
 
     def stepsTable(props: Props, p: StepsTableFocus, s: State): TagMod =

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -113,14 +113,11 @@ object Settings {
     val reactVirtualized = "9.13.0"
     val reactClipboard   = "5.0.0"
 
-    //Apache XMLRPC
-    val apacheXMLRPC   = "3.1.3"
-
-    val opencsv        = "2.1"
-
-    val epicsService   = "0.17"
+    val apacheXMLRPC      = "3.1.3"
+    val opencsv           = "2.1"
+    val epicsService      = "0.17"
     val gmpCommandRecords = "0.6.5"
-    val guava          = "16.0.1"
+    val guava             = "16.0.1"
   }
 
   /**


### PR DESCRIPTION
This PR adds a display for the FPU. This is instrument dependent so unfortunately we had to copy the FPU enumerations from ocs. Hopefully this won't be needed when we use the gem model

It was tested with F2, GmosS and GmosN

Note that the steps table is getting very crowded. I added a task to review this as a whole once all the subcomponents are completed

Some screenshots
F2:
![screenshot 2017-12-07 11 02 56](https://user-images.githubusercontent.com/3615303/33719322-213f4df8-db3f-11e7-819a-d71e6b2453a4.png)

GmosS with built in masks
![screenshot 2017-12-07 10 56 22](https://user-images.githubusercontent.com/3615303/33719341-2b0c4d7c-db3f-11e7-87fa-e7fecb22e181.png)

GmosN with custom masks
![screenshot 2017-12-07 10 53 54](https://user-images.githubusercontent.com/3615303/33719357-3595f90a-db3f-11e7-8763-a15895d78f65.png)
