### PR TITLE
Update scalajs-bundler and simplify app build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -362,12 +362,8 @@ lazy val seqexecCommonSettings = Seq(
   mainClass in Compile := Some("seqexec.web.server.http4s.WebServerLauncher"),
   // This is important to keep the file generation order correctly
   parallelExecution in Universal := false,
-  // Black magic. Not even sbt gurus understand how to make this work
-  mappings in (Compile, packageBin) := (mappings in (Compile, packageBin)).dependsOn(webpack in (seqexec_web_client, Compile, fullOptJS)).value,
-  // This is fairly ugly. It may improve in future versions of scalajs-bundler
-  mappings in (Compile, packageBin) ++= (npmUpdate in (seqexec_web_client, Compile, fullOptJS)).map { f =>
-    (f * ("*.js" || "*.mp3" || "*.css" || "*.html" || "*.woff" || "*.woff2" || "*.ttf" || "*.eot" || "*.svg")) pair (f => Some(f.getName))
-  }.value,
+  // Depend on webpack and add the assets created by webpack
+  mappings in (Compile, packageBin) ++= (webpack in (seqexec_web_client, Compile, fullOptJS)).value.map { f => f.data -> f.data.getName() },
   test := {},
   // Name of the launch script
   executableScriptName := "seqexec-server",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,7 +28,7 @@ addSbtPlugin("com.dwijnand"      % "sbt-dynver"             % "3.0.0")
 addSbtPlugin("org.wartremover"   % "sbt-wartremover"        % "2.2.1")
 
 // Use NPM modules rather than webjars
-addSbtPlugin("ch.epfl.scala"     % "sbt-scalajs-bundler"    % "0.13.0-RC1")
+addSbtPlugin("ch.epfl.scala"     % "sbt-scalajs-bundler"    % "0.13.0")
 
 // Used to find dependencies
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph"  % "0.9.0")


### PR DESCRIPTION
A new version of `scalajs-bundler` now properly exports the list of assets. `sbt-native-packager` can now use this list to properly package the app in one pass