### PR TITLE
SEQNG-448: Breakpoint bar should extends to all the width of the table

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -262,7 +262,7 @@ object StepsTableContainer {
         <.td(
           if (step.breakpoint) SeqexecStyles.breakpointTrOn else SeqexecStyles.breakpointTrOff,
           SeqexecStyles.tdNoPadding,
-          ^.colSpan := 5
+          ^.colSpan := 11
         )
       )
 


### PR DESCRIPTION
Tiny fix. `colSpan` should match the amount of columns and that's been increasing lately

![screenshot 2017-12-18 12 13 26](https://user-images.githubusercontent.com/3615303/34113368-3b5bc182-e3ee-11e7-915a-f87c35af59a2.png)
