### PR TITLE
SEQNG-540: Added code to display disperser column for GMOS-S

### DIFF
--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/Model.scala
@@ -353,7 +353,7 @@ object Model {
   /**
     * Metadata about the sequence required on the exit point
     */
-  // TODO Une a proper instrument class
+  // TODO Use a proper instrument class
   @Lenses final case class SequenceMetadata(
     instrument: Instrument,
     observer: Option[Observer],

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
@@ -59,7 +59,7 @@ trait ModelLenses {
 
   // Param name of a StepConfig
   def configParamValueO(system: SystemName, param: String): Optional[StepConfig, String] =
-    systemConfigL(system)                ^<-? // observe paramaters
+    systemConfigL(system)                ^<-? // observe parameters
     some                                 ^|-> // focus on the option
     paramValueL(system.withParam(param)) ^<-? // find the target name
     some                                      // focus on the option
@@ -180,6 +180,14 @@ trait ModelLenses {
   // Composite lens to find the instrument filter
   val instrumentFilterO: Optional[Step, String] =
     stepObserveOptional(SystemName.instrument, "filter", Iso.id[String].asPrism)
+
+  // Composite lens to find the instrument disperser for GMOS
+  val instrumentDisperserO: Optional[Step, String] =
+    stepObserveOptional(SystemName.instrument, "disperser", Iso.id[String].asPrism)
+
+  // Composite lens to find the central wavelength for a disperser
+  val instrumentDisperserLambdaO: Optional[Step, Double] =
+    stepObserveOptional(SystemName.instrument, "disperserLambda", stringToDoubleP)
 
   // Lens to find p offset
   def telescopeOffsetO(x: OffsetAxis): Optional[Step, Double] =

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/enumerations.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/enumerations.scala
@@ -158,4 +158,30 @@ object enumerations {
       "CUSTOM_MASK" -> "Custom Mask"
     )
   }
+
+  object disperser {
+    val GmosSDisperser: Map[String, String] = Map(
+      "MIRROR"      -> "Mirror",
+      "B1200_G5321" -> "B1200",
+      "R831_G5322"  -> "R831",
+      "B600_G5323"  -> "B600",
+      "R600_G5324"  -> "R600",
+      "R400_G5325"  -> "R400",
+      "R150_G5326"  -> "R150"
+    )
+
+    // TODO: Do we still need to include the obsolete filters here?
+    // TODO: For now, omitting. See GmosNorthType.DisperserNorth if needed.
+    // TODO: If needed, the reverse mapping will not be well-defined,
+    // TODO: e.g. B600 maps to B600_G5303 and B600_G5307.
+    val GmosNDisperser: Map[String, String] = Map(
+      "MIRROR"      -> "Mirror",
+      "B1200_G5301" -> "B1200",
+      "R831_G5302"  -> "R831",
+      "B600_G5307"  -> "B600",
+      "R600_G5304"  -> "R600",
+      "R400_G5305"  -> "R400",
+      "R150_G5308"  -> "R150"
+    )
+  }
 }

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/enumerations.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/enumerations.scala
@@ -170,10 +170,6 @@ object enumerations {
       "R150_G5326"  -> "R150"
     )
 
-    // TODO: Do we still need to include the obsolete filters here?
-    // TODO: For now, omitting. See GmosNorthType.DisperserNorth if needed.
-    // TODO: If needed, the reverse mapping will not be well-defined,
-    // TODO: e.g. B600 maps to B600_G5303 and B600_G5307.
     val GmosNDisperser: Map[String, String] = Map(
       "MIRROR"      -> "Mirror",
       "B1200_G5301" -> "B1200",

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/properties.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/properties.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.seqexec.model
+
+import edu.gemini.seqexec.model.Model.Instrument
+import edu.gemini.seqexec.model.Model.Instrument.{F2, GNIRS, GmosN, GmosS}
+
+object properties {
+  sealed trait InstrumentProperties
+  case object Disperser extends InstrumentProperties
+
+  val instrumentProperties: Map[Instrument, Set[InstrumentProperties]] = Map(
+    F2 -> Set.empty,
+    GmosS -> Set(Disperser),
+    GmosN -> Set(Disperser),
+    GNIRS -> Set(Disperser)
+  )
+}

--- a/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
+++ b/modules/edu.gemini.seqexec.model/src/test/scala/edu/gemini/seqexec/model/ModelLensesSpec.scala
@@ -53,4 +53,6 @@ class ModelLensesSpec extends FunSuite with Discipline with ModelLenses {
   checkAll("instrument fpu mode Optional", OptionalTests(instrumentFPUModeO))
   checkAll("instrument fpu custom mask Optional", OptionalTests(instrumentFPUCustomMaskO))
   checkAll("instrument filter Optional", OptionalTests(instrumentFilterO))
+  checkAll("instrument disperser Optional", OptionalTests(instrumentDisperserO))
+  checkAll("instrument disperser lambda Optional", OptionalTests(instrumentDisperserLambdaO))
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -219,6 +219,7 @@ object DisperserCell {
       // Formatter
       val displayedText = (disperser, centralWavelength) match {
         case (Some(d), Some(w)) => f"$d @ $w%.0f nm"
+        case (Some(d), None)    => d
         case _                  => "Unknown"
       }
       <.div(


### PR DESCRIPTION
This adds, for GMOS-S, a column in the steps table for the disperser, with the form:

`${dispersername} @ ${centralWavelength} nm`

![screen shot 2018-02-19 at 6 08 14 pm](https://user-images.githubusercontent.com/8795653/36491043-8e79e2fc-1708-11e8-9633-16c4c23fd7e4.png)
