### PR TITLE
Correctly proxy the start event

### DIFF
--- a/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/webpack/dev.webpack.config.js
+++ b/modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.client/src/webpack/dev.webpack.config.js
@@ -41,9 +41,10 @@ const Web = Merge(
           changeOrigin: true,
           ws: true
         },
-        "/api/***": {
+        "/api/**": {
           target: "http://localhost:7070",
           logLevel: "debug",
+          changeOrigin: true,
           bypass: function(req, res, proxyOptions) {
             // regex matching everything but js files
             var backendUrls = /(^(.(?!\.js$))+$)/;


### PR DESCRIPTION
Small bug out of the build refactoring. The webpack-dev-server proxy wasn't properly proxying one of the routes used in intialization