### PR TITLE
SEQNG-437: Shorten web page

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -144,7 +144,7 @@ object LogArea {
             "No log entries"
           ),
         overscanRowCount = 10,
-        height = 300,
+        height = 200,
         rowCount = p.rowCount(s),
         rowHeight = 30,
         rowClassName = rowClassName(s) _,

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -94,8 +94,13 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val stepsListPane: StyleA = style (
-    maxHeight(24.3.em),
-    minHeight(24.3.em)
+    (maxHeight :=! "calc(100vh - 52.5em)"),
+    minHeight(21.3.em)
+  )
+
+  val stepsListPaneWithControls: StyleA = style (
+    (maxHeight :=! "calc(100vh - 55.5em)"),
+    minHeight(18.1.em)
   )
 
   val stepsListBody: StyleA = style() // Marker css
@@ -142,7 +147,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val emptyInstrumentTab: StyleA = style(
-    minHeight(31.8.em)
+    (maxHeight :=! "calc(100vh - 48.1em)"),
+    minHeight(25.7.em)
   )
 
   val instrumentTab: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -98,6 +98,10 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     minHeight(21.3.em)
   )
 
+  val instrumentTabSegment: StyleA = style (
+    (minHeight :=! "calc(100vh - 48.2em)"),
+  )
+
   val stepsListPaneWithControls: StyleA = style (
     (maxHeight :=! "calc(100vh - 55.5em)"),
     minHeight(18.1.em)
@@ -146,10 +150,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     marginBottom(-1.em).important
   )
 
-  val emptyInstrumentTab: StyleA = style(
-    (maxHeight :=! "calc(100vh - 48.1em)"),
-    minHeight(25.7.em)
-  )
+  val emptyInstrumentTab: StyleA = style()
 
   val instrumentTab: StyleA = style(
     minWidth(20.%%),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -99,7 +99,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val instrumentTabSegment: StyleA = style (
-    (minHeight :=! "calc(100vh - 48.2em)"),
+    (height :=! "calc(100vh - 48.2em)"),
+    minHeight(25.4.em)
   )
 
   val stepsListPaneWithControls: StyleA = style (

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -85,6 +85,7 @@ object SequenceTabContent {
         ),
         dataTab := instrument.shows,
         SeqexecStyles.emptyInstrumentTab.unless(sequenceSelected),
+        SeqexecStyles.instrumentTabSegment,
         IconMessage(IconMessage.Props(IconInbox, Some("No sequence loaded"), IconMessage.Style.Warning)).unless(sequenceSelected),
         p.connect(st => SequenceStepsTableContainer(p.router, p.site, st)).when(sequenceSelected)
       )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -423,7 +423,8 @@ object StepsTableContainer {
     def render(p: Props, s: State): VdomTagOf[Div] = {
       <.div(
         ^.cls := "ui row scroll pane",
-        SeqexecStyles.stepsListPane,
+        SeqexecStyles.stepsListPaneWithControls.when(p.status.isLogged),
+        SeqexecStyles.stepsListPane.unless(p.status.isLogged),
         //^.ref := scrollRef,
         p.steps.whenDefined { tab =>
           tab.stepConfigDisplayed.map { i =>


### PR DESCRIPTION
There is a request to make the page fit on the console ops without a scroll bar. this PR does it by manipulating the css through some magic and reducing the height of the log area. This is how it looks on the consoles:

![screenshot 2018-01-03 14 09 58](https://user-images.githubusercontent.com/3615303/34582826-18b8d744-f174-11e7-8fe9-50d45996c2d3.png)

And on the emulator with some notes:
![screenshot 2018-01-04 17 17 31](https://user-images.githubusercontent.com/3615303/34582894-549360f4-f174-11e7-82ed-fe17409f071d.png)

This change has a drawback on larger screen as it wastes space. So the central part with the steps will grow and shrink (to some extent) on window changes. This can be appreciated on the following video

https://monosnap.com/file/0UVbfezmevwrpOOsdj9b6FzRPjyZiZ