### PR TITLE
Scala.js upgrade and use sbt-crossproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import Settings.LibraryVersions
 import Settings.Plugins
 import Common._
 import AppsCommon._
-import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport.crossProject
 import sbt.Keys._
 import NativePackagerHelper._
+import sbtcrossproject.{crossProject, CrossType}
 
 name := Settings.Definitions.name
 
@@ -118,7 +118,9 @@ lazy val edu_gemini_seqexec_web = project.in(file("modules/edu.gemini.seqexec.we
   .aggregate(edu_gemini_seqexec_web_server, edu_gemini_seqexec_web_client, edu_gemini_seqexec_web_shared_JS, edu_gemini_seqexec_web_shared_JVM)
 
 // a special crossProject for configuring a JS/JVM/shared structure
-lazy val edu_gemini_seqexec_web_shared = (crossProject.crossType(CrossType.Pure) in file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared"))
+lazy val edu_gemini_seqexec_web_shared = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.shared"))
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(GitBranchPrompt)
   .disablePlugins(RevolverPlugin)
@@ -271,7 +273,8 @@ lazy val edu_gemini_seqexec_server = project
 
 // Unfortunately crossProject doesn't seem to work properly at the module/build.sbt level
 // We have to define the project properties at this level
-lazy val edu_gemini_seqexec_model = crossProject.crossType(CrossType.Pure)
+lazy val edu_gemini_seqexec_model = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
   .in(file("modules/edu.gemini.seqexec.model"))
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(GitBranchPrompt)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,5 +1,9 @@
 import sbt._
 import java.lang.{Runtime => JRuntime}
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+import sbtcrossproject.{crossProject, CrossType}
+import sbtcrossproject.CrossPlugin.autoImport._
+import scalajscrossproject.ScalaJSCrossPlugin.autoImport.{toScalaJSGroupID => _, _}
 
 /**
  * Application settings and dependencies
@@ -65,13 +69,13 @@ object Settings {
     val scalaVersion = "2.12.6"
 
     // ScalaJS libraries
-    val scalaDom                = "0.9.5"
+    val scalaDom                = "0.9.6"
     val scalajsReact            = "1.2.0"
     val booPickle               = "1.3.0"
     val diode                   = "1.1.3"
     val diodeReact              = "1.1.3.120"
     val javaTimeJS              = "2.0.0-M13"
-    val javaLogJS               = "0.1.3"
+    val javaLogJS               = "0.1.4"
     val scalaJQuery             = "1.2"
     val scalaJSReactVirtualized = "0.2.0"
     val scalaJSReactClipboard   = "0.3.0"
@@ -130,8 +134,6 @@ object Settings {
     * Global libraries
     */
   object Libraries {
-    import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
-
     // Test Libraries
     val TestLibs = Def.setting(Seq(
       "org.typelevel"              %%% "cats-testkit"              % LibraryVersions.catsVersion         % "test",
@@ -229,7 +231,7 @@ object Settings {
   object PluginVersions {
     // Compiler plugins
     val paradiseVersion    = "2.1.1"
-    val kpVersion          = "0.9.6"
+    val kpVersion          = "0.9.7"
   }
 
   object Plugins {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,10 @@
 // Gives support for Scala.js compilation
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.22")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.23")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.4.0")
 
 // sbt revolver lets launching applications from the sbt console
 addSbtPlugin("io.spray"          % "sbt-revolver"           % "0.9.1")


### PR DESCRIPTION
Scala.js update to 0.6.23. this is a bit more complex update as scala.js only crossprojects have been deprecated in favor or `sbt-crossproject`