### PR TITLE
SEQNG-500: Restore highlight on hover

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -469,6 +469,16 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     mobileRow
   )
 
+  val row: StyleA = style("ReactVirtualized__Table__row")(
+    display.flex,
+    flexDirection.row,
+    alignItems.center,
+    &.hover(
+      backgroundColor(rgba(0, 0, 0, 0.05)),
+      color(rgba(0, 0, 0, 0.95))
+    )
+  )
+
   val headerRowStyle: StyleA = style(
     rowMixin,
     backgroundColor(c"#F9FAFB"),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -570,7 +570,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val iconCell: StyleA = style(
-    iconCellMixin
+    iconCellMixin,
+    paddingBottom(8.px)
   )
 
   val runningIconCell: StyleA = style(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -140,28 +140,28 @@ object StepsTable {
       SeqexecStyles.stepRow
   }).htmlClass
 
-  def rowHeight(p: Props)(i: Int): Int = (p.rowGetter(i), p.offsetsDisplay) match {
-    case (StepRow(StandardStep(_, _, _, true, _, _, _, _)), OffsetsDisplay.DisplayOffsets(_)) =>
+  def displayOffsets(p: Props): Boolean =
+    p.stepsList.headOption.flatMap(stepTypeO.getOption) match {
+      case Some(StepType.Object) => true
+      case _                     => false
+    }
+
+  def rowHeight(p: Props)(i: Int): Int = p.rowGetter(i) match {
+    case StepRow(StandardStep(_, _, _, true, _, _, _, _)) if displayOffsets(p) =>
       HeightWithOffsets + BreakpointLineHeight
-    case (StepRow(s: Step), _) if s.status === StepState.Running                              =>
+    case StepRow(s: Step) if s.status === StepState.Running                    =>
       SeqexecStyles.runningRowHeight
-    case (_, OffsetsDisplay.DisplayOffsets(_))                                                =>
+    case _ if displayOffsets(p)                                                =>
       HeightWithOffsets
-    case (StepRow(StandardStep(_, _, _, true, _, _, _, _)), _)                                =>
+    case StepRow(StandardStep(_, _, _, true, _, _, _, _))                      =>
       SeqexecStyles.rowHeight + BreakpointLineHeight
-    case _                                                                                    =>
+    case _                                                                     =>
       SeqexecStyles.rowHeight
   }
 
   class Backend {
     private val PhoneCut = 412
     private val LargePhoneCut = 767
-
-    def displayOffsets(p: Props): Boolean =
-      p.stepsList.headOption.flatMap(stepTypeO.getOption) match {
-        case Some(StepType.Object) => true
-        case _                     => false
-      }
 
     // Columns for the table
     private def columns(p: Props, s: Size): List[Table.ColumnArg] = {

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/css/virtualized.css
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/resources/css/virtualized.css
@@ -4,12 +4,6 @@
 .ReactVirtualized__Table__Grid {
 }
 
-.ReactVirtualized__Table__row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
 .ReactVirtualized__Table__headerTruncatedText {
   display: inline-block;
   max-width: 100%;


### PR DESCRIPTION
This PR updates the table to highlight the row when the mouse hovers over it. It's easier to see on the video

it also fixes a bug on calculating the row heights

![screencast 2018-02-09 13-02-18](https://user-images.githubusercontent.com/3615303/36036827-a53786d4-0d99-11e8-9525-29b3eb293b00.gif)
