### PR TITLE
SEQNG-445 SEQNG-446 Implemented stop and abort while paused for GMOS.

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/package.scala
@@ -395,7 +395,7 @@ package object engine {
     def handleSystemEvent(se: SystemEvent): HandleP[Unit] = se match {
       case Completed(id, i, r)     => Logger.debug("Engine: Action completed") *> complete(id, i, r)
       case PartialResult(id, i, r) => Logger.debug("Engine: Partial result") *> partialResult(id, i, r)
-      case Paused(id, i, r)           => Logger.debug("Engine: Action paused")  *> actionPause(id, i, r)
+      case Paused(id, i, r)        => Logger.debug("Engine: Action paused")  *> actionPause(id, i, r)
       case Failed(id, i, e)        => Logger.debug("Engine: Action failed") *> fail(id)(i, e)
       case Busy(id)                => Logger.debug("Engine: Resources needed for this sequence are in use")
       case Executed(id)            => Logger.debug("Engine: Execution completed") *> next(id)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
@@ -142,6 +142,8 @@ object ObserveCommand {
   object Paused extends Result
   object Stopped extends Result
   object Aborted extends Result
+
+  implicit val equal: Equal[Result] = Equal.equalA[Result]
 }
 
 object EpicsCodex {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/InstrumentSystem.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/InstrumentSystem.scala
@@ -23,9 +23,13 @@ object InstrumentSystem {
   final case class StopObserveCmd(self: SeqAction[Unit]) extends AnyVal
   final case class AbortObserveCmd(self: SeqAction[Unit]) extends AnyVal
   final case class PauseObserveCmd(self: SeqAction[Unit]) extends AnyVal
-  final case class ContinueObserveCmd(self: SeqAction[ObserveCommand.Result]) extends AnyVal
+  final case class ContinuePausedCmd(self: SeqAction[ObserveCommand.Result]) extends AnyVal
+  final case class StopPausedCmd(self: SeqAction[ObserveCommand.Result]) extends AnyVal
+  final case class AbortPausedCmd(self: SeqAction[ObserveCommand.Result]) extends AnyVal
   final case class Controllable(stop: StopObserveCmd,
                                 abort: AbortObserveCmd,
                                 pause: PauseObserveCmd,
-                                continue: ContinueObserveCmd) extends ObserveControl
+                                continue: ContinuePausedCmd,
+                                stopPaused: StopPausedCmd,
+                                abortPaused: AbortPausedCmd) extends ObserveControl
 }

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -133,11 +133,11 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
     }
 
   def stopObserve(q: EventQueue, seqId: SPObservationID): Task[Unit] = q.enqueueOne(
-    Event.actionStop(seqId.stringValue, translator.stopObserve)
+    Event.actionStop(seqId.stringValue, translator.stopObserve(seqId.stringValue))
   )
 
   def abortObserve(q: EventQueue, seqId: SPObservationID): Task[Unit] = q.enqueueOne(
-    Event.actionStop(seqId.stringValue, translator.abortObserve)
+    Event.actionStop(seqId.stringValue, translator.abortObserve(seqId.stringValue))
   )
 
   def pauseObserve(q: EventQueue, seqId: SPObservationID): Task[Unit] = q.enqueueOne(
@@ -145,7 +145,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
   )
 
   def resumeObserve(q: EventQueue, seqId: SPObservationID): Task[Unit] = q.enqueueOne(
-    Event.getSeqState(seqId.stringValue, translator.resumeObserve(seqId.stringValue))
+    Event.getSeqState(seqId.stringValue, translator.resumePaused(seqId.stringValue))
   )
 
   private def notifyODB(i: (Event, Engine.State)): Task[(Event, Engine.State)] = {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/Gmos.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/Gmos.scala
@@ -38,7 +38,9 @@ abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosContro
     StopObserveCmd(controller.stopObserve),
     AbortObserveCmd(controller.abortObserve),
     PauseObserveCmd(controller.pauseObserve),
-    ContinueObserveCmd(controller.resumeObserve)
+    ContinuePausedCmd(controller.resumePaused),
+    StopPausedCmd(controller.stopPaused),
+    AbortPausedCmd(controller.abortPaused)
   )
 
   val Log: Logger = getLogger

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosController.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosController.scala
@@ -39,7 +39,12 @@ trait GmosController[T<:GmosController.SiteDependentTypes] {
 
   def pauseObserve: SeqAction[Unit]
 
-  def resumeObserve: SeqAction[ObserveCommand.Result]
+  def resumePaused: SeqAction[ObserveCommand.Result]
+
+  def stopPaused: SeqAction[ObserveCommand.Result]
+
+  def abortPaused: SeqAction[ObserveCommand.Result]
+
 }
 
 object GmosController {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerSim.scala
@@ -77,11 +77,23 @@ private class GmosControllerSim[T<:SiteDependentTypes](name: String) extends Gmo
     TrySeq(())
   } )
 
-  override def resumeObserve: SeqAction[ObserveCommand.Result] = EitherT( Task {
+  override def resumePaused: SeqAction[ObserveCommand.Result] = EitherT( Task {
       Log.debug(s"Simulate resuming Gmos $name observation")
       pauseFlag.set(false)
       observeTic(false, false, false, 5000)
     } )
+
+  override def stopPaused: SeqAction[ObserveCommand.Result] = EitherT( Task {
+    Log.debug(s"Simulate stopping Gmos $name paused observation")
+    pauseFlag.set(false)
+    observeTic(true, false, false, 1000)
+  } )
+
+  override def abortPaused: SeqAction[ObserveCommand.Result] = EitherT( Task {
+    Log.debug(s"Simulate aborting Gmos $name paused observation")
+    pauseFlag.set(false)
+    observeTic(false, true, false, 5000)
+  } )
 }
 
 object GmosControllerSim {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosEpics.scala
@@ -70,24 +70,38 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::pause"))
   }
 
+  private val stopCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::stop"))
+  private val observeAS: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::observeCmd",
+      GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
+
   object continueCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::continue"))
-    override protected val os: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::continueCmd",
-      GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
+    override protected val os: Option[CaApplySender] = observeAS
   }
 
   object stopCmd extends EpicsCommand {
-    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::stop"))
+    override protected val cs: Option[CaCommandSender] = stopCS
   }
 
+  object stopAndWaitCmd extends ObserveCommand {
+    override protected val cs: Option[CaCommandSender] = stopCS
+    override protected val os: Option[CaApplySender] = observeAS
+  }
+
+  private val abortCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::abort"))
+
   object abortCmd extends EpicsCommand {
-    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::abort"))
+    override protected val cs: Option[CaCommandSender] = abortCS
+  }
+
+  object abortAndWait extends ObserveCommand {
+    override protected val cs: Option[CaCommandSender] = abortCS
+    override protected val os: Option[CaApplySender] = observeAS
   }
 
   object observeCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::observe"))
-    override protected val os: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::observeCmd",
-      GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
+    override protected val os: Option[CaApplySender] = observeAS
 
     val label: Option[CaParameter[String]] = cs.map(_.getString("label"))
     def setLabel(v: String): SeqAction[Unit] = setParameter(label, v)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -94,9 +94,9 @@ object StepsControlButtons {
           case PauseObservation            =>
             Button(Button.Props(icon = Some(IconPause), color = Some("teal"), dataTooltip = Some("Pause the current exposure"), onClick = $.runState(handleObsPause(p.id, p.step.id))))
           case StopObservation             =>
-            Button(Button.Props(icon = Some(IconStop), color = Some("orange"), dataTooltip = Some("Stop the current exposure early"), disabled = s.stopRequested || SequenceState.internalStopRequested(p.sequenceState), onClick = $.runState(handleStop(p.id, p.step.id))))
+            Button(Button.Props(icon = Some(IconStop), color = Some("orange"), dataTooltip = Some("Stop the current exposure early"), onClick = $.runState(handleStop(p.id, p.step.id))))
           case AbortObservation            =>
-            Button(Button.Props(icon = Some(IconTrash), color = Some("red"), dataTooltip = Some("Abort the current exposure"), disabled = s.stopRequested || SequenceState.internalStopRequested(p.sequenceState), onClick = $.runState(handleAbort(p.id, p.step.id))))
+            Button(Button.Props(icon = Some(IconTrash), color = Some("red"), dataTooltip = Some("Abort the current exposure"), onClick = $.runState(handleAbort(p.id, p.step.id))))
           case ResumeObservation           =>
             Button(Button.Props(icon = Some(IconPlay), color = Some("blue"), dataTooltip = Some("Resume the current exposure"), onClick = $.runState(handleObsResume(p.id, p.step.id))))
           // Hamamatsu operations


### PR DESCRIPTION
The Stop and Abort normally work by having the Observe Action running and monitoring certain EPICS channels, while the Stop (or Abort) command is sent in a concurrent thread. The Observe Action detects that an EPICS command was executed, and when the observation ends, it finishes with a proper result.
This changes when the Observe is paused. In that case, the Observe Action stops running, and finishes with a Paused result. The Stop and Abort resume the action providing a continuation Task. The Task sends the EPICS command and monitors some EPICS channels to detect when the observation ends.
The functionality was tested with the real instrument.
  