### PR TITLE
SEQNG-312: Display fileId of executed steps

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -113,6 +113,8 @@ object StepProgressCell {
         <.p("Skipped")
       case (_, _) if props.step.skip                                                        =>
         <.p("Skip")
+      case (_, StandardStep(_, _, StepState.Completed, _, _, Some(fileId), _, _))             =>
+        <.p(SeqexecStyles.componentLabel, fileId)
       case (_, _)                                                                           =>
         <.p(SeqexecStyles.componentLabel, props.step.shows)
     }


### PR DESCRIPTION
This feature got lost when we moved to `react-virtualized`. This restores displaying the file id for executed steps

<img width="554" alt="screenshot 2018-02-23 15 00 53" src="https://user-images.githubusercontent.com/3615303/36609425-8844f102-18ab-11e8-9801-ddf0caca3668.png">
