### PR TITLE
SEQNG-486 Case insensitive comparison of current and required disperser

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerEpics.scala
@@ -133,8 +133,8 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
     val disperser = encoders.disperser.encode(d.disperser)
     def disperserModeDecode(v : Int): String = if(v===0) disperserMode0 else disperserMode1
 
-    smartSetParam(disperser, GmosEpics.instance.disperser, CC.setDisperser(disperser)) *>
-      smartSetParam( disperserMode0, GmosEpics.instance.disperserMode.map(disperserModeDecode), CC.setDisperserMode(disperserMode0)) *>
+    smartSetParam(disperser.toUpperCase, GmosEpics.instance.disperser.map(_.toUpperCase), CC.setDisperser(disperser)) *>
+      smartSetParam(disperserMode0, GmosEpics.instance.disperserMode.map(disperserModeDecode), CC.setDisperserMode(disperserMode0)) *>
       d.order.filter(_ => d.disperser != Disperser.MIRROR).fold(SeqAction.void)(o =>
         smartSetParam(disperserOrderEncoderInt.encode(o), GmosEpics.instance.disperserOrder, CC.setDisperserOrder(disperserOrderEncoder.encode(o)))) *>
       d.lambda.filter(_ => d.disperser != Disperser.MIRROR && !d.order.contains(Order.ZERO)).fold(SeqAction.void)(o =>


### PR DESCRIPTION
This is to fix an issue with Seqexec always configuring the grating when position was mirror, because the requested position was all lower case, while the status value was all upper case.