### PR TITLE
Action pause and resume

### DIFF
--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CarState.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CarState.java
@@ -5,6 +5,6 @@
 
 package edu.gemini.epics.acm;
 
-enum CarState {
+public enum CarState {
     IDLE, PAUSED, BUSY, ERROR
 }

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
@@ -3,8 +3,6 @@
 
 package edu.gemini.seqexec.engine
 
-import scalaz._
-
 import monocle.Lens
 import monocle.macros.GenLens
 
@@ -13,16 +11,16 @@ import edu.gemini.seqexec.model.Model.{Conditions, Operator}
 /**
   * A Map of `Sequence`s.
   */
-final case class Engine[+A](sequences: Map[Sequence.Id, Sequence[A]])
+final case class Engine(sequences: Map[Sequence.Id, Sequence])
 
 object Engine {
 
   type Id = String
 
-  def sequences[A]: Lens[Engine[A], Map[Sequence.Id, Sequence[A]]] =
-    GenLens[Engine[A]](_.sequences)
+  def sequences[A]: Lens[Engine, Map[Sequence.Id, Sequence]] =
+    GenLens[Engine](_.sequences)
 
-  def empty[A]: Engine[A] = Engine(Map.empty)
+  def empty: Engine = Engine(Map.empty)
 
 // This fails to compile with the error "not found: type $anon"
 //  implicit val engineFunctor = new Functor[Engine] {

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -3,7 +3,6 @@
 
 package edu.gemini.seqexec.engine
 
-import scalaz._
 import scalaz.syntax.std.option._
 
 import edu.gemini.seqexec.model.Model.{CloudCover, Conditions, ImageQuality, SkyBackground, WaterVapor, Operator, Observer}
@@ -24,7 +23,7 @@ object Event {
   def start(id: Sequence.Id, user: UserDetails): Event = EventUser(Start(id, user.some))
   def pause(id: Sequence.Id, user: UserDetails): Event = EventUser(Pause(id, user.some))
   def cancelPause(id: Sequence.Id, user: UserDetails): Event = EventUser(CancelPause(id, user.some))
-  def load(id: Sequence.Id, sequence: Sequence[Action \/ Result]): Event = EventUser(Load(id, sequence))
+  def load(id: Sequence.Id, sequence: Sequence): Event = EventUser(Load(id, sequence))
   def unload(id: Sequence.Id): Event = EventUser(Unload(id))
   def breakpoint(id: Sequence.Id, user: UserDetails, step: Step.Id, v: Boolean): Event = EventUser(Breakpoint(id, user.some, step, v))
   def setOperator(name: Operator, user: UserDetails): Event = EventUser(SetOperator(name, user.some))
@@ -42,6 +41,7 @@ object Event {
   def failed(id: Sequence.Id, i: Int, e: Result.Error): Event = EventSystem(Failed(id, i, e))
   def completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]): Event = EventSystem(Completed(id, i, r))
   def partial[R<:PartialVal](id: Sequence.Id, i: Int, r: Partial[R]): Event = EventSystem(PartialResult(id, i, r))
+  def paused(id: Sequence.Id, i: Int): Event = EventSystem(Paused(id, i))
   def busy(id: Sequence.Id): Event = EventSystem(Busy(id))
   def executed(id: Sequence.Id): Event = EventSystem(Executed(id))
   def executing(id: Sequence.Id): Event = EventSystem(Executing(id))

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -36,6 +36,7 @@ object Event {
   val poll: Event = EventUser(Poll)
   def getState(f: (Engine.State) => Task[Option[Process[Task, Event]]]): Event = EventUser(GetState(f))
   def actionStop(id: Sequence.Id, f: (Sequence.State) => Option[Process[Task, Event]]): Event = EventUser(ActionStop(id, f))
+  def actionResume(id: Sequence.Id, i: Int, c: Task[Result]): Event = EventUser(ActionResume(id, i, c))
   def logMsg(msg: String): Event = EventUser(Log(msg))
 
   def failed(id: Sequence.Id, i: Int, e: Result.Error): Event = EventSystem(Failed(id, i, e))

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Step.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Step.scala
@@ -43,7 +43,7 @@ object Step {
     // Find an error in the Step
     step.executions.flatten.find(Action.errored).flatMap { x => x.state match {
       case Action.Failed(Result.Error(msg)) => msg.some
-      case _ => None
+      case _                                => None
       // Return error or continue with the rest of the checks
     }}.map(StepState.Error).getOrElse(
       // It's possible to have a Step with empty executions when a completed
@@ -118,10 +118,7 @@ object Step {
         resources,
         breakpoint,
         skip,
-        // TODO: Functor composition?
-        done ++
-          List(focus.execution) ++
-          pending
+        done ++ List(focus.execution) ++ pending
       )
   }
 

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/SystemEvent.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/SystemEvent.scala
@@ -14,6 +14,7 @@ import edu.gemini.seqexec.engine.Result.{OK, Partial, PartialVal, RetVal}
 sealed trait SystemEvent
 final case class Completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]) extends SystemEvent
 final case class PartialResult[R<:PartialVal](id: Sequence.Id, i: Int, r: Partial[R]) extends SystemEvent
+final case class Paused(id: Sequence.Id, i: Int) extends SystemEvent
 final case class Failed(id: Sequence.Id, i: Int, e: Result.Error) extends SystemEvent
 final case class Busy(id: Sequence.Id) extends SystemEvent
 final case class Executed(id: Sequence.Id) extends SystemEvent

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/UserEvent.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/UserEvent.scala
@@ -6,7 +6,6 @@ package edu.gemini.seqexec.engine
 import edu.gemini.seqexec.model.Model.{CloudCover, Conditions, ImageQuality, Observer, Operator, SkyBackground, WaterVapor}
 import edu.gemini.seqexec.model.UserDetails
 
-import scalaz.\/
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 import scalaz.std.string._
@@ -26,7 +25,7 @@ sealed trait UserEvent {
 final case class Start(id: Sequence.Id, user: Option[UserDetails]) extends UserEvent
 final case class Pause(id: Sequence.Id, user: Option[UserDetails]) extends UserEvent
 final case class CancelPause(id: Sequence.Id, user: Option[UserDetails]) extends UserEvent
-final case class Load(id: Sequence.Id, sequence: Sequence[Action \/ Result]) extends UserEvent {
+final case class Load(id: Sequence.Id, sequence: Sequence) extends UserEvent {
   val user: Option[UserDetails] = None
 }
 final case class Unload(id: Sequence.Id) extends UserEvent {
@@ -53,6 +52,12 @@ final case class GetState(f: (Engine.State) => Task[Option[Process[Task, Event]]
 final case class ActionStop(id: Sequence.Id, f: (Sequence.State) => Option[Process[Task, Event]]) extends UserEvent {
   val user: Option[UserDetails] = None
 }
+
+// Uses `cont` to resume execution of a paused Action. If the Action is not paused, it does nothing.
+final case class ActionResume(id: Sequence.Id, i: Int, cont: Task[Result]) extends UserEvent {
+  val user: Option[UserDetails] = None
+}
+
 final case class Log(msg: String) extends UserEvent {
   val user: Option[UserDetails] = None
 }

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -271,7 +271,7 @@ package object engine {
     * It also updates the `State` as needed.
     */
   // Send the expected event when the `Action` is executed
-  // It doesn't catch run time exceptions. If desired, the Action as to do it itself.
+  // It doesn't catch run time exceptions. If desired, the Action has to do it itself.
   private def act(id: Sequence.Id, t: (ActionGen, Int), cx: ActionMetadata): Process[Task, Event] = t match {
     case (gen, i) =>
       Process.eval(gen(cx)).flatMap {

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/ExecutionSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/ExecutionSpec.scala
@@ -5,17 +5,17 @@ package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.model.ActionType
 
-import scalaz._
-import Scalaz._
 import org.scalatest._
 
 import scalaz.concurrent.Task
 
 class ExecutionSpec extends FlatSpec with Matchers {
 
-  val ok: Result = Result.OK(Result.Observed("dummyId"))
-  val action: Action = fromTask(ActionType.Observe, Task(ok))
-  val curr: Execution = Execution(List(ok.right, action.left))
+  private val observeResult: Result.Response = Result.Observed("dummyId")
+  private val ok: Result = Result.OK(observeResult)
+  private val completedAction: Action = fromTask(ActionType.Observe, Task(ok)).copy(state = Action.Completed(observeResult))
+  private val action: Action = fromTask(ActionType.Observe, Task(ok))
+  private val curr: Execution = Execution(List(completedAction, action))
 
   "currentify" should "be None only when an Execution is empty" in {
     assert(Execution.currentify(List(action, action)).nonEmpty)
@@ -34,11 +34,11 @@ class ExecutionSpec extends FlatSpec with Matchers {
   }
 
   "marking an index out of bounds" should "not modify the execution" in {
-    assert(curr.mark(3)(Result.Error(ActionType.Undefined, "")) === curr)
+    assert(curr.mark(3)(Result.Error("")) === curr)
   }
 
   "marking an index inbound" should "modify the execution" in {
-    assert(curr.mark(1)(Result.Error(ActionType.Undefined, "")) !== curr)
+    assert(curr.mark(1)(Result.Error("")) !== curr)
   }
 
 }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -17,7 +17,7 @@ import scalaz._
 import Scalaz._
 import scalaz.Nondeterminism
 import scalaz.concurrent.Task
-import scalaz.stream.{Cause, Process, async}
+import scalaz.stream.{Process, async}
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class packageSpec extends FlatSpec with NonImplicitAssertions {
@@ -143,37 +143,71 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
   it should "be in Running status after starting" in {
     val p = Process.eval(Task.now(Event.start(seqId, user)))
     val qs = process(p)(qs1).take(1).runLast.unsafePerformSync.map(_._2)
-    assert(qs.map(_.sequences(seqId).status).forall(_ === SequenceState.Running))
+    assert(qs.map(_.sequences(seqId).status === SequenceState.Running).getOrElse(false))
   }
 
   it should "be 0 pending executions after execution" in {
     val qs = runToCompletion(qs1)
-    assert(qs.map(_.sequences(seqId).pending).forall(_.isEmpty))
+    assert(qs.map(_.sequences(seqId).pending.isEmpty).getOrElse(false))
   }
 
   it should "be 2 Steps done after execution" in {
     val qs = runToCompletion(qs1)
-    assert(qs.map(_.sequences(seqId).done.length).forall(_ === 2))
+    assert(qs.map(_.sequences(seqId).done.length === 2).getOrElse(false))
   }
 
-  ignore should "Print execution" in {
-    val p = Process.eval(Task(Event.start(seqId, user)))
-    intercept[Cause.Terminated](
-      process(p)(qs1).run.unsafePerformSync
+  private def actionPause: Option[Engine.State] = {
+    val s0: Engine.State = Engine.State(Conditions.default,
+      None,
+      Map((seqId, Sequence.State.init(Sequence(
+        "First",
+        SequenceMetadata(GmosS, None, ""),
+        List(
+          Step(
+            1,
+            None,
+            config,
+            Set(GmosS),
+            breakpoint = false,
+            skip = false,
+            List(
+              List(fromTask(ActionType.Undefined,
+              Task(Result.Paused)))
+            )
+          )
+        )
+      ) ) ) )
     )
+    val p = Process.eval(Task.now(Event.start(seqId, user)))
+
+    process(p)(s0).runLast.unsafePerformSync.map(_._2)
   }
 
-  ignore should "Print execution with pause" in {
-    val p = Process.emitAll(List(Event.start(seqId, user), Event.pause(seqId, user), Event.start(seqId, user))).evalMap(Task.now(_))
-    intercept[Cause.Terminated](
-       process(p)(qs1).run.unsafePerformSync
-    )
+  "sequence state" should "stay as running when action pauses itself" in {
+    assert(actionPause.map(_.sequences(seqId).status === SequenceState.Running).getOrElse(false))
+  }
+
+  "action state" should "change to Paused if output is Paused" in {
+    assert(actionPause.map(_.sequences(seqId).current.execution.forall(_.state === Action.Paused)).getOrElse(false))
+  }
+
+  "engine" should "run sequence to completion after resuming a paused action" in {
+    val p = Process.eval(Task.now(Event.actionResume(seqId, 0, Task(Result.OK(Result.Configured(GmosS))))))
+
+    val result = actionPause.map(process(p)(_).drop(1).takeThrough(
+      a => !isFinished(a._2.sequences(seqId).status)
+    ).runLast.timed(5.seconds).unsafePerformSyncAttempt)
+    val qso = result.map(_.map(_.map(_._2)))
+
+    assert(qso.map(qs => qs.isRight && qs.forall(x => x.isDefined && x.map(_.sequences(seqId).current.actions.isEmpty).getOrElse(false) &&
+      x.map(_.sequences(seqId).status === SequenceState.Completed).getOrElse(false))).getOrElse(false))
+
   }
 
   it should "not run 2nd sequence because it's using the same resource" in {
     val p = Process.emitAll(List(Event.start(seqId1, user), Event.start(seqId2, user))).evalMap(Task.now(_))
     assert(
-      process(p)(qs2).take(6).runLast.unsafePerformSync.map(_._2.sequences(seqId2)).forall(_.status === SequenceState.Idle)
+      process(p)(qs2).take(6).runLast.unsafePerformSync.map(_._2.sequences(seqId2)).map(_.status === SequenceState.Idle)getOrElse(false)
     )
   }
 
@@ -181,7 +215,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
     val p = Process.emitAll(List(Event.start(seqId1, user), Event.start(seqId3, user))).evalMap(Task.now(_))
 
     assert(
-      process(p)(qs3).take(6).runLast.unsafePerformSync.map(_._2.sequences(seqId3)).forall(_.status === SequenceState.Running)
+      process(p)(qs3).take(6).runLast.unsafePerformSync.map(_._2.sequences(seqId3).status === SequenceState.Running).getOrElse(false)
     )
   }
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -199,9 +199,16 @@ object Model {
 
   sealed trait ActionStatus
   object ActionStatus {
+    // Action is not yet run
     case object Pending extends ActionStatus
+    // Action run and completed
     case object Completed extends ActionStatus
+    // Action currently running
     case object Running extends ActionStatus
+    // Action run but paused
+    case object Paused extends ActionStatus
+    // Action run but failed to complete
+    case object Failed extends ActionStatus
 
     implicit val equal: Equal[ActionStatus] = Equal.equalA[ActionStatus]
   }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -32,6 +32,8 @@ trait ModelBooPicklers {
     .addConcreteType[ActionStatus.Pending.type]
     .addConcreteType[ActionStatus.Completed.type]
     .addConcreteType[ActionStatus.Running.type]
+    .addConcreteType[ActionStatus.Paused.type]
+    .addConcreteType[ActionStatus.Failed.type]
 
   implicit val stepStatePickler = compositePickler[StepState]
     .addConcreteType[StepState.Pending.type]

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -363,9 +363,8 @@ object SeqexecEngine {
       case _                 => configStatus(step.executions)
     }
 
-  //protected[server] def observeStatus(executions: List[List[engine.Action]]): ActionStatus = executions.flatten.find(x => x.kind === ActionType.Observe).map(x => actionStateToStatus(x.state)).getOrElse(ActionStatus.Pending)
-
-  protected[server] def observeStatus(executions: List[List[engine.Action]], configStatus: List[(Resource, ActionStatus)]): ActionStatus = {
+  protected[server] def observeStatus(executions: List[List[engine.Action]],
+                                      configStatus: List[(Resource, ActionStatus)]): ActionStatus = {
     def containsPartial(e: List[engine.Action]): Boolean =
       e.map(_.state).exists {
         case Action.PartiallyCompleted(_) => true

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -10,7 +10,7 @@ import edu.gemini.epics.acm.CaService
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.spModel.core.Site
 import edu.gemini.seqexec.engine
-import edu.gemini.seqexec.engine.{Action, Engine, Event, EventSystem, Executed, Failed, Result, Sequence}
+import edu.gemini.seqexec.engine.{Action, Engine, Event, EventSystem, Executed, Failed, Sequence}
 import edu.gemini.seqexec.engine.Result.{FileIdAllocated, Partial}
 import edu.gemini.seqexec.server.ConfigUtilOps._
 import edu.gemini.seqexec.odb.SmartGcal
@@ -159,7 +159,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
   }
 
   private def loadEvents(seqId: SPObservationID): SeqAction[List[Event]] = {
-    val t: EitherT[Task, SeqexecFailure, (List[SeqexecFailure], Option[Sequence[Action \/ Result]])] = for {
+    val t: EitherT[Task, SeqexecFailure, (List[SeqexecFailure], Option[Sequence])] = for {
       odbSeq       <- EitherT(Task.delay(odbProxy.read(seqId)))
       progIdString <- EitherT(Task.delay(odbSeq.config.extract(OCS_KEY / InstConstants.PROGRAMID_PROP).as[String].leftMap(ConfigUtilOps.explainExtractError)))
       _            <- EitherT.fromTryCatchNonFatal(Task.now(SPProgramID.toProgramID(progIdString))).leftMap(e => SeqexecFailure.SeqexecException(e): SeqexecFailure)
@@ -193,6 +193,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.GetState(_)            => NullEvent
       case engine.ActionStop(_, _)       => ActionStopRequested(svs)
       case engine.Log(msg)               => NewLogMessage(msg)
+      case engine.ActionResume(_, _, _)  => NullEvent
     }
     case engine.EventSystem(se) => se match {
       // TODO: Sequence completed event not emited by engine.
@@ -205,12 +206,13 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.Executing(_)                                              => SequenceUpdated(svs)
       case engine.Finished(_)                                               => SequenceCompleted(svs)
       case engine.Null                                                      => NullEvent
+      case engine.Paused(_, _)                                              => NullEvent
     }
   }
 
-  def viewSequence(seq: SequenceAR, st: SequenceState): SequenceView = {
+  def viewSequence(seq: Sequence, st: SequenceState): SequenceView = {
 
-    def engineSteps(seq: SequenceAR): List[Step] = {
+    def engineSteps(seq: Sequence): List[Step] = {
 
       // TODO: Calculate the whole status here and remove `Engine.Step.status`
       // This will be easier once the exact status labels in the UI are fixed.
@@ -286,10 +288,6 @@ object SeqexecEngine {
     instForceError = false,
     10.seconds)
 
-  // TODO: Better name and move it to `engine`
-  type SequenceAR = engine.Sequence[engine.Action \/ engine.Result]
-  type StepAR = engine.Step[engine.Action \/ engine.Result]
-
   // Couldn't find this on Scalaz
   def splitWhere[A](l: List[A])(p: (A => Boolean)): (List[A], List[A]) =
     l.splitAt(l.indexWhere(p))
@@ -297,24 +295,36 @@ object SeqexecEngine {
   def splitAfter[A](l: List[A])(p: (A => Boolean)): (List[A], List[A]) =
     l.splitAt(l.indexWhere(p) + 1)
 
+  private[server] def actionStateToStatus(s: engine.Action.ActionState): ActionStatus = s match {
+    case engine.Action.Idle                  => ActionStatus.Pending
+    case engine.Action.Completed(_)          => ActionStatus.Completed
+    case engine.Action.Started               => ActionStatus.Running
+    case engine.Action.PartiallyCompleted(_) => ActionStatus.Running
+    case engine.Action.Paused                => ActionStatus.Paused
+    case engine.Action.Failed(_)             => ActionStatus.Failed
+  }
+
   private def kindToResource(kind: ActionType): List[Resource] = kind match {
     case ActionType.Configure(r) => List(r)
     case _                       => Nil
   }
 
-  private[server] def configStatus(executions: List[List[engine.Action \/ engine.Result]]): List[(Resource, ActionStatus)] = {
+  private[server] def separateActions(ls: List[Action]): (List[Action], List[Action]) =  ls.partition{ _.state match {
+    case engine.Action.Completed(_) => false
+    case engine.Action.Failed(_)    => false
+    case _                          => true
+  } }
+
+  private[server] def configStatus(executions: List[List[engine.Action]]): List[(Resource, ActionStatus)] = {
     // Remove undefined actions
-    val ex = executions.filter {
-      case x => !x.rights.exists(_.kind === ActionType.Undefined)
-    }
+    val ex = executions.filter { !separateActions(_)._2.exists(_.kind === ActionType.Undefined) }
     // Split where at least one is running
-    val (current, pending) = splitAfter(ex)(ex => ex.lefts.nonEmpty)
+    val (current, pending) = splitAfter(ex)(separateActions(_)._1.nonEmpty)
 
     // Calculate the state up to the current
     val configStatus = current.foldLeft(Map.empty[Resource, ActionStatus]) {
       case (s, e) =>
-        val (a, r) = e.separate
-          .bimap(
+        val (a, r) = separateActions(e).bimap(
             _.flatMap(a => kindToResource(a.kind).strengthR(ActionStatus.Running)).toMap,
             _.flatMap(r => kindToResource(r.kind).strengthR(ActionStatus.Completed)).toMap)
         s ++ a ++ r
@@ -324,7 +334,7 @@ object SeqexecEngine {
     val presentSystems = configStatus.keys.toList
     // Calculate status of pending items
     val systemsPending = pending.map {
-      s => s.separate.bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
+      s => separateActions(s).bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
     }.flatMap {
       x => x._1.strengthR(ActionStatus.Pending) ::: x._2.strengthR(ActionStatus.Completed)
     }.filter {
@@ -337,9 +347,9 @@ object SeqexecEngine {
   /**
    * Calculates the config status for pending steps
    */
-  private[server] def pendingConfigStatus(executions: List[List[engine.Action \/ engine.Result]]): List[(Resource, ActionStatus)] =
+  private[server] def pendingConfigStatus(executions: List[List[engine.Action]]): List[(Resource, ActionStatus)] =
     executions.map {
-      s => s.separate.bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
+      s => separateActions(s).bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
     }.flatMap {
       x => x._1 ::: x._2
     }.distinct.strengthR(ActionStatus.Pending).sortBy(_._1)
@@ -347,26 +357,28 @@ object SeqexecEngine {
   /**
    * Overall pending status for a step
    */
-  private def stepConfigStatus(step: StepAR): List[(Resource, ActionStatus)] =
+  private def stepConfigStatus(step: engine.Step): List[(Resource, ActionStatus)] =
     engine.Step.status(step) match {
       case StepState.Pending => pendingConfigStatus(step.executions)
       case _                 => configStatus(step.executions)
     }
 
-  protected[server] def observeStatus(executions: List[List[engine.Action \/ engine.Result]], configStatus: List[(Resource, ActionStatus)]): ActionStatus = {
-    def containsPartial(e: List[engine.Action \/ engine.Result]): Boolean =
-      e.rights.exists {
-        case Partial(FileIdAllocated(_), _) => true
-        case _                              => false
+  //protected[server] def observeStatus(executions: List[List[engine.Action]]): ActionStatus = executions.flatten.find(x => x.kind === ActionType.Observe).map(x => actionStateToStatus(x.state)).getOrElse(ActionStatus.Pending)
+
+  protected[server] def observeStatus(executions: List[List[engine.Action]], configStatus: List[(Resource, ActionStatus)]): ActionStatus = {
+    def containsPartial(e: List[engine.Action]): Boolean =
+      e.map(_.state).exists {
+        case Action.PartiallyCompleted(_) => true
+        case _                            => false
       }
 
-    def containsObserve(e: List[engine.Action \/ engine.Result]): Boolean =
-      e.rights.map(_.kind).contains(ActionType.Observe)
+    def containsObserve(e: List[engine.Action]): Boolean =
+      separateActions(e)._2.map(_.kind).contains(ActionType.Observe)
 
     if (configStatus.forall(_._2 === ActionStatus.Completed)) {
       // Find one with kind observe
       executions.filter { e =>
-        val (a, r) = e.separate.bimap(_.map(_.kind), _.map(_.kind))
+        val (a, r) = separateActions(e).bimap(_.map(_.kind), _.map(_.kind))
         a.contains(ActionType.Observe) || r.contains(ActionType.Observe)
       }.map {
         case e if containsPartial(e) => ActionStatus.Running
@@ -376,7 +388,7 @@ object SeqexecEngine {
     } else ActionStatus.Pending
   }
 
-  def viewStep(step: StepAR): StandardStep = {
+  def viewStep(step: engine.Step): StandardStep = {
     val configStatus = stepConfigStatus(step)
     StandardStep(
       id = step.id,

--- a/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqTranslateSpec.scala
@@ -17,7 +17,6 @@ import edu.gemini.seqexec.server.tcs.TcsControllerEpics
 import edu.gemini.spModel.core.{Peer, Site}
 import org.scalatest.FlatSpec
 
-import scalaz.syntax.either._
 import scalaz.Kleisli
 import scalaz.concurrent.Task
 
@@ -40,7 +39,7 @@ class SeqTranslateSpec extends FlatSpec {
           breakpoint = false,
           skip = false,
           List(
-            List(Action(ActionType.Observe, Kleisli(v => Task(Result.OK(Result.Observed("DummyFileId"))))).left)
+            List(Action(ActionType.Observe, Kleisli(v => Task(Result.OK(Result.Observed("DummyFileId")))), Action.Idle))
           )
         )
       )
@@ -57,7 +56,7 @@ class SeqTranslateSpec extends FlatSpec {
           breakpoint = false,
           skip = false,
           List(
-            List(Action(ActionType.Configure(TCS), Kleisli(v => Task(Result.OK(Result.Configured(Resource.TCS))))).left)
+            List(Action(ActionType.Configure(TCS), Kleisli(v => Task(Result.OK(Result.Configured(Resource.TCS)))), Action.Idle))
           )
         )
       )

--- a/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqexecEngineSpec.scala
@@ -10,21 +10,17 @@ import edu.gemini.seqexec.model.Model.{ActionStatus, Instrument, Resource}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scalaz.concurrent.Task
-import scalaz.\/
-import scalaz.syntax.either._
 
 class SeqexecEngineSpec extends FlatSpec with Matchers {
-  val dummyTask: Task[Result] = Task.delay(Result.OK(Result.Configured(Resource.TCS)))
-  def running(resource: Resource): Action \/ Result =
-    engine.fromTask(ActionType.Configure(resource), dummyTask).left[Result]
-  def done(resource: Resource): Action \/ Result =
-    Result.OK(Result.Configured(resource)).right[Action]
-  def observing: Action \/ Result =
-    engine.fromTask(ActionType.Observe, dummyTask).left[Result]
-  def observed: Action \/ Result =
-    Result.OK(Result.Observed("fileId")).right[Action]
-  def fileId: Action \/ Result =
-    Result.Partial(Result.FileIdAllocated("fileId"), engine.fromTask(ActionType.Observe, dummyTask)).right[Action]
+  def configureTask(resource: Resource): Task[Result] = Task.delay(Result.OK(Result.Configured(resource)))
+  def pendingAction(resource: Resource): Action =
+    engine.fromTask(ActionType.Configure(resource), configureTask(resource))
+  def running(resource: Resource): Action = pendingAction(resource).copy(state = Action.Started)
+  def done(resource: Resource): Action = pendingAction(resource).copy(state = Action.Completed(Result.Configured(resource)))
+  val fileId = "fileId"
+  def observing: Action = engine.fromTask(ActionType.Observe, Task.delay(Result.OK(Result.Observed(fileId))))
+  def fileIdReady: Action = observing.copy(state = Action.PartiallyCompleted(Result.FileIdAllocated(fileId)))
+  def observed: Action = observing.copy(state = Action.Completed(Result.Observed(fileId)))
 
   "SeqexecEngine configStatus" should
     "build empty without tasks" in {
@@ -32,74 +28,76 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
     }
     it should "be all running if none has a result" in {
       val status = List(Resource.TCS -> ActionStatus.Running)
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
         List(running(Resource.TCS)))
       SeqexecEngine.configStatus(executions) shouldBe status
     }
     it should "be all running if none has a result 2" in {
       val status = List(Resource.TCS -> ActionStatus.Running, Instrument.GmosN -> ActionStatus.Running)
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
         List(running(Resource.TCS), running(Instrument.GmosN)))
       SeqexecEngine.configStatus(executions) shouldBe status
     }
     it should "be some complete and some running if none has a result even when the previous execution is complete" in {
       val status = List(Resource.TCS -> ActionStatus.Completed, Instrument.GmosN -> ActionStatus.Running)
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
         List(done(Resource.TCS)),
         List(done(Resource.TCS), running(Instrument.GmosN)))
       SeqexecEngine.configStatus(executions) shouldBe status
     }
     it should "be some complete and some pending if one will be done in the future" in {
       val status = List(Resource.TCS -> ActionStatus.Completed, Instrument.GmosN -> ActionStatus.Running)
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
         List(running(Instrument.GmosN)),
-        List(done(Resource.TCS), done(Instrument.GmosN)))
+        List(done(Resource.TCS), done(Instrument.GmosN))
+      )
       SeqexecEngine.configStatus(executions) shouldBe status
     }
     it should "stop at the first with running steps" in {
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
         List(running(Instrument.GmosN)),
-        List(running(Instrument.GmosN), running(Resource.TCS)))
+        List(running(Instrument.GmosN), running(Resource.TCS))
+      )
       val status = List(Resource.TCS -> ActionStatus.Pending, Instrument.GmosN -> ActionStatus.Running)
       SeqexecEngine.configStatus(executions) shouldBe status
     }
     it should "stop evaluating where at least one is running even while some are done" in {
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
+        List(done(Resource.TCS), done(Instrument.GmosN)),
         List(done(Resource.TCS), running(Instrument.GmosN)),
-        List(done(Resource.TCS), running(Instrument.GmosN)),
-        List(done(Resource.TCS), running(Instrument.GmosN), running(Resource.Gcal)))
+        List(pendingAction(Resource.TCS), pendingAction(Instrument.GmosN), pendingAction(Resource.Gcal)))
       val status = List(Resource.TCS -> ActionStatus.Completed, Resource.Gcal -> ActionStatus.Pending, Instrument.GmosN -> ActionStatus.Running)
       SeqexecEngine.configStatus(executions) shouldBe status
     }
 
   "SeqexecEngine pending configStatus" should
     "build empty without tasks" in {
-      SeqexecEngine.pendingConfigStatus(Nil) shouldBe List.empty
+      SeqexecEngine.configStatus(Nil) shouldBe List.empty
     }
     it should "be all pending while one is running" in {
       val status = List(Resource.TCS -> ActionStatus.Pending)
-      val executions: List[List[Action \/ Result]] = List(
-        List(running(Resource.TCS)))
+      val executions: List[List[Action]] = List(
+        List(pendingAction(Resource.TCS)))
       SeqexecEngine.pendingConfigStatus(executions) shouldBe status
     }
     it should "be all pending with mixed" in {
       val status = List(Resource.TCS -> ActionStatus.Pending, Instrument.GmosN -> ActionStatus.Pending)
-      val executions: List[List[Action \/ Result]] = List(
-        List(running(Resource.TCS), done(Instrument.GmosN)))
+      val executions: List[List[Action]] = List(
+        List(pendingAction(Resource.TCS), done(Instrument.GmosN)))
       SeqexecEngine.pendingConfigStatus(executions) shouldBe status
     }
     it should "be all pending on mixed combinations" in {
       val status = List(Resource.TCS -> ActionStatus.Pending, Instrument.GmosN -> ActionStatus.Pending)
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
         List(done(Resource.TCS)),
-        List(done(Resource.TCS), running(Instrument.GmosN)))
+        List(done(Resource.TCS), pendingAction(Instrument.GmosN)))
       SeqexecEngine.pendingConfigStatus(executions) shouldBe status
     }
     it should "be all pending with multiple resources" in {
-      val executions: List[List[Action \/ Result]] = List(
-        List(done(Resource.TCS), running(Instrument.GmosN)),
-        List(done(Resource.TCS), running(Instrument.GmosN)),
-        List(done(Resource.TCS), running(Instrument.GmosN), running(Resource.Gcal)))
+      val executions: List[List[Action]] = List(
+        List(done(Resource.TCS), pendingAction(Instrument.GmosN)),
+        List(done(Resource.TCS), pendingAction(Instrument.GmosN)),
+        List(done(Resource.TCS), pendingAction(Instrument.GmosN), pendingAction(Resource.Gcal)))
       val status = List(Resource.TCS -> ActionStatus.Pending, Resource.Gcal -> ActionStatus.Pending, Instrument.GmosN -> ActionStatus.Pending)
       SeqexecEngine.pendingConfigStatus(executions) shouldBe status
     }
@@ -118,20 +116,20 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
     }
     it should "be running if there is an action observe" in {
       val status = List(Resource.TCS -> ActionStatus.Completed)
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
         List(done(Resource.TCS), observing))
       SeqexecEngine.observeStatus(executions, status) shouldBe ActionStatus.Running
     }
     it should "be done if there is a result observe" in {
       val status = List(Resource.TCS -> ActionStatus.Completed)
-      val executions: List[List[Action \/ Result]] = List(
+      val executions: List[List[Action]] = List(
         List(done(Resource.TCS), observed))
       SeqexecEngine.observeStatus(executions, status) shouldBe ActionStatus.Completed
     }
     it should "be running if there is a partial result with the file id" in {
       val status = List(Resource.TCS -> ActionStatus.Completed)
-      val executions: List[List[Action \/ Result]] = List(
-        List(done(Resource.TCS), fileId))
+      val executions: List[List[Action]] = List(
+        List(done(Resource.TCS), fileIdReady))
       SeqexecEngine.observeStatus(executions, status) shouldBe ActionStatus.Running
     }
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -146,12 +146,16 @@ object StepsTableContainer {
       case ActionStatus.Pending   => "gray"
       case ActionStatus.Running   => "yellow"
       case ActionStatus.Completed => "green"
+      case ActionStatus.Paused    => "orange"
+      case ActionStatus.Failed    => "red"
     }
 
     def labelIcon(status: ActionStatus): Option[Icon] = status match {
       case ActionStatus.Pending   => None
       case ActionStatus.Running   => IconCircleNotched.copyIcon(loading = true).some
       case ActionStatus.Completed => IconCheckmark.some
+      case ActionStatus.Paused    => IconPause.some
+      case ActionStatus.Failed    => IconStopCircle.some
     }
 
     def statusLabel(system: Resource, status: ActionStatus): VdomNode =


### PR DESCRIPTION
This PR modifies the definition of Action, adding a state. Execution is no longer a collection of Actions and Results, but a collection of Actions in (possibly) different states.
Actions can now end in a Paused state. In that case the Sequence is considered as still running. A new event was introduced, ActionResume, which provide a Task that is run as the continuation of the paused Action.

This will be used to implement the observe pause/resume. As I envision it, the pause will directly send a pause command to the instrument, causing the currently running observe Action to end with a Pause result. The resume will put an ActionResume. Its Task will send the resume to the instrument, and wait for the completion of the observation.