### PR TITLE
Updated epics libraries

### DIFF
--- a/modules/edu.gemini.epics.acm/src/test/java/edu/gemini/epics/acm/test/CaStatusAcceptorTest.java
+++ b/modules/edu.gemini.epics.acm/src/test/java/edu/gemini/epics/acm/test/CaStatusAcceptorTest.java
@@ -68,7 +68,11 @@ public final class CaStatusAcceptorTest {
             caService.unbind();
             caService = null;
         }
-        simulator.stop();
+
+        if (simulator != null) {
+            simulator.stop();
+            simulator = null;
+        }
     }
 
     @Test

--- a/modules/edu.gemini.epics.acm/src/test/java/edu/gemini/epics/acm/test/XMLBuilderTest.java
+++ b/modules/edu.gemini.epics.acm/src/test/java/edu/gemini/epics/acm/test/XMLBuilderTest.java
@@ -43,13 +43,13 @@ public final class XMLBuilderTest {
 
     @AfterClass
     public static void tearDown() {
-        if (simulator != null) {
-            simulator.stop();
-            simulator = null;
-        }
         if (caService != null) {
             caService.unbind();
             caService = null;
+        }
+        if (simulator != null) {
+            simulator.stop();
+            simulator = null;
         }
     }
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -112,10 +112,10 @@ object Settings {
 
     val apacheXMLRPC      = "3.1.3"
     val opencsv           = "2.1"
-    val epicsService      = "1.0.1"
-    val gmpCommandRecords = "0.7.1"
-    val giapiJmsUtil      = "0.5.1"
-    val giapiJmsProvider  = "1.6.1"
+    val epicsService      = "1.0.2"
+    val gmpCommandRecords = "0.7.2"
+    val giapiJmsUtil      = "0.5.2"
+    val giapiJmsProvider  = "1.6.2"
     val guava             = "25.0-jre"
   }
 


### PR DESCRIPTION
This PR contains the epics libraries with the latest versions of jca and caj. @jluhrs you can use these for testing of the epics issues but the unit tests are failing.