### PR TITLE
Improved encoding of boopickle

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/encoder/BooPickleInstances.scala
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/src/main/scala/edu/gemini/seqexec/web/server/http4s/encoder/BooPickleInstances.scala
@@ -10,10 +10,9 @@ import boopickle.Pickler
 import cats.Applicative
 import cats.effect.Sync
 import org.http4s._
-import org.http4s.EntityEncoder.byteArrayEncoder
+import org.http4s.EntityEncoder.chunkEncoder
 import org.http4s.headers.`Content-Type`
-import scodec.bits.ByteVector
-
+import fs2.Chunk
 import scala.util.{Failure, Success}
 
 /**
@@ -42,8 +41,8 @@ trait BooPickleInstances {
     }
 
   def booEncoderOf[F[_]: Applicative, A: Pickler]: EntityEncoder[F, A] =
-    byteArrayEncoder[F].contramap[A] { v =>
-      ByteVector(Pickle.intoBytes(v)).toArray
+    chunkEncoder[F].contramap[A] { v =>
+      Chunk.ByteBuffer(Pickle.intoBytes(v))
     }.withContentType(`Content-Type`(MediaType.`application/octet-stream`))
 
 }


### PR DESCRIPTION
This is a small improvement on how boopickle is encoded in http4s. It reduces a byte array copy per message.  I hope to provide these encoders to be integrated in http4s