### PR TITLE
SEQNG-451 Log error messages from failed actions.

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -38,7 +38,10 @@ object Event {
   def getSeqState(id: Sequence.Id, f: (Sequence.State) => Option[Process[Task, Event]]): Event = EventUser(GetSeqState(id, f))
   def actionStop(id: Sequence.Id, f: (Sequence.State) => Option[Process[Task, Event]]): Event = EventUser(ActionStop(id, f))
   def actionResume(id: Sequence.Id, i: Int, c: Task[Result]): Event = EventUser(ActionResume(id, i, c))
-  def logMsg(msg: String): Event = EventUser(Log(msg))
+  def logDebugMsg(msg: String): Event = EventUser(LogDebug(msg))
+  def logInfoMsg(msg: String): Event = EventUser(LogInfo(msg))
+  def logWarningMsg(msg: String): Event = EventUser(LogWarning(msg))
+  def logErrorMsg(msg: String): Event = EventUser(LogError(msg))
 
   def failed(id: Sequence.Id, i: Int, e: Result.Error): Event = EventSystem(Failed(id, i, e))
   def completed[R<:Result.RetVal](id: Sequence.Id, i: Int, r: Result.OK[R]): Event = EventSystem(Completed(id, i, r))

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/UserEvent.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/UserEvent.scala
@@ -64,6 +64,19 @@ final case class ActionResume(id: Sequence.Id, i: Int, cont: Task[Result]) exten
   val user: Option[UserDetails] = None
 }
 
-final case class Log(msg: String) extends UserEvent {
+final case class LogDebug(msg: String) extends UserEvent {
   val user: Option[UserDetails] = None
 }
+
+final case class LogInfo(msg: String) extends UserEvent {
+  val user: Option[UserDetails] = None
+}
+
+final case class LogWarning(msg: String) extends UserEvent {
+  val user: Option[UserDetails] = None
+}
+
+final case class LogError(msg: String) extends UserEvent {
+  val user: Option[UserDetails] = None
+}
+

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelBooPicklers.scala
@@ -123,7 +123,6 @@ object ModelBooPicklers {
     .addConcreteType[SequencePaused]
     .addConcreteType[ExposurePaused]
     .addConcreteType[ResourcesBusy]
-    .addConcreteType[NewLogMessage]
     .addConcreteType[ServerLogMessage]
     .addConcreteType[NullEvent.type]
 

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/BoopicklingSpec.scala
@@ -90,10 +90,6 @@ class BoopicklingSpec extends FlatSpec with Matchers with PropertyChecks {
       // events
       testPickleUnpickle[ExposurePaused]
     }
-    it should "pickle/depickle NewLogMessage" in {
-      // events
-      testPickleUnpickle[NewLogMessage]
-    }
     it should "pickle/depickle SequencesQueue[SequenceId]" in {
       // events
       testPickleUnpickle[SequencesQueue[SequenceId]]

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/SharedModelArbitraries.scala
@@ -49,7 +49,6 @@ object SharedModelArbitraries {
   implicit val speArb = implicitly[Arbitrary[SequencePauseRequested]]
   implicit val spcArb = implicitly[Arbitrary[SequencePauseCanceled]]
   implicit val asrArb = implicitly[Arbitrary[ActionStopRequested]]
-  implicit val lmArb  = implicitly[Arbitrary[NewLogMessage]]
   implicit val slmArb = implicitly[Arbitrary[ServerLogMessage]]
   implicit val neArb  = implicitly[Arbitrary[NullEvent.type]]
   implicit val opArb  = implicitly[Arbitrary[OperatorUpdated]]

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -238,7 +238,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     seqState,
     toInstrumentSys(seqState.toSequence.metadata.instrument).toOption.flatMap(_.observeControl match {
       case Controllable(StopObserveCmd(stop), _, _, _, _, _) => Some(Process.eval(stop.run.map{
-        case -\/(e) => Event.logMsg(SeqexecFailure.explain(e))
+        case -\/(e) => Event.logErrorMsg(SeqexecFailure.explain(e))
         case _      => Event.nullEvent
       }))
       case _                                                 => none
@@ -249,7 +249,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     seqState,
     toInstrumentSys(seqState.toSequence.metadata.instrument).toOption.flatMap(_.observeControl match {
       case Controllable(_, AbortObserveCmd(abort), _, _, _, _) => Some(Process.eval(abort.run.map{
-        case -\/(e) => Event.logMsg(SeqexecFailure.explain(e))
+        case -\/(e) => Event.logErrorMsg(SeqexecFailure.explain(e))
         case _      => Event.nullEvent
       }))
       case _                                                   => none
@@ -259,7 +259,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
   def pauseObserve(seqState: Sequence.State): Option[Process[Task, Event]] = deliverObserveCmd( seqState,
     toInstrumentSys(seqState.toSequence.metadata.instrument).toOption.flatMap(_.observeControl match {
       case Controllable(_, _, PauseObserveCmd(pause), _, _, _) => Some(Process.eval(pause.run.map{
-        case -\/(e) => Event.logMsg(SeqexecFailure.explain(e))
+        case -\/(e) => Event.logErrorMsg(SeqexecFailure.explain(e))
         case _      => Event.nullEvent
       }))
       case _                                                   => none


### PR DESCRIPTION
Also, errors while loading sequences are now logged as warnings, and errors in the observe commands are logged as errors.