### PR TITLE
Don't return empty responses

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -88,13 +88,13 @@ class SeqexecUIApiRoutes(auth: AuthenticationService, events: (server.EventQueue
           val userName = user.fold(_ => "Anonymous", _.displayName)
           // Always return ok
           // Use remoteAddr to avoid an expensive DNS lookup
-          Task.delay(clientLog.info(s"$userName on ${auth.req.remoteAddr.getOrElse("Unknown")}: ${msg.msg}")) *> Ok()
+          Task.delay(clientLog.info(s"$userName on ${auth.req.remoteAddr.getOrElse("Unknown")}: ${msg.msg}")) *> Ok("")
         }
 
       case auth @ POST -> Root / "seqexec" / "start" as user =>
         val userName = user.fold(_ => "Anonymous", _.displayName)
         // Always return ok
-        Task.delay(clientLog.info(s"$userName connected from ${auth.req.remoteHost.getOrElse("Unknown")}")) *> Ok()
+        Task.delay(clientLog.info(s"$userName connected from ${auth.req.remoteHost.getOrElse("Unknown")}")) *> Ok("")
 
       case GET -> Root / "seqexec" / "events" as user        =>
         // Stream seqexec events to clients and a ping


### PR DESCRIPTION
I noted the browser debugger doesn't understand well these empty responses, so I'm returning an empty string instead. This change has no effect in the application except when displaying the logs on development