### PR TITLE
SEQNG-483: Sort session queue

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -406,7 +406,7 @@ object SeqexecEngine {
   private val taskUnit = Task.now(())
 
   // scalastyle:off
-  def seqexecConfiguration: Kleisli[Task, Config, Settings] = Kleisli { cfg: Config => {
+  def seqexecConfiguration: Kleisli[Task, Config, Settings] = Kleisli { cfg: Config =>
     val site = cfg.require[String]("seqexec-engine.site") match {
       case "GS" => Site.GS
       case "GN" => Site.GN
@@ -493,7 +493,7 @@ object SeqexecEngine {
                        odbQueuePollingInterval)
       )
 
-    }
+
   }
   // scalastyle:on
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/circuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/circuit.scala
@@ -19,6 +19,8 @@ import edu.gemini.seqexec.web.client.actions.{OpenLoginBox, CloseLoginBox, OpenR
 
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
+import scalaz.Order
+import scalaz.std.AllInstances._
 import scalaz.syntax.equal._
 
 object circuit {
@@ -35,6 +37,10 @@ object circuit {
   // UI even if other parts of the root model change
   final case class WebSocketsFocus(sequences: LoadedSequences, user: Option[UserDetails], site: Option[SeqexecSite], firstLoad: Boolean) extends UseValueEq
   final case class SequenceInQueue(id: SequenceId, status: SequenceState, instrument: Instrument, active: Boolean, name: String, targetName: Option[TargetName], runningStep: Option[(Int, Int)]) extends UseValueEq
+  object SequenceInQueue {
+    implicit val order: Order[SequenceInQueue] = Order.orderBy(_.id)
+    implicit val ordering: scala.math.Ordering[SequenceInQueue] = order.toScalaOrdering
+  }
   final case class StatusAndLoadedSequencesFocus(isLogged: Boolean, sequences: List[SequenceInQueue]) extends UseValueEq
   final case class HeaderSideBarFocus(status: ClientStatus, conditions: Conditions, operator: Option[Operator]) extends UseValueEq
   final case class InstrumentStatusFocus(instrument: Instrument, active: Boolean, idState: Option[(SequenceId, SequenceState)], runningStep: Option[(Int, Int)]) extends UseValueEq
@@ -79,7 +85,7 @@ object circuit {
           val targetName = firstScienceStepTargetNameT.headOption(s)
           SequenceInQueue(s.id, s.status, s.metadata.instrument, active, s.metadata.name, targetName, s.runningStep)
         }
-        StatusAndLoadedSequencesFocus(c.uiModel.user.isDefined, sequencesInQueue)
+        StatusAndLoadedSequencesFocus(c.uiModel.user.isDefined, sequencesInQueue.sorted)
       }
 
     // Reader for sequences on display


### PR DESCRIPTION
This PR will display the queue sorted by the sequence id. Before it was backed by a map keys, thus sorting was undefined

The changes as purely front end as there isn't much benefit on having the list sorted on the backend

![screenshot 2018-01-18 10 42 00](https://user-images.githubusercontent.com/3615303/35100936-63784d5a-fc3c-11e7-9462-6cf45108fead.png)
