### PR TITLE
SEQNG-432: Status bar blocks last line of log

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -82,9 +82,15 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val queueListPane: StyleA = style (
-    maxHeight(15.45.em),
-    minHeight(15.45.em),
-    marginTop(0.px).important
+    marginTop(0.px).important,
+    media.only.screen.maxWidth(767.px)(
+      maxHeight(10.1.em),
+      minHeight(10.1.em)
+    ),
+    media.only.screen.minWidth(767.px)(
+      maxHeight(15.45.em),
+      minHeight(15.45.em)
+    )
   )
 
   val stepsListPane: StyleA = style (
@@ -326,7 +332,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     width(100.%%),
     marginBottom(0.px),
     marginTop(0.px),
-    backgroundColor(c"#F5F5F5")
+    backgroundColor(c"#F5F5F5"),
+    borderRadius.unset
   )
 
   val stepsTable: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -316,11 +316,16 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     )
   )
 
+  val logArea: StyleA = style(
+    marginBottom(3.em) // Matches the height of the footer
+  )
+
   val footerSegment: StyleA = style("ui.footer")(
     position.fixed,
     bottom(0.px),
     width(100.%%),
     marginBottom(0.px),
+    marginTop(0.px),
     backgroundColor(c"#F5F5F5")
   )
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -90,7 +90,8 @@ object SeqexecMain {
           ),
           <.div(
             ^.cls := "ui row",
-            SeqexecStyles.shorterRow,
+            // Add margin to avoid covering the footer
+            SeqexecStyles.logArea,
             logConnect(l => LogArea(p.site, l))
           )
         ),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -75,11 +75,11 @@ object SeqexecMain {
             ^.cls := "ui row",
             SeqexecStyles.shorterRow,
             <.div(
-              ^.cls := "ten wide column",
+              ^.cls := "sixteen wide mobile ten wide tablet ten wide computer column",
               QueueTableSection(p.ctl)
             ),
             <.div(
-              ^.cls := "six wide column",
+              ^.cls := "six wide column tablet computer only",
               headerSideBarConnect(HeadersSideBar.apply)
             )
           ),


### PR DESCRIPTION
The status bar can block part of the UI if the height of the screen is too low. This fixes that adding a border to the log area

Also in this PR there are some improvements on small sizes though there is still work to do on that area. It was tested on an iPad and iPhone 6s