### PR TITLE
SEQNG-575: GMP update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,9 @@ parallelExecution in (ThisBuild, Test) := false
 
 cancelable in Global := true
 
+// Uncomment for local gmp testing
+// resolvers in ThisBuild += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/Projects/maven-repo/releases"
+
 // Settings to use git to define the version of the project
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
   val dirtySuffix = if (out.dirtySuffix.mkString("", "").nonEmpty) {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -116,9 +116,9 @@ object Settings {
 
     val apacheXMLRPC      = "3.1.3"
     val opencsv           = "2.1"
-    val epicsService      = "0.18"
-    val gmpCommandRecords = "0.6.6"
-    val guava             = "16.0.1"
+    val epicsService      = "1.0.0"
+    val gmpCommandRecords = "0.7.0"
+    val guava             = "24.1-jre"
   }
 
   /**


### PR DESCRIPTION
The GMP has been updated upstream to run on java 1.8 and scala 2.12
This PR updates the dependencies to use the new release