### PR TITLE
Updated to use scala-java-time 2.0.0-M13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,9 +37,6 @@ git.uncommittedSignifier in ThisBuild := Some("UNCOMMITTED")
 
 enablePlugins(GitBranchPrompt)
 
-resolvers in ThisBuild +=
-  Resolver.sonatypeRepo("snapshots")
-
 //////////////
 // Projects
 //////////////

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -74,7 +74,7 @@ object Settings {
     val scalaCSS                = "0.5.5"
     val booPickle               = "1.2.6"
     val diode                   = "1.1.3"
-    val javaTimeJS              = "2.0.0-M13-SNAPSHOT"
+    val javaTimeJS              = "2.0.0-M13"
     val javaLogJS               = "0.1.3"
     val scalaJQuery             = "1.2"
     val scalaJSReactVirtualized = "0.0.9"


### PR DESCRIPTION
Use the official release of scala-java-time. This release is a lot smaller and thus reduces the time to build the fast optimized client