### PR TITLE
Use sbt-dynver to produce the version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,14 +28,20 @@ cancelable in Global := true
 
 // Settings to use git to define the version of the project
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
-  val dirtySuffix = out.dirtySuffix.dropPlus.mkString("-", "-UNCOMMITED")
-  out.ref.dropV.value + out.commitSuffix.mkString("+", "-", "") + dirtySuffix
+  val dirtySuffix = if (out.dirtySuffix.mkString("", "").nonEmpty) {
+    "-UNCOMMITED"
+  } else {
+    ""
+  }
+  s"-${out.commitSuffix.sha}$dirtySuffix"
 }
 
 def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
 
+val dateFormatter = java.time.format.DateTimeFormatter.BASIC_ISO_DATE
+
 inThisBuild(List(
-  version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
+  version := dateFormatter.format(dynverCurrentDate.value.toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDate()) + dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
   dynver := {
      val d = new java.util.Date
      sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))

--- a/build.sbt
+++ b/build.sbt
@@ -41,11 +41,7 @@ def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer times
 val dateFormatter = java.time.format.DateTimeFormatter.BASIC_ISO_DATE
 
 inThisBuild(List(
-  version := dateFormatter.format(dynverCurrentDate.value.toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDate()) + dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
-  dynver := {
-     val d = new java.util.Date
-     sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
-  }
+  version := dateFormatter.format(dynverCurrentDate.value.toInstant.atZone(java.time.ZoneId.of("UTC")).toLocalDate) + dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value))
 ))
 
 enablePlugins(GitBranchPrompt)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,6 +21,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header"             % "3.0.1")
 
 // Built the version out of git
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"                % "0.9.3")
+addSbtPlugin("com.dwijnand"      % "sbt-dynver"             % "3.0.0")
 
 addSbtPlugin("org.wartremover"   % "sbt-wartremover"        % "2.2.1")
 


### PR DESCRIPTION
This PR changes the way to calculate the version in such a way that the hash is always shown. The format is
`<last-tag>+<commits-after-last-tag>-<hash>|-<date>-<time>-UNCOMMITED|`

The part between `|` is only used if there are uncommitted changes

There are 4 scenarios:
* We are on a tag without Uncommitted changes, in that case, the version is:
 **0.8.7+0-468910be**

* We are on a tag with uncommmited changes:
 **0.8.7+0-468910be-20180321-1931-UNCOMMITED**

* We have commits after the last tag:
 **0.8.6+17-468910be**

* Commits after the last tag and uncommited changes
 **0.8.7+0-468910be-20180321-1931-UNCOMMITED**

@tpolecat, @swalker2m , @arturog8m  Does this seem right?