### PR TITLE
SEQNG-353 Implemented observe resume command for GMOS.

### DIFF
--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -451,7 +451,7 @@ public class CaObserveSenderImpl implements CaApplySender {
                         case IDLE: return new WaitObserveStart(cm);
                         case BUSY: return new WaitObserveCompletion(cm, getStopMark(), getAbortMark());
                         case ERROR: {
-                            failCommandWithCarError(cm);
+                            failCommandWithObserveCarError(cm);
                             return IdleState;
                         }
                         case PAUSED: {
@@ -520,7 +520,7 @@ public class CaObserveSenderImpl implements CaApplySender {
                     return new WaitObserveCompletion(cm, getStopMark(), getAbortMark());
                 }
                 case ERROR: {
-                    failCommandWithCarError(cm);
+                    failCommandWithObserveCarError(cm);
                     return IdleState;
                 }
                 case PAUSED: {
@@ -574,7 +574,7 @@ public class CaObserveSenderImpl implements CaApplySender {
                     return IdleState;
                 }
                 case ERROR:{
-                    failCommandWithCarError(cm);
+                    failCommandWithObserveCarError(cm);
                     return IdleState;
                 }
                 case PAUSED: {
@@ -694,7 +694,7 @@ public class CaObserveSenderImpl implements CaApplySender {
                     return IdleState;
                 }
                 case ERROR:{
-                    failCommandWithCarError(cm);
+                    failCommandWithObserveCarError(cm);
                     return IdleState;
                 }
                 case PAUSED: {
@@ -822,6 +822,21 @@ public class CaObserveSenderImpl implements CaApplySender {
             String msg = null;
             try {
                 msg = car.getOmssValue();
+            } catch (CAException | TimeoutException e) {
+                LOG.warning(e.getMessage());
+            }
+            cm.completeFailure(new CaCommandError(msg));
+        } );
+    }
+
+    private void failCommandWithObserveCarError(final CaCommandMonitorImpl cm) {
+        // I found that if I try to read OMSS or MESS from the same thread that
+        // is processing a channel notifications, the reads fails with a
+        // timeout. But it works if the read is done later from another thread.
+        executor.execute(() -> {
+            String msg = null;
+            try {
+                msg = observeCar.getOmssValue();
             } catch (CAException | TimeoutException e) {
                 LOG.warning(e.getMessage());
             }

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Execution.scala
@@ -77,7 +77,7 @@ object Execution {
   def actionStateFromResult(r: Result): (Action.State => Action.State) = s => r match {
     case Result.OK(x)         => s.copy(runState = Action.Completed(x))
     case Result.Partial(x, _) => s.copy(partials = x :: s.partials )
-    case Result.Paused        => s.copy(runState = Action.Paused)
+    case Result.Paused(c)     => s.copy(runState = Action.Paused(c))
     case e@Result.Error(_)    => s.copy(runState = Action.Failed(e))
   }
 }
@@ -94,10 +94,11 @@ object Result {
   // Base traits for results. They make harder to pass the wrong value.
   trait RetVal
   trait PartialVal
+  trait PauseContext
 
   final case class OK[R <: RetVal](response: R) extends Result
   final case class Partial[R <: PartialVal](response: R, continuation: ActionGen) extends Result
-  object Paused extends Result
+  final case class Paused[C <: PauseContext](ctx: PauseContext) extends Result
   // TODO: Replace the message by a richer Error type like `SeqexecFailure`
   final case class Error(msg: String) extends Result {
     override val errMsg: Option[String] = Some(msg)

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/SystemEvent.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/SystemEvent.scala
@@ -3,7 +3,7 @@
 
 package edu.gemini.seqexec.engine
 
-import edu.gemini.seqexec.engine.Result.{OK, Partial, PartialVal, RetVal}
+import edu.gemini.seqexec.engine.Result._
 
 /**
   * Created by jluhrs on 9/25/17.
@@ -14,7 +14,7 @@ import edu.gemini.seqexec.engine.Result.{OK, Partial, PartialVal, RetVal}
 sealed trait SystemEvent
 final case class Completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]) extends SystemEvent
 final case class PartialResult[R<:PartialVal](id: Sequence.Id, i: Int, r: Partial[R]) extends SystemEvent
-final case class Paused(id: Sequence.Id, i: Int) extends SystemEvent
+final case class Paused[C <: PauseContext](id: Sequence.Id, i: Int, r: Result.Paused[C]) extends SystemEvent
 final case class Failed(id: Sequence.Id, i: Int, e: Result.Error) extends SystemEvent
 final case class Busy(id: Sequence.Id) extends SystemEvent
 final case class Executed(id: Sequence.Id) extends SystemEvent

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/UserEvent.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/UserEvent.scala
@@ -47,9 +47,14 @@ case object Poll extends UserEvent {
 final case class GetState(f: (Engine.State) => Task[Option[Process[Task, Event]]]) extends UserEvent {
   val user: Option[UserDetails] = None
 }
+// Generic event to put a function in the main Process process, which takes an
+// action depending on the current state of a specific sequence
+final case class GetSeqState(id: Sequence.Id, f: Sequence.State => Option[Process[Task, Event]]) extends UserEvent {
+  val user: Option[UserDetails] = None
+}
 // Calls a user given function in the main Process process to stop an Action.
 // It sets the Sequence to be stopped. The user function is called only if the Sequence is running.
-final case class ActionStop(id: Sequence.Id, f: (Sequence.State) => Option[Process[Task, Event]]) extends UserEvent {
+final case class ActionStop(id: Sequence.Id, f: Sequence.State => Option[Process[Task, Event]]) extends UserEvent {
   val user: Option[UserDetails] = None
 }
 

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/packageSpec.scala
@@ -172,7 +172,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
             skip = false,
             List(
               List(fromTask(ActionType.Undefined,
-              Task(Result.Paused)))
+              Task(Result.Paused(new Result.PauseContext {} ))))
             )
           )
         )
@@ -188,7 +188,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
   }
 
   "action state" should "change to Paused if output is Paused" in {
-    assert(actionPause.map(_.sequences(seqId).current.execution.forall(_.state.runState === Action.Paused)).getOrElse(false))
+    assert(actionPause.map(_.sequences(seqId).current.execution.forall{Action.paused}).getOrElse(false))
   }
 
   "engine" should "run sequence to completion after resuming a paused action" in {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
@@ -9,6 +9,7 @@ import java.util.{Timer, TimerTask}
 import java.util.concurrent.locks.ReentrantLock
 
 import edu.gemini.epics.acm._
+import edu.gemini.seqexec.server.EpicsCommand.safe
 import edu.gemini.seqexec.server.SeqexecFailure.SeqexecException
 import org.log4s._
 import squants.Time
@@ -106,6 +107,7 @@ object EpicsCommand {
 trait ObserveCommand {
   import ObserveCommand._
 
+  protected val cs: Option[CaCommandSender]
   protected val os: Option[CaApplySender]
 
   def post: SeqAction[Result] =
@@ -128,6 +130,10 @@ trait ObserveCommand {
         }
       }
     }
+
+  def mark: SeqAction[Unit] = safe(EitherT(Task.delay {
+    cs.map(_.mark().right).getOrElse(SeqexecFailure.Unexpected("Unable to mark command.").left)
+  }))
 }
 
 object ObserveCommand {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/InstrumentSystem.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/InstrumentSystem.scala
@@ -23,7 +23,7 @@ object InstrumentSystem {
   final case class StopObserveCmd(self: SeqAction[Unit]) extends AnyVal
   final case class AbortObserveCmd(self: SeqAction[Unit]) extends AnyVal
   final case class PauseObserveCmd(self: SeqAction[Unit]) extends AnyVal
-  final case class ContinueObserveCmd(self: SeqAction[Unit]) extends AnyVal
+  final case class ContinueObserveCmd(self: SeqAction[ObserveCommand.Result]) extends AnyVal
   final case class Controllable(stop: StopObserveCmd,
                                 abort: AbortObserveCmd,
                                 pause: PauseObserveCmd,

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/Gmos.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/Gmos.scala
@@ -34,8 +34,12 @@ abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosContro
 
   override val contributorName: String = "gmosdc"
 
-  override val observeControl: InstrumentSystem.ObserveControl = Controllable(StopObserveCmd(controller.stopObserve), AbortObserveCmd(controller.abortObserve),
-    PauseObserveCmd(controller.pauseObserve), ContinueObserveCmd(SeqAction.void))
+  override val observeControl: InstrumentSystem.ObserveControl = Controllable(
+    StopObserveCmd(controller.stopObserve),
+    AbortObserveCmd(controller.abortObserve),
+    PauseObserveCmd(controller.pauseObserve),
+    ContinueObserveCmd(controller.resumeObserve)
+  )
 
   val Log: Logger = getLogger
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosController.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosController.scala
@@ -38,6 +38,8 @@ trait GmosController[T<:GmosController.SiteDependentTypes] {
   def abortObserve: SeqAction[Unit]
 
   def pauseObserve: SeqAction[Unit]
+
+  def resumeObserve: SeqAction[ObserveCommand.Result]
 }
 
 object GmosController {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerEpics.scala
@@ -246,6 +246,13 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
     _ <- GmosEpics.instance.pauseCmd.mark
     _ <- GmosEpics.instance.pauseCmd.post
   } yield ()
+
+  override def resumeObserve: SeqAction[ObserveCommand.Result] = for {
+      _ <- EitherT(Task(Log.info("Resume Gmos observation").right))
+      _ <- GmosEpics.instance.continueCmd.mark
+      ret <- GmosEpics.instance.continueCmd.post
+      _ <- EitherT(Task(Log.info("Completed Gmos observation").right))
+    } yield ret
 }
 
 object GmosControllerEpics {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosEpics.scala
@@ -70,8 +70,10 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::pause"))
   }
 
-  object continueCmd extends EpicsCommand {
+  object continueCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::continue"))
+    override protected val os: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::continueCmd",
+      GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
   }
 
   object stopCmd extends EpicsCommand {
@@ -83,7 +85,7 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
   }
 
   object observeCmd extends ObserveCommand {
-    private val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::observe"))
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::observe"))
     override protected val os: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::observeCmd",
       GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
 

--- a/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/edu.gemini.seqexec.server/src/test/scala/edu/gemini/seqexec/server/SeqTranslateSpec.scala
@@ -53,7 +53,7 @@ class SeqTranslateSpec extends FlatSpec {
   // Observe started, but with file Id already allocated
   private val s3: Sequence.State = s.start(0).mark(0)(Result.Partial(Result.FileIdAllocated(fileId), Kleisli(_=>Task(Result.OK(Result.Observed(fileId))))))
   // Observe paused
-  private val s4: Sequence.State = s.mark(0)(Result.Paused)
+  private val s4: Sequence.State = s.mark(0)(Result.Paused(new Result.PauseContext {}))
   // Observe failed
   private val s5: Sequence.State = s.mark(0)(Result.Error("error"))
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -7,7 +7,7 @@ import edu.gemini.seqexec.model.Model._
 import edu.gemini.seqexec.model.operations.ObservationOperations._
 import edu.gemini.seqexec.model.operations._
 import edu.gemini.seqexec.web.client.ModelOps._
-import edu.gemini.seqexec.web.client.actions.{RequestAbort, RequestObsPause, RequestStop}
+import edu.gemini.seqexec.web.client.actions.{RequestAbort, RequestObsPause, RequestObsResume, RequestStop}
 import edu.gemini.seqexec.web.client.circuit.{SeqexecCircuit, StepsTableFocus}
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
 import edu.gemini.seqexec.web.client.semanticui.elements.button.Button
@@ -71,6 +71,9 @@ object StepsControlButtons {
   def requestObsPause(id: SequenceId, stepId: Int): Callback =
     Callback(SeqexecCircuit.dispatch(RequestObsPause(id, stepId)))
 
+  def requestObsResume(id: SequenceId, stepId: Int): Callback =
+    Callback(SeqexecCircuit.dispatch(RequestObsResume(id, stepId)))
+
   def handleStop(id: SequenceId, stepId: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestStop(id, stepId)) >> ST.mod(_.copy(stopRequested = true, abortRequested = true)).liftCB
 
@@ -79,6 +82,9 @@ object StepsControlButtons {
 
   def handleObsPause(id: SequenceId, stepId: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestObsPause(id, stepId)) >> ST.mod(_.copy(stopRequested = true, abortRequested = true)).liftCB
+
+  def handleObsResume(id: SequenceId, stepId: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
+    ST.retM(requestObsResume(id, stepId)) >> ST.mod(_.copy(stopRequested = true, abortRequested = true)).liftCB
 
   private val component = ScalaComponent.builder[Props]("StepsControlButtons")
     .initialState(State(stopRequested = false, abortRequested = false))
@@ -93,7 +99,7 @@ object StepsControlButtons {
           case AbortObservation            =>
             Button(Button.Props(icon = Some(IconTrash), color = Some("red"), dataTooltip = Some("Abort the current exposure"), disabled = s.stopRequested || p.sequenceState === SequenceState.Stopping, onClick = $.runState(handleAbort(p.id, p.step.id))))
           case ResumeObservation           =>
-            Button(Button.Props(icon = Some(IconPlay), color = Some("blue"), dataTooltip = Some("Resume the current exposure")))
+            Button(Button.Props(icon = Some(IconPlay), color = Some("blue"), dataTooltip = Some("Resume the current exposure"), onClick = $.runState(handleObsResume(p.id, p.step.id))))
           // Hamamatsu operations
           case PauseImmediatelyObservation =>
             Button(Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure immediately")))

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
@@ -47,6 +47,7 @@ object actions {
   final case class RequestStop(id: SequenceId, step: Int) extends Action
   final case class RequestAbort(id: SequenceId, step: Int) extends Action
   final case class RequestObsPause(id: SequenceId, step: Int) extends Action
+  final case class RequestObsResume(id: SequenceId, step: Int) extends Action
 
   final case class RunStarted(s: SequenceId) extends Action
   final case class RunPaused(s: SequenceId) extends Action
@@ -62,6 +63,7 @@ object actions {
   final case class RunAbortFailed(s: SequenceId) extends Action
   final case class RunObsPause(s: SequenceId) extends Action
   final case class RunObsPauseFailed(s: SequenceId) extends Action
+  final case class RunObsResumeFailed(s: SequenceId) extends Action
 
   final case class ShowStep(id: SequenceId, step: Int) extends Action
   final case class UnShowStep(i: Instrument) extends Action

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/handlers.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/handlers.scala
@@ -143,6 +143,9 @@ object handlers {
       case RequestObsPause(id, step) =>
         effectOnly(Effect(SeqexecWebClient.pauseObs(id, step).map(r => if (r.error) RunObsPauseFailed(id) else RunObsPause(id))))
 
+      case RequestObsResume(id, step) =>
+        effectOnly(Effect(SeqexecWebClient.resumeObs(id, step).map(r => if (r.error) RunObsResumeFailed(id) else RunObsPause(id))))
+
     }
 
     def handleOperationResult: PartialFunction[Any, ActionResult[M]] = {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -98,6 +98,16 @@ object SeqexecWebClient extends ModelBooPicklers {
   }
 
   /**
+    * Requests the backend to resume the current exposure
+    */
+  def resumeObs(sid: SequenceId, step: Int): Future[RegularCommand] = {
+    Ajax.post(
+      url = s"$baseUrl/commands/$sid/$step/resumeObs",
+      responseType = "arraybuffer"
+    ).map(unpickle[RegularCommand])
+  }
+
+  /**
     * Requests the backend to set the operator name of a sequence
     */
   def setOperator(name: Operator): Future[RegularCommand] = {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -87,12 +87,18 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: server.Event
         resp <- Ok(s"Abort requested for $obsId on step $stepId")
       } yield resp
 
-
     case POST -> Root / obsId / stepId / "pauseObs" as _ =>
       for {
         obs  <- \/.fromTryCatchNonFatal(new SPObservationID(obsId)).fold(e => Task.fail(e), Task.now)
         _    <- se.pauseObserve(inputQueue, obs)
         resp <- Ok(s"Pause observation requested for $obsId on step $stepId")
+      } yield resp
+
+    case POST -> Root / obsId / stepId / "resumeObs" as _ =>
+      for {
+        obs  <- \/.fromTryCatchNonFatal(new SPObservationID(obsId)).fold(e => Task.fail(e), Task.now)
+        _    <- se.resumeObserve(inputQueue, obs)
+        resp <- Ok(s"Resume observation requested for $obsId on step $stepId")
       } yield resp
 
     case POST -> Root / "operator" / name as user =>


### PR DESCRIPTION
Send "continue" command to GMOS when the user presses the resume button. It checks that the sequence is running and the observe Action is active.
The resumed observation monitoring is the same that for non resumed observations, including the detection of  stop or abort commands.
The "pause" and "continue" command were tested with the real instrument.