### PR TITLE
Generated size reduction

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -4,6 +4,7 @@
 package edu.gemini.seqexec.model
 
 import boopickle.Default._
+// import boopickle.PicklerHelper
 import edu.gemini.seqexec.model.Model._
 import edu.gemini.seqexec.model.events.SeqexecEvent
 import edu.gemini.seqexec.model.events.SeqexecEvent._
@@ -15,8 +16,8 @@ import java.time.Instant
   * Boopickle can auto derived encoders but it is preferred to make
   * them explicitly
   */
-@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Throw", "org.wartremover.warts.OptionPartial"))
-trait ModelBooPicklers {
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.PublicInference", "org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Throw", "org.wartremover.warts.OptionPartial"))
+object ModelBooPicklers {
   // Composite pickler for the seqexec event hierarchy
   // It is not strictly need but reduces the size of the js
   implicit val sequenceStatePickler = compositePickler[SequenceState]

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -4,7 +4,6 @@
 package edu.gemini.seqexec.model
 
 import boopickle.Default._
-// import boopickle.PicklerHelper
 import edu.gemini.seqexec.model.Model._
 import edu.gemini.seqexec.model.events.SeqexecEvent
 import edu.gemini.seqexec.model.events.SeqexecEvent._
@@ -27,6 +26,8 @@ object ModelBooPicklers {
   implicit val resourcePickler = generatePickler[Resource]
 
   implicit val operatorPickler = generatePickler[Operator]
+
+  implicit val systemNamePickler = generatePickler[SystemName]
 
   implicit val observerPickler = generatePickler[Observer]
 
@@ -85,7 +86,7 @@ object ModelBooPicklers {
   implicit val stepPickler = compositePickler[Step]
     .addConcreteType[StandardStep]
 
-  implicit val sequnceMetadataPickler = generatePickler[SequenceMetadata]
+  implicit val sequenceMetadataPickler = generatePickler[SequenceMetadata]
 
   implicit val stepConfigPickler = generatePickler[SequenceView]
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -18,6 +18,46 @@ import java.time.Instant
   */
 @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.PublicInference", "org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Throw", "org.wartremover.warts.OptionPartial"))
 object ModelBooPicklers {
+  //**********************
+  // IMPORTANT The order of the picklers is very relevant to the generated size
+  // add them with care
+  //**********************
+  implicit val instrumentPickler = generatePickler[Instrument]
+
+  implicit val resourcePickler = generatePickler[Resource]
+
+  implicit val operatorPickler = generatePickler[Operator]
+
+  implicit val observerPickler = generatePickler[Observer]
+
+  implicit val userDetailsPickler = generatePickler[UserDetails]
+
+  implicit val instantPickler = transformPickler((t: Long) => Instant.ofEpochMilli(t))(_.toEpochMilli)
+
+  implicit val cloudCoverPickler = compositePickler[CloudCover]
+    .addConcreteType[CloudCover.Any.type]
+    .addConcreteType[CloudCover.Percent50.type]
+    .addConcreteType[CloudCover.Percent70.type]
+    .addConcreteType[CloudCover.Percent80.type]
+
+  implicit val imageQualityPickler = compositePickler[ImageQuality]
+    .addConcreteType[ImageQuality.Any.type]
+    .addConcreteType[ImageQuality.Percent20.type]
+    .addConcreteType[ImageQuality.Percent70.type]
+    .addConcreteType[ImageQuality.Percent85.type]
+
+  implicit val skyBackgroundPickler = compositePickler[SkyBackground]
+    .addConcreteType[SkyBackground.Any.type]
+    .addConcreteType[SkyBackground.Percent20.type]
+    .addConcreteType[SkyBackground.Percent50.type]
+    .addConcreteType[SkyBackground.Percent80.type]
+
+  implicit val waterVaporPickler = compositePickler[WaterVapor]
+    .addConcreteType[WaterVapor.Any.type]
+    .addConcreteType[WaterVapor.Percent20.type]
+    .addConcreteType[WaterVapor.Percent50.type]
+    .addConcreteType[WaterVapor.Percent80.type]
+
   // Composite pickler for the seqexec event hierarchy
   // It is not strictly need but reduces the size of the js
   implicit val sequenceStatePickler = compositePickler[SequenceState]
@@ -45,18 +85,18 @@ object ModelBooPicklers {
   implicit val stepPickler = compositePickler[Step]
     .addConcreteType[StandardStep]
 
-  implicit val stepConfigPickler = generatePickler[SequenceView]
+  implicit val sequnceMetadataPickler = generatePickler[SequenceMetadata]
 
-  implicit val datePickler = transformPickler((t: Long) => Instant.ofEpochMilli(t))(_.toEpochMilli)
+  implicit val stepConfigPickler = generatePickler[SequenceView]
 
   implicit val serverLogLevelPickler = compositePickler[ServerLogLevel]
     .addConcreteType[ServerLogLevel.INFO.type]
     .addConcreteType[ServerLogLevel.WARN.type]
     .addConcreteType[ServerLogLevel.ERROR.type]
 
-  implicit val operatorPickler = generatePickler[Operator]
-
   implicit val sequenceQueueIdPickler = generatePickler[SequencesQueue[SequenceId]]
+
+  implicit val sequenceQueueViewPickler = generatePickler[SequencesQueue[SequenceView]]
 
   // Composite pickler for the seqexec event hierarchy
   // It is not strictly need but reduces the size of the js
@@ -83,30 +123,6 @@ object ModelBooPicklers {
     .addConcreteType[NewLogMessage]
     .addConcreteType[ServerLogMessage]
     .addConcreteType[NullEvent.type]
-
-  implicit val cloudCoverPickler = compositePickler[CloudCover]
-    .addConcreteType[CloudCover.Any.type]
-    .addConcreteType[CloudCover.Percent50.type]
-    .addConcreteType[CloudCover.Percent70.type]
-    .addConcreteType[CloudCover.Percent80.type]
-
-  implicit val imageQualityPickler = compositePickler[ImageQuality]
-    .addConcreteType[ImageQuality.Any.type]
-    .addConcreteType[ImageQuality.Percent20.type]
-    .addConcreteType[ImageQuality.Percent70.type]
-    .addConcreteType[ImageQuality.Percent85.type]
-
-  implicit val skyBackgroundPickler = compositePickler[SkyBackground]
-    .addConcreteType[SkyBackground.Any.type]
-    .addConcreteType[SkyBackground.Percent20.type]
-    .addConcreteType[SkyBackground.Percent50.type]
-    .addConcreteType[SkyBackground.Percent80.type]
-
-  implicit val waterVaporPickler = compositePickler[WaterVapor]
-    .addConcreteType[WaterVapor.Any.type]
-    .addConcreteType[WaterVapor.Percent20.type]
-    .addConcreteType[WaterVapor.Percent50.type]
-    .addConcreteType[WaterVapor.Percent80.type]
 
   /**
     * In most cases http4s will use the limit of a byte buffer but not for websockets

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -15,7 +15,8 @@ import org.scalatest.prop.PropertyChecks
   * Tests Serialization/Deserialization using BooPickle
   */
 @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.Throw", "org.wartremover.warts.OptionPartial", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Equals"))
-class BoopicklingSpec extends FlatSpec with Matchers with PropertyChecks with ModelBooPicklers {
+class BoopicklingSpec extends FlatSpec with Matchers with PropertyChecks {
+  import ModelBooPicklers._
   import SharedModelArbitraries._
 
   def testPickleUnpickle[A](implicit pickler: Pickler[A], arb: Arbitrary[A]): Assertion = {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/handlers.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/handlers.scala
@@ -9,6 +9,7 @@ import java.time.Instant
 import diode.util.RunAfterJS
 import diode.{Action, ModelRW, NoAction, Effect, ActionHandler, ActionResult}
 import diode.data.{Pending, Pot, Ready}
+import boopickle.DefaultBasic._
 
 import edu.gemini.seqexec.model.{ModelBooPicklers, UserDetails}
 import edu.gemini.seqexec.model.Model._
@@ -25,7 +26,6 @@ import edu.gemini.seqexec.web.client.services.{SeqexecWebClient, Audio}
 import edu.gemini.seqexec.web.client.model.SeqexecAppRootModel.LoadedSequences
 
 import org.scalajs.dom._
-import boopickle.Default._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.scalajs.js.typedarray.{ArrayBuffer, TypedArrayBuffer}
@@ -353,7 +353,9 @@ object handlers {
     * Handles the WebSocket connection and performs reconnection if needed
     */
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-  class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends ActionHandler(modelRW) with Handlers with ModelBooPicklers {
+  class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends ActionHandler(modelRW) with Handlers {
+    import ModelBooPicklers._
+
     private implicit val runner = new RunAfterJS
 
     private val logger = Logger.getLogger(this.getClass.getSimpleName)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -4,6 +4,7 @@
 package edu.gemini.seqexec.web.client.services
 
 import java.util.logging.LogRecord
+import boopickle.Default._
 
 import edu.gemini.seqexec.model.{ModelBooPicklers, UserDetails, UserLoginRequest}
 import edu.gemini.seqexec.model.Model.{Conditions, CloudCover, ImageQuality, SkyBackground, WaterVapor, Operator, Step, SequencesQueue, SequenceId}
@@ -13,7 +14,6 @@ import edu.gemini.seqexec.web.common.LogMessage._
 import org.scalajs.dom.ext.{Ajax, AjaxException}
 import org.scalajs.dom.XMLHttpRequest
 import scala.scalajs.js.URIUtils._
-import boopickle.Default._
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -25,7 +25,9 @@ import scalaz.syntax.show._
   * Encapsulates remote calls to the Seqexec Web API
   */
 @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.OptionPartial", "org.wartremover.warts.Throw"))
-object SeqexecWebClient extends ModelBooPicklers {
+object SeqexecWebClient {
+  import ModelBooPicklers._
+
   private val baseUrl = "/api/seqexec"
 
   // Decodes the binary response with BooPickle, errors are not handled

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/logback.xml
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/logback.xml
@@ -69,7 +69,6 @@
 
         <root level="DEBUG">
             <appender-ref ref="STDOUT" />
-            <appender-ref ref="logstash" />
         </root>
     </else>
   </if>

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -33,7 +33,8 @@ import scalaz.stream.{Exchange, Process}
 /**
   * Rest Endpoints under the /api route
   */
-class SeqexecUIApiRoutes(auth: AuthenticationService, events: (server.EventQueue, Topic[SeqexecEvent]), se: SeqexecEngine) extends BooEncoders with ModelBooPicklers with ModelLenses {
+class SeqexecUIApiRoutes(auth: AuthenticationService, events: (server.EventQueue, Topic[SeqexecEvent]), se: SeqexecEngine) extends BooEncoders with ModelLenses {
+  import ModelBooPicklers._
 
   // Logger for client messages
   private val clientLog = getLogger

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/test/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
@@ -36,7 +36,9 @@ import org.scalatest.{FlatSpec, Matchers, NonImplicitAssertions}
 import scala.concurrent.duration._
 
 @SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Equals", "org.wartremover.warts.OptionPartial"))
-class SeqexecUIApiRoutesSpec extends FlatSpec with Matchers with UriFunctions with ModelBooPicklers with StringSyntax with NonImplicitAssertions {
+class SeqexecUIApiRoutesSpec extends FlatSpec with Matchers with UriFunctions with StringSyntax with NonImplicitAssertions {
+  import ModelBooPicklers._
+
   private val config = AuthenticationConfig(devMode = true, Hours(8), "token", "abc", useSSL = false, LDAPConfig(Nil))
   private val engine = SeqexecEngine(SeqexecEngine.defaultSettings.copy(date = LocalDate.now))
   private val authService = AuthenticationService(config)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/commands.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared/src/main/scala/edu/gemini/seqexec/web/common/commands.scala
@@ -5,6 +5,7 @@ package edu.gemini.seqexec.web.common
 
 import boopickle.Default._
 import edu.gemini.seqexec.model.Model.StepConfig
+import edu.gemini.seqexec.model.ModelBooPicklers
 
 sealed trait CliCommand {
   def command: String
@@ -18,6 +19,8 @@ final case class SequenceConfig(command: String, error: Boolean, response: Strin
 final case class SequenceStatus(command: String, error: Boolean, response: String, steps: List[String]) extends CliCommand
 
 object CliCommand {
+  import ModelBooPicklers._
+
   // Pickler for the commands hierarchy
   @SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.OptionPartial","org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.Equals"))
   implicit val commandsPickler: boopickle.CompositePickler[CliCommand] = compositePickler[CliCommand]


### PR DESCRIPTION
I've been struggling with slow compilation times and very large generated js size. In particular the size of the unoptimized generated js means we spend a long time compiling  and creates issues to run it quickly on firefox. 

After some research I found one issue with how the macros and implicits for boopickle can lead to an explosion of generated code. Turns out that explicitly defining a couple of missing implicits and changing the order are helpful.

Thanks to this we went from:

| subject  |Before |After|
| ------------- | ------------- |---------|
| Generated classes  | 12K  | 200 |
| Unoptimized JS  | 39M  | 12M |
| Optimized JS | 5.9M | 3.2M |

This PR would alleviate a bit my problems but there are still optimizations to do on this area

A moral of the story is that simple details like the order of defining implicits especially when using macros can have bad effects even if the code compiles right

Also travis times has been reduced in about 2 minutesa