### PR TITLE
SEQNG-392: Disable the creation of source maps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,8 +152,8 @@ lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seq
     npmDevDependencies in Compile += "uglifyjs-webpack-plugin" -> LibraryVersions.uglifyJs,
     // Use a different Webpack configuration file for production and create a single bundle without source maps
     webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.config.js"),
-    emitSourceMaps in fullOptJS := false,
-    emitSourceMaps in Test := false,
+    webpackEmitSourceMaps := false,
+    emitSourceMaps := false,
     // Requires the DOM for tests
     requiresDOM in Test := true,
     // Disable tests to speed up builds


### PR DESCRIPTION
While source maps are theoretically useful in practice I never use them and introduce a non trivial delay on compilation. it reduced the client cold build from 100s  to 70s

This PR will disable source maps in all cases