### PR TITLE
SEQNG-454: Disable the breakpoint mark on the first step and on error

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -53,7 +53,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
     if (settings.tcsSim) TcsControllerSim else TcsControllerEpics,
     if (settings.gcalSim) GcalControllerSim else GcalControllerEpics,
     if (settings.instSim) {
-      if (settings.instForceError) Flamingos2ControllerSimBad
+      if (settings.instForceError) Flamingos2ControllerSimBad(settings.failAt)
       else Flamingos2ControllerSim
     } else Flamingos2ControllerEpics,
     if (settings.instSim) GmosControllerSim.south else GmosSouthControllerEpics,
@@ -277,6 +277,7 @@ object SeqexecEngine {
                       gwsKeywords: Boolean,
                       gcalKeywords: Boolean,
                       instForceError: Boolean,
+                      failAt: Int,
                       odbQueuePollingInterval: Duration)
   def apply(settings: Settings): SeqexecEngine = new SeqexecEngine(settings)
 
@@ -295,6 +296,7 @@ object SeqexecEngine {
     gwsKeywords = false,
     gcalKeywords = false,
     instForceError = false,
+    failAt = 0,
     10.seconds)
 
   // Couldn't find this on Scalaz
@@ -437,6 +439,7 @@ object SeqexecEngine {
     val gwsKeywords             = cfg.require[Boolean]("seqexec-engine.gwsKeywords")
     val gcalKeywords            = cfg.require[Boolean]("seqexec-engine.gcalKeywords")
     val instForceError          = cfg.require[Boolean]("seqexec-engine.instForceError")
+    val failAt                  = cfg.require[Int]("seqexec-engine.failAt")
     val odbQueuePollingInterval = Duration(cfg.require[String]("seqexec-engine.odbQueuePollingInterval"))
     val tops                    = decodeTops(cfg.require[String]("seqexec-engine.tops"))
     val caAddrList              = cfg.lookup[String]("seqexec-engine.epics_ca_addr_list")
@@ -498,6 +501,7 @@ object SeqexecEngine {
                        gwsKeywords,
                        gcalKeywords,
                        instForceError,
+                       failAt,
                        odbQueuePollingInterval)
       )
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/ModelOps.scala
@@ -122,8 +122,7 @@ object ModelOps {
     def file: Option[String] = None
 
     def canSetBreakpoint: Boolean = s.status match {
-      case StepState.Pending | StepState.Skipped | StepState.Paused => true
-      case _ if hasError                                            => true
+      case StepState.Pending | StepState.Skipped | StepState.Paused => s.id > 0
       case _                                                        => false
     }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/app.conf
@@ -51,7 +51,10 @@ seqexec-engine {
     gwsKeywords = false
     # gcalKeywords = true implies initialization of Gcal EPICS. Set to false before committing to git
     gcalKeywords = false
+    # Set to true on development to simulate errors on f2
     instForceError = false
+    # if instForceError is true fail at the given iteration
+    failAt = 2
     odbQueuePollingInterval = "3 seconds"
     tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gw=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"
     epics_ca_addr_list = "127.0.0.1"


### PR DESCRIPTION
The breakpoint mark shouldn't be present on errors or the first step
Also this adds more configurability to the erroring flamingos2 controller simulator