### PR TITLE
SEQNG-530 Prevent accessing EPICS objects before initialization.

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -22,9 +22,9 @@ object GnirsControllerEpics extends GnirsController {
   import GnirsController._
   import EpicsCodex._
 
-  private val epicsSys = GnirsEpics.instance
-  private val ccCmd = epicsSys.configCCCmd
-  private val dcCmd = epicsSys.configDCCmd
+  private def epicsSys = GnirsEpics.instance
+  private def ccCmd = epicsSys.configCCCmd
+  private def dcCmd = epicsSys.configDCCmd
 
   val readModeEncoder: EncodeEpicsValue[ReadMode, (Int, Int)] = EncodeEpicsValue {
     case ReadMode.VERY_BRIGHT => (1, 1)


### PR DESCRIPTION
The problem was hidden in GMOS, but crashed the Seqexec in the South because of GNIRS.