### PR TITLE
SEQNG-525: Fix border for tables shorter than full heigh

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/LogArea.scala
@@ -34,7 +34,7 @@ object CopyLogToClipboard {
     .render_P { p =>
       // Callback
       val onCopy: OnCopy = (_, _) => Callback.log(s"Copied $p")
-      CopyToClipboard(CopyToClipboard.props(p, onCopy = onCopy), <.div(^.cls := "copydiv", IconCopy.copyIcon(link = true, extraStyles = List(SeqexecStyles.logIconRow))))
+      CopyToClipboard(CopyToClipboard.props(p, onCopy = onCopy), <.div(IconCopy.copyIcon(link = true, extraStyles = List(SeqexecStyles.logIconRow))))
     }.build
 
   def apply(p: String): Unmounted[String, Unit, Unit] = component(p)
@@ -44,6 +44,9 @@ object CopyLogToClipboard {
   * Area to display a sequence's log
   */
 object LogArea {
+  private val CssSettings = scalacss.devOrProdDefaults
+  import CssSettings._
+
   // Date time formatter
   private val formatter  = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SS")
   // ScalaJS defined trait
@@ -125,14 +128,15 @@ object LogArea {
       Column(Column.props(TimestampWidth, "local", label = "Timestamp", disableSort = true)),
       Column(Column.props(LevelWidth, "level", label = "Level", disableSort = true)),
       Column(Column.props(size.width.toInt - TimestampWidth - LevelWidth - ClipboardWidth, "msg", label = "Message", disableSort = true)),
-      Column(Column.props(ClipboardWidth, "clip", disableSort = true, headerRenderer = clipboardHeaderRenderer, cellRenderer = clipboardCellRenderer))
+      Column(Column.props(ClipboardWidth, "clip", disableSort = true, flexShrink = 0, flexGrow = 0, headerRenderer = clipboardHeaderRenderer, cellRenderer = clipboardCellRenderer, className = SeqexecStyles.clipboardIconDiv.htmlClass, headerClassName = SeqexecStyles.clipboardIconHeader.htmlClass))
     )
 
-    def rowClassName(s: State)(i: Int): String = (p.rowGetter(s)(i) match {
-      case LogRow(_, ServerLogLevel.INFO, _, _)  => SeqexecStyles.infoLog
-      case LogRow(_, ServerLogLevel.WARN, _, _)  => SeqexecStyles.warningLog
-      case LogRow(_, ServerLogLevel.ERROR, _, _) => SeqexecStyles.errorLog
-      case _                                     => SeqexecStyles.headerRowStyle
+    def rowClassName(s: State)(i: Int): String = ((i, p.rowGetter(s)(i)) match {
+      case (-1, _)                                    => SeqexecStyles.headerRowStyle
+      case (_, LogRow(_, ServerLogLevel.INFO, _, _))  => SeqexecStyles.stepRow + SeqexecStyles.infoLog
+      case (_, LogRow(_, ServerLogLevel.WARN, _, _))  => SeqexecStyles.stepRow + SeqexecStyles.warningLog
+      case (_, LogRow(_, ServerLogLevel.ERROR, _, _)) => SeqexecStyles.stepRow + SeqexecStyles.errorLog
+      case _                                          => SeqexecStyles.stepRow
     }).htmlClass
 
     Table(
@@ -141,6 +145,7 @@ object LogArea {
         noRowsRenderer = () =>
           <.div(
             ^.cls := "ui center aligned segment noRows",
+            SeqexecStyles.noRowsSegment,
             ^.height := 270.px,
             "No log entries"
           ),

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -359,8 +359,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     outline.none,
     minHeight(headerHeight.px),
     height(headerHeight.px),
-    paddingLeft(6.px),
-    paddingTop(6.px)
+    paddingLeft(7.px),
+    paddingTop(7.px)
   )
 
   // Override styles used by react-virtualized
@@ -388,7 +388,6 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val rowMixin: StyleS = mixin(
-    leftBorderMixin,
     topBorderMixin,
     rightBorderMixin
   )
@@ -411,12 +410,9 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     justifyContent.flexStart
   )
 
-  val controlCellHeader: StyleA = style(
-    paddingBottom((headerHeight/4).px)
-  )
-
   val tableGrid: StyleA = style("ReactVirtualized__Table__Grid")(
-    topBorderMixin,
+    leftBorderMixin,
+    rightBorderMixin,
     bottomBorderMixin,
     outline.none
   )
@@ -449,8 +445,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     marginLeft(auto)
   )
 
-  // This must be defined before rowColumn
   val settingsCellRow: StyleA = style(
+    minWidth(35.px).important,
     paddingRight(5.px).important,
     paddingLeft(0.px).important,
     overflow.unset.important
@@ -476,11 +472,16 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     &.hover(
       backgroundColor(rgba(0, 0, 0, 0.05)),
       color(rgba(0, 0, 0, 0.95))
+    ),
+    &.firstOfType(
+      borderTop.none
     )
   )
 
   val headerRowStyle: StyleA = style(
     rowMixin,
+    leftBorderMixin,
+    bottomBorderMixin,
     backgroundColor(c"#F9FAFB"),
     minHeight(headerHeight.px),
     height(headerHeight.px)
@@ -557,7 +558,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val statusCellMixin: StyleS = mixin(
-    alignContent.center,
+    alignItems.center,
     display.flex,
     height(100.%%),
     width(100.%%),
@@ -741,5 +742,29 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
 
   val labelPointer: StyleA = style(
     cursor.pointer
+  )
+
+  val noRowsSegment: StyleA = style(
+    border.none.important
+  )
+
+  val clipboardIconDiv: StyleA = style(
+    minWidth(38.px),
+    display.flex,
+    paddingTop(4.px),
+    justifyContent.center,
+    alignItems.center,
+    height(100.%%),
+    width(100.%%)
+  )
+
+  val clipboardIconHeader: StyleA = style(
+    display.flex,
+    paddingTop(4.px),
+    justifyContent.center,
+    alignItems.center,
+    height(100.%%),
+    width(100.%%),
+    paddingLeft(3.px)
   )
 }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -36,7 +36,7 @@ object ColWidths {
   val FilterWidth: Int = 100
   val FPUWidth: Int = 100
   val ObjectTypeWidth: Int = 75
-  val SettingsWidth: Int = 27
+  val SettingsWidth: Int = 34
 }
 
 /**


### PR DESCRIPTION
These are some improvements to the way tables are displayed. For example, when a table was too short the borders didn't extend all the way down and we'd get double borders sometimes

The difference is subtle but enough for me to notice it

