### PR TITLE
SEQNG-212: Display an indication on the UI when there are resource conflicts

### DIFF
--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Engine.scala
@@ -5,7 +5,7 @@ package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.engine.Event._
 import edu.gemini.seqexec.engine.Result.{PartialVal, PauseContext, RetVal}
-import edu.gemini.seqexec.model.Model.{Conditions, Observer, Resource, SequenceState}
+import edu.gemini.seqexec.model.Model.{ClientID, Conditions, Observer, Resource, SequenceState}
 import org.log4s.getLogger
 import scalaz.concurrent.Task
 import scalaz.{Applicative, Kleisli, MonadState, StateT}
@@ -92,7 +92,7 @@ class Engine[D: ActionMetadataGenerator, U](implicit ev: ActionMetadataGenerator
   private def switch(id: Sequence.Id)(st: SequenceState): HandleP[Unit] =
     modifyS(id)(s => Sequence.State.status.set(st)(s))
 
-  private def start(id: Sequence.Id): HandleP[Unit] =
+  private def start(id: Sequence.Id, clientId: ClientID): HandleP[Unit] =
     resources.flatMap(
       other => getS(id).flatMap {
         case Some(seq) =>
@@ -102,7 +102,7 @@ class Engine[D: ActionMetadataGenerator, U](implicit ev: ActionMetadataGenerator
               putS(id)(Sequence.State.status.set(SequenceState.Running.init)(seq.skips.getOrElse(seq).rollback)) *>
                 send(Event.executing(id))
             // Some resources are being used
-            else send(busy(id))
+            else send(busy(id, clientId))
           else unit
         case None      => unit
       }
@@ -298,7 +298,7 @@ class Engine[D: ActionMetadataGenerator, U](implicit ev: ActionMetadataGenerator
     */
   private def run(ev: EventType): HandleP[StateType] = {
     def handleUserEvent(ue: UserEventType): HandleP[Unit] = ue match {
-      case Start(id, _)               => Logger.debug("Engine: Started") *> start(id)
+      case Start(id, _, clientId)     => Logger.debug("Engine: Started") *> start(id, clientId)
       case Pause(id, _)               => Logger.debug("Engine: Pause requested") *> pause(id)
       case CancelPause(id, _)         => Logger.debug("Engine: Pause canceled") *> cancelPause(id)
       case Load(id, seq)              => Logger.debug("Engine: Sequence loaded") *> load(id, seq)
@@ -325,7 +325,7 @@ class Engine[D: ActionMetadataGenerator, U](implicit ev: ActionMetadataGenerator
       case PartialResult(id, i, r) => Logger.debug("Engine: Partial result") *> partialResult(id, i, r)
       case Paused(id, i, r)        => Logger.debug("Engine: Action paused") *> actionPause(id, i, r)
       case Failed(id, i, e)        => logError(e) *> fail(id)(i, e)
-      case Busy(id)                => Logger.warning(s"Cannot run sequence $id because required systems are in use.")
+      case Busy(id, _)             => Logger.warning(s"Cannot run sequence $id because required systems are in use.")
       case BreakpointReached(_)    => Logger.debug("Engine: Breakpoint reached")
       case Executed(id)            => Logger.debug("Engine: Execution completed") *> next(id)
       case Executing(id)           => Logger.debug("Engine: Executing") *> execute(id)

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/Event.scala
@@ -19,7 +19,7 @@ final case class EventSystem(se: SystemEvent) extends Event[Nothing]
 
 object Event {
 
-  def start[D<:Engine.Types](id: Sequence.Id, user: UserDetails): Event[D] = EventUser[D](Start(id, user.some))
+  def start[D<:Engine.Types](id: Sequence.Id, user: UserDetails, clientId: ClientID): Event[D] = EventUser[D](Start(id, user.some, clientId))
   def pause[D<:Engine.Types](id: Sequence.Id, user: UserDetails): Event[D] = EventUser[D](Pause(id, user.some))
   def cancelPause[D<:Engine.Types](id: Sequence.Id, user: UserDetails): Event[D] = EventUser[D](CancelPause(id, user.some))
   def load[D<:Engine.Types](id: Sequence.Id, sequence: Sequence): Event[D] = EventUser[D](Load(id, sequence))
@@ -43,7 +43,7 @@ object Event {
   def partial[R<:Result.PartialVal](id: Sequence.Id, i: Int, r: Result.Partial[R]): Event[Nothing] = EventSystem(PartialResult(id, i, r))
   def paused[C <: Result.PauseContext](id: Sequence.Id, i: Int, c: Result.Paused[C]): Event[Nothing] = EventSystem(Paused(id, i, c))
   def breakpointReached(id: Sequence.Id): Event[Nothing] = EventSystem(BreakpointReached(id))
-  def busy(id: Sequence.Id): Event[Nothing] = EventSystem(Busy(id))
+  def busy(id: Sequence.Id, clientId: ClientID): Event[Nothing] = EventSystem(Busy(id, clientId))
   def executed(id: Sequence.Id): Event[Nothing] = EventSystem(Executed(id))
   def executing(id: Sequence.Id): Event[Nothing] = EventSystem(Executing(id))
   def finished(id: Sequence.Id): Event[Nothing] = EventSystem(Finished(id))

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/SystemEvent.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/SystemEvent.scala
@@ -4,10 +4,8 @@
 package edu.gemini.seqexec.engine
 
 import edu.gemini.seqexec.engine.Result._
+import edu.gemini.seqexec.model.Model.ClientID
 
-/**
-  * Created by jluhrs on 9/25/17.
-  */
 /**
   * Events generated internally by the Engine.
   */
@@ -16,7 +14,7 @@ final case class Completed[R<:RetVal](id: Sequence.Id, i: Int, r: OK[R]) extends
 final case class PartialResult[R<:PartialVal](id: Sequence.Id, i: Int, r: Partial[R]) extends SystemEvent
 final case class Paused[C <: PauseContext](id: Sequence.Id, i: Int, r: Result.Paused[C]) extends SystemEvent
 final case class Failed(id: Sequence.Id, i: Int, e: Result.Error) extends SystemEvent
-final case class Busy(id: Sequence.Id) extends SystemEvent
+final case class Busy(id: Sequence.Id, clientId: ClientID) extends SystemEvent
 final case class BreakpointReached(id: Sequence.Id) extends SystemEvent
 final case class Executed(id: Sequence.Id) extends SystemEvent
 final case class Executing(id: Sequence.Id) extends SystemEvent

--- a/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/UserEvent.scala
+++ b/modules/edu.gemini.seqexec.engine/src/main/scala/edu/gemini/seqexec/engine/UserEvent.scala
@@ -19,7 +19,7 @@ sealed trait UserEvent[+D<:Engine.Types] {
   def username: String = ~user.map(_.username)
 }
 
-final case class Start(id: Sequence.Id, user: Option[UserDetails]) extends UserEvent[Nothing]
+final case class Start(id: Sequence.Id, user: Option[UserDetails], clientId: ClientID) extends UserEvent[Nothing]
 final case class Pause(id: Sequence.Id, user: Option[UserDetails]) extends UserEvent[Nothing]
 final case class CancelPause(id: Sequence.Id, user: Option[UserDetails]) extends UserEvent[Nothing]
 final case class Load(id: Sequence.Id, sequence: Sequence) extends UserEvent[Nothing] {

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/SequenceSpec.scala
@@ -15,9 +15,8 @@ import org.scalatest.Matchers._
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 
-/**
-  * Created by jluhrs on 9/29/16.
-  */
+import java.util.UUID
+
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class SequenceSpec extends FlatSpec {
   private val seqId ="TEST-01"
@@ -80,7 +79,7 @@ class SequenceSpec extends FlatSpec {
   }
 
   def runToCompletion(s0: Engine.State[Unit]): Option[Engine.State[Unit]] = {
-    executionEngine.process(Process.eval(Task.now(Event.start(seqId, user))))(s0).drop(1).takeThrough(
+    executionEngine.process(Process.eval(Task.now(Event.start(seqId, user, UUID.randomUUID()))))(s0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).runLast.unsafePerformSync.map(_._2)
   }

--- a/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
+++ b/modules/edu.gemini.seqexec.engine/src/test/scala/edu/gemini/seqexec/engine/StepSpec.scala
@@ -17,9 +17,8 @@ import edu.gemini.seqexec.model.{ActionType, UserDetails}
 import scala.Function.const
 import scalaz.Kleisli
 
-/**
-  * Created by jluhrs on 9/29/16.
-  */
+import java.util.UUID
+
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class StepSpec extends FlatSpec {
 
@@ -81,7 +80,7 @@ class StepSpec extends FlatSpec {
 
   def triggerStart(q: async.mutable.Queue[executionEngine.EventType]): Action = fromTask(ActionType.Undefined,
     for {
-      _ <- q.enqueueOne(Event.start(seqId, user))
+      _ <- q.enqueueOne(Event.start(seqId, user, UUID.randomUUID()))
       // Same case that the pause action
     } yield Result.OK(Result.Configured(Resource.TCS)))
 
@@ -93,13 +92,13 @@ class StepSpec extends FlatSpec {
   }
 
   def runToCompletion(s0: Engine.State[Unit]): Option[Engine.State[Unit]] = {
-    executionEngine.process(Process.eval(Task.now(Event.start(seqId, user))))(s0).drop(1).takeThrough(
+    executionEngine.process(Process.eval(Task.now(Event.start(seqId, user, UUID.randomUUID()))))(s0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).runLast.unsafePerformSync.map(_._2)
   }
 
   def runToCompletionL(s0: Engine.State[Unit]): List[Engine.State[Unit]] = {
-    executionEngine.process(Process.eval(Task.now(Event.start(seqId, user))))(s0).drop(1).takeThrough(
+    executionEngine.process(Process.eval(Task.now(Event.start(seqId, user, UUID.randomUUID()))))(s0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).runLog.unsafePerformSync.map(_._2).toList
   }
@@ -140,7 +139,7 @@ class StepSpec extends FlatSpec {
         )
       )
 
-    val qs1 = q.enqueueOne(Event.start(seqId, user)).flatMap(_ => executionEngine.process(q.dequeue)(qs0).drop(1).takeThrough(
+    val qs1 = q.enqueueOne(Event.start(seqId, user, UUID.randomUUID())).flatMap(_ => executionEngine.process(q.dequeue)(qs0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).runLast).unsafePerformSync.map(_._2)
 
@@ -187,7 +186,7 @@ class StepSpec extends FlatSpec {
         )
       )
 
-    val qs1 = executionEngine.process(Process.eval(Task.now(Event.start(seqId, user))))(qs0).take(1).runLast.unsafePerformSync.map(_._2)
+    val qs1 = executionEngine.process(Process.eval(Task.now(Event.start(seqId, user, UUID.randomUUID()))))(qs0).take(1).runLast.unsafePerformSync.map(_._2)
 
     inside (qs1.flatMap(_.sequences.get(seqId))) {
       case Some(Sequence.State.Zipper(zipper, status)) =>
@@ -310,7 +309,7 @@ class StepSpec extends FlatSpec {
         )
       )
 
-    val qss = q.enqueueOne(Event.start(seqId, user)).flatMap(_ => executionEngine.process(q.dequeue)(qs0).drop(1).takeThrough(
+    val qss = q.enqueueOne(Event.start(seqId, user, UUID.randomUUID)).flatMap(_ => executionEngine.process(q.dequeue)(qs0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).runLog).unsafePerformSync
 

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/ModelLenses.scala
@@ -81,7 +81,7 @@ trait ModelLenses {
       case e @ SequencePauseCanceled(_)   => e.copy(view = q)
       case e @ SequenceRefreshed(_, _)    => e.copy(view = q)
       case e @ ActionStopRequested(_)     => e.copy(view = q)
-      case e @ ResourcesBusy(_, _)        => e.copy(view = q)
+      case e @ ResourcesBusy(_, _, _)     => e.copy(view = q)
       case e @ SequenceError(_, _)        => e.copy(view = q)
       case e @ SequencePaused(_, _)       => e.copy(view = q)
       case e @ ExposurePaused(_, _)       => e.copy(view = q)

--- a/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/events.scala
+++ b/modules/edu.gemini.seqexec.model/src/main/scala/edu/gemini/seqexec/model/events.scala
@@ -64,7 +64,7 @@ object events {
 
     final case class ActionStopRequested(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 
-    final case class ResourcesBusy(obsId: SequenceId, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+    final case class ResourcesBusy(obsId: SequenceId, view: SequencesQueue[SequenceView], clientId: ClientID) extends SeqexecModelUpdate with ForClient
 
     final case class SequenceUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
 

--- a/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
+++ b/modules/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecEngine.scala
@@ -76,8 +76,8 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
 
   def load(q: EventQueue, seqId: SPObservationID): Task[SeqexecFailure \/ Unit] = loadEvents(seqId).flatMapF(q.enqueueAll(_).map(_.right)).run
 
-  def start(q: EventQueue, id: SPObservationID, user: UserDetails): Task[SeqexecFailure \/ Unit] =
-    q.enqueueOne(Event.start(id.stringValue(), user)).map(_.right)
+  def start(q: EventQueue, id: SPObservationID, user: UserDetails, clientId: ClientID): Task[SeqexecFailure \/ Unit] =
+    q.enqueueOne(Event.start(id.stringValue(), user, clientId)).map(_.right)
 
   def requestPause(q: EventQueue, id: SPObservationID, user: UserDetails): Task[SeqexecFailure \/ Unit] =
     q.enqueueOne(Event.pause(id.stringValue(), user)).map(_.right)
@@ -262,7 +262,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
 
   private def toSeqexecEvent(ev: executeEngine.EventType)(svs: => SequencesQueue[SequenceView]): SeqexecEvent = ev match {
     case engine.EventUser(ue) => ue match {
-      case engine.Start(_, _)            => SequenceStart(svs)
+      case engine.Start(_, _, _)         => SequenceStart(svs)
       case engine.Pause(_, _)            => SequencePauseRequested(svs)
       case engine.CancelPause(_, _)      => SequencePauseCanceled(svs)
       case engine.Load(id, _)            => SequenceLoaded(id, svs)
@@ -287,7 +287,7 @@ class SeqexecEngine(settings: SeqexecEngine.Settings) {
       case engine.PartialResult(_, _, Partial(FileIdAllocated(fileId), _))  => FileIdStepExecuted(fileId, svs)
       case engine.PartialResult(_, _, _)                                    => SequenceUpdated(svs)
       case engine.Failed(id, _, _)                                          => SequenceError(id, svs)
-      case engine.Busy(id)                                                  => ResourcesBusy(id, svs)
+      case engine.Busy(id, clientId)                                        => ResourcesBusy(id, svs, clientId)
       case engine.Executed(s)                                               => StepExecuted(s, svs)
       case engine.Executing(_)                                              => SequenceUpdated(svs)
       case engine.Finished(_)                                               => SequenceCompleted(svs)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -84,7 +84,7 @@ object SequenceControl {
           val runContinueButton = s"${isPartiallyExecuted ? "Continue" | "Run"} from step $nextStepToRun"
           List(
             // Sync button
-            controlButton(IconRefresh, "purple", $.runState(requestSync(id)), (!allowedToExecute || !s.canSync) && !inConflict, s"Sync sequence", s"Sync $inConflict")
+            controlButton(IconRefresh, "purple", $.runState(requestSync(id)), (!allowedToExecute || !s.canSync) && !inConflict, "Sync sequence", "Sync")
               .when(status.isIdle || status.isError),
             // Run button
             controlButton(IconPlay, "blue", $.runState(requestRun(id)), (!allowedToExecute || !s.canRun) && !inConflict, runContinueTooltip, runContinueButton)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -78,16 +78,16 @@ object SequenceControl {
       val allowedToExecute = isLogged && isConnected
       <.div(
         control.whenDefined { m =>
-          val ControlModel(id, isPartiallyExecuted, nextStep, status) = m
+          val ControlModel(id, isPartiallyExecuted, nextStep, status, inConflict) = m
           val nextStepToRun = nextStep.getOrElse(0) + 1
           val runContinueTooltip = s"${isPartiallyExecuted ? "Continue" | "Run"} the sequence from the step $nextStepToRun"
           val runContinueButton = s"${isPartiallyExecuted ? "Continue" | "Run"} from step $nextStepToRun"
           List(
             // Sync button
-            controlButton(IconRefresh, "purple", $.runState(requestSync(id)), !allowedToExecute || !s.canSync, "Sync sequence", "Sync")
+            controlButton(IconRefresh, "purple", $.runState(requestSync(id)), (!allowedToExecute || !s.canSync) && !inConflict, s"Sync sequence", s"Sync $inConflict")
               .when(status.isIdle || status.isError),
             // Run button
-            controlButton(IconPlay, "blue", $.runState(requestRun(id)), !allowedToExecute || !s.canRun, runContinueTooltip, runContinueButton)
+            controlButton(IconPlay, "blue", $.runState(requestRun(id)), (!allowedToExecute || !s.canRun) && !inConflict, runContinueTooltip, runContinueButton)
               .when(status.isIdle || status.isError),
             // Cancel pause button
             controlButton(IconBan, "brown", $.runState(requestCancelPause(id)), !allowedToExecute || !s.canCancelPause, "Cancel process to pause the sequence", "Cancel Pause")

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/actions.scala
@@ -103,6 +103,8 @@ object actions {
       s"${s.getClass.getSimpleName}(${view.id})"
     case s @ InitialSyncToPage(view)                     =>
       s"${s.getClass.getSimpleName}(${view.id})"
+    case s @ SyncToRunning(view)                     =>
+      s"${s.getClass.getSimpleName}(${view.id})"
     case a                                               =>
       s"$a"
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/circuit.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/model/circuit.scala
@@ -122,6 +122,7 @@ object circuit {
     private val globalLogHandler         = new GlobalLogHandler(zoomTo(_.uiModel.globalLog))
     private val conditionsHandler        = new ConditionsHandler(zoomTo(_.uiModel.sequences.conditions))
     private val operatorHandler          = new OperatorHandler(zoomTo(_.uiModel.sequences.operator))
+    private val remoteRequestsHandler    = new RemoteRequestsHandler(zoomTo(_.clientId))
 
     override protected def initialModel = SeqexecAppRootModel.initial
 
@@ -213,6 +214,7 @@ object circuit {
       globalLogHandler,
       conditionsHandler,
       operatorHandler,
+      remoteRequestsHandler,
       navigationHandler)
 
     /**

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/services/SeqexecWebClient.scala
@@ -52,9 +52,9 @@ object SeqexecWebClient {
   /**
     * Requests the backend to execute a sequence
     */
-  def run(id: SequenceId): Future[RegularCommand] = {
+  def run(id: SequenceId, clientId: ClientID): Future[RegularCommand] = {
     Ajax.post(
-      url = s"$baseUrl/commands/$id/start",
+      url = s"$baseUrl/commands/$id/start/$clientId",
       responseType = "arraybuffer"
     ).map(unpickle[RegularCommand])
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -40,12 +40,12 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: server.Event
     case GET  -> Root  / obsId / "count" as _ =>
       Ok(toCommandResult("count", commands.showCount(obsId)))
 
-    case POST -> Root / obsId / "start" as user =>
+    case POST -> Root / obsId / "start" / ClientIDVar(clientId) as user =>
       for {
         obs <-
             \/.fromTryCatchNonFatal(new SPObservationID(obsId))
               .fold(e => Task.fail(e), Task.now)
-        _     <- se.start(inputQueue, obs, user)
+        _     <- se.start(inputQueue, obs, user, clientId)
         resp  <- Ok(s"Started sequence $obs")
       } yield resp
 


### PR DESCRIPTION
When there is a resource conflict (an attempt to run a sequence no an instrument in use) a notification is displayed. However, this is displayed to all the clients. This fixes that and only the user requesting running the sequence will be notified