### PR TITLE
SEQNG-413A: URL markers for step id

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -21,7 +21,6 @@ import org.scalajs.dom.html.TableRow
 import scalacss.ScalaCssReact._
 import scalaz.syntax.show._
 import scalaz.syntax.equal._
-import scalaz.syntax.std.option._
 
 object QueueTableBody {
   type SequencesModel = ModelProxy[StatusAndLoadedSequencesFocus]
@@ -51,7 +50,7 @@ object QueueTableBody {
 
   def showSequence(p: Props, s: SequenceInQueue): Callback =
     // Request to display the selected sequence
-    p.sequences.dispatchCB(NavigateTo(InstrumentPage(s.instrument, s.id.some))) >> p.sequences.dispatchCB(SelectIdToDisplay(s.id))
+    p.sequences.dispatchCB(NavigateTo(SequencePage(s.instrument, s.id, 0))) >> p.sequences.dispatchCB(SelectIdToDisplay(s.id))
 
   private val component = ScalaComponent.builder[Props]("QueueTableBody")
     .render_P { p =>
@@ -108,36 +107,36 @@ object QueueTableBody {
                 <.td(
                   ^.cls := "collapsing",
                   selectableRowCls.toTagMod,
-                  p.ctl.link(InstrumentPage(s.instrument, s.id.some))(leftColumnIcon).unless(inProcess),
+                  p.ctl.link(SequencePage(s.instrument, s.id, 0))(leftColumnIcon).unless(inProcess),
                   leftColumnIcon.when(inProcess)
                 ),
                 <.td(
                   ^.cls := "collapsing",
                   selectableRowCls.toTagMod,
-                  p.ctl.link(InstrumentPage(s.instrument, s.id.some))(s.id).unless(inProcess),
+                  p.ctl.link(SequencePage(s.instrument, s.id, 0))(s.id).unless(inProcess),
                   s.id.when(inProcess)
                 ),
                 <.td(
                   ^.cls := "collapsing",
                   selectableRowCls.toTagMod,
-                  p.ctl.link(InstrumentPage(s.instrument, s.id.some))(stepAtText).unless(inProcess),
+                  p.ctl.link(SequencePage(s.instrument, s.id, 0))(stepAtText).unless(inProcess),
                   stepAtText.when(inProcess)
                 ),
                 <.td(
                   selectableRowCls.toTagMod,
-                  p.ctl.link(InstrumentPage(s.instrument, s.id.some))(s.instrument.shows).unless(inProcess),
+                  p.ctl.link(SequencePage(s.instrument, s.id, 0))(s.instrument.shows).unless(inProcess),
                   s.instrument.shows.when(inProcess)
                 ),
                 <.td(
                   selectableRowCls.toTagMod,
                   SeqexecStyles.notInMobile,
-                  p.ctl.link(InstrumentPage(s.instrument, s.id.some))(targetName).unless(inProcess),
+                  p.ctl.link(SequencePage(s.instrument, s.id, 0))(targetName).unless(inProcess),
                   targetName.when(inProcess)
                 ).when(isLogged),
                 <.td(
                   selectableRowCls.toTagMod,
                   SeqexecStyles.notInMobile,
-                  p.ctl.link(InstrumentPage(s.instrument, s.id.some))(s.name).unless(inProcess),
+                  p.ctl.link(SequencePage(s.instrument, s.id, 0))(s.name).unless(inProcess),
                   s.name.when(inProcess)
                 ).when(isLogged)
               )

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -739,4 +739,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     paddingTop(0.6.em)
   )
 
+  val labelPointer: StyleA = style(
+    cursor.pointer
+  )
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -112,16 +112,16 @@ object SeqexecMain {
 object SeqexecUI {
   final case class RouterProps(page: InstrumentPage, router: RouterCtl[InstrumentPage])
 
+  def pageTitle(site: SeqexecSite)(p: SeqexecPages): String = p match {
+    case SequenceConfigPage(_, id, _) => s"Seqexec - $id"
+    case SequencePage(_, id, _)       => s"Seqexec - $id"
+    case InstrumentPage(i)            => s"Seqexec - ${i.show}"
+    case _                            => s"Seqexec - ${site.shows}"
+  }
+
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def router(site: SeqexecSite): IO[Router[SeqexecPages]] = {
     val instrumentNames = site.instruments.map(i => (i.shows, i)).list.toList.toMap
-
-    def pageTitle(p: SeqexecPages): String = p match {
-      case SequenceConfigPage(_, id, _) => s"Seqexec - $id"
-      case SequencePage(_, id, _)       => s"Seqexec - $id"
-      case InstrumentPage(i)            => s"Seqexec - ${i.show}"
-      case _                            => s"Seqexec - ${site.shows}"
-    }
 
     val routerConfig = RouterConfigDsl[SeqexecPages].buildConfig { dsl =>
       import dsl._
@@ -151,7 +151,7 @@ object SeqexecUI {
         .onPostRender((_, next) =>
           Callback.when(next =/= SeqexecCircuit.zoom(_.uiModel.navLocation).value)(Callback(SeqexecCircuit.dispatch(NavigateSilentTo(next)))))
         .renderWith { case (_, r) => <.div(r.render()).render}
-        .setTitle(pageTitle)
+        .setTitle(pageTitle(site))
         .logToConsole
     }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -22,7 +22,6 @@ import scalacss.ScalaCssReact._
 import scala.scalajs.js.timers.SetTimeoutHandle
 import scalaz.syntax.show._
 import scalaz.syntax.equal._
-import scalaz.syntax.std.option._
 import scalaz.effect.IO
 
 object AppTitle {
@@ -119,8 +118,8 @@ object SeqexecUI {
 
     def pageTitle(p: SeqexecPages): String = p match {
       case SequenceConfigPage(_, id, _) => s"Seqexec - $id"
-      case InstrumentPage(_, Some(id))  => s"Seqexec - $id"
-      case InstrumentPage(i, None)      => s"Seqexec - ${i.show}"
+      case SequencePage(_, id, _)       => s"Seqexec - $id"
+      case InstrumentPage(i)            => s"Seqexec - ${i.show}"
       case _                            => s"Seqexec - ${site.shows}"
     }
 
@@ -135,21 +134,20 @@ object SeqexecUI {
         }(p => (p.instrument.shows, p.obsId, p.step))) {
           case x @ SequenceConfigPage(i, _, _) if site.instruments.list.toList.contains(i) => x
         } ~> dynRenderR((p, r) => SeqexecMain(site, r))
-      | dynamicRoute(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+").option)
+      | dynamicRoute(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+"))
         .pmap {
-          case (i, Some(s)) => instrumentNames.get(i).map(InstrumentPage(_, s.some))
-          case (i, None)    => instrumentNames.get(i).map(InstrumentPage(_, None))
+          case (i, s) => instrumentNames.get(i).map(SequencePage(_, s, 0))
         }(p => (p.instrument.shows, p.obsId))) {
-          case x @ InstrumentPage(i, _) if site.instruments.list.toList.contains(i) => x
+          case x @ SequencePage(i, _, _) if site.instruments.list.toList.contains(i) => x
         } ~> dynRenderR((p, r) => SeqexecMain(site, r))
       | dynamicRoute(("/" ~ string("[a-zA-Z0-9-]+"))
-        .pmap(i => instrumentNames.get(i).map(InstrumentPage(_, None)))(p => p.instrument.shows)) {
-          case x @ InstrumentPage(i, _) if site.instruments.list.toList.contains(i) => x
+        .pmap(i => instrumentNames.get(i).map(InstrumentPage(_)))(p => p.instrument.shows)) {
+          case x @ InstrumentPage(i) if site.instruments.list.toList.contains(i) => x
         } ~> dynRenderR((p, r) => SeqexecMain(site, r))
       )
         .notFound(redirectToPage(Root)(Redirect.Push))
         // Runtime verification that all pages are routed
-        .verify(Root, site.instruments.list.toList.map(i => InstrumentPage(i, None)): _*)
+        .verify(Root, site.instruments.list.toList.map(i => InstrumentPage(i)): _*)
         .onPostRender((_, next) =>
           Callback.when(next =/= SeqexecCircuit.zoom(_.uiModel.navLocation).value)(Callback(SeqexecCircuit.dispatch(NavigateSilentTo(next)))))
         .renderWith { case (_, r) => <.div(r.render()).render}

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecUI.scala
@@ -117,6 +117,13 @@ object SeqexecUI {
   def router(site: SeqexecSite): IO[Router[SeqexecPages]] = {
     val instrumentNames = site.instruments.map(i => (i.shows, i)).list.toList.toMap
 
+    def pageTitle(p: SeqexecPages): String = p match {
+      case SequenceConfigPage(_, id, _) => s"Seqexec - $id"
+      case InstrumentPage(_, Some(id))  => s"Seqexec - $id"
+      case InstrumentPage(i, None)      => s"Seqexec - ${i.show}"
+      case _                            => s"Seqexec - ${site.shows}"
+    }
+
     val routerConfig = RouterConfigDsl[SeqexecPages].buildConfig { dsl =>
       import dsl._
 
@@ -146,6 +153,7 @@ object SeqexecUI {
         .onPostRender((_, next) =>
           Callback.when(next =/= SeqexecCircuit.zoom(_.uiModel.navLocation).value)(Callback(SeqexecCircuit.dispatch(NavigateSilentTo(next)))))
         .renderWith { case (_, r) => <.div(r.render()).render}
+        .setTitle(pageTitle)
         .logToConsole
     }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -101,7 +101,7 @@ object SequenceTabsBody {
     .stateless
     .render_P(p =>
       <.div(
-        InstrumentsTabs(p.site),
+        InstrumentsTabs(InstrumentsTabs.Props(p.router, p.site)),
         p.instrumentConnects.map(c => c(s => SequenceTabContent(p.router, p.site, s))).toList.toTagMod
       )
     ).build

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -3,7 +3,7 @@
 
 package edu.gemini.seqexec.web.client.components.sequence.toolbars
 
-import edu.gemini.seqexec.model.Model.{Instrument, SequenceId, SeqexecSite}
+import edu.gemini.seqexec.model.Model.{Instrument, SequenceId, SeqexecSite, StepId}
 import edu.gemini.seqexec.web.client.model.Pages._
 import edu.gemini.seqexec.web.client.circuit.SeqexecCircuit
 import edu.gemini.seqexec.web.client.components.SeqexecStyles
@@ -20,11 +20,12 @@ import scalacss.ScalaCssReact._
   * Toolbar when displaying a step configuration
   */
 object StepConfigToolbar {
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite, instrument: Instrument, id: Option[SequenceId], step: Int) {
+  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite, instrument: Instrument, id: Option[SequenceId], step: StepId) {
     protected[sequence] val sequenceInfoConnects = site.instruments.list.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i)))).toMap
   }
 
-  def backToSequence(i: Instrument, id: Option[SequenceId]): Callback = SeqexecCircuit.dispatchCB(NavigateSilentTo(InstrumentPage(i, id)))
+  def backToSequence(p: Props): Callback =
+    p.id.map(si => SeqexecCircuit.dispatchCB(NavigateSilentTo(SequencePage(p.instrument, si, p.step)))).getOrEmpty
 
   private val component = ScalaComponent.builder[Props]("StepConfigToolbar")
     .stateless
@@ -47,8 +48,8 @@ object StepConfigToolbar {
             ^.cls := "ui left floated eight wide column",
             SeqexecStyles.shorterFields,
             <.div(
-              p.router.link(InstrumentPage(p.instrument, p.id))
-                (Button(Button.Props(icon = Some(IconChevronLeft), labeled = true, onClick = backToSequence(p.instrument, p.id)), "Back"))
+              p.router.link(SequencePage(p.instrument, p.id.getOrElse(""), p.step))
+                (Button(Button.Props(icon = Some(IconChevronLeft), labeled = true, onClick = backToSequence(p)), "Back"))
             )
           ),
           <.div(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
@@ -18,7 +18,7 @@ object actions {
   // Actions
   final case class NavigateTo(page: Pages.SeqexecPages) extends Action
   final case class NavigateSilentTo(page: Pages.SeqexecPages) extends Action
-  final case class SyncToPage(view: SequenceView) extends Action
+  final case class InitialSyncToPage(view: SequenceView) extends Action
   final case class SyncToRunning(view: SequenceView) extends Action
   final case class SyncPageToRemovedSequence(id: SequenceId) extends Action
   final case class SyncPageToAddedSequence(i: Instrument, id: SequenceId) extends Action

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/circuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/circuit.scala
@@ -12,6 +12,7 @@ import japgolly.scalajs.react.Callback
 import edu.gemini.seqexec.model.UserDetails
 import edu.gemini.seqexec.model.Model._
 import edu.gemini.seqexec.web.client.model._
+import edu.gemini.seqexec.web.client.model.Pages
 import edu.gemini.seqexec.web.client.lenses._
 import edu.gemini.seqexec.web.client.handlers._
 import edu.gemini.seqexec.web.client.model.SeqexecAppRootModel.LoadedSequences
@@ -36,7 +37,7 @@ object circuit {
 
   // All these classes are focused views of the root model. They are used to only update small sections of the
   // UI even if other parts of the root model change
-  final case class WebSocketsFocus(sequences: LoadedSequences, user: Option[UserDetails], site: Option[SeqexecSite], firstLoad: Boolean) extends UseValueEq
+  final case class WebSocketsFocus(location: Pages.SeqexecPages, sequences: LoadedSequences, user: Option[UserDetails], site: Option[SeqexecSite], firstLoad: Boolean) extends UseValueEq
   final case class SequenceInQueue(id: SequenceId, status: SequenceState, instrument: Instrument, active: Boolean, name: String, targetName: Option[TargetName], runningStep: Option[(Int, Int)]) extends UseValueEq
   object SequenceInQueue {
     implicit val order: Order[SequenceInQueue] = Order.orderBy(_.id)
@@ -63,7 +64,7 @@ object circuit {
 
     // Model read-writers
     private val webSocketFocusRW: ModelRW[SeqexecAppRootModel, WebSocketsFocus] =
-      zoomRW(m => WebSocketsFocus(m.uiModel.sequences, m.uiModel.user, m.site, m.uiModel.firstLoad)) ((m, v) => m.copy(uiModel = m.uiModel.copy(sequences = v.sequences, user = v.user, firstLoad = v.firstLoad), site = v.site))
+      zoomRW(m => WebSocketsFocus(m.uiModel.navLocation, m.uiModel.sequences, m.uiModel.user, m.site, m.uiModel.firstLoad)) ((m, v) => m.copy(uiModel = m.uiModel.copy(sequences = v.sequences, user = v.user, firstLoad = v.firstLoad), site = v.site))
 
     private val wsHandler                = new WebSocketHandler(zoomTo(_.ws))
     private val wsEventsHandler          = new WebSocketEventsHandler(webSocketFocusRW)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/handlers.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/handlers.scala
@@ -567,9 +567,13 @@ object handlers {
         val observer = value.user.map(_.displayName)
         val newSequence = view.queue.find(_.id === id)
         val updateObserverE = observer.fold(VoidEffect)(o => Effect(Future(UpdateObserver(id, o): Action)))
+        val inInstrumentPage = value.location match {
+          case Root | InstrumentPage(_) => true
+          case _                        => false
+        }
         val syncPageE = for {
           s <- newSequence
-          if view.queue.length === 1
+          if inInstrumentPage
         } yield Effect(Future(SyncPageToAddedSequence(s.metadata.instrument, id): Action))
         val effects = updateObserverE + syncPageE.fold(VoidEffect)(identity)
         updated(value.copy(sequences = filterSequences(view), firstLoad = false), effects)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -24,7 +24,8 @@ object model {
     sealed trait SeqexecPages
 
     case object Root extends SeqexecPages
-    final case class InstrumentPage(instrument: Instrument, obsId: Option[SequenceId]) extends SeqexecPages
+    final case class InstrumentPage(instrument: Instrument) extends SeqexecPages
+    final case class SequencePage(instrument: Instrument, obsId: SequenceId, step: StepId) extends SeqexecPages
     final case class SequenceConfigPage(instrument: Instrument, obsId: SequenceId, step: Int) extends SeqexecPages
 
     implicit val equal: Equal[SeqexecPages] = Equal.equalA

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/semanticui/elements/label/Label.scala
@@ -28,41 +28,53 @@ object Pointing {
 object Label {
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   final case class Props(text: String,
-    htmlFor : Option[String] = None,
-    color   : Option[String] = None,
-    tag     : Boolean = false,
-    basic   : Boolean = false,
-    size    : Size = Size.NotSized,
-    pointing: Pointing = Pointing.None,
-    icon    : Option[Icon] = None,
-    extraStyles: List[scalacss.internal.StyleA] = Nil)
+    htmlFor                  : Option[String] = None,
+    color                    : Option[String] = None,
+    tag                      : Boolean = false,
+    basic                    : Boolean = false,
+    link                     : Boolean = false,
+    size                     : Size = Size.NotSized,
+    pointing                 : Pointing = Pointing.None,
+    icon                     : Option[Icon] = None,
+    extraStyles              : List[scalacss.internal.StyleA] = Nil)
+
+  def content(p: Props): List[TagMod] = List(
+    ^.cls := p.color.fold("ui label")(u => s"ui $u label"),
+    p.extraStyles.map(scalacssStyleaToTagMod).toTagMod,
+    ^.classSet(
+      "basic"          -> p.basic,
+      "tag"            -> p.tag,
+      "tiny"           -> (p.size === Size.Tiny),
+      "mini"           -> (p.size === Size.Mini),
+      "small"          -> (p.size === Size.Small),
+      "large"          -> (p.size === Size.Large),
+      "big"            -> (p.size === Size.Big),
+      "huge"           -> (p.size === Size.Huge),
+      "massive"        -> (p.size === Size.Massive),
+      "pointing"       -> (p.pointing === Pointing.Up),
+      "pointing below" -> (p.pointing === Pointing.Down),
+      "left pointing"  -> (p.pointing === Pointing.Left),
+      "right pointing" -> (p.pointing === Pointing.Right)
+    ),
+    ^.htmlFor :=? p.htmlFor,
+    p.icon.whenDefined,
+    p.text
+  )
 
   private val component = ScalaComponent.builder[Props]("Label")
     .stateless
     .renderPC((_, p, c) =>
-      <.label(
-        ^.cls := p.color.fold("ui label")(u => s"ui $u label"),
-        p.extraStyles.map(scalacssStyleaToTagMod).toTagMod,
-        ^.classSet(
-          "basic"          -> p.basic,
-          "tag"            -> p.tag,
-          "tiny"           -> (p.size === Size.Tiny),
-          "mini"           -> (p.size === Size.Mini),
-          "small"          -> (p.size === Size.Small),
-          "large"          -> (p.size === Size.Large),
-          "big"            -> (p.size === Size.Big),
-          "huge"           -> (p.size === Size.Huge),
-          "massive"        -> (p.size === Size.Massive),
-          "pointing"       -> (p.pointing === Pointing.Up),
-          "pointing below" -> (p.pointing === Pointing.Down),
-          "left pointing"  -> (p.pointing === Pointing.Left),
-          "right pointing" -> (p.pointing === Pointing.Right)
-        ),
-        ^.htmlFor :=? p.htmlFor,
-        p.icon.whenDefined,
-        p.text,
-        c
-      )
+      if (p.link) {
+        <.a(
+          content(p).toTagMod,
+          c
+        )
+      } else {
+        <.label(
+          content(p).toTagMod,
+          c
+        )
+      }
     ).build
 
   def apply(p: Props, children: VdomNode*): Unmounted[Props, Unit, Unit] = component(p)(children: _*)


### PR DESCRIPTION
This is the first part of a change to get the urls to contain the step. Once I started I noted several small defects that could be improved and they are contained on this PR:

* Display the routes on the title

![screenshot 2018-02-23 17 47 16](https://user-images.githubusercontent.com/3615303/36616201-a6d18fca-18c1-11e8-9476-39f86a5ff295.png)

* Have proper links displayed when hovering on a table
<img width="561" alt="monosnap 2018-02-23 17-52-23" src="https://user-images.githubusercontent.com/3615303/36616438-7e592d18-18c2-11e8-889b-a3223ff94a88.png">

* Some small improvements on what's loaded when a sequence is running or the page is just launched with elements on the queue