### PR TITLE
SEQNG-443: Show filter

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
@@ -163,6 +163,10 @@ trait ModelLenses {
   val instrumentFPUCustomMaskO: Optional[Step, String] =
     stepObserveOptional(SystemName.instrument, "fpuCustomMask", Iso.id[String].asPrism)
 
+  // Composite lens to find the instrument filter
+  val instrumentFilterO: Optional[Step, String] =
+    stepObserveOptional(SystemName.instrument, "filter", Iso.id[String].asPrism)
+
   // Lens to find p offset
   def telescopeOffsetO(x: OffsetAxis): Optional[Step, Double] =
     stepObserveOptional(SystemName.telescope, x.configItem, stringToDoubleP)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/enumerations.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/enumerations.scala
@@ -9,6 +9,91 @@ package edu.gemini.seqexec.model
  * Should be gone when we integrate into gem
  */
 object enumerations {
+  object filter {
+    val GmosSFilter: Map[String, String] = Map(
+      "NONE" -> "None",
+      "u_G0332" -> "u_G0332",
+      "g_G0325" -> "g_G0325",
+      "r_G0326" -> "r_G0326",
+      "i_G0327" -> "i_G0327",
+      "z_G0328" -> "z_G0328",
+      "Z_G0343" -> "Z_G0343",
+      "Y_G0344" -> "Y_G0344",
+      "GG455_G0329" -> "GG455_G0329",
+      "OG515_G0330" -> "OG515_G0330",
+      "RG610_G0331" -> "RG610_G0331",
+      "RG780_G0334" -> "RG780_G0334",
+      "CaT_G0333" -> "CaT_G0333",
+      "HartmannA_G0337_r_G0326" -> "HartmannA_G0337 + r_G0326",
+      "HartmannB_G0338_r_G0326" -> "HartmannB_G0338 + r_G0326",
+      "g_G0325_GG455_G0329" -> "g_G0325 + GG455_G0329",
+      "g_G0325_OG515_G0330" -> "g_G0325 + OG515_G0330",
+      "r_G0326_RG610_G0331" -> "r_G0326 + RG610_G0331",
+      "i_G0327_RG780_G0334" -> "i_G0327 + RG780_G0334",
+      "i_G0327_CaT_G0333" -> "i_G0327 + CaT_G0333",
+      "z_G0328_CaT_G0333" -> "z_G0328 + CaT_G0333",
+      "Ha_G0336" -> "Ha_G0336",
+      "SII_G0335" -> "SII_G0335",
+      "HaC_G0337" -> "HaC_G0337",
+      "OIII_G0338" -> "OIII_G0338",
+      "OIIIC_G0339" -> "OIIIC_G0339",
+      "HeII_G0340" -> "HeII_G0340",
+      "HeIIC_G0341" -> "HeIIC_G0341",
+      "Lya395_G0342" -> "Lya395_G0342",
+      "OVI_G0347" -> "OVI_G0347",
+      "OVIC_G0348" -> "OVIC_G0348"
+    )
+
+    val GmosNFilter: Map[String, String] = Map(
+      "NONE" -> "None",
+      "g_G0301" -> "g_G0301",
+      "r_G0303" -> "r_G0303",
+      "i_G0302" -> "i_G0302",
+      "z_G0304" -> "z_G0304",
+      "Z_G0322" -> "Z_G0322",
+      "Y_G0323" -> "Y_G0323",
+      "GG455_G0305" -> "GG455_G0305",
+      "OG515_G0306" -> "OG515_G0306",
+      "RG610_G0307" -> "RG610_G0307",
+      "CaT_G0309" -> "CaT_G0309",
+      "Ha_G0310" -> "Ha_G0310",
+      "HaC_G0311" -> "HaC_G0311",
+      "DS920_G0312" -> "DS920_G0312",
+      "SII_G0317" -> "SII_G0317",
+      "OIII_G0318" -> "OIII_G0318",
+      "OIIIC_G0319" -> "OIIIC_G0319",
+      "HeII_G0320" -> "HeII_G0320",
+      "HeIIC_G0321" -> "HeIIC_G0321",
+      "OVI_G0345" -> "OVI_G0345",
+      "OVIC_G0346" -> "OVIC_G0346",
+      "HartmannA_G0313_r_G0303" -> "HartmannA_G0313 + r_G0303",
+      "HartmannB_G0314_r_G0303" -> "HartmannB_G0314 + r_G0303",
+      "g_G0301_GG455_G0305" -> "g_G0301 + GG455_G0305",
+      "g_G0301_OG515_G0306" -> "g_G0301 + OG515_G0306",
+      "r_G0303_RG610_G0307" -> "r_G0303 + RG610_G0307",
+      "i_G0302_CaT_G0309" -> "i_G0302 + CaT_G0309",
+      "z_G0304_CaT_G0309" -> "z_G0304 + CaT_G0309",
+      "u_G0308" -> "u_G0308"
+    )
+
+    val F2Filter: Map[String, String] = Map(
+      "OPEN" -> "Open",
+      "Y" -> "Y (1.02 um)",
+      "F1056" -> "F1056 (1.056 um)",
+      "F1063" -> "F1063 (1.063 um)",
+      "J_LOW" -> "J-low (1.15 um)",
+      "J" -> "J (1.25 um)",
+      "H" -> "H (1.65 um)",
+      "K_LONG" -> "K-long (2.20 um)",
+      "K_SHORT" -> "K-short (2.15 um)",
+      "K_BLUE" -> "K-blue (2.06 um)",
+      "K_RED" -> "K-red (2.31 um)",
+      "JH" -> "JH (spectroscopic)",
+      "HK" -> "HK (spectroscopic)",
+      "DARK" -> "Dark"
+    )
+
+  }
 
   object fpu {
     val CustomMaskKey = "CUSTOM_MASK"

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -52,4 +52,5 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("instrument fpu Optional", OptionalTests(instrumentFPUO))
   checkAll("instrument fpu mode Optional", OptionalTests(instrumentFPUModeO))
   checkAll("instrument fpu custom mask Optional", OptionalTests(instrumentFPUCustomMaskO))
+  checkAll("instrument filter Optional", OptionalTests(instrumentFilterO))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -336,7 +336,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     fontStyle.italic
   )
 
-  val fpuLabel: StyleA = style(
+  val componentLabel: StyleA = style(
     fontSize.smaller,
     textOverflow := "ellipsis",
     overflow.hidden,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -162,7 +162,7 @@ object FPUCell {
 
       <.div(
         ^.cls := "center aligned",
-        SeqexecStyles.fpuLabel,
+        SeqexecStyles.componentLabel,
         fpuValue.getOrElse("Unknown"): String
       )
     }
@@ -170,6 +170,40 @@ object FPUCell {
 
   def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }
+
+/**
+ * Component to display the FPU
+ */
+object FilterCell {
+  final case class Props(s: Step, i: Instrument)
+
+  private val component = ScalaComponent.builder[Props]("FilterCell ")
+    .stateless
+    .render_P { p =>
+
+      val nameMapper: Map[String, String] = p.i match {
+        case Instrument.GmosS => enumerations.filter.GmosSFilter
+        case Instrument.GmosN => enumerations.filter.GmosNFilter
+        case Instrument.F2    => enumerations.filter.F2Filter
+        case _                => Map.empty
+      }
+
+      val filter = for {
+        filter  <- instrumentFilterO.getOption(p.s)
+      } yield nameMapper.getOrElse(filter, filter)
+
+
+      <.div(
+        ^.cls := "center aligned",
+        SeqexecStyles.componentLabel,
+        filter.getOrElse("Unknown"): String
+      )
+    }
+    .build
+
+  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+}
+
 /**
  * Component to display the exposure time and coadds
  */

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -161,7 +161,7 @@ object FPUCell {
       } yield nameMapper.getOrElse(fpu, fpu)
 
       <.div(
-        ^.cls := "center aligned",
+        ^.cls := "left aligned",
         SeqexecStyles.componentLabel,
         fpuValue.getOrElse("Unknown"): String
       )
@@ -172,7 +172,7 @@ object FPUCell {
 }
 
 /**
- * Component to display the FPU
+ * Component to display the Filter
  */
 object FilterCell {
   final case class Props(s: Step, i: Instrument)
@@ -194,7 +194,7 @@ object FilterCell {
 
 
       <.div(
-        ^.cls := "center aligned",
+        ^.cls := "left aligned",
         SeqexecStyles.componentLabel,
         filter.getOrElse("Unknown"): String
       )
@@ -222,16 +222,17 @@ object ExposureTime {
       val coadds = observeCoaddsO.getOption(p.s)
 
       // TODO Find a better way to output math-style text
-      val seconds = List(<.span(^.display := "inline-block", ^.marginLeft := 5.px, "["), <.span(^.display := "inline-block", ^.verticalAlign := "text-bottom", ^.fontStyle := "italic", "s"), <.span(^.display := "inline-block", "]"))
+      val seconds = List(<.span(^.display := "inline-block", ^.marginLeft := 5.px, "["), <.span(^.display := "inline-block", ^.verticalAlign := "none", ^.fontStyle := "italic", "s"), <.span(^.display := "inline-block", "]"))
 
       val displayedText: TagMod = (coadds, exposureTime) match {
-        case (c, Some(e)) if c.exists(_ > 1) => (List(<.span(^.display := "inline-block", s"${~c.map(_.shows)} "), <.span(^.display := "inline-block", ^.verticalAlign := "text-bottom", "\u2A2F"), <.span(^.display := "inline-block", s"${formatExposureTime(e)}")) ::: seconds).toTagMod
+        case (c, Some(e)) if c.exists(_ > 1) => (List(<.span(^.display := "inline-block", s"${~c.map(_.shows)} "), <.span(^.display := "inline-block", ^.verticalAlign := "none", "\u2A2F"), <.span(^.display := "inline-block", s"${formatExposureTime(e)}")) ::: seconds).toTagMod
         case (_, Some(e))                    => ((s"${formatExposureTime(e)}": VdomNode) :: seconds).toTagMod
         case _                               => EmptyVdom
       }
 
       <.div(
         ^.cls := "center aligned",
+        SeqexecStyles.componentLabel,
         displayedText
       )
     }
@@ -245,8 +246,8 @@ object ExposureTime {
  */
 object GuidingBlock {
   final case class Props(s: Step)
-  private val guidingIcon = IconCrosshairs.copyIcon(color = "green".some, size = Size.Big)
-  private val noGuidingIcon = IconBan.copyIcon(size = Size.Big)
+  private val guidingIcon = IconCrosshairs.copyIcon(color = "green".some, size = Size.Large)
+  private val noGuidingIcon = IconBan.copyIcon(size = Size.Large)
   private val component = ScalaComponent.builder[Props]("OffsetValues")
     .stateless
     .render_P { p =>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -75,6 +75,7 @@ object StepsTableHeader {
           TableHeader(TableHeader.Props(width = Width.Three), "Offset").unless(displayOffsets),
           TableHeader(TableHeader.Props(width = Width.One), "Guiding"),
           TableHeader(TableHeader.Props(width = Width.One), "Exposure"),
+          TableHeader(TableHeader.Props(width = Width.Two), "Filter"),
           TableHeader(TableHeader.Props(width = Width.Two), "FPU"),
           TableHeader(TableHeader.Props(width = Width.Two, aligned = Aligned.Right), "Type"),
           TableHeader(TableHeader.Props(collapsing = true, width = Width.Eight), "Progress"),
@@ -339,6 +340,13 @@ object StepsTableContainer {
         ExposureTime(ExposureTime.Props(step, instrument))
       )
 
+    private def stepFilterCell(instrument: Instrument, step: Step, i: Int) =
+      <.td( // Column object type
+        ^.onDoubleClick --> selectRow(step, i),
+        ^.cls := "right aligned",
+        FilterCell(FilterCell.Props(step, instrument))
+      )
+
     private def stepFPUCell(instrument: Instrument, step: Step, i: Int) =
       <.td( // Column object type
         ^.onDoubleClick --> selectRow(step, i),
@@ -382,6 +390,7 @@ object StepsTableContainer {
         offsetDisplayCell(offsetsDisplay, step, i),
         stepGuidingCell(step, i),
         stepExposureTimeCell(p.instrument, step, i),
+        stepFilterCell(p.instrument, step, i),
         stepFPUCell(p.instrument, step, i),
         stepObjectTypeCell(step, i),
         stepProgressCell(step, state, i),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -296,18 +296,22 @@ object StepsTableContainer {
           case StepType.Dark                            => "black"
           case StepType.Calibration                     => "blue"
         }
-        Label(Label.Props(st.shows, color = stepTypeColor.some))
+        Label(Label.Props(st.shows, color = stepTypeColor.some, size = Size.Small))
       }
 
     private def stepIconCell(p: StepsTableFocus, step: Step, i: Int) =
       <.td( // Column step icon
         ^.onDoubleClick --> selectRow(step, i),
-        stepIcon(p, step, i)
+        <.div(
+          ^.cls := "center aligned",
+          stepIcon(p, step, i)
+        )
       )
 
     private def stepNumberCell(step: Step, i: Int) =
       <.td( // Column step number
         ^.onDoubleClick --> selectRow(step, i),
+        SeqexecStyles.componentLabel,
         i + 1
       )
 
@@ -315,6 +319,7 @@ object StepsTableContainer {
       <.td( // Column step status
         ^.onDoubleClick --> selectRow(step, i),
         ^.cls := "middle aligned",
+        SeqexecStyles.componentLabel,
         stepDisplay(status, p, state, step)
       )
 
@@ -343,14 +348,12 @@ object StepsTableContainer {
     private def stepFilterCell(instrument: Instrument, step: Step, i: Int) =
       <.td( // Column object type
         ^.onDoubleClick --> selectRow(step, i),
-        ^.cls := "right aligned",
         FilterCell(FilterCell.Props(step, instrument))
       )
 
     private def stepFPUCell(instrument: Instrument, step: Step, i: Int) =
       <.td( // Column object type
         ^.onDoubleClick --> selectRow(step, i),
-        ^.cls := "right aligned",
         FPUCell(FPUCell.Props(step, instrument))
       )
 
@@ -365,9 +368,10 @@ object StepsTableContainer {
       <.td( // Column progress
         ^.onDoubleClick --> selectRow(step, i),
         ^.classSet(
-          "top aligned"    -> step.isObserving,
+          "center aligned"    -> step.isObserving,
           "middle aligned" -> !step.isObserving
         ),
+        SeqexecStyles.componentLabel,
         stepProgress(state, step)
       )
 


### PR DESCRIPTION
This PR adds support to display the filter for GmosS, GmosN and F2. As for FPU unfortunately we need to copy the filter names from ocs.

Some other ui tweaks are added to match the font size of filter and fpu

Here's a screenshot
![screenshot 2017-12-19 12 39 19](https://user-images.githubusercontent.com/3615303/34165004-da4316d0-e4b9-11e7-8b23-65a761dc4670.png)
