### PR TITLE
Use a custom tzdb

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,9 @@ git.uncommittedSignifier in ThisBuild := Some("UNCOMMITTED")
 
 enablePlugins(GitBranchPrompt)
 
+resolvers in ThisBuild +=
+  Resolver.sonatypeRepo("snapshots")
+
 //////////////
 // Projects
 //////////////
@@ -124,12 +127,15 @@ lazy val edu_gemini_seqexec_web_server = project.in(file("modules/edu.gemini.seq
 lazy val edu_gemini_seqexec_web_client = project.in(file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client"))
   .enablePlugins(ScalaJSPlugin)
   .enablePlugins(ScalaJSBundlerPlugin)
+  .enablePlugins(TzdbPlugin)
   .enablePlugins(BuildInfoPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(GitBranchPrompt)
   .disablePlugins(RevolverPlugin)
   .settings(commonJSSettings: _*)
   .settings(
+    wartremoverExcluded += sourceManaged.value / "main" / "java" / "time" / "zone" / "TzdbZoneRulesProvider.scala",
+    zonesFilter := {(z: String) => z == "America/Santiago" || z == "Pacific/Honolulu"},
     // Needed for Monocle macros
     addCompilerPlugin(Plugins.paradisePlugin),
     webpackBundlingMode := BundlingMode.LibraryOnly(),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -74,7 +74,7 @@ object Settings {
     val scalaCSS                = "0.5.4"
     val booPickle               = "1.2.6"
     val diode                   = "1.1.3"
-    val javaTimeJS              = "2.0.0-M12"
+    val javaTimeJS              = "2.0.0-M13-SNAPSHOT"
     val javaLogJS               = "0.1.3"
     val scalaJQuery             = "1.2"
     val scalaJSReactVirtualized = "0.0.6"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,5 +27,10 @@ addSbtPlugin("org.wartremover"   % "sbt-wartremover"        % "2.2.1")
 // Use NPM modules rather than webjars
 addSbtPlugin("ch.epfl.scala"     % "sbt-scalajs-bundler"    % "0.10.0")
 
+resolvers +=
+  Resolver.sonatypeRepo("snapshots")
+
+addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.1.0-SNAPSHOT")
+
 // Avoids a warning message when starting sbt-git
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"


### PR DESCRIPTION
This is an experimental option to reduce the code size on the client by only including the data for our relevant timezones. Note this is using a SNAPSHOT of `scala-java-time` I expect it to go final after some more testing