### PR TITLE
SEQNG-450 Changed monitoring procedure for observe.

### DIFF
--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -198,10 +198,10 @@ public final class CaService {
      * @throws CAException
      */
     public CaApplySender createObserveSender(String name, String applyRecord,
-            String carRecord, String stopCmdRecord, String abortCmdRecord, String description) throws CAException {
+            String carRecord, String observeCarRecord, String stopCmdRecord, String abortCmdRecord, String description) throws CAException {
         CaObserveSenderImpl observe = observeSenders.get(name);
         if (observe == null) {
-            observe = new CaObserveSenderImpl(name, applyRecord, carRecord, stopCmdRecord, abortCmdRecord,
+            observe = new CaObserveSenderImpl(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
                     description, epicsService);
             observeSenders.put(name, observe);
         }
@@ -209,8 +209,8 @@ public final class CaService {
     }
 
     public CaApplySender createObserveSender(String name, String applyRecord,
-            String carRecord) throws CAException {
-        return createObserveSender(name, applyRecord, carRecord, null, null, null);
+            String carRecord, String observeCarRecord) throws CAException {
+        return createObserveSender(name, applyRecord, carRecord, observeCarRecord, null, null, null);
     }
 
     /**

--- a/modules/edu.gemini.seqexec.server/src/main/resources/Gmos.xml
+++ b/modules/edu.gemini.seqexec.server/src/main/resources/Gmos.xml
@@ -70,6 +70,31 @@
             <record>endObserve</record>
             <description>End Observe</description>
         </command>
+        <command name="gmos::continue">
+            <record>continue</record>
+            <description>Continue observation</description>
+        </command>
+        <command name="gmos::observe">
+            <record>observe</record>
+            <description>Observe</description>
+            <parameter name="label">
+                <channel>observe.A</channel>
+                <type>STRING</type>
+                <description>DHS data label</description>
+            </parameter>
+        </command>
+        <command name="gmos::pause">
+            <record>pause</record>
+            <description>Pause observation</description>
+        </command>
+        <command name="gmos::abort">
+            <record>abort</record>
+            <description>Abort observation</description>
+        </command>
+        <command name="gmos::stop">
+            <record>stop</record>
+            <description>Stop observation</description>
+        </command>
     </Apply>
     <Apply name="gmos::dcapply">
         <top>gm</top>
@@ -238,37 +263,6 @@
                 <channel>dc:roi.G</channel>
                 <type>INTEGER</type>
                 <description>CCD X size</description>
-            </parameter>
-        </command>
-        <command name="gmos::pause">
-            <record>pause</record>
-            <description>Pause observation</description>
-        </command>
-        <command name="gmos::abort">
-            <record>abort</record>
-            <description>Abort observation</description>
-        </command>
-        <command name="gmos::stop">
-            <record>stop</record>
-            <description>Stop observation</description>
-        </command>
-    </Apply>
-    <Apply name="gmos::observeapply">
-        <top>gm</top>
-        <apply>apply</apply>
-        <car>dc:observeC</car>
-        <description>Observe Apply Record</description>
-        <command name="gmos::continue">
-            <record>continue</record>
-            <description>Continue observation</description>
-        </command>
-        <command name="gmos::observe">
-            <record>observe</record>
-            <description>Observe</description>
-            <parameter name="label">
-                <channel>observe.A</channel>
-                <type>STRING</type>
-                <description>DHS data label</description>
             </parameter>
         </command>
     </Apply>

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/flamingos2/Flamingos2Epics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/flamingos2/Flamingos2Epics.scala
@@ -4,7 +4,7 @@
 package edu.gemini.seqexec.server.flamingos2
 
 import edu.gemini.epics.acm._
-import edu.gemini.seqexec.server.{EpicsCommand, EpicsSystem, ObserveCommand, SeqAction}
+import edu.gemini.seqexec.server.{EpicsCommand, EpicsSystem, SeqAction}
 import org.log4s.{Logger, getLogger}
 
 final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) {
@@ -40,9 +40,8 @@ final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) 
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::stop"))
   }
 
-  object observeCmd extends ObserveCommand {
-    private val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::observe"))
-    override protected val os: Option[CaApplySender] = Option(epicsService.createObserveSender("flamingos2::observeCmd", "flamingos2::apply", F2_TOP + "dc:observeC"))
+  object observeCmd extends EpicsCommand {
+    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::observe"))
 
     private val label = cs.map(_.getString("label"))
     def setLabel(v: String): SeqAction[Unit] = setParameter(label, v)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosEpics.scala
@@ -85,7 +85,7 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
   object observeCmd extends ObserveCommand {
     private val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::observe"))
     override protected val os: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::observeCmd",
-      GMOS_TOP + "apply", GMOS_TOP + "dc:observeC", GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
+      GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
 
     val label: Option[CaParameter[String]] = cs.map(_.getString("label"))
     def setLabel(v: String): SeqAction[Unit] = setParameter(label, v)


### PR DESCRIPTION
Before, the monitoring would check the gm:apply and gm:dc:observeC fields to check when the command started and was completed (or paused, or failed). It also checked the consistency of the CLID fields, and would treat a change on the CLID as an error. In other words, it treated the observe as an atomic command; a new command issued while the observe was in progress was treated as an error. This caused problems for issuing commands abort, stop or pause.
The solution implemented is to treat the observe command as a command with a delayed status. The command execution is monitored normally with the records gm:apply and gm:applyC, and then the value of gm:dc:observeC is monitored to find when the observation finishes.