### PR TITLE
SEQNG-601: Sync button disabled

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -171,12 +171,21 @@ object model {
                             resourceConflict: ResourcesConflict,
                             globalLog: GlobalLog,
                             sequencesOnDisplay: SequencesOnDisplay,
+                            syncInProgress: Boolean,
                             firstLoad: Boolean)
 
   object SeqexecUIModel {
     val noSequencesLoaded: SequencesQueue[SequenceView] = SequencesQueue[SequenceView](Conditions.default, None, Nil)
-    val initial: SeqexecUIModel = SeqexecUIModel(Pages.Root, None, noSequencesLoaded,
-      SectionClosed, ResourcesConflict(SectionClosed, None), GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed), SequencesOnDisplay.empty, firstLoad = true)
+    val initial: SeqexecUIModel = SeqexecUIModel(
+      Pages.Root,
+      None,
+      noSequencesLoaded,
+      SectionClosed,
+      ResourcesConflict(SectionClosed, None),
+      GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
+      SequencesOnDisplay.empty,
+      syncInProgress = false,
+      firstLoad = true)
   }
 
   /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -37,7 +37,7 @@ object SeqexecWebClient {
 
   def sync(id: SequenceId): Future[SequencesQueue[SequenceId]] =
     Ajax.get(
-      url = s"$baseUrl/sequence/$id",
+      url = s"$baseUrl/commands/$id/sync",
       responseType = "arraybuffer"
     )
     .map(unpickle[SequencesQueue[SequenceId]])

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -92,7 +92,8 @@ trait ArbitrariesWebClient {
         u  <- arbitrary[Option[UserDetails]]
         ws <- arbitrary[WebSocketConnection]
         r  <- arbitrary[Boolean]
-      } yield ClientStatus(u, ws, r)
+        s  <- arbitrary[Boolean]
+      } yield ClientStatus(u, ws, r, s)
     }
 
   implicit val cssCogen: Cogen[ClientStatus] =

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -8,7 +8,7 @@ import edu.gemini.pot.sp.SPObservationID
 import seqexec.server.Commands
 import seqexec.server.SeqexecEngine
 import seqexec.server
-import seqexec.model.Model.{ClientID, CloudCover, Conditions, ImageQuality, Observer, Operator, SkyBackground, WaterVapor}
+import seqexec.model.Model.{SequenceId, SequencesQueue, ClientID, CloudCover, Conditions, ImageQuality, Observer, Operator, SkyBackground, WaterVapor}
 import seqexec.model.UserDetails
 import seqexec.web.server.model.CommandsModel._
 import seqexec.web.server.http4s.encoder._
@@ -66,8 +66,15 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: server.Event
        newVal <- IO.fromEither(Either.catchNonFatal(bp.toBoolean))
        _      <- se.setBreakpoint(inputQueue, obs, user, step, newVal)
        resp   <- Ok(s"Set breakpoint in step $step of sequence $obsId")
-
      } yield resp
+
+    case GET -> Root / obsId / "sync" as _ =>
+      for {
+        obs   <- IO.fromEither(Either.catchNonFatal(new SPObservationID(obsId)))
+        u     <- se.load(inputQueue, obs)
+        resp  <- u.fold(_ => NotFound(s"Not found sequence $obsId"), _ =>
+          Ok(SequencesQueue[SequenceId](Conditions.default, None, List(obsId))))
+      } yield resp
 
    case POST -> Root / obsId / stepId / "skip" / bp as user =>
      for {

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -108,7 +108,7 @@ object WebServerLauncher extends StreamApp[IO] with LogInitialization {
       .withWebSockets(true)
       .mountService(new StaticRoutes(conf.devMode, OcsBuildInfo.builtAtMillis).service, "/")
       .mountService(new SeqexecCommandRoutes(as, events._1, se).service, "/api/seqexec/commands")
-      .mountService(new SeqexecUIApiRoutes(conf.devMode, as, events, se).service, "/api")
+      .mountService(new SeqexecUIApiRoutes(conf.devMode, as, events._2).service, "/api")
     conf.sslConfig.fold(builder) { ssl =>
       val storeInfo = StoreInfo(ssl.keyStore, ssl.keyStorePwd)
       builder.withSSL(storeInfo, ssl.certPwd, "TLS")

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -103,12 +103,12 @@ object WebServerLauncher extends StreamApp[IO] with LogInitialization {
   /**
     * Configures and builds the web server
     */
-  def webServer(as: AuthenticationService, events: (server.EventQueue, Topic[IO, SeqexecEvent]), se: SeqexecEngine): Kleisli[Stream[IO, ?], WebServerConfiguration, StreamApp.ExitCode] = Kleisli { conf =>
+  def webServer(as: AuthenticationService, inputs: server.EventQueue, outputs: Topic[IO, SeqexecEvent], se: SeqexecEngine): Kleisli[Stream[IO, ?], WebServerConfiguration, StreamApp.ExitCode] = Kleisli { conf =>
     val builder = BlazeBuilder[IO].bindHttp(conf.port, conf.host)
       .withWebSockets(true)
       .mountService(new StaticRoutes(conf.devMode, OcsBuildInfo.builtAtMillis).service, "/")
-      .mountService(new SeqexecCommandRoutes(as, events._1, se).service, "/api/seqexec/commands")
-      .mountService(new SeqexecUIApiRoutes(conf.devMode, as, events._2).service, "/api")
+      .mountService(new SeqexecCommandRoutes(as, inputs, se).service, "/api/seqexec/commands")
+      .mountService(new SeqexecUIApiRoutes(conf.devMode, as, outputs).service, "/api")
     conf.sslConfig.fold(builder) { ssl =>
       val storeInfo = StoreInfo(ssl.keyStore, ssl.keyStorePwd)
       builder.withSSL(storeInfo, ssl.certPwd, "TLS")
@@ -172,7 +172,7 @@ object WebServerLauncher extends StreamApp[IO] with LogInitialization {
         as <- authService.run(ac)
         _  <- logStart.run(wc)
         _  <- logToClients(out)
-      } yield Stream(redirectWebServer.run(wc), webServer(as, (in, out), et).run(wc)).join(2)
+      } yield Stream(redirectWebServer.run(wc), webServer(as, in, out, et).run(wc)).join(2)
 
     // I have taken this from the examples at:
     // https://github.com/gvolpe/advanced-http4s/blob/master/src/main/scala/com/github/gvolpe/fs2/PubSub.scala


### PR DESCRIPTION
The sync button gets disable after pressing Sync. Thes PR fixes it by moving the state of sync in progress to the top level model

There is also an extra simplification as the `sync` url routes are different than for other commands. This PR fixes that and simplifying the routes definition on the server side as well