### PR TITLE
SEQNG-518 Implemented workaround for non-compliant CAR in GEM5 systems.

### DIFF
--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaCarRecord.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaCarRecord.java
@@ -15,7 +15,7 @@ import gov.aps.jca.TimeoutException;
 
 import java.util.logging.Logger;
 
-final class CaCarRecord {
+final class CaCarRecord<C extends Enum<C> & CarStateGeneric> {
     private static final Logger LOG = Logger.getLogger(CaCarRecord.class
             .getName());
 
@@ -25,15 +25,17 @@ final class CaCarRecord {
 
     private final String epicsName;
     private EpicsReader epicsReader;
+    private Class<C> carClass;
     private ReadOnlyClientEpicsChannel<Integer> clid;
-    private ReadOnlyClientEpicsChannel<CarState> val;
+    private ReadOnlyClientEpicsChannel<C> val;
     private ReadOnlyClientEpicsChannel<String> omss;
 
     private ChannelListener<Integer> clidListener;
-    private ChannelListener<CarState> valListener;
+    private ChannelListener<C> valListener;
 
-    CaCarRecord(String epicsName, EpicsService epicsService) {
+    CaCarRecord(String epicsName, Class<C> carClass, EpicsService epicsService) {
         this.epicsName = epicsName;
+        this.carClass = carClass;
         epicsReader = new EpicsReaderImpl(epicsService);
 
         updateChannels();
@@ -49,7 +51,7 @@ final class CaCarRecord {
             LOG.warning(e.getMessage());
         }
         try {
-            val = epicsReader.getEnumChannel(epicsName + CAR_VAL_SUFFIX, CarState.class);
+            val = epicsReader.getEnumChannel(epicsName + CAR_VAL_SUFFIX, carClass);
             if(valListener!=null) {
                 val.registerListener(valListener);
             }
@@ -112,21 +114,21 @@ final class CaCarRecord {
         clidListener = null;
     }
 
-    void registerValListener(ChannelListener<CarState> listener) throws CAException {
+    void registerValListener(ChannelListener<C> listener) throws CAException {
         if(val!=null) {
             val.registerListener(listener);
         }
         valListener = listener;
     }
 
-    void unregisterValListener(ChannelListener<CarState> listener) throws CAException {
+    void unregisterValListener(ChannelListener<C> listener) throws CAException {
         if(val!=null) {
             val.unRegisterListener(listener);
         }
         valListener = null;
     }
 
-    CarState getValValue() throws CAException, TimeoutException {
+    C getValValue() throws CAException, TimeoutException {
         return val.getFirst();
     }
 

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaCommandSenderTest.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaCommandSenderTest.java
@@ -11,15 +11,15 @@ import gov.aps.jca.CAException;
 import gov.aps.jca.TimeoutException;
 
 public final class CaCommandSenderTest {
-    private static final Logger LOG = Logger.getLogger(CaCommandSenderTest.class.getName()); 
+    private static final Logger LOG = Logger.getLogger(CaCommandSenderTest.class.getName());
 
-    
+
     public static void main(String[] args) throws CAException {
         CaService.setAddressList("172.16.2.20");
         CaService service = CaService.getInstance();
 
         CaApplySender apply;
-        apply = service.createApplySender("apply", "tc1:apply", "tc1:applyC");
+        apply = service.createApplySender("apply", "tc1:apply", "tc1:applyC", false);
 
         CaCommandSender cs = service.createCommandSender("sourceA", apply, null);
         try {
@@ -30,12 +30,12 @@ public final class CaCommandSenderTest {
             parCoord1.set(Double.toString(Math.random() * 360.0));
             parCoord2.set(Double.toString(Math.random() * 50.0 + 30.0));
             CaCommandMonitor cm = cs.postCallback(new CaCommandListener() {
-                
+
                 @Override
                 public void onSuccess() {
                     System.out.println("Command completed successfully.");
                 }
-                
+
                 @Override
                 public void onFailure(Exception cause) {
                     System.out.println("Command completed with error " + cause.getMessage());

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -31,7 +31,7 @@ import gov.aps.jca.CAException;
  * The method <code>unbind()</code> must be called to stop the service. Failing
  * to do it will keep the application running. References to the CaService must
  * not be used once <code>unbind()</code> has been called.
- * 
+ *
  * @author jluhrs
  *
  */
@@ -65,7 +65,7 @@ public final class CaService {
 
     /**
      * Sets the list of IP addresses used to discover EPICS channels.
-     * 
+     *
      * @param addrList
      *            the list of IP addresses used to discover EPICS channels.
      */
@@ -75,7 +75,7 @@ public final class CaService {
 
     /**
      * Retrieves the CaService single instance.
-     * 
+     *
      * @return the single instance of CaService.
      */
     public static CaService getInstance() {
@@ -119,7 +119,7 @@ public final class CaService {
     /**
      * Creates a status acceptor. If the status acceptor already exists, it
      * returns the existing object.
-     * 
+     *
      * @param name
      *            the name of the new status acceptor.
      * @param description
@@ -142,7 +142,7 @@ public final class CaService {
 
     /**
      * Retrieves an existing status acceptor.
-     * 
+     *
      * @param name
      *            the name of the status acceptor.
      * @return the status acceptor, or <code>null</code> if it does not exist.
@@ -154,7 +154,7 @@ public final class CaService {
     /**
      * Creates an apply sender. If the apply sender already exists, it returns
      * the existing object.
-     * 
+     *
      * @param name
      *            the name of the new apply sender.
      * @param applyRecord
@@ -167,19 +167,25 @@ public final class CaService {
      * @throws CAException
      */
     public CaApplySender createApplySender(String name, String applyRecord,
-            String carRecord, String description) throws CAException {
+            String carRecord, Boolean gem5, String description) throws CAException {
         CaApplySenderImpl apply = applySenders.get(name);
         if (apply == null) {
-            apply = new CaApplySenderImpl(name, applyRecord, carRecord,
-                    description, epicsService);
+            if(gem5) {
+                apply = new CaApplySenderImpl<>(name, applyRecord, carRecord,
+                        description, CarStateGEM5.class, epicsService);
+            }
+            else {
+                apply = new CaApplySenderImpl<>(name, applyRecord, carRecord,
+                        description, CarState.class, epicsService);
+            }
             applySenders.put(name, apply);
         }
         return apply;
     }
 
     public CaApplySender createApplySender(String name, String applyRecord,
-            String carRecord) throws CAException {
-        return createApplySender(name, applyRecord, carRecord, null);
+            String carRecord, Boolean gem5) throws CAException {
+        return createApplySender(name, applyRecord, carRecord, gem5, null);
     }
 
     /**
@@ -198,24 +204,30 @@ public final class CaService {
      * @throws CAException
      */
     public CaApplySender createObserveSender(String name, String applyRecord,
-            String carRecord, String observeCarRecord, String stopCmdRecord, String abortCmdRecord, String description) throws CAException {
+            String carRecord, String observeCarRecord, Boolean gem5, String stopCmdRecord, String abortCmdRecord, String description) throws CAException {
         CaObserveSenderImpl observe = observeSenders.get(name);
         if (observe == null) {
-            observe = new CaObserveSenderImpl(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
-                    description, epicsService);
+            if(gem5) {
+                observe = new CaObserveSenderImpl(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
+                        description, CarStateGEM5.class, epicsService);
+            }
+            else  {
+                observe = new CaObserveSenderImpl(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
+                        description, CarState.class, epicsService);
+            }
             observeSenders.put(name, observe);
         }
         return observe;
     }
 
     public CaApplySender createObserveSender(String name, String applyRecord,
-            String carRecord, String observeCarRecord) throws CAException {
-        return createObserveSender(name, applyRecord, carRecord, observeCarRecord, null, null, null);
+            String carRecord, String observeCarRecord, Boolean gem5) throws CAException {
+        return createObserveSender(name, applyRecord, carRecord, observeCarRecord, gem5, null, null, null);
     }
 
     /**
      * Retrieves an existing apply sender.
-     * 
+     *
      * @param name
      *            the name of the apply sender.
      * @return the apply sender, or <code>null</code> if it does not exist.
@@ -227,7 +239,7 @@ public final class CaService {
     /**
      * Creates an command sender. If the command sender already exists, it
      * returns the existing object.
-     * 
+     *
      * @param name
      *            the name of the new command sender.
      * @param apply
@@ -257,7 +269,7 @@ public final class CaService {
 
     /**
      * Retrieves an existing command sender.
-     * 
+     *
      * @param name
      *            the name of the command sender.
      * @return the command sender, or <code>null</code> if it does not exist.
@@ -268,7 +280,7 @@ public final class CaService {
 
     /**
      * Retrieves the names of all existing command senders
-     * 
+     *
      * @return a set of all the command sender names.
      */
     public ImmutableSet<String> getCommandSenderNames() {
@@ -277,7 +289,7 @@ public final class CaService {
 
     /**
      * Retrieves the names of all existing apply senders
-     * 
+     *
      * @return a set of all the command sender names.
      */
     public ImmutableSet<String> getApplySenderNames() {
@@ -286,7 +298,7 @@ public final class CaService {
 
     /**
      * Retrieves the names of all existing status acceptors
-     * 
+     *
      * @return a set of all the status acceptors names.
      */
     public ImmutableSet<String> getStatusAcceptorsNames() {
@@ -296,7 +308,7 @@ public final class CaService {
     /**
      * Destroys a command sender with a given name. If the command sender does
      * not exists, it does nothing.
-     * 
+     *
      * @param name the name of the command sender to destroy.
      */
     public void destroyCommandSender(String name) {
@@ -309,7 +321,7 @@ public final class CaService {
     /**
      * Destroys a apply sender with a given name. If the apply sender does
      * not exists, it does nothing.
-     * 
+     *
      * @param name the name of the apply sender to destroy.
      */
     public void destroyApplySender(String name) {
@@ -322,7 +334,7 @@ public final class CaService {
     /**
      * Destroys a status acceptor with a given name. If the status acceptor does
      * not exists, it does nothing.
-     * 
+     *
      * @param name the name of the status acceptor to destroy.
      */
     public void destroyStatusAcceptor(String name) {

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CarStateGEM5.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CarStateGEM5.java
@@ -5,8 +5,8 @@
 
 package edu.gemini.epics.acm;
 
-public enum CarState implements CarStateGeneric {
-    IDLE, PAUSED, BUSY, ERROR;
+public enum CarStateGEM5 implements CarStateGeneric {
+    IDLE, PAUSED, BUSY, ERR;
 
     @Override
     public Boolean isIdle() {
@@ -25,6 +25,6 @@ public enum CarState implements CarStateGeneric {
 
     @Override
     public Boolean isError() {
-        return this == ERROR;
+        return this == ERR;
     }
 }

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CarStateGeneric.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CarStateGeneric.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package edu.gemini.epics.acm;
+
+public interface CarStateGeneric {
+    Boolean isIdle();
+    Boolean isPaused();
+    Boolean isBusy();
+    Boolean isError();
+}

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/XMLBuilder.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/XMLBuilder.java
@@ -25,22 +25,22 @@ import gov.aps.jca.CAException;
  * Class XMLBuilder builds Command Senders and Status Acceptors, retrieving
  * their parameter definitions from a XML configuration file. It builds the
  * Apply Senders required by the Command Senders automatically.
- * 
+ *
  * The format of the XML configuration file is defined in file CaSchema.xsd.
- * 
+ *
  * The prefix of each EPICS channel name defined in the XML configuration file
  * is defined by one of multiple Top element. All the attributes of a Status
  * Acceptor share the same Top. All the parameters of a Command Sender share the
  * same Top, which is the same used by its associated Apply Sender.
- * 
+ *
  * This class follows the Builder pattern. Configuration methods can be chained.
- * 
+ *
  * @author jluhrs
  *
  */
 public final class XMLBuilder {
-    
-    private static final Logger LOG = Logger.getLogger(XMLBuilder.class.getName()); 
+
+    private static final Logger LOG = Logger.getLogger(XMLBuilder.class.getName());
 
     private static final String CONFIG_SCHEMA_FILE = "/CaSchema.xsd";
     private static final String XMLSCHEMA_URL = "http://www.w3.org/2001/XMLSchema";
@@ -53,7 +53,7 @@ public final class XMLBuilder {
 
     /**
      * Loads the Command Senders and Status Acceptors definitions from a file.
-     * 
+     *
      * @param fileName
      *            the file name.
      * @return this XMLBuilder object.
@@ -65,7 +65,7 @@ public final class XMLBuilder {
 
     /**
      * Loads the Command Senders and Status Acceptors from a data stream.
-     * 
+     *
      * @param iStream
      *            the data stream.
      * @return this XMLBuilder object.
@@ -94,7 +94,7 @@ public final class XMLBuilder {
     /**
      * Sets the CaService to use for building Command Senders and Status
      * Acceptors
-     * 
+     *
      * @param service
      *            the CaService.
      * @return this XMLBuilder object.
@@ -108,7 +108,7 @@ public final class XMLBuilder {
      * Sets the value of a named Top, used as a prefix for the EPICS channels
      * names of Command Senders and Status Acceptors created subsequently. If
      * the named Top already exists, its value is overwritten.
-     * 
+     *
      * @param top
      *            the name of the Top.
      * @param value
@@ -122,7 +122,7 @@ public final class XMLBuilder {
 
     /**
      * Creates a specific Command Sender, using the current configuration.
-     * 
+     *
      * @param commandName
      *            the name of the Command Sender
      * @return the Command Sender, or <code>null</code> if it could not be
@@ -142,7 +142,7 @@ public final class XMLBuilder {
 
     /**
      * Creates a specific Status Acceptor, using the current configuration.
-     * 
+     *
      * @param statusName
      *            the name of the Status Acceptor
      * @return the Status Acceptor, or <code>null</code> if it could not be
@@ -192,6 +192,7 @@ public final class XMLBuilder {
                 apply = service.createApplySender(applyDef.getName(),
                         tops.get(applyDef.getTop()) + applyDef.getApply(),
                         tops.get(applyDef.getTop()) + applyDef.getCar(),
+                        applyDef.isGem5() != null && applyDef.isGem5(),
                         applyDef.getDescription());
             } catch (CAException e) {
                 apply = null;

--- a/modules/edu.gemini.epics.acm/src/main/resources/CaSchema.xsd
+++ b/modules/edu.gemini.epics.acm/src/main/resources/CaSchema.xsd
@@ -60,6 +60,7 @@
 			<xs:element name="top" type="xs:string" />
 			<xs:element name="apply" type="xs:string" />
 			<xs:element name="car" type="xs:string" />
+			<xs:element name="gem5" type="xs:boolean" minOccurs="0" />
 			<xs:element name="description" type="xs:string" minOccurs="0" />
 			<xs:element name="command" type="tns:CommandType"
 				minOccurs="1" maxOccurs="unbounded" />

--- a/modules/edu.gemini.epics.acm/src/test/java/edu/gemini/epics/acm/test/CaCommandSenderTest.java
+++ b/modules/edu.gemini.epics.acm/src/test/java/edu/gemini/epics/acm/test/CaCommandSenderTest.java
@@ -30,7 +30,7 @@ import gov.aps.jca.TimeoutException;
 
 public final class CaCommandSenderTest {
 
-    private static final Logger LOG = Logger.getLogger(CaCommandSenderTest.class.getName()); 
+    private static final Logger LOG = Logger.getLogger(CaCommandSenderTest.class.getName());
 
     private static final String CA_ADDR_LIST = "127.0.0.1";
     private static final String TOP = "test";
@@ -72,12 +72,12 @@ public final class CaCommandSenderTest {
             simulator = null;
         }
     }
-    
+
     @Before
     public void setUp() throws CAException, TimeoutException {
         //Make sure commands are clear
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
 
         apply.clear();
 
@@ -87,7 +87,7 @@ public final class CaCommandSenderTest {
     @Test
     public void testCreateApplySender() throws CAException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         assertNotNull("Unable to create CaApplySender", apply);
 
         caService.destroyApplySender(APPLY_NAME);
@@ -96,7 +96,7 @@ public final class CaCommandSenderTest {
     @Test
     public void testGetApplySender() throws CAException {
         CaApplySender apply1 = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaApplySender apply2 = caService.getApplySender(APPLY_NAME);
 
         assertEquals("Retrieved the wrong CaStatusAcceptor.", apply1, apply2);
@@ -107,9 +107,9 @@ public final class CaCommandSenderTest {
     @Test
     public void testCreateCommandSender() throws CAException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
-        
+
         assertNotNull("Unable to create CaCommandSender", cs);
 
         caService.destroyApplySender(APPLY_NAME);
@@ -119,7 +119,7 @@ public final class CaCommandSenderTest {
     @Test
     public void testGetCommandSender() throws CAException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs1 = caService.createCommandSender(CS_NAME, apply, null);
         CaCommandSender cs2 = caService.getCommandSender(CS_NAME);
 
@@ -132,7 +132,7 @@ public final class CaCommandSenderTest {
     @Test
     public void testCreateParameter() throws CaException, CAException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
         CaParameter<String> param = cs.addString(PARAM1_NAME, PARAM1_CHANNEL);
 
@@ -146,7 +146,7 @@ public final class CaCommandSenderTest {
     public void testRejectParameterCreationWithDifferentType()
             throws CaException, CAException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
 
         cs.addString(PARAM1_NAME, PARAM1_CHANNEL);
@@ -160,7 +160,7 @@ public final class CaCommandSenderTest {
     public void testRejectParameterCreationWithDifferentChannel()
             throws CaException, CAException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
 
         cs.addString(PARAM1_NAME, PARAM1_CHANNEL);
@@ -173,7 +173,7 @@ public final class CaCommandSenderTest {
     @Test
     public void testGetParameter() throws CaException, CAException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
         CaParameter<String> param1 = cs.addString(PARAM1_NAME, PARAM1_CHANNEL);
         CaParameter<String> param2 = cs.getString(PARAM1_NAME);
@@ -188,7 +188,7 @@ public final class CaCommandSenderTest {
     @Test
     public void testGetInfo() throws CaException, CAException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
         cs.addString(PARAM1_NAME, PARAM1_CHANNEL);
         cs.addString(PARAM2_NAME, PARAM2_CHANNEL);
@@ -211,7 +211,7 @@ public final class CaCommandSenderTest {
     public void testSetParameter() throws CAException, TimeoutException,
             CaException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
         CaParameter<String> param1 = cs.addString(PARAM1_NAME, PARAM1_CHANNEL);
 
@@ -227,7 +227,7 @@ public final class CaCommandSenderTest {
         String val = attr.value();
 
         assertEquals("Unable to write parameter value.", VALUE, val);
-        
+
         caService.destroyApplySender(APPLY_NAME);
         caService.destroyCommandSender(CS_NAME);
     }
@@ -236,7 +236,7 @@ public final class CaCommandSenderTest {
     public void testTriggerUnmarkedCommand() throws CAException,
             TimeoutException, CaException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
 
         CaCommandMonitor cm = cs.post();
@@ -256,7 +256,7 @@ public final class CaCommandSenderTest {
     public void testTriggerCommandWithParameter() throws CAException,
             TimeoutException, CaException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply, null);
         CaParameter<String> param1 = cs.addString(PARAM1_NAME, PARAM1_CHANNEL);
 
@@ -278,7 +278,7 @@ public final class CaCommandSenderTest {
     public void testTriggerCommandWithMark() throws CAException,
             TimeoutException, CaException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply,
                 NORMAL_CAD);
 
@@ -300,7 +300,7 @@ public final class CaCommandSenderTest {
     public void testCommandError() throws CAException, TimeoutException,
             CaException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply,
                 ERROR_CAD);
 
@@ -323,7 +323,7 @@ public final class CaCommandSenderTest {
     public void testRetrieveCommandError() throws CAException,
             TimeoutException, CaException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply,
                 ERROR_CAD);
 
@@ -348,7 +348,7 @@ public final class CaCommandSenderTest {
     public void testCommandTimeout() throws CAException, TimeoutException,
             CaException {
         CaApplySender apply = caService.createApplySender(APPLY_NAME, APPLY,
-                CAR);
+                CAR, false);
         CaCommandSender cs = caService.createCommandSender(CS_NAME, apply,
                 TIMEOUT_CAD);
 

--- a/modules/edu.gemini.seqexec.server/src/main/resources/Gnirs.xml
+++ b/modules/edu.gemini.seqexec.server/src/main/resources/Gnirs.xml
@@ -5,6 +5,7 @@
         <top>nirs</top>
         <apply>apply</apply>
         <car>applyC</car>
+        <gem5>true</gem5>
         <description>IS Primary Apply Record </description>
         <command name="nirs::config">
             <description>Setup a Configuration</description>

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosEpics.scala
@@ -72,7 +72,7 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
 
   private val stopCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::stop"))
   private val observeAS: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::observeCmd",
-      GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
+      GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", false, GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
 
   object continueCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::continue"))

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/GnirsEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/GnirsEpics.scala
@@ -93,7 +93,7 @@ class GnirsEpics(epicsService: CaService, tops: Map[String, String]) {
 
   private val stopCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("nirs::stop"))
   private val observeAS: Option[CaApplySender] = Option(epicsService.createObserveSender("nirs::observeCmd",
-      GNIRS_TOP + "apply", GNIRS_TOP + "applyC", GNIRS_TOP + "dc:observeC", GNIRS_TOP + "stop", GNIRS_TOP + "abort", ""))
+      GNIRS_TOP + "apply", GNIRS_TOP + "applyC", GNIRS_TOP + "dc:observeC", true, GNIRS_TOP + "stop", GNIRS_TOP + "abort", ""))
 
   object stopCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = stopCS


### PR DESCRIPTION
GEM5 systems use a definition for the CAR values that is different from later systems. I had to implement a workaround.
I put a new flag in the definition of a Apply record in the Schema file. it is used by XMLBuilder to automatically use the right definition for CAR records.