### PR TITLE
SEQNG-440: Enable displaying settings of disabled steps

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -504,7 +504,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     minWidth(35.px).important,
     paddingRight(5.px).important,
     paddingLeft(0.px).important,
-    overflow.unset.important
+    overflow.unset.important,
+    pointerEvents := "auto"
   )
 
   val rowColumn: StyleA = style("ReactVirtualized__Table__rowColumn")(


### PR DESCRIPTION
This is a tiny fix to support displaying the step settings table for done steps. Those are marked as disabled but this fix lets the last column to accept clicks