### PR TITLE
SEQNG-583: Obs queue column widths sometimes too narrow

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -12,11 +12,13 @@ import edu.gemini.seqexec.web.client.model.Pages._
 import edu.gemini.seqexec.web.client.ModelOps._
 import edu.gemini.seqexec.web.client.services.HtmlConstants.iconEmpty
 import edu.gemini.seqexec.web.client.semanticui.elements.icon.Icon.{IconAttention, IconCheckmark, IconCircleNotched, IconSelectedRadio}
+import edu.gemini.web.client.utils._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.router.RouterCtl
 import react.virtualized._
+import scala.math.max
 
 import scalacss.ScalaCssReact._
 import scalaz.syntax.show._
@@ -91,9 +93,11 @@ object QueueTableBody {
 
   private def obsNameRenderer(p: Props) = linkedTextRenderer(p){ r => <.p(SeqexecStyles.queueText, r.name) }
 
+  private def statusText(status: SequenceState, runningStep: Option[RunningStep]): String =
+    s"${status.shows} ${runningStep.map(u => s" ${u.shows}").getOrElse("")}"
+
   private def stateRenderer(p: Props) = linkedTextRenderer(p){ r =>
-    val stepAtText = r.status.shows + r.runningStep.map(u => s" ${u.shows}").getOrElse("")
-    <.p(SeqexecStyles.queueText, stepAtText)
+    <.p(SeqexecStyles.queueText, statusText(r.status, r.runningStep))
   }
 
   private def instrumentRenderer(p: Props) = linkedTextRenderer(p){ r => <.p(SeqexecStyles.queueText, r.instrument.shows) }
@@ -129,6 +133,8 @@ object QueueTableBody {
   private val IconColumnWidth = 12
   private val ObsIdColumnWidth = 140
   private val StateColumnWidth = 80
+  private val InstrumentColumnWidth = 80
+  private val NameColumnWidth = 140
   private val TargetNameColumnWidth = 140
 
   val statusHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
@@ -137,21 +143,35 @@ object QueueTableBody {
       ^.width := IconColumnWidth.px
     )
 
+  val QueueColumnStyle: String = SeqexecStyles.queueTextColumn.htmlClass
+
   private def columns(p: Props, s: Size): List[Table.ColumnArg] = {
     val isLogged = p.sequences().isLogged
-    val targetColumn = Column(Column.props(TargetNameColumnWidth, "target", flexShrink = 1, flexGrow = 3, label = "Target", cellRenderer = targetRenderer(p), className = SeqexecStyles.queueTextColumn.htmlClass))
-    val nameColumn = Column(Column.props(TargetNameColumnWidth, "obsName", flexShrink = 1, flexGrow = 3, label = "Obs. Name", cellRenderer = obsNameRenderer(p), className = SeqexecStyles.queueTextColumn.htmlClass))
-    val (loggedInWidth, loggedInColumns) = s.width match {
-      case w if w < PhoneCut      => (0, Nil)
-      case w if w < LargePhoneCut => (TargetNameColumnWidth, List(targetColumn))
-      case _                      => (2 * TargetNameColumnWidth, List(targetColumn, nameColumn))
+
+    // Calculate the column's width
+    val (obsColumnWidth, statusColumnWidth, instrumentColumnWidth, nameColumnWidth, targetNameColumnWidth) = p.sequences().sequences.map {
+      case SequenceInQueue(id, st, i, _, n, t, r) =>
+        (tableTextWidth(id), tableTextWidth(statusText(st, r)), tableTextWidth(i.shows), tableTextWidth(n), tableTextWidth(t.getOrElse("")))
+    }.foldLeft((ObsIdColumnWidth, StateColumnWidth, InstrumentColumnWidth, NameColumnWidth, TargetNameColumnWidth)) {
+      case ((o, s, i, n, t), (co, cs, ci, cn, ct)) =>
+        (max(o, co), max(s, cs), max(i, ci), max(n, cn), max(t, ct))
     }
-    val instWidth = s.width - IconColumnWidth - ObsIdColumnWidth - StateColumnWidth - loggedInWidth + 2
+
+    // Columns displayed when logged in
+    val targetColumn = Column(Column.props(targetNameColumnWidth, "target", flexShrink = 0, flexGrow = 2, label = "Target", cellRenderer = targetRenderer(p), className = QueueColumnStyle))
+    val nameColumn = Column(Column.props(nameColumnWidth, "obsName", flexShrink = 0, flexGrow = 3, label = "Obs. Name", cellRenderer = obsNameRenderer(p), className = QueueColumnStyle))
+
+    val loggedInColumns = s.width match {
+      case w if w < PhoneCut      => Nil
+      case w if w < LargePhoneCut => List(targetColumn)
+      case _                      => List(targetColumn, nameColumn)
+    }
+
     val regularColumns = List(
       Column(Column.props(IconColumnWidth, "status", flexShrink = 0, flexGrow = 0, label = "", cellRenderer = statusIconRenderer(p), headerRenderer = statusHeaderRenderer, className = SeqexecStyles.queueIconColumn.htmlClass)),
-      Column(Column.props(ObsIdColumnWidth, "obsId", flexShrink = 0, flexGrow = 0, label = "Obs. ID", cellRenderer = obsIdRenderer(p), className = SeqexecStyles.queueTextColumn.htmlClass)),
-      Column(Column.props(StateColumnWidth, "state", flexShrink = 0, flexGrow = 0, label = "State", cellRenderer = stateRenderer(p), className = SeqexecStyles.queueTextColumn.htmlClass)),
-      Column(Column.props(instWidth.toInt, "instrument", flexShrink = 0, flexGrow = 1, label = "Instrument", cellRenderer = instrumentRenderer(p), className = SeqexecStyles.queueTextColumn.htmlClass))
+      Column(Column.props(obsColumnWidth, "obsId", flexShrink = 0, flexGrow = 2, label = "Obs. ID", cellRenderer = obsIdRenderer(p), className = QueueColumnStyle)),
+      Column(Column.props(statusColumnWidth, "state", flexShrink = 0, flexGrow = 0, label = "State", cellRenderer = stateRenderer(p), className = QueueColumnStyle)),
+      Column(Column.props(instrumentColumnWidth, "instrument", flexShrink = 0, flexGrow = 1, label = "Instrument", cellRenderer = instrumentRenderer(p), className = QueueColumnStyle))
     )
     isLogged.fold(regularColumns ::: loggedInColumns, regularColumns)
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/QueueArea.scala
@@ -130,12 +130,13 @@ object QueueTableBody {
 
   private val PhoneCut = 400
   private val LargePhoneCut = 570
-  private val IconColumnWidth = 12
+  private val IconColumnWidth = 20
   private val ObsIdColumnWidth = 140
   private val StateColumnWidth = 80
   private val InstrumentColumnWidth = 80
   private val NameColumnWidth = 140
   private val TargetNameColumnWidth = 140
+  private val ColumnPadding = 10 + 1 // Taken from SeqexecStyles.queueText padding and 1 for border
 
   val statusHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
     <.div(
@@ -158,8 +159,8 @@ object QueueTableBody {
     }
 
     // Columns displayed when logged in
-    val targetColumn = Column(Column.props(targetNameColumnWidth, "target", flexShrink = 0, flexGrow = 2, label = "Target", cellRenderer = targetRenderer(p), className = QueueColumnStyle))
-    val nameColumn = Column(Column.props(nameColumnWidth, "obsName", flexShrink = 0, flexGrow = 3, label = "Obs. Name", cellRenderer = obsNameRenderer(p), className = QueueColumnStyle))
+    val targetColumn = Column(Column.props(targetNameColumnWidth + ColumnPadding, "target", minWidth = TargetNameColumnWidth / 2, flexShrink = 2, flexGrow = 2, label = "Target", cellRenderer = targetRenderer(p), className = QueueColumnStyle))
+    val nameColumn = Column(Column.props(nameColumnWidth + ColumnPadding, "obsName", minWidth = NameColumnWidth / 2, flexShrink = 2, flexGrow = 2, label = "Obs. Name", cellRenderer = obsNameRenderer(p), className = QueueColumnStyle))
 
     val loggedInColumns = s.width match {
       case w if w < PhoneCut      => Nil
@@ -169,9 +170,9 @@ object QueueTableBody {
 
     val regularColumns = List(
       Column(Column.props(IconColumnWidth, "status", flexShrink = 0, flexGrow = 0, label = "", cellRenderer = statusIconRenderer(p), headerRenderer = statusHeaderRenderer, className = SeqexecStyles.queueIconColumn.htmlClass)),
-      Column(Column.props(obsColumnWidth, "obsId", flexShrink = 0, flexGrow = 2, label = "Obs. ID", cellRenderer = obsIdRenderer(p), className = QueueColumnStyle)),
-      Column(Column.props(statusColumnWidth, "state", flexShrink = 0, flexGrow = 0, label = "State", cellRenderer = stateRenderer(p), className = QueueColumnStyle)),
-      Column(Column.props(instrumentColumnWidth, "instrument", flexShrink = 0, flexGrow = 1, label = "Instrument", cellRenderer = instrumentRenderer(p), className = QueueColumnStyle))
+      Column(Column.props(obsColumnWidth + ColumnPadding, "obsId", minWidth = ObsIdColumnWidth, flexShrink = 0, flexGrow = 0, label = "Obs. ID", cellRenderer = obsIdRenderer(p), className = QueueColumnStyle)),
+      Column(Column.props(statusColumnWidth + ColumnPadding, "state", minWidth = StateColumnWidth, flexShrink = 0, flexGrow = 0, label = "State", cellRenderer = stateRenderer(p), className = QueueColumnStyle)),
+      Column(Column.props(instrumentColumnWidth + ColumnPadding, "instrument", minWidth = InstrumentColumnWidth, flexShrink = 0, flexGrow = 0, label = "Instrument", cellRenderer = instrumentRenderer(p), className = QueueColumnStyle))
     )
     isLogged.fold(regularColumns ::: loggedInColumns, regularColumns)
   }

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/SeqexecStyles.scala
@@ -117,7 +117,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val queueText: StyleA = style(
-    paddingLeft(0.7.em),
+    paddingLeft(10.px),
     textOverflow := "ellipsis",
     overflow.hidden,
     wordWrap.breakWord,
@@ -125,7 +125,7 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
   )
 
   val queueIconColumn: StyleA = style(
-    minWidth(19.px).important,
+    minWidth(20.px).important,
     queueCenterCell
   )
 
@@ -480,8 +480,8 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     outline.none,
     minHeight(headerHeight.px),
     height(headerHeight.px),
-    paddingLeft(7.px),
-    paddingTop(7.px)
+    display.flex,
+    alignItems.center
   )
 
   // Override styles used by react-virtualized
@@ -490,6 +490,11 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     display.flex,
     flexDirection.row,
     alignItems.center
+  )
+
+  // Override styles used by react-virtualized
+  val headerTruncatedText: StyleA = style("ReactVirtualized__Table__headerTruncatedText")(
+    paddingLeft(7.px)
   )
 
   val firstHeaderColumn: StyleA = style("ReactVirtualized__Table__headerColumn:first-of-type")(
@@ -529,6 +534,10 @@ object SeqexecStyles extends scalacss.StyleSheet.Inline {
     display.flex,
     alignItems.center,
     justifyContent.flexStart
+  )
+
+  val tableHeaderIcons: StyleA = style(
+    paddingBottom(4.px)
   )
 
   val tableGrid: StyleA = style("ReactVirtualized__Table__Grid")(

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
@@ -40,8 +40,6 @@ object OffsetFns {
   def offsetValueFormat(off: Offset): String =
     f" ${off.value}%003.2f″"
 
-  def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
-
   def offsetText(axis: OffsetAxis)(step: Step): String =
     offsetValueFormat(axis match {
       case OffsetAxis.AxisP => telescopeOffsetPO.getOption(step).getOrElse(TelescopeOffset.P.Zero)

--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/main/scala/edu/gemini/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -187,7 +187,7 @@ object StepsTable {
         else
           None
       List(
-        p.steps.map(i => Column(Column.props(ColWidths.ControlWidth, "ctl", label = "Icon", disableSort = true, cellRenderer = stepControlRenderer(i, p, recomputeRowHeightsCB), flexShrink = 0, className = SeqexecStyles.controlCellRow.htmlClass, headerRenderer = controlHeaderRenderer))),
+        p.steps.map(i => Column(Column.props(ColWidths.ControlWidth, "ctl", label = "Icon", disableSort = true, cellRenderer = stepControlRenderer(i, p, recomputeRowHeightsCB), flexShrink = 0, className = SeqexecStyles.controlCellRow.htmlClass, headerRenderer = controlHeaderRenderer, headerClassName = (SeqexecStyles.centeredCell + SeqexecStyles.tableHeaderIcons).htmlClass))),
         Column(Column.props(ColWidths.IdxWidth, "idx", label = "Step", disableSort = true, flexShrink = 0, cellRenderer = stepIdRenderer)).some,
         p.steps.map(i => Column(Column.props(ColWidths.StateWidth, "state", label = "Control", flexShrink = 1, flexGrow = 4, disableSort = true, cellRenderer = stepProgressRenderer(i, p)))),
         offsetColumn.filter(_ => offsetVisible),
@@ -196,7 +196,7 @@ object StepsTable {
         p.steps.map(i => Column(Column.props(ColWidths.FilterWidth, "filter", label = "Filter", flexShrink = 0, flexGrow = 1, disableSort = true, className = SeqexecStyles.centeredCell.htmlClass, cellRenderer = stepFilterRenderer(i.instrument)))).filter(_ => filterVisible),
         p.steps.map(i => Column(Column.props(ColWidths.FPUWidth, "fpu", label = "FPU", flexShrink = 4, flexGrow = 1, disableSort = true, className = SeqexecStyles.centeredCell.htmlClass, cellRenderer = stepFPURenderer(i.instrument)))).filter(_ => fpuVisible),
         p.steps.map(i => Column(Column.props(ColWidths.ObjectTypeWidth, "type", label = "Type", flexShrink = 3, disableSort = true, className = SeqexecStyles.centeredCell.htmlClass, cellRenderer = stepObjectTypeRenderer(objectSize)))),
-        p.steps.map(i => Column(Column.props(ColWidths.SettingsWidth, "set", label = "", disableSort = true, cellRenderer = settingsControlRenderer(p, i), flexShrink = 0, className = SeqexecStyles.settingsCellRow.htmlClass, headerRenderer = settingsHeaderRenderer)))
+        p.steps.map(i => Column(Column.props(ColWidths.SettingsWidth, "set", label = "", disableSort = true, cellRenderer = settingsControlRenderer(p, i), flexShrink = 0, className = SeqexecStyles.settingsCellRow.htmlClass, headerRenderer = settingsHeaderRenderer, headerClassName = (SeqexecStyles.centeredCell + SeqexecStyles.tableHeaderIcons).htmlClass)))
       ).collect { case Some(x) => x }
     }
 

--- a/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/utils.scala
+++ b/modules/edu.gemini.web.client.facades/src/main/scala/edu/gemini/web/client/facades/semanticui/utils.scala
@@ -9,16 +9,18 @@ import scala.math
 
 trait utils {
   type Canvas = html.Canvas
-  type Ctx2D = dom.CanvasRenderingContext2D
+  type Ctx2D  = dom.CanvasRenderingContext2D
 
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def textWidth(text: String, font: String): Int = {
     val canvas = dom.document.createElement("canvas").asInstanceOf[Canvas]
-    val ctx = canvas.getContext("2d").asInstanceOf[Ctx2D]
+    val ctx    = canvas.getContext("2d").asInstanceOf[Ctx2D]
     ctx.font = font
     val metrics = ctx.measureText(text)
     math.round(metrics.width.toFloat)
   }
+
+  def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
 }
 
 object utils extends utils

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,7 +26,7 @@ addSbtPlugin("com.dwijnand"      % "sbt-dynver"             % "3.0.0")
 addSbtPlugin("org.wartremover"   % "sbt-wartremover"        % "2.2.1")
 
 // Use NPM modules rather than webjars
-addSbtPlugin("ch.epfl.scala"     % "sbt-scalajs-bundler"    % "0.10.0")
+addSbtPlugin("ch.epfl.scala"     % "sbt-scalajs-bundler"    % "0.12.0")
 
 // Generate a custom tzdb
 addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.1.2")


### PR DESCRIPTION
The width of the columns on the obs queue was fixed and sometimes that produced text to be truncated. This PR adds a simple calculation of the text length to better estimate the columns' width

It also fixes some styles issues that sometimes made the table misaligned

Before:
<img width="869" alt="seqexec - gs-engabc-2018a-q-1-85 2018-04-06 11-13-33" src="https://user-images.githubusercontent.com/3615303/38454386-f5ad55f6-3a3c-11e8-9733-258d4c67c036.png">

After:
<img width="735" alt="seqexec - gs-engabc-2018a-q-1-72 2018-04-07 08-15-51" src="https://user-images.githubusercontent.com/3615303/38454389-fd5db0d4-3a3c-11e8-9495-c8522d877d78.png">
