### PR TITLE
SEQNG-533: Keep more log in the scroll buffer

### DIFF
--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
@@ -129,12 +129,12 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
   }
 
   override def applyConfig(config: Flamingos2Config): SeqAction[Unit] = for {
-    _ <- EitherT(Task(Log.info("Start Flamingos2 configuration").right))
+    _ <- EitherT(Task(Log.debug("Start Flamingos2 configuration").right))
     _ <- setDCConfig(config.dc)
     _ <- setCCConfig(config.cc)
     _ <- Flamingos2Epics.instance.configCmd.setTimeout(ConfigTimeout)
     _ <- Flamingos2Epics.instance.post
-    _ <- EitherT(Task(Log.info("Completed Flamingos2 configuration").right))
+    _ <- EitherT(Task(Log.debug("Completed Flamingos2 configuration").right))
   } yield ()
 
   override def observe(fileId: ImageFileId, expTime: Time): SeqAction[ImageFileId] = for {
@@ -144,7 +144,7 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
   } yield fileId
 
   override def endObserve =  for {
-      _ <- EitherT(Task(Log.info("Send endObserve to Flamingos2").right))
+      _ <- EitherT(Task(Log.debug("Send endObserve to Flamingos2").right))
       _ <- Flamingos2Epics.instance.endObserveCmd.setTimeout(DefaultTimeout)
       _ <- Flamingos2Epics.instance.endObserveCmd.mark
       _ <- Flamingos2Epics.instance.endObserveCmd.post

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gmos/GmosControllerEpics.scala
@@ -201,7 +201,7 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
   } yield ()
 
   override def endObserve: SeqAction[Unit] = for {
-    _ <- EitherT(Task(Log.info("Send endObserve to Gmos").right))
+    _ <- EitherT(Task(Log.debug("Send endObserve to Gmos").right))
     _ <- GmosEpics.instance.endObserveCmd.setTimeout(DefaultTimeout)
     _ <- GmosEpics.instance.endObserveCmd.mark
     _ <- GmosEpics.instance.endObserveCmd.post
@@ -215,11 +215,11 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
   } yield ()
 
   override def resumePaused(expTime: Time): SeqAction[ObserveCommand.Result] = for {
-    _ <- EitherT(Task(Log.info("Resume Gmos observation").right))
+    _ <- EitherT(Task(Log.debug("Resume Gmos observation").right))
     _ <- GmosEpics.instance.continueCmd.setTimeout(expTime+ReadoutTimeout)
     _ <- GmosEpics.instance.continueCmd.mark
     ret <- GmosEpics.instance.continueCmd.post
-    _ <- EitherT(Task(Log.info("Completed Gmos observation").right))
+    _ <- EitherT(Task(Log.debug("Completed Gmos observation").right))
   } yield ret
 
   override def stopPaused = for {

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -229,10 +229,10 @@ object GnirsControllerEpics extends GnirsController {
   }
 
   override def applyConfig(config: GnirsConfig): SeqAction[Unit] =
-    SeqAction(Log.info("Starting GNIRS configuration")) *>
+    SeqAction(Log.debug("Starting GNIRS configuration")) *>
       setDCParams(config.dc) *>
       setCCParams(config.cc) *>
-      SeqAction(Log.info("Completed GNIRS configuration"))
+      SeqAction(Log.debug("Completed GNIRS configuration"))
 
 
   override def observe(fileId: ImageFileId, expTime: Time): SeqAction[ObserveCommand.Result] = for {
@@ -242,7 +242,7 @@ object GnirsControllerEpics extends GnirsController {
   } yield ret
 
   override def endObserve: SeqAction[Unit] = for {
-    _ <- EitherT(Task(Log.info("Send endObserve to GNIRS").right))
+    _ <- EitherT(Task(Log.debug("Send endObserve to GNIRS").right))
     _ <- GnirsEpics.instance.endObserveCmd.setTimeout(DefaultTimeout)
     _ <- GnirsEpics.instance.endObserveCmd.mark
     _ <- GnirsEpics.instance.endObserveCmd.post

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/tcs/TcsControllerEpics.scala
@@ -393,11 +393,11 @@ object TcsControllerEpics extends TcsController {
 
     subsystems.tail.foldLeft(configSubsystem(subsystems.head))((b, a) => b *> configSubsystem(a)) *>
       TcsEpics.instance.post *>
-      EitherT(Task(Log.info("TCS configuration command post").right)) *>
+      EitherT(Task(Log.debug("TCS configuration command post").right)) *>
       (if(subsystems.toList.contains(Subsystem.Mount))
         TcsEpics.instance.waitInPosition(tcsTimeout) *> EitherT(Task(Log.info("TCS inposition").right))
       else if(subsystems.toList.contains(Subsystem.ScienceFold))
-        TcsEpics.instance.waitAGInPosition(agTimeout) *> EitherT(Task(Log.info("AG inposition").right))
+        TcsEpics.instance.waitAGInPosition(agTimeout) *> EitherT(Task(Log.debug("AG inposition").right))
       else SeqAction.void)
   }
 

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/model.scala
@@ -132,7 +132,7 @@ object model {
   object SeqexecUIModel {
     val noSequencesLoaded: SequencesQueue[SequenceView] = SequencesQueue[SequenceView](Conditions.default, None, Nil)
     val initial: SeqexecUIModel = SeqexecUIModel(Pages.Root, None, noSequencesLoaded,
-      SectionClosed, ResourcesConflict(SectionClosed, None), GlobalLog(FixedLengthBuffer.unsafeFromInt(100)), SequencesOnDisplay.empty, true)
+      SectionClosed, ResourcesConflict(SectionClosed, None), GlobalLog(FixedLengthBuffer.unsafeFromInt(500)), SequencesOnDisplay.empty, true)
   }
 
   /**


### PR DESCRIPTION
As requested we'll keep a longer log in memory in clients and reduce some messages from INFO to DEBUG