### PR TITLE
SEQNG-504: Show breakpoints in steps to be skipped in a disabled state

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -271,6 +271,13 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     borderBottom.none
   )
 
+  val breakpointTrOnSkipped: StyleA = style(
+    height(4.px),
+    backgroundColor(c"#767676"), // Match semantic UI grey
+    borderTop.none.important,
+    borderBottom.none
+  )
+
   val breakpointTrOff: StyleA = style(
     height(0.px),
     backgroundColor(lightgray),
@@ -315,6 +322,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     borderRight(1.px, solid, rgba(34,36,38,0.1)).important
   )
 
+  // used as a reference, don't delete
   val trBreakpoint: StyleA = style()
   // This defines the hover for the gutter
   //SeqexecStyles-trNoBorder:hover > td:first-child {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -260,7 +260,11 @@ object StepsTableContainer {
           )
         ),
         <.td(
-          if (step.breakpoint) SeqexecStyles.breakpointTrOn else SeqexecStyles.breakpointTrOff,
+          (step.breakpoint, step.skip) match {
+            case (true, true) => SeqexecStyles.breakpointTrOnSkipped
+            case (true, _)    => SeqexecStyles.breakpointTrOn
+            case _            => SeqexecStyles.breakpointTrOff
+          },
           SeqexecStyles.tdNoPadding,
           ^.colSpan := 11
         )


### PR DESCRIPTION
This PR shows breakpoints on skipped states as gray instead of brown, as:

![screenshot 2018-01-29 12 04 47](https://user-images.githubusercontent.com/3615303/35517548-8b439e52-04ed-11e8-82c5-f90c6e98ef43.png)
