### PR TITLE
Several fixes for GNIRS

### DIFF
--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -206,7 +206,7 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ca
         @Override
         public State onApplyValChange(Integer val) {
             if (val > 0) {
-                if (carClid != null && carClid.equals(val)) {
+                if (carVal != null && carClid != null && carClid.equals(val)) {
                     if (carVal.isError()) {
                         failCommandWithCarError(cm);
                         return IdleState;

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -206,7 +206,7 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ca
         @Override
         public State onApplyValChange(Integer val) {
             if (val > 0) {
-                if (carVal != null && carClid != null && carClid.equals(val)) {
+                if (carVal != null && val.equals(carClid)) {
                     if (carVal.isError()) {
                         failCommandWithCarError(cm);
                         return IdleState;

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaCommandSender.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaCommandSender.java
@@ -16,21 +16,21 @@ import java.util.Set;
 public interface CaCommandSender {
     /**
      * Retrieves the name of this command sender.
-     * 
+     *
      * @return name of this command sender.
      */
     String getName();
 
     /**
      * Retrieves the description for this Command Sender
-     * 
+     *
      * @return the description of this Command Sender
      */
     String getDescription();
 
     /**
      * Retrieves the names of the parameters of this command sender.
-     * 
+     *
      * @return set of parameter names.
      */
     Set<String> getInfo();
@@ -55,7 +55,7 @@ public interface CaCommandSender {
 
     /**
      * Trigger the EPICS apply record. The command return immediately.
-     * 
+     *
      * @return an object that implements <code>CaCommandMonitor</code>, which
      *         can be used to monitor the command execution and retrieve its
      *         result.
@@ -65,7 +65,7 @@ public interface CaCommandSender {
     /**
      * Trigger the EPICS apply record and waits until the command processing
      * completes.
-     * 
+     *
      * @return an object that implements <code>CaCommandMonitor</code>, which
      *         can be used to monitor the command execution and retrieve its
      *         result.
@@ -74,13 +74,13 @@ public interface CaCommandSender {
 
     /**
      * Trigger the EPICS apply record. The command return immediately.
-     * 
+     *
      * @param callback
      *            an object that implements <code>CaCommandListener</code>,
      *            which will be notified when the command execution state
      *            changes. The object will be used only for this execution of
      *            the command
-     * 
+     *
      * @return an object that implements <code>CaCommandMonitor</code>, which
      *         can be used to monitor the command execution and retrieve its
      *         result.
@@ -92,7 +92,7 @@ public interface CaCommandSender {
      * the parameter already exist, the existing object is used. CaException is
      * thrown if the existing parameter is of a different type or uses a
      * different EPICS channel.
-     * 
+     *
      * @param name
      *            the name of the parameter.
      * @param channel
@@ -119,7 +119,7 @@ public interface CaCommandSender {
      * the parameter already exist, the existing object is used. CaException is
      * thrown if the existing parameter is of a different type or uses a
      * different EPICS channel.
-     * 
+     *
      * @param name
      *            the name of the parameter.
      * @param channel
@@ -146,7 +146,7 @@ public interface CaCommandSender {
      * the parameter already exist, the existing object is used. CaException is
      * thrown if the existing parameter is of a different type or uses a
      * different EPICS channel.
-     * 
+     *
      * @param name
      *            the name of the parameter.
      * @param channel
@@ -169,11 +169,38 @@ public interface CaCommandSender {
             throws CaException;
 
     /**
+     * Adds a parameter of type <code>Enum</code> to this command sender. If
+     * the parameter already exist, the existing object is used. CaException is
+     * thrown if the existing parameter is of a different type or uses a
+     * different EPICS channel.
+     *
+     * @param name
+     *            the name of the parameter.
+     * @param channel
+     *            the full EPICS channel name for the parameter
+     * @param description
+     *            optional description for the parameter
+     * @return the parameter
+     * @throws CaException
+     */
+    <T extends Enum<T>> CaParameter<T> addEnum(String name, String channel, Class<T> enumType,
+                                String description) throws CaException;
+
+    <T extends Enum<T>> CaParameter<T> addEnum(String name, String channel, Class<T> enumType)
+            throws CaException;
+
+    <T extends Enum<T>> CaParameter<T> addEnum(String name, String channel, Class<T> enumType,
+                                String description, boolean isCADParameter) throws CaException;
+
+    <T extends Enum<T>> CaParameter<T> addEnum(String name, String channel, Class<T> enumType, boolean isCADParameter)
+            throws CaException;
+
+    /**
      * Adds a parameter of type <code>String</code> to this command sender. If
      * the parameter already exist, the existing object is used. CaException is
      * thrown if the existing parameter is of a different type or uses a
      * different EPICS channel.
-     * 
+     *
      * @param name
      *            the name of the parameter.
      * @param channel
@@ -197,7 +224,7 @@ public interface CaCommandSender {
 
     /**
      * Removes a parameter from this command sender (optional operation).
-     * 
+     *
      * @param name
      *            the name of the parameter to remove.
      */
@@ -205,7 +232,7 @@ public interface CaCommandSender {
 
     /**
      * Retrieves an existing parameter of type <code>Integer</code>.
-     * 
+     *
      * @param name
      *            the name of the parameter.
      * @return the parameter, or <code>null</code> if it does not exist or is of
@@ -215,7 +242,7 @@ public interface CaCommandSender {
 
     /**
      * Retrieves an existing parameter of type <code>Double</code>.
-     * 
+     *
      * @param name
      *            the name of the parameter.
      * @return the parameter, or <code>null</code> if it does not exist or is of
@@ -225,7 +252,7 @@ public interface CaCommandSender {
 
     /**
      * Retrieves an existing parameter of type <code>Float</code>.
-     * 
+     *
      * @param name
      *            the name of the parameter.
      * @return the parameter, or <code>null</code> if it does not exist or is of
@@ -235,7 +262,7 @@ public interface CaCommandSender {
 
     /**
      * Retrieves an existing parameter of type <code>String</code>.
-     * 
+     *
      * @param name
      *            the name of the parameter.
      * @return the parameter, or <code>null</code> if it does not exist or is of

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -297,7 +297,7 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
         @Override
         public CaObserveSenderImpl.State onApplyValChange(Integer val) {
             if (val > 0) {
-                if (carClid != null && carClid.equals(val) && carState != null) {
+                if (val.equals(carClid) && carState != null) {
                     if (carState.isError()) {
                         failCommandWithCarError(cm);
                         return IdleState;

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -276,36 +276,36 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
 
     private final class WaitPreset implements CaObserveSenderImpl.State {
         final CaCommandMonitorImpl cm;
-        final CarStateGeneric carVal;
-        final CarStateGeneric observeCarVal;
+        final CarStateGeneric carState;
+        final CarStateGeneric observeCarState;
         final Integer carClid;
 
         WaitPreset(CaCommandMonitorImpl cm) {
             this.cm = cm;
-            this.carVal = null;
+            this.carState = null;
             this.carClid = null;
-            this.observeCarVal = null;
+            this.observeCarState = null;
         }
 
-        private WaitPreset(CaCommandMonitorImpl cm, CarStateGeneric carVal, Integer carClid, CarStateGeneric observeCarVal) {
+        private WaitPreset(CaCommandMonitorImpl cm, CarStateGeneric carState, Integer carClid, CarStateGeneric observeCarState) {
             this.cm = cm;
-            this.carVal = carVal;
+            this.carState = carState;
             this.carClid = carClid;
-            this.observeCarVal = observeCarVal;
+            this.observeCarState = observeCarState;
         }
 
         @Override
         public CaObserveSenderImpl.State onApplyValChange(Integer val) {
             if (val > 0) {
-                if (carClid != null && carClid.equals(val) && carVal != null) {
-                    if (carVal.isError()) {
+                if (carClid != null && carClid.equals(val) && carState != null) {
+                    if (carState.isError()) {
                         failCommandWithCarError(cm);
                         return IdleState;
-                    } else if (carVal.isBusy()) {
-                        return new CaObserveSenderImpl.WaitCompletion(cm, val, observeCarVal);
+                    } else if (carState.isBusy()) {
+                        return new CaObserveSenderImpl.WaitCompletion(cm, val, observeCarState);
                     }
                 }
-                return new CaObserveSenderImpl.WaitStart(cm, val, carVal, carClid, observeCarVal);
+                return new CaObserveSenderImpl.WaitStart(cm, val, carState, carClid, observeCarState);
             } else {
                 failCommandWithApplyError(cm);
                 return IdleState;
@@ -314,17 +314,17 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
 
         @Override
         public CaObserveSenderImpl.State onCarValChange(CarStateGeneric val) {
-            return new CaObserveSenderImpl.WaitPreset(cm, val, carClid, observeCarVal);
+            return new CaObserveSenderImpl.WaitPreset(cm, val, carClid, observeCarState);
         }
 
         @Override
         public CaObserveSenderImpl.State onCarClidChange(Integer val) {
-            return new CaObserveSenderImpl.WaitPreset(cm, carVal, val, observeCarVal);
+            return new CaObserveSenderImpl.WaitPreset(cm, carState, val, observeCarState);
         }
 
         @Override
-        public State onObserveCarValChange(CarStateGeneric carState)  {
-            return new CaObserveSenderImpl.WaitPreset(cm, carVal, carClid, carState);
+        public State onObserveCarValChange(CarStateGeneric val)  {
+            return new CaObserveSenderImpl.WaitPreset(cm, carState, carClid, val);
         }
 
         @Override

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaParameterImpl.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaParameterImpl.java
@@ -13,8 +13,8 @@ import gov.aps.jca.CAException;
 import gov.aps.jca.TimeoutException;
 
 abstract class CaParameterImpl<T> implements CaParameter<T> {
-    
-    private static final Logger LOG = Logger.getLogger(CaParameterImpl.class.getName()); 
+
+    private static final Logger LOG = Logger.getLogger(CaParameterImpl.class.getName());
 
     private final String name;
     private final String channel;
@@ -189,6 +189,25 @@ abstract class CaParameterImpl<T> implements CaParameter<T> {
             CaTypedParameter<Float> param = new CaTypedParameter<>(name, channel, description, epicsWriter);
             try {
                 param.bind(epicsWriter.getFloatChannel(channel));
+            } catch(Throwable e) {
+                LOG.warning(e.getMessage());
+            }
+            return param;
+        }
+    }
+
+    static public <E extends Enum<E> > CaParameterImpl<E> createEnumParameter(
+            String name, String channel, String description, Class<E> enumType, EpicsWriter epicsWriter) {
+        return createEnumParameter(name, channel, description, enumType, epicsWriter, true);
+    }
+    static public <E extends Enum<E> > CaParameterImpl<E> createEnumParameter(
+            String name, String channel, String description, Class<E> enumType, EpicsWriter epicsWriter, boolean isCADParameter) {
+        if(isCADParameter) {
+            return new CaCADParameter<E>(name, channel, description, epicsWriter);
+        } else {
+            CaTypedParameter<E> param = new CaTypedParameter<>(name, channel, description, epicsWriter);
+            try {
+                param.bind(epicsWriter.getEnumChannel(channel, enumType));
             } catch(Throwable e) {
                 LOG.warning(e.getMessage());
             }

--- a/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorImpl.java
+++ b/modules/edu.gemini.epics.acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorImpl.java
@@ -18,7 +18,7 @@ import gov.aps.jca.CAException;
 
 final class CaStatusAcceptorImpl implements CaStatusAcceptor {
 
-    private static final Logger LOG = Logger.getLogger(CaStatusAcceptorImpl.class.getName()); 
+    private static final Logger LOG = Logger.getLogger(CaStatusAcceptorImpl.class.getName());
 
     private final String name;
     private final String description;
@@ -239,6 +239,7 @@ final class CaStatusAcceptorImpl implements CaStatusAcceptor {
         integerAttributes.remove(name);
         shortAttributes.remove(name);
         stringAttributes.remove(name);
+        enumAttributes.remove(name);
     }
 
     @Override
@@ -253,6 +254,7 @@ final class CaStatusAcceptorImpl implements CaStatusAcceptor {
         set.addAll(integerAttributes.keySet());
         set.addAll(shortAttributes.keySet());
         set.addAll(stringAttributes.keySet());
+        set.addAll(enumAttributes.keySet());
         return set;
     }
 
@@ -325,6 +327,7 @@ final class CaStatusAcceptorImpl implements CaStatusAcceptor {
         floatAttributes.clear();
         integerAttributes.clear();
         shortAttributes.clear();
+        enumAttributes.clear();
 
         epicsReader = null;
     }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/operations.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/operations.scala
@@ -57,6 +57,13 @@ object operations {
     def sequenceOperations: List[SequenceOperations] = Nil
   }
 
+  private val GnirsSupportedOperations = new SupportedOperations {
+    def observationOperations(s: Step): List[ObservationOperations] =
+      s.isObservePaused.fold(List(ObservationOperations.StopObservation, ObservationOperations.AbortObservation), List(ObservationOperations.StopObservation, ObservationOperations.AbortObservation))
+
+    def sequenceOperations: List[SequenceOperations] = Nil
+  }
+
   private val NilSupportedOperations = new SupportedOperations {
     def observationOperations(s: Step): List[ObservationOperations] = Nil
     def sequenceOperations: List[SequenceOperations] = Nil
@@ -65,7 +72,8 @@ object operations {
   private val instrumentOperations: Map[Instrument, SupportedOperations] = Map(
     (F2    -> F2SupportedOperations),
     (GmosS -> GmosSupportedOperations),
-    (GmosN -> GmosSupportedOperations)
+    (GmosN -> GmosSupportedOperations),
+    (GNIRS -> GnirsSupportedOperations)
   )
 
   final implicit class SupportedOperationsOps(val i: Instrument) extends AnyVal {

--- a/modules/edu.gemini.seqexec.server/src/main/resources/Gnirs.xml
+++ b/modules/edu.gemini.seqexec.server/src/main/resources/Gnirs.xml
@@ -100,9 +100,10 @@
                 <description>Low Noise Rds</description>
             </parameter>
             <parameter name="exposureTime">
-                <channel>dc:obsSetup.G</channel>
+                <channel>dc:integTime.VAL</channel>
                 <type>DOUBLE</type>
                 <description>Exposure Time</description>
+                <isCAD>false</isCAD>
             </parameter>
             <parameter name="wcs">
                 <channel>dc:setWcs.A</channel>
@@ -120,9 +121,10 @@
                 <description>Detector Bias</description>
             </parameter>
             <parameter name="coadds">
-                <channel>dc:obsSetup.E</channel>
-                <type>INTEGER</type>
+                <channel>dc:coadds.VAL</channel>
+                <type>DOUBLE</type>
                 <description>numcoadds</description>
+                <isCAD>false</isCAD>
             </parameter>
         </command>
         <command name="nirs::endObserve">

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqTranslate.scala
@@ -243,7 +243,6 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     case _      => Event.nullEvent
   }
 
-  // This code assumes that if an instrument can not stop a running exposure, it cannot stop a paused one either.
   def stopObserve(seqId: Sequence.Id)(seqState: Sequence.State): Option[Process[Task, Event]] = {
     def f(oc: ObserveControl): Option[SeqAction[Unit]] = oc match {
       case OpticControl(StopObserveCmd(stop), _, _, _, _, _) => Some(stop)
@@ -253,7 +252,6 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     deliverObserveCmd(seqState, f).orElse(stopPaused(seqId)(seqState))
   }
 
-  // This code assumes that if an instrument can not abort a running exposure, it cannot abort a paused one either.
   def abortObserve(seqId: Sequence.Id)(seqState: Sequence.State): Option[Process[Task, Event]] = {
     def f(oc: ObserveControl): Option[SeqAction[Unit]] = oc match {
       case OpticControl(_, AbortObserveCmd(abort), _, _, _, _) => Some(abort)
@@ -349,6 +347,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
       case DarkOrBias(inst)      => toInstrumentSys(inst).map(List(_))
       case _                     => TrySeq.fail(Unexpected(s"Unsupported step type $stepType"))
     }
+
   }
 
   // I cannot use a sealed trait as base, because I cannot have all systems in one source file (too big),

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/Gnirs.scala
@@ -11,7 +11,7 @@ import edu.gemini.seqexec.server.gnirs.GnirsController.{CCConfig, DCConfig, Othe
 import edu.gemini.seqexec.server.{ConfigResult, ConfigUtilOps, InstrumentSystem, ObserveCommand, SeqAction, SeqObserve, SeqexecFailure, TrySeq}
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.seqcomp.SeqConfigNames.{INSTRUMENT_KEY, OBSERVE_KEY}
-import edu.gemini.spModel.obscomp.InstConstants.{EXPOSURE_TIME_KEY, DARK_OBSERVE_TYPE, BIAS_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
+import edu.gemini.spModel.obscomp.InstConstants.{DARK_OBSERVE_TYPE, BIAS_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
 import edu.gemini.spModel.gemini.gnirs.InstGNIRS._
 import edu.gemini.spModel.gemini.gnirs.GNIRSConstants.{INSTRUMENT_NAME_PROP, WOLLASTON_PRISM_PROP}
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams._
@@ -53,10 +53,10 @@ object Gnirs {
   val name: String = INSTRUMENT_NAME_PROP
 
   def extractExposureTime(config: Config): ExtractFailure\/Time =
-    config.extract(EXPOSURE_TIME_KEY).as[java.lang.Double].map(_.toDouble.seconds)
+    config.extract(OBSERVE_KEY / EXPOSURE_TIME_PROP).as[java.lang.Double].map(_.toDouble.seconds)
 
   def extractCoadds(config: Config): ExtractFailure\/Int =
-    config.extract(INSTRUMENT_KEY / COADDS_PROP).as[java.lang.Integer].map(_.toInt)
+    config.extract(OBSERVE_KEY / COADDS_PROP).as[java.lang.Integer].map(_.toInt)
 
   def fromSequenceConfig(config: Config): TrySeq[GnirsController.GnirsConfig] =
     (getCCConfig(config) |@| getDCConfig(config))(GnirsController.GnirsConfig(_, _))

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/GnirsEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/GnirsEpics.scala
@@ -82,8 +82,8 @@ class GnirsEpics(epicsService: CaService, tops: Map[String, String]) {
     val detBias: Option[CaParameter[JDouble]] = cs.map(_.getDouble("detBias"))
     def setDetBias(v: Double): SeqAction[Unit] = setParameter(detBias, JDouble.valueOf(v))
 
-    val coadds: Option[CaParameter[Integer]] = cs.map(_.getInteger("coadds"))
-    def setCoadds(v: Int): SeqAction[Unit] = setParameter(coadds, Integer.valueOf(v))
+    val coadds: Option[CaParameter[JDouble]] = cs.map(_.getDouble("coadds"))
+    def setCoadds(v: Int): SeqAction[Unit] = setParameter(coadds, JDouble.valueOf(v.toDouble))
 
   }
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/TcsControllerEpics.scala
@@ -201,6 +201,7 @@ object TcsControllerEpics extends TcsController {
       Model.Instrument.GmosS -> SFInstName("gmos"),
       Model.Instrument.GmosN -> SFInstName("gmos"),
       Model.Instrument.GSAOI -> SFInstName("gsaoi"),
+      Model.Instrument.GNIRS -> SFInstName("gnirs"),
       Model.Instrument.F2    -> SFInstName("f2"),
       Model.Instrument.GPI   -> SFInstName("gpi")
     )
@@ -369,8 +370,8 @@ object TcsControllerEpics extends TcsController {
 
   private def setM2Guide(c: M2GuideConfig): SeqAction[Unit] = TcsEpics.instance.m2GuideCmd.setState(encode(c))
 
-  private val tcsTimeout = Seconds(30)
-  private val agTimeout = Seconds(30)
+  private val tcsTimeout = Seconds(60)
+  private val agTimeout = Seconds(60)
 
   override def applyConfig(subsystems: NonEmptyList[Subsystem], tcs: TcsConfig): SeqAction[Unit] = {
     def configSubsystem(subsystem: Subsystem): SeqAction[Unit] = subsystem match {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/TcsEpics.scala
@@ -304,7 +304,7 @@ final class TcsEpics(epicsService: CaService, tops: Map[String, String]) {
    * an error. A better solution is to detect the edge, from not in position to in-position.
    */
   private val AGSettleTime = 1100.milliseconds
-  def waitAGInPosition(timeout: Time): SeqAction[Unit] = SeqAction(Thread.sleep(AGSettleTime.toMilliseconds.toInt)) *>
+  def waitAGInPosition(timeout: Time): SeqAction[Unit] = SeqAction(Thread.sleep(AGSettleTime.toMilliseconds.toLong)) *>
     waitForValue[java.lang.Double](agInPositionAttr, 1.0, timeout, "AG inposition flag")
 
   def hourAngle: Option[String] = Option(tcsState.getStringAttribute("ha").value)

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/TcsEpics.scala
@@ -9,8 +9,10 @@ import edu.gemini.seqexec.server.{EpicsCommand, EpicsSystem, SeqAction}
 import edu.gemini.seqexec.server.EpicsUtil._
 import org.log4s.{Logger, getLogger}
 import squants.Time
+import squants.time.TimeConversions._
 
 import scala.collection.JavaConverters._
+import scalaz.syntax.apply._
 
 /**
  * TcsEpics wraps the non-functional parts of the EPICS ACM library to interact with TCS. It has all the objects used
@@ -298,8 +300,12 @@ final class TcsEpics(epicsService: CaService, tops: Map[String, String]) {
 
 
   // `waitAGInPosition` works like `waitInPosition`, but for the AG in-position flag.
-  def waitAGInPosition(timeout: Time): SeqAction[Unit] = waitForValue[java.lang.Double](
-    agInPositionAttr, 1.0, timeout, "AG inposition flag")
+  /* TODO: AG inposition can take up to 1[s] to react to a TCS command. If the value is read before that, it may induce
+   * an error. A better solution is to detect the edge, from not in position to in-position.
+   */
+  private val AGSettleTime = 1100.milliseconds
+  def waitAGInPosition(timeout: Time): SeqAction[Unit] = SeqAction(Thread.sleep(AGSettleTime.toMilliseconds.toInt)) *>
+    waitForValue[java.lang.Double](agInPositionAttr, 1.0, timeout, "AG inposition flag")
 
   def hourAngle: Option[String] = Option(tcsState.getStringAttribute("ha").value)
 


### PR DESCRIPTION
This PR includes several fixes for GNIRS:
* Changed the channels for parameters *exposure time* and *coadds* to be the same used by the ISD. (Why the ISD shows the input parameters and not the applied values is beyond me).
* Fixed `NullPointerException` in `CaApplySenderImp`
* Implemented an ugly workaround to an issue with the AG in-position (should work on a better solution).
* Incremented timeouts for waiting for telescope an AG in-position.
* Read *coadds* from the right property.
* Implemented support for `Enum` parameters in Command Sender. I thought I needed it for GNIRS, but at the end it was not necessary.