### PR TITLE
SEQNG-277: Merge codebases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.class
 *.log
+*.swp
+.#*
 *.iml
 .metals/
 .DS_Store
@@ -31,18 +33,37 @@ buildinfo.properties
 
 # Scala-IDE specific
 .scala_dependencies
-.worksheet
+.cache
+.classpath
+.project
+.worksheet/
+bin/
+.settings/
+.idea
+*.ipr
+*.iws
 
-# Idea specific
-.idea/
+# OS X
+.DS_Store
 
-# Ensime
+# Tags
+.tags
+GPATH
+GRTAGS
+GTAGS
+
+# ENSIME
 .ensime
 .ensime_cache/
 .#*
+ensime.sbt
 
+archive
+smartgcal
+.jvmopts
 # Node modules
 node_modules/
+package-lock.json
 
 # Project specific
 modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/log/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,47 @@
 language: scala
-scala:
-- 2.12.6
+
+dist: trusty
+
+sudo: required
+
 jdk:
-- oraclejdk8
+  - oraclejdk8
+
+scala:
+  - 2.12.6
+
+addons:
+  postgresql: "9.5"
+
+before_script:
+  - psql -c 'create database gem' -U postgres
+
+install:
+  - . $HOME/.nvm/nvm.sh
+  - nvm install stable
+  - nvm use stable
+  - npm install jsdom
+  - pip install --user awscli
+script:
+  - sbt headerCheck test:headerCheck scalastyle sql/flywayMigrate compile test ui/fastOptJS ui/fullOptJS
+  - sbt -Docs3.skipDependencyUpdates headerCheck test:headerCheck scalastyle test seqexec_web_client/fastOptJS::webpack
+  - sbt -Docs3.skipDependencyUpdates seqexec_web_client/fullOptJS::webpack
+
+after_script:
+  - $TRAVIS_BUILD_DIR/build/weigh.sh
+
 cache:
   directories:
-  - "$HOME/.ivy2/cache"
-  - "$HOME/.sbt/boot/"
+  - $HOME/.sbt/0.13/dependency
+  - $HOME/.sbt/boot/scala*
+  - $HOME/.sbt/launchers
+  - $HOME/.ivy2/cache
+  - $HOME/.nvm
+  - $HOME/.coursier
+
 before_cache:
-- find $HOME/.ivy2 -name "ivydata-*.properties" -delete
-- find $HOME/.sbt -name "*.lock" -delete
-install:
-- ". $HOME/.nvm/nvm.sh"
-- nvm install 8.7.0
-- nvm use 8.7.0
-- npm install jsdom
-script:
-- sbt -Docs3.skipDependencyUpdates headerCheck test:headerCheck scalastyle test seqexec_web_client/fastOptJS::webpack
-- sbt -Docs3.skipDependencyUpdates seqexec_web_client/fullOptJS::webpack
-after_script:
-- $TRAVIS_BUILD_DIR/build/weigh.sh
+  - du -h -d 1 $HOME/.ivy2/cache
+  - du -h -d 2 $HOME/.sbt/
+  - du -h -d 2 $HOME/.coursier/
+  - find $HOME/.sbt -name "*.lock" -type f -delete
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ install:
   - npm install jsdom
   - pip install --user awscli
 script:
-  - sbt -Docs3.skipDependencyUpdates headerCheck test:headerCheck scalastyle sql/flywayMigrate compile test ui/fastOptJS ui/fullOptJS seqexec_web_client/fastOptJS::webpack
-  - sbt -Docs3.skipDependencyUpdates seqexec_web_client/fullOptJS::webpack
+  - sbt -jvm-opts travis-jvmopts -Docs3.skipDependencyUpdates headerCheck test:headerCheck scalastyle sql/flywayMigrate compile test ui/fastOptJS ui/fullOptJS seqexec_web_client/fastOptJS::webpack seqexec_web_client/fullOptJS::webpack
 
 after_script:
   - $TRAVIS_BUILD_DIR/build/weigh.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ install:
   - npm install jsdom
   - pip install --user awscli
 script:
-  - sbt headerCheck test:headerCheck scalastyle sql/flywayMigrate compile test ui/fastOptJS ui/fullOptJS
-  - sbt -Docs3.skipDependencyUpdates headerCheck test:headerCheck scalastyle test seqexec_web_client/fastOptJS::webpack
+  - sbt -Docs3.skipDependencyUpdates headerCheck test:headerCheck scalastyle sql/flywayMigrate compile test ui/fastOptJS ui/fullOptJS seqexec_web_client/fastOptJS::webpack
   - sbt -Docs3.skipDependencyUpdates seqexec_web_client/fullOptJS::webpack
 
 after_script:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,67 @@
+
+
+# Design Principles - Addressed
+
+This is a rough accounting of the design problems addressed so far.
+
+### Axis Mundi
+
+The Postgres database is the center of the world and the application design flows outward.
+
+- We want the database to maintain as much consistency as possible, such that any program interacting with the database (not just the new ODB) will see an accurate view of the world and will only be able to make modifications that are "legal" under some definition of well-formedness.
+- We want the database to be queryable easily, such that a read-replica can be made available to science staff for their own use. To this end some *checked* denormalization (such as program ids being broken into site, year, etc.) is ok.
+- Similarly astronomical units need to be in a science-friendly format, and we may need server-side functions for doing computations. We need to be cautious about pushing too much *business* logic into the database but support for domain-specific data types is probably reasonable.
+- Enumerated types like filters, dispersers, etc., are important for reporting and consistency checking and need to be defined in the database. We use code-generation to read these in at compile time and make them available as proper enumerated types in our Scala code.
+- Events should be logged to the database and echoed to traditional file logs in case database connectivity fails.
+
+The schema now represents the following notions:
+
+- Programs
+  - Title
+  - Structured ID
+- Users
+  - Name, Email, Password, Staff flag
+  - Relationship to a given program (PI, Science Contact, etc.)
+- Observations
+  - Structured ID, Name
+- Steps
+  - Bias, Dark, Gcal, Science
+  - Instrument-specific (F2 only so far)
+- Enumerated Types
+  - Site
+  - Program Type
+  - Program Role (for users)
+  - Instrument
+  - Gcal config (Filter, Lamp)
+  - F2 config (Disper, Filter, FPU, Lyot Wheel)
+
+The data model more or less reflects the above, and some read/write database access is provided but it's not totally built out. Basically just what's needed for import and simple queries.
+
+### Data Model and Level of Detail
+
+We need a straightforward way to deal with *portions* of the data model (for instance a list of programs without any observation information, for an "Open" dialog) without a proliferation of specialized model classes.
+
+- Model classes are parameterized on their children; i.e., any type that is represented by a foreign key in the schema. A `Program[Observation[...]]` is a program with a list of observations, a bit like the current model; a`Program[Observation.Id]` is a program with a list of observation *ids*; a `Program[Nothing]` has no observation information at all.
+- This keeps the model representation simple and flexible for dealing with the varying levels of detail needed for the UI, and means we don't have to load and ship any more information than necessary.
+
+### Data Import
+
+A separate project module (dependent on OCS) reads old XML files and then inserts programs into the new database. This works for the portion of the model described above, with the exception of users and roles which haven't been added yet.
+
+### CRDT-based Clients (i.e., no checkin/checkout or sync)
+
+The OCS program sync problem is hugely complicated and we are determined to avoid it. The new system will have no notion of "offline mode" and edits will be propagated immediately. We intend to use conflict-free replicated data types (CRDTs) for client applications to allow simultaneous editing without need for explicit sync (think Google Docs). Shane has implemented such a type that is in principle capable of handling sequence editing.
+
+
+
+# Design Principles - Pending
+
+### Continuous Deployment
+
+I want to break the 6-month development cycle and try continuous deployment: commits to `master` are pushed to a test environment automatically, and can be promoted to production automatically or on demand. This means we need to figure out schema migration, client notification, and so on.
+
+It also means that we need to integrate the notion of time into some portions of our model, so we can switch filters on the fly for example without affecting historical data, and can add a new instrument before it's available for use.
+
+### Client Design
+
+We anticipate using a web-based front end but have not spent much time thinking about it other than the CRDT requirement above.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 1998-2016 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright (c) 1998-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
 All rights reserved.
 
 Unless otherwise stated, the copyright of this software is owned by AURA.

--- a/README.md
+++ b/README.md
@@ -1,77 +1,171 @@
-# OCS3
 
-[![Build Status](https://travis-ci.org/gemini-hlsw/ocs3.svg?branch=develop)](https://travis-ci.org/gemini-hlsw/ocs3)
+# Gem Prototype
 
-This project aims to build the next generation Observatory Control System (OCS). At the time of this writing, only the Seqexec has been integrated. This setup has the following goals
+This is the initial work on a Postgres-based back end, with an API based around recent work on the flat sequence model. It doesn't do very much yet.
 
-- Adhere to the simplest possible sbt structure.
-- No need for OSGi
-- Use managed dependencies
-- Support of web applications using scala.js
-- Testing supported on both JVM and JS backends
+### Setting Up
 
-## Structure
-The project contains a single `modules` subtree. Inside that module each of the bundles is located. Web applications are further devided internally to have the server side, client side and shared code compiled to their respective backends
+You need Postgres 9.5 or better. I **highly** recommend using [Postgres.app](http://postgresapp.com/) which is much much easier than dealing with a "real" installation. You need to add its binaries to your path, something along the lines of
 
 ```
-ocs3/
- |
- +-- modules/
- |    |
- |    +-- edu.gemini.seqexec.server/
- |    +-- edu.gemini.seqexec.shared/
- |    +-- edu.gemini.seqexec.web/
- |           |
- |           +-- edu.gemini.seqexec.web.shared/
- |           +-- edu.gemini.seqexec.web.server/
- |           +-- edu.gemini.seqexec.web.client/
- +-- app/
-```
-`app` contains build.sbt definitions for deployable applications
-
-## Settings
-
-Settings and module versions are defined in the file `project/Settings.scala`
-
-## SBT
-
-To provide `sbt` with enough memory, it is recommended that you set:
-```
-SBT_OPTS='-XX:ReservedCodeCacheSize=512M -Xmx4096M -Xss2M -Dfile.encoding=UTF-8 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxMetaspaceSize=2G'
+export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin
 ```
 
-## Testing
-
-`ScalaTest` has been chosen as the test framework since it works in both scala.js and jvm. `ScalaCheck` is also supported running with `ScalaTest`.
-Sample tests using `scalatest` and `scalacheck` are included in some modules. You can run `test` at the root level or on a module basis.
-
-Note that IDEA doesn't support running tests on scala.js. See this [issue](https://github.com/scalatest/scalatest/issues/743)
-
-To tests the javascript side you need to install node and jsdom. In OSX using `brew` you can do:
+Next you can run the following to create the database and user.
 
 ```
-brew install node
-npm install jsdom
-npm -g install yarn
+psql -c 'create user postgres createdb'
+psql -c 'create database gem' -U postgres
 ```
 
-`node` should be at least on version `0.6.x`, check it with `node --version` once installed
-
-Don't install jsdom at the global level (with the -g option) as it doesn't work properly with scala.js
-
-## IDEA
-
-Before opening the project in IDEA, run a top-level compile at least once to generate code that will be picked up by IDEA
-
-IDEA can open directly the project's sbt. Go to
+Now initialize the database by running the migration script.
 
 ```
-File -> Open
+sbt sql/flywayMigrate
 ```
 
-And find the file `ocs/build.sbt`. IDEA should show a dialog box to import the project. You may need to select the appropriate JVM version (1.8) and IDEA will import the project.
-`sbt` files may have highlight errors due to this [bug](https://youtrack.jetbrains.com/issue/SCL-9599). Otherwise, sbt import seems to work quite well.
+You can also just do `sql/flywayMigrate` from the sbt prompt if you already have sbt running. You will repeat this step each time the schema changes. It's not part of the build yet but probably will be soon.
 
-**Note:** Sbt import in IDEA changes very often. This has been tested on IDEA C 2016.1 and the Scala plugin version 3.0
+If you ever want to wipe out the database and start over, you can do
 
-**Note:** If you need to re-generate the project, delete the `.idea` folder
+```
+psql -c 'drop database gem' -U postgres
+```
+
+And then re-run steps 2 and 3 above. At any time you can say
+
+```
+psql -U postgres -d gem
+```
+
+to poke around with the database on the commandline. For real work I recommend a more full-featured front end. I use [Toad](https://www.toadworld.com/products/toad-mac-edition) but there are a lot of options.
+
+### Generating Enumerated Types
+
+There are many enumerated types in the database, represented by tables named `e_whatever`. The Scala equivalents are generated *on demand* by queries, then checked into source control like normal source files.
+This is only needed if you update the contents of an enum in the schema, or add/modify a the generation
+code in the `sql` project. In any case, you can [re]-generate the enumerated types thus:
+
+```
+sbt genEnums
+```
+
+The source files appear in `modules/core/shared/src/main/scala/gem/enum`.
+
+### Generating Schema Documentation
+
+You can do `sbt schemaSpy` to generate a little website about the database using [SchemaSpy](http://schemaspy.org/). It will appear in `modules/sql/target/schemaspy`.
+
+### Importing
+
+There are several options for importing existing OCS2 program and Smart Gcal data.
+
+#### Importing Old Programs
+
+You can import old programs, but unfortunately not in the standard Phase 2 XML format exported from the ODB or OT. The importer works with a modified XML format which you can obtain via the `exportOcs3` OSGi shell command running in an ODB.  It works just like `exportXML` but writes the program with expanded sequence steps.  This is a big part of what enables the importer to work without ocs2 dependencies.
+
+To import these modified `.xml` files into Postgres you need to create a symlink to a directory containing the program files first:
+
+```
+ln -s /path/to/some/old/xml/files archive
+```
+
+You can then import from the `sbt` prompt:
+
+```
+sbt> ocs2/runMain gem.ocs2.FileImporter 123     Import the first 123 programs.
+```
+
+You can skip the program limit argument if you want to import all the program files.
+
+Right now just a sketch is imported:
+
+- referenced semesters;
+- programs (structured id and title)
+- observations (title, instrument)
+- sequence steps, generically, with slices for
+  - bias
+  - dark
+  - gcal
+  - science (offset p/q)
+    - F2
+
+There are no other instrument-specific slices for science steps yet.
+
+
+#### Importing Smart Gcal Configuration
+
+Smart Gcal configuration is stored in database tables instead of in `.csv` files downloaded from SVN as in OCS2.  The `.csv` files can be imported, though much like old program `.xml` files, we use a modified format.  To obtain compatible Smart Gcal `.csv` files from OCS2, start the ODB and use the `exportSmartGcal` shell command providing the name of a directory into which to write the files.
+
+Next, make a symlink to the directory containing the `.csv` files that were exported:
+
+```
+ln -s /path/to/old/smart/gcal/csv smartgcal
+```
+
+Having created the symlink, you can then import from the `sbt` prompt:
+
+```
+sbt> ocs2/runMain gem.ocs2.SmartGcalImporter
+```
+
+#### Import Server
+
+You can run an import server which will import programs or observations on demand directly from a running OCS2 Observing Database.  You start it with
+
+```
+sbt> ocs2/runMain gem.ocs2.ImportServer [odb-hostname]
+```
+
+where the `odb-hostname` defaults to `localhost` if not specified.  Once running, it accepts http requests to import data.  For example, to import program `GS-2017A-Q-1` from the ODB:
+
+```
+http://localhost:8989/import/prog/GS-2017A-Q-1
+```
+
+or to just get observation `GS-2017A-Q-1-2`:
+
+```
+http://localhost:8989/import/obs/GS-2017A-Q-1-2
+```
+
+When you re-import a program or observation, any existing data associated with it is first purged.
+
+
+#### Import Menu
+
+Another option for importing is to just type the following at the sbt prompt
+
+```
+sbt> ocs2/run
+
+Multiple main classes detected, select one to run:
+
+ [1] gem.ocs2.FileImporter
+ [2] gem.ocs2.ImportServer
+ [3] gem.ocs2.SmartGcalImporter
+```
+
+If you pick the program importer, it will import everything which is the same as explicitly passing in `Int.MaxValue`.
+
+
+### Schema Updates
+
+If you need to update the schema you can just make changes locally and then truncate user data and do a dump.
+
+```
+psql -c "truncate log; truncate program cascade; delete from gem_user where id != 'root'" -d gem -U postgres
+pg_dump -U postgres -d gem > create.sql
+```
+
+### Trouble shooting
+
+* If you see this message when setting up the db for the first time:
+```
+ERROR: must be owner of extension plpgsql
+```
+
+Assign super user privileges to postgres
+```
+alter role postgres superuser;
+```

--- a/StepIndex.md
+++ b/StepIndex.md
@@ -1,0 +1,94 @@
+## Step Indices Issue
+
+Sequence steps are modeled in Scala with a simple ADT:
+
+````scala
+sealed abstract class Step[A] extends Product with Serializable {
+  def instrument: A
+}
+
+final case class BiasStep   [A](instrument: A)                             extends Step[A]
+final case class DarkStep   [A](instrument: A)                             extends Step[A]
+final case class GcalStep   [A](instrument: A, gcal:      GcalConfig)      extends Step[A]
+final case class ScienceStep[A](instrument: A, telescope: TelescopeConfig) extends Step[A]
+final case class SmartStep  [A](instrument: A, smartCal:  SmartCalConfig)  extends Step[A]
+````
+
+The database model mirrors this simple hierarchy with a "base" `step` table:
+
+````sql
+CREATE TABLE step (
+    observation_id character varying(40) NOT NULL,
+    index          smallint              NOT NULL,
+    instrument     identifier            NOT NULL,
+    step_type      step_type             NOT NULL
+);
+````
+
+and "sub" tables for the various step types:
+
+````sql
+CREATE TABLE step_science (
+    index          smallint              NOT NULL,
+    observation_id character varying(40) NOT NULL,
+    offset_p       double precision      NOT NULL,
+    offset_q       double precision      NOT NULL
+);
+````
+
+Here the primary key of each of the tables is the combination `(observation_id, index)`,
+where matching values are used to stitch together the base and sub type rows into a
+complete step.  The primary key does double duty, uniquely identifying and also ordering
+steps, and yet the order is not fixed.  In fact one of the main selling points of a
+flattened sequence model is that it should permit steps to be arranged, reordered, and
+updated as necessary.  Imagine for example inserting a step at the beginning of a long
+sequence.  This would imply changing the primary key of every step in the sequence that
+follows.
+
+
+## Proposal
+
+The step table needs to track the `observation_id` identifying the observation to which
+it belongs but the primary key could be a unique id that is unrelated to the order of
+the step. This id then serves as a permanant link between the base and sub tables.
+
+````sql
+CREATE TABLE step (
+    step_id        SERIAL                PRIMARY KEY,
+    observation_id character varying(40) NOT NULL,
+    ...
+);
+
+CREATE TABLE step_science (
+    step_science id integer               PRIMARY KEY REFERENCES step ON DELETE CASADE,
+    observation_id  character varying(40) NOT NULL,
+    ...
+);
+```` 
+
+Ordering can take advantage of the Logoot index algorithm that allows steps to
+be inserted between any two other steps at any time without the need to update
+any other table row.  To do this, a `location` column with type `integer[]` could
+be added to the `step` table.   For example, to insert a step between steps at
+locations `[5]` and `[6]`, the location `[5, 5]` could be assigned for example.
+
+The database orders arrays on an element-by-element basis such that `[5]` sorts
+before `[5, 5]` and both before `[5, 8]`, or `[6]`.  In fact, given sufficient
+spacing between subsequent step locations the need to introduce a second array
+element will rarely if ever arise.
+
+````sql
+CREATE TABLE step (
+    step_id        SERIAL                PRIMARY KEY,
+    observation_id character varying(40) NOT NULL,
+    location       integer[]             NOT NULL,
+    instrument     identifier            NOT NULL,
+    step_type      step_type             NOT NULL, 
+    UNIQUE (observation_id, location)
+);
+````
+
+Note the `UNIQUE` constraint preventing two steps from residing at the same spot.
+There is no need, of course, to repeat the `location` column in the sub tables
+like `step_science`.
+

--- a/build.sbt
+++ b/build.sbt
@@ -310,13 +310,14 @@ lazy val main = project
     }
 
   )
+
 lazy val giapi = project
   .in(file("modules/giapi"))
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(GitBranchPrompt)
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(Shapeless.value, CatsEffect.value, Fs2, GiapiJmsUtil, GiapiJmsProvider, GiapiStatusService, Giapi, GiapiCommandsClient) ++ Logging
+    libraryDependencies ++= Seq(Cats.value, Mouse.value, Shapeless.value, CatsEffect.value, Fs2, GiapiJmsUtil, GiapiJmsProvider, GiapiStatusService, Giapi, GiapiCommandsClient) ++ Logging
   )
 
 // Common utilities for web server projects
@@ -341,7 +342,7 @@ lazy val web_client = project
       // By necessity facades will have unused params
       "-Ywarn-unused:params"
     ))),
-    libraryDependencies ++= Seq(ScalaJSDom.value, JQuery.value) ++ ReactScalaJS.value
+    libraryDependencies ++= Seq(Cats.value, ScalaJSDom.value, JQuery.value) ++ ReactScalaJS.value
   )
 
 // a special crossProject for configuring a JS/JVM/shared structure
@@ -454,6 +455,8 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
     ),
     libraryDependencies ++= Seq(
       JQuery.value,
+      Cats.value,
+      Mouse.value,
       CatsEffect.value,
       ScalaJSDom.value,
       JavaTimeJS.value,
@@ -509,7 +512,7 @@ lazy val seqexec_model = crossProject(JVMPlatform, JSPlatform)
   .enablePlugins(GitBranchPrompt)
   .settings(
     addCompilerPlugin(Plugins.paradisePlugin),
-    libraryDependencies ++= BooPickle.value +: Monocle.value
+    libraryDependencies ++= Seq(Mouse.value, BooPickle.value) ++ Monocle.value
   )
   .jvmSettings(
     commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,10 @@ import AppsCommon._
 import sbt.Keys._
 import NativePackagerHelper._
 import sbtcrossproject.{crossProject, CrossType}
+import com.typesafe.sbt.packager.docker._
+
+// our version is determined by the current git state (see project/ImageManifest.scala)
+def imageManifest = ImageManifest.current("postgres:9.6.0").unsafeRunSync
 
 name := Settings.Definitions.name
 
@@ -56,7 +60,7 @@ inThisBuild(List(
 
 enablePlugins(GitBranchPrompt)
 
-// Custom commonds to facilitate web development
+// Custom commands to facilitate web development
 val startAllCommands = List(
   "seqexec_web_server/reStart",
   "seqexec_web_client/fastOptJS::startWebpackDevServer",
@@ -68,17 +72,45 @@ val restartWDSCommands = List(
 )
 
 addCommandAlias("startAll", startAllCommands.mkString(";", ";", ""))
-
 addCommandAlias("restartWDS", restartWDSCommands.mkString(";", ";", ""))
+addCommandAlias("genEnums", "; sql/runMain gem.sql.Main modules/core/shared/src/main/scala/gem/enum")
+addCommandAlias("schemaSpy", "sql/runMain org.schemaspy.Main -t pgsql -port 5432 -db gem -o modules/sql/target/schemaspy -u postgres -host localhost -s public")
+addCommandAlias("gemctl", "ctl/runMain gem.ctl.main")//
 
 resolvers in ThisBuild +=
   Resolver.sonatypeRepo("snapshots")
+
+// Before printing the prompt check git to make sure all is well.
+shellPrompt in ThisBuild := { state =>
+  if (version.value != imageManifest.formatVersion) {
+    import scala.Console.{ RED, RESET }
+    print(RED)
+    println(s"Computed version doesn't match the filesystem anymore.")
+    println(s"Please `reload` to get back in sync.")
+    print(RESET)
+  }
+  "> "
+}
 
 ///////////////
 // Root project
 ///////////////
 lazy val ocs3 = preventPublication(project.in(file(".")))
+  .settings(commonSettings)
   .aggregate(
+    coreJVM,
+    coreJS,
+    db,
+    json,
+    ocs2,
+    ephemeris,
+    service,
+    telnetd,
+    ctl,
+    web,
+    sql,
+    main,
+    ui,
     giapi,
     web_server_common,
     web_client,
@@ -94,6 +126,190 @@ lazy val ocs3 = preventPublication(project.in(file(".")))
 //////////////
 // Projects
 //////////////
+lazy val core = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Full)
+  .in(file("modules/core"))
+  .settings(commonSettings)
+  .settings(
+    addCompilerPlugin(Plugins.kindProjectorPlugin),
+    addCompilerPlugin(Plugins.paradisePlugin),
+    libraryDependencies ++= Seq(
+      Cats.value,
+      CatsEffect.value,
+      Mouse.value,
+      Shapeless.value,
+      Atto.value
+    ) ++ Monocle.value
+  )
+  .jsSettings(
+    libraryDependencies +=
+      JavaTimeJS.value,
+    wartremoverExcluded += sourceManaged.value / "main" / "java" / "time" / "zone" / "TzdbZoneRulesProvider.scala",
+    // We only care about these two timezones. UTC is implicitly included
+    zonesFilter         := {(z: String) => z == "America/Santiago" || z == "Pacific/Honolulu"}
+  )
+  .jsSettings(commonJSSettings)
+  .jvmSettings(
+    libraryDependencies += Fs2
+  )
+
+lazy val coreJVM = core.jvm.enablePlugins(AutomateHeaderPlugin)
+lazy val coreJS = core.js.enablePlugins(TzdbPlugin)
+
+lazy val db = project
+  .in(file("modules/db"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(coreJVM % "compile->compile;test->test")
+  .settings(commonSettings)
+  .settings(
+    addCompilerPlugin(Plugins.kindProjectorPlugin),
+    libraryDependencies ++= Doobie,
+    initialCommands += """
+      |import cats._, cats.data._, cats.implicits._, cats.effect._
+      |import doobie._, doobie.implicits._
+      |import gem._, gem.enum._, gem.math._, gem.dao._, gem.dao.meta._, gem.dao.composite._
+      |val xa = Transactor.fromDriverManager[IO](
+      |  "org.postgresql.Driver",
+      |  "jdbc:postgresql:gem",
+      |  "postgres",
+      |  "")
+      |val y = xa.yolo
+      |import y._
+    """.stripMargin.trim
+  )
+
+lazy val json = project
+  .in(file("modules/json"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(coreJVM)
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Circe.value
+  )
+
+lazy val sql = project
+  .in(file("modules/sql"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings ++ flywaySettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      Flyway
+    ) ++ Doobie
+  )
+
+lazy val ocs2 = project
+  .in(file("modules/ocs2"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(coreJVM, db, sql)
+  .settings(commonSettings)
+  .settings(
+    addCompilerPlugin(Plugins.kindProjectorPlugin),
+    libraryDependencies ++= Seq(
+      Fs2,
+      ScalaXml.value,
+      ScalaParserCombinators.value,
+      Http4sXml,
+      Http4sClient,
+    ) ++ Http4s
+  )
+
+lazy val ephemeris = project
+  .in(file("modules/ephemeris"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(coreJVM % "compile->compile;test->test", db, sql)
+  .settings(commonSettings)
+  .settings(
+    addCompilerPlugin(Plugins.kindProjectorPlugin),
+    libraryDependencies ++= Seq(
+      Fs2IO,
+      Http4sClient
+    )
+  )
+
+lazy val service = project
+  .in(file("modules/service"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(coreJVM, db, ephemeris, ocs2)
+  .settings(commonSettings)
+
+lazy val telnetd = project
+  .in(file("modules/telnetd"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(service, sql)
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Tuco
+  )
+
+lazy val web = project
+  .in(file("modules/web"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(service, sql, json)
+  .settings(commonSettings)
+  .settings(
+    addCompilerPlugin(Plugins.kindProjectorPlugin),
+    libraryDependencies ++= Seq(
+      Slf4j,
+      Http4sCirce,
+      JwtCore
+    ) ++ Http4s
+  )
+
+lazy val ui = project
+  .in(file("modules/ui"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(ScalaJSPlugin)
+  .dependsOn(coreJS)
+  .settings(commonSettings)
+  .settings(commonJSSettings)
+  .settings(
+    scalaJSUseMainModuleInitializer := true
+  )
+
+lazy val ctl = project
+  .in(file("modules/ctl"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings (
+    addCompilerPlugin(Plugins.kindProjectorPlugin),
+    resolvers += Resolver.bintrayRepo("bkirwi", "maven"),
+    libraryDependencies ++= Seq(
+      CatsEffect.value,
+      CatsFree.value,
+      Decline
+    ),
+    TaskKey[Unit]("deployTest") := (runMain in Compile).toTask {
+      s" gem.ctl.main --no-ansi --host sbfocstest-lv1.cl.gemini.edu deploy-test ${imageManifest.formatVersion}"
+    } .value,
+    fork in run := true
+  )
+
+lazy val main = project
+  .in(file("modules/main"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(web, telnetd)
+  .settings(commonSettings)
+  .enablePlugins(JavaAppPackaging)
+  .enablePlugins(DockerPlugin)
+  .settings(
+    packageName in Docker := "gem",
+    dockerBaseImage       := "openjdk:8u141",
+    dockerExposedPorts    := List(9090, 9091),
+    dockerRepository      := Some("sbfocsdev-lv1.cl.gemini.edu"),
+    dockerLabels          := imageManifest.labels,
+
+    // Install nc before changing the user
+    dockerCommands       ++= dockerCommands.value.flatMap {
+      case c @ Cmd("USER", args @ _*) =>
+        Seq(
+          ExecCmd("RUN", "apt-get", "update"),
+          ExecCmd("RUN", "apt-get", "--assume-yes", "install", "netcat-openbsd"),
+          c
+        )
+      case cmd => Seq(cmd)
+    }
+
+  )
 lazy val giapi = project
   .in(file("modules/giapi"))
   .enablePlugins(AutomateHeaderPlugin)

--- a/build/weigh.sh
+++ b/build/weigh.sh
@@ -4,3 +4,6 @@ python $TRAVIS_BUILD_DIR/build/weigh_in.py seqexec-library.js
 python $TRAVIS_BUILD_DIR/build/weigh_in.py seqexec_web_client-fastopt-library.js
 # python $TRAVIS_BUILD_DIR/build/weigh_in.py edu_gemini_seqexec_web_client-opt.js
 # python $TRAVIS_BUILD_DIR/build/weigh_in.py edu_gemini_seqexec_web_client-opt-library.js
+cd $TRAVIS_BUILD_DIR/modules/ui/target/scala-2.12/
+python $TRAVIS_BUILD_DIR/build/weigh_in.py gem-ui-fastopt.js
+python $TRAVIS_BUILD_DIR/build/weigh_in.py gem-ui-opt.js

--- a/build/weigh.sh
+++ b/build/weigh.sh
@@ -5,5 +5,5 @@ python $TRAVIS_BUILD_DIR/build/weigh_in.py seqexec_web_client-fastopt-library.js
 # python $TRAVIS_BUILD_DIR/build/weigh_in.py edu_gemini_seqexec_web_client-opt.js
 # python $TRAVIS_BUILD_DIR/build/weigh_in.py edu_gemini_seqexec_web_client-opt-library.js
 cd $TRAVIS_BUILD_DIR/modules/ui/target/scala-2.12/
-python $TRAVIS_BUILD_DIR/build/weigh_in.py gem-ui-fastopt.js
-python $TRAVIS_BUILD_DIR/build/weigh_in.py gem-ui-opt.js
+python $TRAVIS_BUILD_DIR/build/weigh_in.py ui-fastopt.js
+python $TRAVIS_BUILD_DIR/build/weigh_in.py ui-opt.js

--- a/modules/core/jvm/src/main/scala/gem/syntax/Stream.scala
+++ b/modules/core/jvm/src/main/scala/gem/syntax/Stream.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import fs2.{ Chunk, Pull, Stream }
+
+final class StreamOps[F[_], O](val self: Stream[F, O]) {
+
+  /** A filter/fold combination that uses the accumulated result of folding
+    * over the elements since the last element was emitted to determine whether
+    * the current element under examination should be emitted.  The filter
+    * begins with a provided value `z` for the accumulator.  Each successive
+    * value is combined with the accumulated value using a function `f`.  If the
+    * result of `f` matches the predicate `p` then the element is emitted and
+    * the accumulated value is reset to `z`.
+    *
+    * @example {{{
+    * scala> val s = Stream(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    * s: fs2.Stream[fs2.Pure,Int] = Stream(..)
+    *
+    * scala> s.filterOnFold(0)(_ + _, _ % 2 == 0).toList
+    * res0: List[Int] = List(3, 4, 7, 8)
+    * }}}
+    *
+    *
+    * @param z initial value for the accumulator
+    * @param f function that combines the current value with the accumulated
+    *          value
+    * @param p predicate that determines whether the current element should
+    *          be emitted (after being combined with the accumulated value using
+    *          `f`)
+    *
+    * @tparam A type of the accumulated value
+    *
+    * @return a Stream filtered by the accumulator and predicate
+    */
+  def filterOnFold[A](z: A)(f: (A, O) => A, p: A => Boolean): Stream[F, O] = {
+
+    def go(a: A, s: Stream[F,O]): Pull[F,O,Option[Unit]] =
+
+      s.pull.uncons.flatMap {
+        case None           =>
+          Pull.pure(None)
+
+        case Some((hd, tl)) =>
+          Pull.segment(hd.fold((Vector.empty[O], a)) { case ((matching, a), o) =>
+            val aʹ = f(a, o)
+            if (p(aʹ)) (matching :+ o, z) else (matching, aʹ)
+          }.mapResult(_._2)).flatMap { case (matching, aʹ) =>
+            Pull.outputChunk(Chunk.vector(matching)) >> go(aʹ, tl)
+          }
+      }
+
+    go(z, self).stream
+
+  }
+}
+
+trait ToStreamOps {
+  implicit def ToStreamOps[F[_], O](s: Stream[F, O]): StreamOps[F, O] =
+    new StreamOps[F,O](s)
+}
+
+object stream extends ToStreamOps

--- a/modules/core/shared/src/main/scala/gem/Asterism.scala
+++ b/modules/core/shared/src/main/scala/gem/Asterism.scala
@@ -1,0 +1,133 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.Eq
+import cats.data.NonEmptyList
+import gem.enum.Instrument
+
+sealed abstract class Asterism extends Product with Serializable {
+  def targets: NonEmptyList[Target]
+}
+
+object Asterism {
+
+  /** Supertype for asterisms with a single target. */
+  sealed trait SingleTarget extends Asterism {
+    def target: Target
+    override def targets: NonEmptyList[Target] =
+      NonEmptyList.one(target)
+  }
+
+  /** Asterism for Phoenix.
+    * @group Constructors
+    */
+  final case class Phoenix(target: Target) extends SingleTarget
+
+  /** Asterism for Michelle.
+    * @group Constructors
+    */
+  final case class Michelle(target: Target) extends SingleTarget
+
+  /** Asterism for Gnirs.
+    * @group Constructors
+    */
+  final case class Gnirs(target: Target) extends SingleTarget
+
+  /** Asterism for Niri.
+    * @group Constructors
+    */
+  final case class Niri(target: Target) extends SingleTarget
+
+  /** Asterism for Trecs.
+    * @group Constructors
+    */
+  final case class Trecs(target: Target) extends SingleTarget
+
+  /** Asterism for Nici.
+    * @group Constructors
+    */
+  final case class Nici(target: Target) extends SingleTarget
+
+  /** Asterism for Nifs.
+    * @group Constructors
+    */
+  final case class Nifs(target: Target) extends SingleTarget
+
+  /** Asterism for Gpi.
+    * @group Constructors
+    */
+  final case class Gpi(target: Target) extends SingleTarget
+
+  /** Asterism for Gsaoi.
+    * @group Constructors
+    */
+  final case class Gsaoi(target: Target) extends SingleTarget
+
+  /** Asterism for GmosS.
+    * @group Constructors
+    */
+  final case class GmosS(target: Target) extends SingleTarget
+
+  /** Asterism for AcqCam.
+    * @group Constructors
+    */
+  final case class AcqCam(target: Target) extends SingleTarget
+
+  /** Asterism for GmosN.
+    * @group Constructors
+    */
+  final case class GmosN(target: Target) extends SingleTarget
+
+  /** Asterism for Bhros.
+    * @group Constructors
+    */
+  final case class Bhros(target: Target) extends SingleTarget
+
+  /** Asterism for Visitor.
+    * @group Constructors
+    */
+  final case class Visitor(target: Target) extends SingleTarget
+
+  /** Asterism for Flamingos2.
+    * @group Constructors
+    */
+  final case class Flamingos2(target: Target) extends SingleTarget
+
+  /** Dual-target asterism for Ghost.
+    * @group Constructors
+    */
+  final case class GhostDualTarget(ifu1: Target, ifu2: Target) extends Asterism {
+    override def targets: NonEmptyList[Target] =
+      NonEmptyList.of(ifu1, ifu2)
+  }
+
+  /** @group Typeclass Instances */
+  implicit def EqAsterism: Eq[Asterism] =
+    Eq.fromUniversalEquals
+
+  def fromSingleTarget(t: Target, i: Instrument): Option[Asterism] =
+    i match {
+      case Instrument.Phoenix    => Some(Asterism.Phoenix(t))
+      case Instrument.Michelle   => Some(Asterism.Michelle(t))
+      case Instrument.Gnirs      => Some(Asterism.Gnirs(t))
+      case Instrument.Niri       => Some(Asterism.Niri(t))
+      case Instrument.Trecs      => Some(Asterism.Trecs(t))
+      case Instrument.Nici       => Some(Asterism.Nici(t))
+      case Instrument.Nifs       => Some(Asterism.Nifs(t))
+      case Instrument.Gpi        => Some(Asterism.Gpi(t))
+      case Instrument.Gsaoi      => Some(Asterism.Gsaoi(t))
+      case Instrument.GmosS      => Some(Asterism.GmosS(t))
+      case Instrument.AcqCam     => Some(Asterism.AcqCam(t))
+      case Instrument.GmosN      => Some(Asterism.GmosN(t))
+      case Instrument.Bhros      => Some(Asterism.Bhros(t))
+      case Instrument.Visitor    => Some(Asterism.Visitor(t))
+      case Instrument.Flamingos2 => Some(Asterism.Flamingos2(t))
+      case Instrument.Ghost      => None
+    }
+
+ def unsafeFromSingleTarget(t: Target, i: Instrument): Asterism =
+    fromSingleTarget(t, i).getOrElse(sys.error(s"No single-target asterism available for $i"))
+
+}

--- a/modules/core/shared/src/main/scala/gem/CoAdds.scala
+++ b/modules/core/shared/src/main/scala/gem/CoAdds.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Order, Show }
+import cats.instances.short._
+import gem.syntax.prism._
+import monocle.Prism
+
+sealed abstract case class CoAdds private (toShort: Short) {
+  // Sanity check … should be correct via the companion constructor.
+  assert(toShort > 0, s"Invariant violated. $toShort is 1 or greater.")
+}
+
+object CoAdds {
+
+  final val One: CoAdds = fromShort.unsafeGet(1)
+
+  /** @group Typeclass Instances */
+  implicit val CoAddsShow: Show[CoAdds] =
+    Show.fromToString
+
+  /** @group Typeclass Instances */
+  implicit val CoAddsOrd: Order[CoAdds] =
+    Order.by(_.toShort)
+
+  /**
+    * Prism from Short into CoAdds and back.
+    * @group Optics
+    */
+  def fromShort: Prism[Short, CoAdds] =
+    Prism((n: Short) => Some(n).filter(_ > 0).map(new CoAdds(_) {}))(_.toShort)
+
+}

--- a/modules/core/shared/src/main/scala/gem/Dataset.scala
+++ b/modules/core/shared/src/main/scala/gem/Dataset.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Order, Show }
+import cats.implicits._
+import gem.instances.time._
+import gem.syntax.string._
+import gem.optics.Format
+import java.time.Instant
+
+/**
+ * A labeled, timestamped data file.
+ * @group Sequence Model
+ */
+final case class Dataset(
+  label:     Dataset.Label,
+  filename:  String,
+  timestamp: Instant
+)
+
+object Dataset {
+
+  /**
+   * Datasets are labeled by observation and index.
+   * @group Data Types
+   */
+  final case class Label(observationId: Observation.Id, index: Int) {
+    override def toString =
+      Label.fromString.productToString(this)
+  }
+
+  object Label extends LabelOptics {
+
+    /**
+     * Labels are ordered by observation and index.
+     * @group Typeclass Instances
+     */
+    implicit val LabelOrder: Order[Label] =
+      Order.by(a => (a.observationId, a.index))
+
+    /** @group Typeclass Instances */
+    implicit val LabelShow: Show[Label] =
+      Show.fromToString
+
+  }
+
+  trait LabelOptics { this: Label.type =>
+
+    /** Format from Strings into Label and back. */
+    val fromString: Format[String, Label] =
+      Format(s =>
+        s.lastIndexOf('-') match {
+          case -1 => None
+          case  n =>
+            val (a, b) = s.splitAt(n)
+            b.drop(1).parseIntOption.filter(_ > 0).flatMap { n =>
+              Observation.Id.fromString(a).map(oid => Dataset.Label(oid, n))
+            }
+        }, l => f"${l.observationId.format}-${l.index}%03d"
+      )
+
+  }
+
+  /**
+   * Datasets are ordered by their labels, which are normally unique. For completeness they are further
+   * ordered by timestamp and filename.
+   * @group Typeclass Instances
+   */
+  implicit val DatasetOrder: Order[Dataset] =
+    Order.by(a => (a.label, a.timestamp, a.filename))
+
+  /** @group Typeclass Instances */
+  implicit val DatasetShow: Show[Dataset] =
+    Show.fromToString
+
+}

--- a/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisKey.scala
@@ -1,0 +1,130 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.enum.EphemerisKeyType
+import gem.parser.EphemerisKeyParsers
+import gem.syntax.parser._
+import gem.syntax.string._
+import gem.optics.Format
+
+import cats.{ Order, Show }
+import cats.implicits._
+import monocle.macros.Lenses
+
+/** Ephemeris data lookup key which uniquely identifies a non-sidreal object in
+  * the database.
+  */
+sealed trait EphemerisKey extends Product with Serializable {
+
+  import EphemerisKey.{ AsteroidNew, AsteroidOld, Comet, MajorBody, UserSupplied }
+
+  /** Human readable desgination that discriminates among ephemeris keys of the
+    * same type.
+    */
+  def des: String
+
+  /** Extracts the ephemeris lookup key type.
+    */
+  def keyType: EphemerisKeyType =
+    this match {
+      case AsteroidNew(_)  => EphemerisKeyType.AsteroidNew
+      case AsteroidOld(_)  => EphemerisKeyType.AsteroidOld
+      case Comet(_)        => EphemerisKeyType.Comet
+      case MajorBody(_)    => EphemerisKeyType.MajorBody
+      case UserSupplied(_) => EphemerisKeyType.UserSupplied
+    }
+
+}
+
+
+object EphemerisKey extends EphemerisOptics {
+
+  /** Unique Horizons designation, which should allow for reproducible ephemeris
+    * queries <b>if</b> the values passed to the constructors are extracted
+    * correctly from search results.
+    */
+  sealed abstract class Horizons(val queryString: String) extends EphemerisKey
+
+  /** Horizons designation for asteroids, old and new style.
+    */
+  sealed abstract class Asteroid(s: String) extends Horizons(s)
+
+  /** Designation for a comet, in the current apparition. Example: `C/1973 E1`
+    * for Kohoutek, yielding the query string `NAME=C/1973 E1;CAP`.
+    */
+  @Lenses final case class Comet(des: String) extends Horizons(s"NAME=$des;CAP")
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object Comet
+
+  /** Designation for an asteroid under modern naming conventions. Example:
+    * `1971 UC1` for 1896 Beer, yielding a query string `ASTNAM=1971 UC1`.
+    */
+  @Lenses final case class AsteroidNew(des: String) extends Asteroid(s"ASTNAM=$des")
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object AsteroidNew
+
+  /** Designation for an asteroid under "old" naming conventions. These are
+    * small numbers. Example: `4` for Vesta, yielding a query string `4;`
+    */
+  @Lenses final case class AsteroidOld(num: Int) extends Asteroid(s"$num;") {
+    override def des: String =
+      num.toString
+  }
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object AsteroidOld
+
+  /** Designation for a major body (planet or satellite thereof). These have
+    * small numbers. Example: `606` for Titan, yielding a query string `606`.
+    */
+  @Lenses final case class MajorBody(num: Int) extends Horizons(s"$num") {
+    override def des: String =
+      num.toString
+  }
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object MajorBody
+
+  /** Identifies a user-supplied collection of ephemeris data, where the number
+    * comes from a database sequence.
+    */
+  @Lenses final case class UserSupplied(id: Int) extends EphemerisKey {
+    override def des: String =
+      id.toString
+  }
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object UserSupplied
+
+  implicit val ShowEphemerisKey: Show[EphemerisKey] =
+    Show.fromToString
+
+  implicit val OrderEphemerisKey: Order[EphemerisKey] =
+    Order.by(fromString.reverseGet)
+}
+
+trait EphemerisOptics { this: EphemerisKey.type =>
+
+  val fromString: Format[String, EphemerisKey] =
+    Format(
+      EphemerisKeyParsers.ephemerisKey.parseExact,
+      k => {
+        val (keyType, des) = fromTypeAndDes.reverseGet(k)
+        s"${keyType.tag}_${des}"
+      }
+    )
+
+  val fromTypeAndDes: Format[(EphemerisKeyType, String), EphemerisKey] =
+    Format(
+      { case (t, des) =>
+        t match {
+          case EphemerisKeyType.Comet        => Some(Comet(des))
+          case EphemerisKeyType.AsteroidNew  => Some(AsteroidNew(des))
+          case EphemerisKeyType.AsteroidOld  => des.parseIntOption.map(AsteroidOld(_))
+          case EphemerisKeyType.MajorBody    => des.parseIntOption.map(MajorBody(_))
+          case EphemerisKeyType.UserSupplied => des.parseIntOption.map(UserSupplied(_))
+        }
+      },
+      k => (k.keyType, k.des)
+    )
+
+}

--- a/modules/core/shared/src/main/scala/gem/EphemerisMeta.scala
+++ b/modules/core/shared/src/main/scala/gem/EphemerisMeta.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.util.Timestamp
+
+import cats.{ Eq, Show }
+
+import monocle.macros.Lenses
+
+
+/** Ephemeris meta data related to updates.
+  *
+  * @param lastUpdate time of last update
+  * @param lastUpdateCheck time of last update check
+  * @param solnRef horizons solution reference, if any (applies to comet and
+  *                asteroid ephemeris data fetched from horizons)
+  */
+@Lenses final case class EphemerisMeta(
+  lastUpdate: Timestamp,
+  lastUpdateCheck: Timestamp,
+  solnRef: Option[HorizonsSolutionRef]
+)
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object EphemerisMeta {
+
+  implicit val eqEphemerisMeta: Eq[EphemerisMeta] =
+    Eq.fromUniversalEquals
+
+  implicit val showEphemerisMeta: Show[EphemerisMeta] =
+    Show.fromToString
+}

--- a/modules/core/shared/src/main/scala/gem/Event.scala
+++ b/modules/core/shared/src/main/scala/gem/Event.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import java.time.Instant
+
+/**
+ * An observing event, with many constuctors.
+ * @group Sequence Model
+ */
+sealed trait Event {
+  def timestamp: Instant
+  def oid: Observation.Id
+}
+
+object Event {
+
+  final case class StartSlew(       timestamp: Instant, oid: Observation.Id) extends Event
+  final case class EndSlew(         timestamp: Instant, oid: Observation.Id) extends Event
+
+  final case class StartVisit(      timestamp: Instant, oid: Observation.Id) extends Event
+  final case class EndVisit(        timestamp: Instant, oid: Observation.Id) extends Event
+
+  final case class StartSequence(   timestamp: Instant, oid: Observation.Id) extends Event
+  final case class EndSequence(     timestamp: Instant, oid: Observation.Id) extends Event
+
+  final case class PauseObserve(    timestamp: Instant, oid: Observation.Id) extends Event
+  final case class ContinueObserve( timestamp: Instant, oid: Observation.Id) extends Event
+  final case class AbortObserve(    timestamp: Instant, oid: Observation.Id) extends Event
+  final case class StopObserve(     timestamp: Instant, oid: Observation.Id) extends Event
+
+  final case class StartIntegration(timestamp: Instant, oid: Observation.Id, step: Int) extends Event
+  final case class EndIntegration(  timestamp: Instant, oid: Observation.Id, step: Int) extends Event
+
+
+  def startSlew(t: Instant, o: Observation.Id): Event       = StartSlew(t, o)
+  def endSlew(t: Instant, o: Observation.Id): Event         = EndSlew(t, o)
+
+  def startVisit(t: Instant, o: Observation.Id): Event      = StartVisit(t, o)
+  def endVisit(t: Instant, o: Observation.Id): Event        = EndVisit(t, o)
+
+  def startSequence(t: Instant, o: Observation.Id): Event   = StartSequence(t, o)
+  def endSequence(t: Instant, o: Observation.Id): Event     = EndSequence(t, o)
+
+  def pauseObserve(t: Instant, o: Observation.Id): Event    = PauseObserve(t, o)
+  def continueObserve(t: Instant, o: Observation.Id): Event = ContinueObserve(t, o)
+  def abortObserve(t: Instant, o: Observation.Id): Event    = AbortObserve(t, o)
+  def stopObserve(t: Instant, o: Observation.Id): Event     = StopObserve(t, o)
+
+  def startIntegration(t: Instant, o: Observation.Id, i: Int): Event = StartIntegration(t, o, i)
+  def endIntegration(t: Instant, o: Observation.Id, i: Int): Event   = EndIntegration(t, o, i)
+
+}

--- a/modules/core/shared/src/main/scala/gem/HorizonsSolutionRef.scala
+++ b/modules/core/shared/src/main/scala/gem/HorizonsSolutionRef.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Eq, Show }
+
+
+/** Horizons solution reference.  Comets and asteriods have a unique version
+  * that is updated when the ephemeris calculation changes.  For our purposes
+  * this is opaque data whose only use is to compare to an earlier version in
+  * order to check for changes.
+  */
+final case class HorizonsSolutionRef(stringValue: String)
+
+object HorizonsSolutionRef {
+
+  implicit val ShowHorizonsSolutionRef: Show[HorizonsSolutionRef] =
+    Show.fromToString
+
+  implicit val EqHorizonsSolutionRef: Eq[HorizonsSolutionRef] =
+    Eq.fromUniversalEquals
+}

--- a/modules/core/shared/src/main/scala/gem/Observation.scala
+++ b/modules/core/shared/src/main/scala/gem/Observation.scala
@@ -1,0 +1,250 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Order, Show }
+import cats.implicits._
+import gem.config.StaticConfig
+import gem.math.Index
+
+/** ADT for an observation, with constructors for each instrument. */
+sealed trait Observation {
+  def title: String
+  def targetEnvironment: TargetEnvironment
+  def staticConfig: StaticConfig
+  def sequence: List[Step]
+}
+
+object Observation {
+
+  /** A Phoenix observation.
+    * @group Constructors
+    */
+  final case class Phoenix(
+    title: String,
+    targetEnvironment: TargetEnvironment.Phoenix,
+    staticConfig: StaticConfig.Phoenix,
+    sequence: List[Step.Phoenix]
+  ) extends Observation
+
+  /** A Michelle observation.
+    * @group Constructors
+    */
+  final case class Michelle(
+    title: String,
+    targetEnvironment: TargetEnvironment.Michelle,
+    staticConfig: StaticConfig.Michelle,
+    sequence: List[Step.Michelle]
+  ) extends Observation
+
+  /** A Gnirs observation.
+    * @group Constructors
+    */
+  final case class Gnirs(
+    title: String,
+    targetEnvironment: TargetEnvironment.Gnirs,
+    staticConfig: StaticConfig.Gnirs,
+    sequence: List[Step.Gnirs]
+  ) extends Observation
+
+  /** A Niri observation.
+    * @group Constructors
+    */
+  final case class Niri(
+    title: String,
+    targetEnvironment: TargetEnvironment.Niri,
+    staticConfig: StaticConfig.Niri,
+    sequence: List[Step.Niri]
+  ) extends Observation
+
+  /** A Trecs observation.
+    * @group Constructors
+    */
+  final case class Trecs(
+    title: String,
+    targetEnvironment: TargetEnvironment.Trecs,
+    staticConfig: StaticConfig.Trecs,
+    sequence: List[Step.Trecs]
+  ) extends Observation
+
+  /** A Nici observation.
+    * @group Constructors
+    */
+  final case class Nici(
+    title: String,
+    targetEnvironment: TargetEnvironment.Nici,
+    staticConfig: StaticConfig.Nici,
+    sequence: List[Step.Nici]
+  ) extends Observation
+
+  /** A Nifs observation.
+    * @group Constructors
+    */
+  final case class Nifs(
+    title: String,
+    targetEnvironment: TargetEnvironment.Nifs,
+    staticConfig: StaticConfig.Nifs,
+    sequence: List[Step.Nifs]
+  ) extends Observation
+
+  /** A Gpi observation.
+    * @group Constructors
+    */
+  final case class Gpi(
+    title: String,
+    targetEnvironment: TargetEnvironment.Gpi,
+    staticConfig: StaticConfig.Gpi,
+    sequence: List[Step.Gpi]
+  ) extends Observation
+
+  /** A Gsaoi observation.
+    * @group Constructors
+    */
+  final case class Gsaoi(
+    title: String,
+    targetEnvironment: TargetEnvironment.Gsaoi,
+    staticConfig: StaticConfig.Gsaoi,
+    sequence: List[Step.Gsaoi]
+  ) extends Observation
+
+  /** A GmosS observation.
+    * @group Constructors
+    */
+  final case class GmosS(
+    title: String,
+    targetEnvironment: TargetEnvironment.GmosS,
+    staticConfig: StaticConfig.GmosS,
+    sequence: List[Step.GmosS]
+  ) extends Observation
+
+  /** A AcqCam observation.
+    * @group Constructors
+    */
+  final case class AcqCam(
+    title: String,
+    targetEnvironment: TargetEnvironment.AcqCam,
+    staticConfig: StaticConfig.AcqCam,
+    sequence: List[Step.AcqCam]
+  ) extends Observation
+
+  /** A GmosN observation.
+    * @group Constructors
+    */
+  final case class GmosN(
+    title: String,
+    targetEnvironment: TargetEnvironment.GmosN,
+    staticConfig: StaticConfig.GmosN,
+    sequence: List[Step.GmosN]
+  ) extends Observation
+
+  /** A Bhros observation.
+    * @group Constructors
+    */
+  final case class Bhros(
+    title: String,
+    targetEnvironment: TargetEnvironment.Bhros,
+    staticConfig: StaticConfig.Bhros,
+    sequence: List[Step.Bhros]
+  ) extends Observation
+
+  /** A Visitor observation.
+    * @group Constructors
+    */
+  final case class Visitor(
+    title: String,
+    targetEnvironment: TargetEnvironment.Visitor,
+    staticConfig: StaticConfig.Visitor,
+    sequence: List[Step.Visitor]
+  ) extends Observation
+
+  /** A Flamingos2 observation.
+    * @group Constructors
+    */
+  final case class Flamingos2(
+    title: String,
+    targetEnvironment: TargetEnvironment.Flamingos2,
+    staticConfig: StaticConfig.Flamingos2,
+    sequence: List[Step.Flamingos2]
+  ) extends Observation
+
+  /** A Ghost observation.
+    * @group Constructors
+    */
+  final case class Ghost(
+    title: String,
+    targetEnvironment: TargetEnvironment.Ghost,
+    staticConfig: StaticConfig.Ghost,
+    sequence: List[Step.Ghost]
+  ) extends Observation
+
+  /** An observation is identified by its program and a serial index. */
+  final case class Id(pid: Program.Id, index: Index) {
+    def format: String =
+      s"${ProgramId.fromString.reverseGet(pid)}-${Index.fromString.reverseGet(index)}"
+  }
+  object Id {
+
+    def fromString(s: String): Option[Observation.Id] =
+      s.lastIndexOf('-') match {
+        case -1 => None
+        case  n =>
+          val (a, b) = s.splitAt(n)
+          Index.fromString.getOption(b.drop(1)).flatMap { i =>
+            Program.Id.fromString.getOption(a).map(Observation.Id(_, i))
+          }
+      }
+
+    def unsafeFromString(s: String): Observation.Id =
+      fromString(s).getOrElse(sys.error("Malformed Observation.Id: " + s))
+
+    /** Observations are ordered by program id and index. */
+    implicit val OrderId: Order[Id] =
+      Order.by(a => (a.pid, a.index))
+
+    implicit val OrderingId: scala.math.Ordering[Id] =
+      OrderId.toOrdering
+
+    implicit val showId: Show[Id] =
+      Show.fromToString
+
+  }
+
+  /** Assemble an Observation from its parts, assuming they're consistent. */
+  def unsafeAssemble(
+    title: String,
+    targetEnvironment: TargetEnvironment,
+    staticConfig: StaticConfig,
+    sequence: List[Step]
+  ): Observation = {
+
+    implicit class SequenceOps(ss: List[Step]) {
+      def narrow[A](pf: PartialFunction[Step, A]): List[A] =
+        ss.collect(pf orElse {
+          case _ => sys.error("inconsistent sequence contains multiple instruments")
+        })
+    }
+
+    (targetEnvironment, staticConfig) match {
+        case (te: TargetEnvironment.Phoenix,    sc: StaticConfig.Phoenix)    => Observation.Phoenix(   title, te, sc, sequence.narrow { case s: Step.Phoenix    => s })
+        case (te: TargetEnvironment.Michelle,   sc: StaticConfig.Michelle)   => Observation.Michelle(  title, te, sc, sequence.narrow { case s: Step.Michelle   => s })
+        case (te: TargetEnvironment.Gnirs,      sc: StaticConfig.Gnirs)      => Observation.Gnirs(     title, te, sc, sequence.narrow { case s: Step.Gnirs      => s })
+        case (te: TargetEnvironment.Niri,       sc: StaticConfig.Niri)       => Observation.Niri(      title, te, sc, sequence.narrow { case s: Step.Niri       => s })
+        case (te: TargetEnvironment.Trecs,      sc: StaticConfig.Trecs)      => Observation.Trecs(     title, te, sc, sequence.narrow { case s: Step.Trecs      => s })
+        case (te: TargetEnvironment.Nici,       sc: StaticConfig.Nici)       => Observation.Nici(      title, te, sc, sequence.narrow { case s: Step.Nici       => s })
+        case (te: TargetEnvironment.Nifs,       sc: StaticConfig.Nifs)       => Observation.Nifs(      title, te, sc, sequence.narrow { case s: Step.Nifs       => s })
+        case (te: TargetEnvironment.Gpi,        sc: StaticConfig.Gpi)        => Observation.Gpi(       title, te, sc, sequence.narrow { case s: Step.Gpi        => s })
+        case (te: TargetEnvironment.Gsaoi,      sc: StaticConfig.Gsaoi)      => Observation.Gsaoi(     title, te, sc, sequence.narrow { case s: Step.Gsaoi      => s })
+        case (te: TargetEnvironment.GmosS,      sc: StaticConfig.GmosS)      => Observation.GmosS(     title, te, sc, sequence.narrow { case s: Step.GmosS      => s })
+        case (te: TargetEnvironment.AcqCam,     sc: StaticConfig.AcqCam)     => Observation.AcqCam(    title, te, sc, sequence.narrow { case s: Step.AcqCam     => s })
+        case (te: TargetEnvironment.GmosN,      sc: StaticConfig.GmosN)      => Observation.GmosN(     title, te, sc, sequence.narrow { case s: Step.GmosN      => s })
+        case (te: TargetEnvironment.Bhros,      sc: StaticConfig.Bhros)      => Observation.Bhros(     title, te, sc, sequence.narrow { case s: Step.Bhros      => s })
+        case (te: TargetEnvironment.Visitor,    sc: StaticConfig.Visitor)    => Observation.Visitor(   title, te, sc, sequence.narrow { case s: Step.Visitor    => s })
+        case (te: TargetEnvironment.Flamingos2, sc: StaticConfig.Flamingos2) => Observation.Flamingos2(title, te, sc, sequence.narrow { case s: Step.Flamingos2 => s })
+        case (te: TargetEnvironment.Ghost,      sc: StaticConfig.Ghost)      => Observation.Ghost(     title, te, sc, sequence.narrow { case s: Step.Ghost      => s })
+        case _ => sys.error("inconsistent observation")
+      }
+
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/Program.scala
+++ b/modules/core/shared/src/main/scala/gem/Program.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.math.Index
+import scala.collection.immutable.TreeMap
+
+/**
+ * A science program, the root data type in the science model.
+ * @group Program Model
+ */
+final case class Program(id: Program.Id, title: String, observations: TreeMap[Index, Observation])
+
+object Program {
+  type Id                 = ProgramId
+  val  Id: ProgramId.type = ProgramId
+}

--- a/modules/core/shared/src/main/scala/gem/ProgramId.scala
+++ b/modules/core/shared/src/main/scala/gem/ProgramId.scala
@@ -1,0 +1,221 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Order, Show }
+import cats.implicits._
+import java.time._
+import java.time.format.DateTimeFormatter
+import gem.enum.{ Site, ProgramType, DailyProgramType }
+import gem.instances.time._
+import gem.math.Index
+import gem.parser.ProgramIdParsers
+import gem.syntax.parser._
+import monocle.Prism
+
+/**
+ * A science program id, which has three constructors: [[gem.ProgramId.Science Science]]` for standard
+ * programs; [[gem.ProgramId.Science Science]] for standard daily engineering and calibration
+ * programs; and [[gem.ProgramId.Nonstandard Nonstandard]]` for all others.
+ * @group Program Model
+ */
+sealed trait ProgramId extends Product with Serializable {
+
+  /** The `Site` associated with this id, if any. */
+  def siteOption: Option[Site]
+
+  /** The `Semester` associated with this id, if any. */
+  def semesterOption: Option[Semester]
+
+  /** The `ProgramType` associated with this id, if any. */
+  def programTypeOption: Option[ProgramType]
+
+}
+
+object ProgramId {
+
+  /** A standard science program id with a site, semester, program type, and positive index. */
+  final case class Science private (
+    site:        Site,
+    semester:    Semester,
+    programType: ProgramType,
+    index:       Index
+  ) extends ProgramId {
+
+    override def siteOption: Option[Site] =
+      Some(site)
+
+    override def semesterOption: Option[Semester] =
+      Some(semester)
+
+    override def programTypeOption: Option[ProgramType] =
+      Some(programType)
+  }
+
+  object Science {
+
+    /** `Science` program ids are ordered pairwise by their data members. */
+    implicit val ScienceOrder: Order[Science] =
+      Order.by(a => (a.site, a.semester, a.programType, a.index))
+
+    /** Parse a string into a Science id, and format in the reverse direction. */
+    def fromString: Prism[String, Science] =
+      Prism(ProgramIdParsers.science.parseExact)(id =>
+        s"${id.site.shortName}-${id.semester.format}-${id.programType.shortName}-${id.index.toShort}"
+      )
+
+  }
+
+  /** A standard daily program id with a site, program type, and local date. */
+  final case class Daily(
+    site:             Site,
+    dailyProgramType: DailyProgramType,
+    localDate:        LocalDate
+  ) extends ProgramId {
+
+    /** The first moment of this observing day, 2pm the day before `localDate`. */
+    lazy val start: ZonedDateTime =
+      ZonedDateTime.of(localDate.minusDays(1), LocalTime.of(14,0,0), site.timezone)
+
+    /** The last moment of this observing day, just before 2pm on 'localDate'. */
+    lazy val end: ZonedDateTime =
+      ZonedDateTime.of(localDate, LocalTime.of(14,0,0).minusNanos(1), site.timezone)
+
+    /** Semester inferred from the `localDate`. */
+    def semester: Semester =
+      Semester.fromLocalDate(localDate)
+
+    /** ProgramType inferred from the `dailyProgramType`. */
+    def programType: ProgramType =
+      dailyProgramType.toProgramType
+
+    /** True if the given instant falls within the observing day defined by `start` and `end`. */
+    def includes(i: Instant): Boolean =
+      start.toInstant <= i && i <= end.toInstant
+
+    override def siteOption: Option[Site] =
+      Some(site)
+
+    override def semesterOption: Option[Semester] =
+      Some(semester)
+
+    override def programTypeOption: Option[ProgramType] =
+      Some(programType)
+
+  }
+  object Daily {
+
+    /** Daily program id for the zoned date and time of the given Site and Instant. */
+    def fromSiteAndInstant(site: Site, instant: Instant, programType: DailyProgramType): Daily = {
+      val zdt  = ZonedDateTime.ofInstant(instant, site.timezone)
+      val end  = zdt.`with`(LocalTime.of(14, 0, 0, 0))
+      val zdtʹ = if (zdt.toInstant < end.toInstant) zdt else zdt.plusDays(1)
+      apply(site, programType, zdtʹ.toLocalDate)
+    }
+
+    /** `Daily` program ids are ordered pairwise by their data members. */
+    implicit val DailyOrder: Order[Daily] =
+      Order.by(a => (a.site, a.dailyProgramType, a.localDate))
+
+    /** Parse a string into a Daily id, and format in the reverse direction. */
+    val fromString: Prism[String, Daily] = {
+      val ymd = DateTimeFormatter.ofPattern("yyyyMMdd")
+      Prism(ProgramIdParsers.daily.parseExact)(id =>
+        f"${id.site.shortName}-${id.dailyProgramType.shortName}${ymd.format(id.localDate)}"
+      )
+    }
+
+  }
+
+  /**
+   * Parser for a non-standard program id of the general form `site-semester-type-tail` where
+   * any subset of the structured portion is permitted as long as it appears in the proper order.
+   * This is the catch-all type for otherwise unparseable ids, so it is guaranteed that the string
+   * representation of a `Nonstandard` via `.format` is *not* parseable in to a standard science or
+   * daily program id. This data type has no public constructor and no `.copy` method, as these
+   * could violate the above invariant. The only way to get an instance is via `.fromString`.
+   */
+  sealed abstract case class Nonstandard(
+    override val siteOption:        Option[Site],
+    override val semesterOption:    Option[Semester],
+    override val programTypeOption: Option[ProgramType],
+                 tail:              String
+  ) extends ProgramId
+
+  object Nonstandard {
+
+    /**
+     * Format the components of a `Nonstandard`, which may result in a string that *cannot* be
+     * re-parsed into a Nonstandard program id because it instead parses into a more structured
+     * type (i.e., Daily or Science). Nonstandard is the fallback.
+     */
+    def format(
+      siteOption:        Option[Site],
+      semesterOption:    Option[Semester],
+      programTypeOption: Option[ProgramType],
+      tail:              String
+    ): String =
+      List(
+        siteOption       .map(_.shortName).toList,
+        semesterOption   .map(_.format)   .toList,
+        programTypeOption.map(_.shortName).toList,
+        List(tail)
+      ).flatten.intercalate("-")
+
+    /** `Nonstandard` program ids are ordered pairwise by their data members. */
+    implicit val NonStandardOrder: Order[Nonstandard] =
+      Order.by(a => (a.siteOption, a.semesterOption, a.programTypeOption, a.tail))
+
+    /** Parse a string into a Nonstandard id, and format in the reverse direction. */
+    val fromString: Prism[String, Nonstandard] =
+      Prism[String, Nonstandard] { s =>
+        // We need to try to parse the other types first because if they match we don't.
+        ProgramId.fromString.getOption(s) collect { case id: Nonstandard => id }
+      } { id => format(id.siteOption, id.semesterOption, id.programTypeOption, id.tail) }
+
+  }
+
+  /**
+   * Programs are ordered lexically by prodict prefix (Daily, Nonstandard, then Science) and then
+   * by the defined orderings for individual cases when constructors match.
+   */
+  implicit val ProgramIdOrder: Order[ProgramId] =
+    Order.from {
+      case (a: Science,     b: Science)     => a compare b
+      case (a: Daily,       b: Daily)       => a compare b
+      case (a: Nonstandard, b: Nonstandard) => a compare b
+      case (a,              b)              => a.productPrefix compare b.productPrefix
+    }
+
+  /**
+   * `Ordering` instance for Scala standard library.
+   * @see ProgramIdOrder
+   */
+  implicit val ProgramIdOrdering: scala.math.Ordering[ProgramId] =
+    ProgramIdOrder.toOrdering
+
+  implicit val ProgramIdShow: Show[ProgramId] =
+    Show.fromToString
+
+  /**
+   * Parse a `ProgramId` from string, if possible, and format canonically in the revese direction.
+   * Note that the parser is very lenient, and any String containing no whitespace is a valid
+   * program id.
+   */
+  val fromString: Prism[String, ProgramId] =
+    Prism { (s: String) =>
+      Science.fromString.getOption(s) orElse
+      Daily  .fromString.getOption(s) orElse
+      // Do this only in the last case, and only here, to guarantee you can never get a Nonstandard
+      // that can be formatted and re-parsed as a Science or Daily program id. This is important.
+      ProgramIdParsers.nonstandard.parseExact(s).map {
+        case (os, om, op, t) => new Nonstandard(os, om, op, t) {}
+      }
+    } {
+      case s: Science     => Science    .fromString.reverseGet(s)
+      case d: Daily       => Daily      .fromString.reverseGet(d)
+      case n: Nonstandard => Nonstandard.fromString.reverseGet(n)
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/Semester.scala
+++ b/modules/core/shared/src/main/scala/gem/Semester.scala
@@ -1,0 +1,148 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Order, Show }
+import cats.effect.IO
+import cats.implicits._
+import gem.enum.{ Half, Site }
+import gem.instances.time._
+import gem.math.LocalObservingNight
+import gem.parser.SemesterParsers
+import gem.syntax.parser._
+import java.time._
+import java.time.Month._
+
+/**
+ * A (Year, Half) pair.
+ * @group Program Model
+ */
+final case class Semester(year: Year, half: Half) {
+
+  /**
+   * This Semester plus the given number of years. Raises a `DateTimeException` for final year out
+   * of range -999999999 - 999999999.
+   */
+  def plusYears(n: Int): Semester =
+    copy(year = year.plusYears(n.toLong))
+
+  /** This Semester plus the given number of half-years. */
+  def plusSemesters(n: Int): Semester = {
+    val yy = year.getValue
+    val hs = yy * 2 + half.toInt * yy.signum + n
+    Semester(Year.of(hs / 2), Half.unsafeFromInt(hs.abs % 2))
+  }
+
+  /** The semester immediately following this one. */
+  def next: Semester =
+    plusSemesters(1)
+
+  /** The semester immediately preceding this one. */
+  def prev: Semester =
+    plusSemesters(-1)
+
+  /** Module of various representations of the first instant of the semester, *inclusive*. */
+  object start {
+    lazy val yearMonth: YearMonth = YearMonth.of(year.getValue, half.startMonth)
+    lazy val localDate: LocalDate = LocalDate.of(year.getValue, half.startMonth, 1)
+    lazy val localDateTime: LocalDateTime = LocalDateTime.of(localDate, LocalTime.MIDNIGHT).minusHours(10) // 2pm the day before
+    def zonedDateTime(zoneId: ZoneId): ZonedDateTime = ZonedDateTime.of(localDateTime, zoneId)
+    def atSite(site: Site): ZonedDateTime = zonedDateTime(site.timezone)
+  }
+
+  /**
+   * Module of various representations of the last instant of the semester, *inclusive*.
+   * @group Program Model
+   */
+  object end {
+    private def nextYear = (half match { case Half.A => year; case Half.B => year.plusYears(1) }).getValue
+    lazy val yearMonth: YearMonth = YearMonth.of(nextYear, half.endMonth)
+    lazy val localDate: LocalDate = LocalDate.of(nextYear, half.endMonth, half.endMonth.maxLength)
+    lazy val localDateTime: LocalDateTime = LocalDateTime.of(localDate.minusDays(1), LocalTime.MAX).plusHours(14) // 2pm today
+    def zonedDateTime(zoneId: ZoneId): ZonedDateTime = ZonedDateTime.of(localDateTime, zoneId)
+    def atSite(site: Site): ZonedDateTime = zonedDateTime(site.timezone)
+  }
+
+  /** Format as full year and semester half, `2009A`. */
+  def format: String =
+    s"$year$half"
+
+  /** Format as 2-digit year and semester half, `09A`. */
+  def formatShort: String =
+    f"${year.getValue % 100}%02d$half"
+
+  override def toString =
+    f"Semester($format)"
+
+}
+
+object Semester {
+
+  /** Semester for the specified year and month. */
+  def fromYearMonth(ym: YearMonth): Semester = {
+    val m = ym.getMonth
+    val y = m match {
+      case JANUARY => ym.getYear - 1
+      case _       => ym.getYear
+    }
+    Semester(Year.of(y), Half.fromMonth(m))
+  }
+
+  /**
+   * Semester for the specified year and month, exclusive of semester start and inclusive of
+   * semester end. The semester actually starts at 2pm on the 31st of the January/August, but
+   * this method gives the entire switchover day to the previous semester. A simpler way of saying
+   * this is that this method ignores the day of the month. If you need more precision you must
+   * use a conversion method that includes the time of day.
+   */
+  def fromLocalDate(d: LocalDate): Semester =
+    fromYearMonth(YearMonth.of(d.getYear, d.getMonth))
+
+  /**
+   * Semester for the specified local date and time. This handles the 2pm switchover on the last
+   * day of the semester.
+   */
+  def fromLocalDateTime(d: LocalDateTime): Semester = {
+    val dʹ = LocalObservingNight.fromLocalDateTime(d).toLocalDate
+    fromYearMonth(YearMonth.of(dʹ.getYear, dʹ.getMonth))
+  }
+
+  /**
+   * Semester for the specified zoned date and time. This handles the 2pm switchover on the last
+   * day of the semester.
+   */
+  def fromZonedDateTime(d: ZonedDateTime): Semester =
+    fromLocalDateTime(d.toLocalDateTime)
+
+  /** Semester for the zoned date and time of the given Site and Instant. */
+  def fromSiteAndInstant(s: Site, i: Instant): Semester =
+    fromZonedDateTime(ZonedDateTime.ofInstant(i, s.timezone))
+
+  /** Current semester. */
+  def current(s: Site): IO[Semester] =
+    IO(LocalDateTime.now(s.timezone)).map(fromLocalDateTime)
+
+  /** Parse a full-year Semester like `2009A` from a String, if possible. */
+  def fromString(s: String): Option[Semester] =
+    SemesterParsers.semester.parseExact(s)
+
+  /** Parse a full-year Semester like `2009A` from a String, throwing on failure. */
+  def unsafeFromString(s: String): Semester =
+    fromString(s).getOrElse(sys.error(s"Invalid semester: $s"))
+
+  /** `Semester` is ordered pairwise by its data members. */
+  implicit val SemesterOrder: Order[Semester] =
+    Order.by(a => (a.year, a.half))
+
+  /**
+   * `Ordering` instance for Scala standard library.
+   * @see SemesterOrder
+   */
+  implicit val SemesterOrdering: scala.math.Ordering[Semester] =
+    SemesterOrder.toOrdering
+
+  implicit val SemesterShow: Show[Semester] =
+    Show.fromToString
+
+}

--- a/modules/core/shared/src/main/scala/gem/SmartGcal.scala
+++ b/modules/core/shared/src/main/scala/gem/SmartGcal.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.util.Location
+
+/**
+ * Module of types and constuctors related to Smart GCal.
+ * @group Sequence Model
+ */
+object SmartGcal {
+
+  sealed trait ExpansionError extends Product with Serializable
+
+  type ExpandedSteps = List[Step]
+
+  final case class StepNotFound(loc: Location.Middle) extends ExpansionError
+  case object      NotSmartGcal                       extends ExpansionError
+  case object      NoMappingDefined                   extends ExpansionError
+
+  def stepNotFound(loc: Location.Middle): ExpansionError = StepNotFound(loc)
+  val notSmartGcal: ExpansionError                       = NotSmartGcal
+  val noMappingDefined: ExpansionError                   = NoMappingDefined
+}

--- a/modules/core/shared/src/main/scala/gem/Step.scala
+++ b/modules/core/shared/src/main/scala/gem/Step.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.config._
+import gem.enum.SmartGcalType
+
+sealed trait Step {
+  def dynamicConfig: DynamicConfig
+  def base: Step.Base
+}
+
+object Step {
+
+  // TODO: better name for this
+  sealed trait Base
+  object Base {
+    final case object Bias extends Base
+    final case object Dark extends Base
+    final case class  Gcal(gcal: GcalConfig) extends Base
+    final case class  Science(telescope: TelescopeConfig) extends Base
+    final case class  SmartGcal(smartGcalType: SmartGcalType) extends Base
+  }
+
+  sealed case class Phoenix(dynamicConfig: DynamicConfig.Phoenix, base: Base) extends Step
+  sealed case class Michelle(dynamicConfig: DynamicConfig.Michelle, base: Base) extends Step
+  sealed case class Gnirs(dynamicConfig: DynamicConfig.Gnirs, base: Base) extends Step
+  sealed case class Niri(dynamicConfig: DynamicConfig.Niri, base: Base) extends Step
+  sealed case class Trecs(dynamicConfig: DynamicConfig.Trecs, base: Base) extends Step
+  sealed case class Nici(dynamicConfig: DynamicConfig.Nici, base: Base) extends Step
+  sealed case class Nifs(dynamicConfig: DynamicConfig.Nifs, base: Base) extends Step
+  sealed case class Gpi(dynamicConfig: DynamicConfig.Gpi, base: Base) extends Step
+  sealed case class Gsaoi(dynamicConfig: DynamicConfig.Gsaoi, base: Base) extends Step
+  sealed case class GmosS(dynamicConfig: DynamicConfig.GmosS, base: Base) extends Step
+  sealed case class AcqCam(dynamicConfig: DynamicConfig.AcqCam, base: Base) extends Step
+  sealed case class GmosN(dynamicConfig: DynamicConfig.GmosN, base: Base) extends Step
+  sealed case class Bhros(dynamicConfig: DynamicConfig.Bhros, base: Base) extends Step
+  sealed case class Visitor(dynamicConfig: DynamicConfig.Visitor, base: Base) extends Step
+  sealed case class Flamingos2(dynamicConfig: DynamicConfig.Flamingos2, base: Base) extends Step
+  sealed case class Ghost(dynamicConfig: DynamicConfig.Ghost, base: Base) extends Step
+
+}

--- a/modules/core/shared/src/main/scala/gem/Target.scala
+++ b/modules/core/shared/src/main/scala/gem/Target.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats._
+import cats.implicits._
+
+import gem.math.ProperMotion
+
+import monocle.macros.Lenses
+
+/** A target of observation. */
+@Lenses final case class Target(name: String, track: Either[EphemerisKey, ProperMotion])
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object Target {
+
+  /** Target identifier. */
+  final case class Id(toInt: Int) extends AnyVal
+
+  object Id {
+    /** Ids ordered by wrapped integer value. */
+    implicit val IdOrder: Order[Id] =
+      Order.by(_.toInt)
+  }
+
+  /** A target order based on tracking information.  For sidereal targets this
+    * roughly means by base coordinate without applying proper motion.  For
+    * non-sidereal this means by `EphemerisKey`.
+    */
+  implicit val TargetTrackOrder: Order[Target] =
+    Order.by(t => (t.track, t.name))
+
+  /** Targets ordered by name first and then tracking information.
+    *
+    * Not implicit. The implicit target order is track then name.
+    */
+  val TargetNameOrder: Order[Target] =
+    Order.by(t => (t.name, t.track))
+
+}

--- a/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
+++ b/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
@@ -1,0 +1,191 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.Eq
+import gem.enum.Instrument
+import scala.collection.immutable.TreeSet
+
+/** Collection of targets associated with an observation. */
+sealed trait TargetEnvironment {
+  def asterism: Option[Asterism]
+  def userTargets: TreeSet[UserTarget]
+  override final def toString =
+    s"TargetEnvironment($asterism, $userTargets)"
+}
+
+object TargetEnvironment {
+
+  def fromAsterism(a: Asterism, u: TreeSet[UserTarget]): TargetEnvironment =
+    a match {
+      case a @ Asterism.Phoenix(_)            => Phoenix(Some(a), u)
+      case a @ Asterism.Michelle(_)           => Michelle(Some(a), u)
+      case a @ Asterism.Gnirs(_)              => Gnirs(Some(a), u)
+      case a @ Asterism.Niri(_)               => Niri(Some(a), u)
+      case a @ Asterism.Trecs(_)              => Trecs(Some(a), u)
+      case a @ Asterism.Nici(_)               => Nici(Some(a), u)
+      case a @ Asterism.Nifs(_)               => Nifs(Some(a), u)
+      case a @ Asterism.Gpi(_)                => Gpi(Some(a), u)
+      case a @ Asterism.Gsaoi(_)              => Gsaoi(Some(a), u)
+      case a @ Asterism.GmosS(_)              => GmosS(Some(a), u)
+      case a @ Asterism.AcqCam(_)             => AcqCam(Some(a), u)
+      case a @ Asterism.GmosN(_)              => GmosN(Some(a), u)
+      case a @ Asterism.Bhros(_)              => Bhros(Some(a), u)
+      case a @ Asterism.Visitor(_)            => Visitor(Some(a), u)
+      case a @ Asterism.Flamingos2(_)         => Flamingos2(Some(a), u)
+      case a @ Asterism.GhostDualTarget(_, _) => Ghost(Some(a), u)
+    }
+
+  def fromInstrument(i: Instrument, ts: TreeSet[UserTarget]): TargetEnvironment =
+    i match {
+      case Instrument.Phoenix    => TargetEnvironment.Phoenix(None, ts)
+      case Instrument.Michelle   => TargetEnvironment.Michelle(None, ts)
+      case Instrument.Gnirs      => TargetEnvironment.Gnirs(None, ts)
+      case Instrument.Niri       => TargetEnvironment.Niri(None, ts)
+      case Instrument.Trecs      => TargetEnvironment.Trecs(None, ts)
+      case Instrument.Nici       => TargetEnvironment.Nici(None, ts)
+      case Instrument.Nifs       => TargetEnvironment.Nifs(None, ts)
+      case Instrument.Gpi        => TargetEnvironment.Gpi(None, ts)
+      case Instrument.Gsaoi      => TargetEnvironment.Gsaoi(None, ts)
+      case Instrument.GmosS      => TargetEnvironment.GmosS(None, ts)
+      case Instrument.AcqCam     => TargetEnvironment.AcqCam(None, ts)
+      case Instrument.GmosN      => TargetEnvironment.GmosN(None, ts)
+      case Instrument.Bhros      => TargetEnvironment.Bhros(None, ts)
+      case Instrument.Visitor    => TargetEnvironment.Visitor(None, ts)
+      case Instrument.Flamingos2 => TargetEnvironment.Flamingos2(None, ts)
+      case Instrument.Ghost      => TargetEnvironment.Ghost(None, ts)
+    }
+
+  /** Target environment for Phoenix
+    * @group Constructors
+    */
+  final case class Phoenix(
+    asterism: Option[Asterism.Phoenix],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Michelle
+    * @group Constructors
+    */
+  final case class Michelle(
+    asterism: Option[Asterism.Michelle],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Gnirs
+    * @group Constructors
+    */
+  final case class Gnirs(
+    asterism: Option[Asterism.Gnirs],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Niri
+    * @group Constructors
+    */
+  final case class Niri(
+    asterism: Option[Asterism.Niri],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Trecs
+    * @group Constructors
+    */
+  final case class Trecs(
+    asterism: Option[Asterism.Trecs],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Nici
+    * @group Constructors
+    */
+  final case class Nici(
+    asterism: Option[Asterism.Nici],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Nifs
+    * @group Constructors
+    */
+  final case class Nifs(
+    asterism: Option[Asterism.Nifs],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Gpi
+    * @group Constructors
+    */
+  final case class Gpi(
+    asterism: Option[Asterism.Gpi],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Gsaoi
+    * @group Constructors
+    */
+  final case class Gsaoi(
+    asterism: Option[Asterism.Gsaoi],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for GmosS
+    * @group Constructors
+    */
+  final case class GmosS(
+    asterism: Option[Asterism.GmosS],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for AcqCam
+    * @group Constructors
+    */
+  final case class AcqCam(
+    asterism: Option[Asterism.AcqCam],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for GmosN
+    * @group Constructors
+    */
+  final case class GmosN(
+    asterism: Option[Asterism.GmosN],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Bhros
+    * @group Constructors
+    */
+  final case class Bhros(
+    asterism: Option[Asterism.Bhros],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Visitor
+    * @group Constructors
+    */
+  final case class Visitor(
+    asterism: Option[Asterism.Visitor],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Flamingos2
+    * @group Constructors
+    */
+  final case class Flamingos2(
+    asterism: Option[Asterism.Flamingos2],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  /** Target environment for Ghost
+    * @group Constructors
+    */
+  final case class Ghost(
+    asterism: Option[Asterism.GhostDualTarget],
+    userTargets: TreeSet[UserTarget]
+  ) extends TargetEnvironment
+
+  implicit def EqTargetEnvironment: Eq[TargetEnvironment] =
+    Eq.fromUniversalEquals
+
+}

--- a/modules/core/shared/src/main/scala/gem/Track.scala
+++ b/modules/core/shared/src/main/scala/gem/Track.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.Eq
+
+import gem.enum.Site
+import gem.math._
+import gem.util.Timestamp
+
+import java.time.Instant
+
+import monocle.{ Optional, Prism }
+import monocle.macros.{ Lenses, GenPrism }
+
+/**
+ * Time/site-parameterized coordinates over a span of time. This generalizes proper motion and
+ * ephemerides.
+ */
+sealed trait Track extends Product with Serializable {
+  import Track._
+
+  def at(time: Instant, site: Site): Option[Coordinates]
+
+  def fold[A](f: ProperMotion => A, g: (Map[Site, Ephemeris]) => A): A =
+    this match {
+      case Sidereal(pm)    => f(pm)
+      case Nonsidereal(es) => g(es)
+    }
+
+  def sidereal: Option[Sidereal] =
+    fold(pm => Some(Sidereal(pm)), _ => None)
+
+  def nonsidereal: Option[Nonsidereal] =
+    fold(_ => None, (es) => Some(Nonsidereal(es)))
+
+}
+
+object Track {
+
+  @Lenses final case class Sidereal(properMotion: ProperMotion) extends Track {
+    override def at(time: Instant, site: Site): Option[Coordinates] =
+      Some(properMotion.at(time).baseCoordinates)
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object Sidereal {
+
+    implicit val EqSidereal: Eq[Sidereal] =
+      Eq.fromUniversalEquals
+  }
+
+
+  @Lenses final case class Nonsidereal(ephemerides: Map[Site, Ephemeris]) extends Track {
+
+    override def at(time: Instant, s: Site): Option[Coordinates] =
+      for {
+        i <- Timestamp.fromInstant(time)
+        e <- ephemeris(s)
+        c <- e.get(i)
+      } yield c.coord
+
+    def ephemeris(s: Site): Option[Ephemeris] =
+      ephemerides.get(s)
+
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object Nonsidereal {
+
+    val empty: Nonsidereal =
+      Nonsidereal(Map.empty)
+
+    implicit val EqNonsidereal: Eq[Nonsidereal] =
+      Eq.fromUniversalEquals
+
+  }
+
+  val sidereal: Prism[Track, Sidereal] =
+    GenPrism[Track, Sidereal]
+
+  val nonsidereal: Prism[Track, Nonsidereal] =
+    GenPrism[Track, Nonsidereal]
+
+  val ephemerides: Optional[Track, Map[Site, Ephemeris]] =
+    nonsidereal composeLens Nonsidereal.ephemerides
+
+  implicit val EqTrack: Eq[Track] =
+    Eq.fromUniversalEquals
+}

--- a/modules/core/shared/src/main/scala/gem/User.scala
+++ b/modules/core/shared/src/main/scala/gem/User.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+/**
+ * A Gem user, parameterized on the type of granted program roles, typically
+ * [[gem.enum.ProgramRole ProgramRole]] for a fully specified user, or `Nothing` for a user with
+ * unstated grants. Permissions are granted based on a combination of granted roles, staff status,
+ * and rootness.
+ * @group Application Model
+ */
+final case class User[A](
+  id:        User.Id,
+  firstName: String,
+  lastName:  String,
+  email:     String,
+  isStaff:   Boolean,
+  roles:     Map[Program.Id, Set[A]]
+)
+
+object User {
+  type Id = String // TODO
+  object Id {
+    /** Id of the root user, who always exists. This is a system invariant. */
+    val Root: User.Id = "root"
+  }
+}

--- a/modules/core/shared/src/main/scala/gem/UserTarget.scala
+++ b/modules/core/shared/src/main/scala/gem/UserTarget.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats._
+import cats.implicits._
+
+import gem.enum.UserTargetType
+
+import monocle.macros.Lenses
+
+
+/** Pairs a `Target` and a `UserTargetType`.
+  */
+@Lenses final case class UserTarget(target: Target, targetType: UserTargetType)
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object UserTarget {
+
+  /** UserTarget identifier. */
+  final case class Id(toInt: Int) extends AnyVal
+
+  object Id {
+    /** Ids ordered by wrapped integer value. */
+    implicit val IdOrder: Order[Id] =
+      Order.by(_.toInt)
+  }
+
+  implicit val OrderUserTarget: Order[UserTarget] =
+    Order.by(u => (u.target, u.targetType))
+
+  implicit val OrderingUserTarget: Ordering[UserTarget] =
+    OrderUserTarget.toOrdering
+}

--- a/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
@@ -1,0 +1,294 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package config
+
+import gem.CoAdds
+import gem.enum._
+import gem.math.Wavelength
+import java.time.Duration
+
+/**
+ * Instrument configuration that is specified for each [[gem.Step Step]].
+ * @group Configurations
+ */
+sealed trait DynamicConfig {
+
+  /** Obtains the smart gcal search key that corresponds to the instrument
+    * configuration, if any. This key can be used to find the matching gcal
+    * configuration.
+    * @return corresponding smart gcal search key, if any
+    */
+  def smartGcalKey(s: StaticConfig): Option[SmartGcalSearchKey] =
+    (this, s) match {
+      case (d: DynamicConfig.Flamingos2, _)                => Some(d.key)
+      case (d: DynamicConfig.GmosN, _)                     => Some(d.key)
+      case (d: DynamicConfig.GmosS, _)                     => Some(d.key)
+      case (d: DynamicConfig.Gnirs, s: StaticConfig.Gnirs) => Some(d.key(s))
+      case _                                               => None
+    }
+
+  def toStep(b: Step.Base): Step
+
+}
+
+object DynamicConfig {
+
+  /**
+   * Dynamic configuration for the acquisition camera.
+   * @group Constructors
+   */
+  final case class AcqCam() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.AcqCam =
+      Step.AcqCam(this, b)
+  }
+
+  /**
+   * Dynamic configuration for bHROS (retired).
+   * @group Constructors
+   */
+  final case class Bhros() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Bhros =
+      Step.Bhros(this, b)
+  }
+
+  /**
+   * Dynamic configuration for GHOST.
+   * @group Constructors
+   */
+  final case class Ghost() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Ghost =
+      Step.Ghost(this, b)
+  }
+
+  /**
+   * Dynamic configuration for GPI.
+   * @group Constructors
+   */
+  final case class Gpi() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Gpi =
+      Step.Gpi(this, b)
+  }
+
+  /**
+   * Dynamic configuration for GSAOI.
+   * @group Constructors
+   */
+  final case class Gsaoi() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Gsaoi =
+      Step.Gsaoi(this, b)
+  }
+
+  /**
+   * Dynamic configuration for Michelle (retired).
+   * @group Constructors
+   */
+  final case class Michelle() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Michelle =
+      Step.Michelle(this, b)
+  }
+
+  /**
+   * Dynamic configuration for NICI (retired).
+   * @group Constructors
+   */
+  final case class Nici() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Nici =
+      Step.Nici(this, b)
+  }
+
+  /**
+   * Dynamic configuration for NIFS.
+   * @group Constructors
+   */
+  final case class Nifs() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Nifs =
+      Step.Nifs(this, b)
+  }
+
+  /**
+   * Dynamic configuration for NIRI.
+   * @group Constructors
+   */
+  final case class Niri() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Niri =
+      Step.Niri(this, b)
+  }
+
+  /**
+   * Dynamic configuration for Phoenix.
+   * @group Constructors
+   */
+  final case class Phoenix() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Phoenix =
+      Step.Phoenix(this, b)
+  }
+
+  /**
+   * Dynamic configuration for T-ReCS (retired).
+   * @group Constructors
+   */
+  final case class Trecs() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Trecs =
+      Step.Trecs(this, b)
+  }
+
+  /**
+   * Dynamic configuration for visitor instruments.
+   * @group Constructors
+   */
+  final case class Visitor() extends DynamicConfig {
+    def toStep(b: Step.Base): Step.Visitor =
+      Step.Visitor(this, b)
+  }
+
+
+  /**
+   * Dynamic configuration for FLAMINGOS-2.
+   * @group Constructors
+   */
+  final case class Flamingos2(
+    disperser:     Option[F2Disperser],
+    exposureTime:  Duration,
+    filter:        F2Filter,
+    fpu:           Option[F2Config.F2FpuChoice],
+    lyotWheel:     F2LyotWheel,
+    readMode:      F2ReadMode,
+    windowCover:   F2WindowCover
+  ) extends DynamicConfig {
+
+    def toStep(b: Step.Base): Step.Flamingos2 =
+      Step.Flamingos2(this, b)
+
+    /** Returns the smart gcal search key for this Flamingos2 configuration. */
+    def key: SmartGcalKey.Flamingos2 =
+      SmartGcalKey.Flamingos2(disperser, filter, fpu.flatMap(_.toBuiltin))
+
+  }
+  object Flamingos2 {
+    val Default: Flamingos2 =
+      Flamingos2(None, java.time.Duration.ZERO, F2Filter.Open,
+         None, F2LyotWheel.F16, F2ReadMode.Bright, F2WindowCover.Close)
+  }
+
+  /**
+   * Dynamic configuration for GMOS-N.
+   * @group Constructors
+   */
+  final case class GmosN(
+    common:  GmosConfig.GmosCommonDynamicConfig,
+    grating: Option[GmosConfig.GmosGrating[GmosNorthDisperser]],
+    filter:  Option[GmosNorthFilter],
+    fpu:     Option[Either[GmosConfig.GmosCustomMask, GmosNorthFpu]]
+  ) extends DynamicConfig {
+
+    def toStep(b: Step.Base): Step.GmosN =
+      Step.GmosN(this, b)
+
+    /** Returns the smart gcal search key for this GMOS-N configuration. */
+    def key: SmartGcalKey.GmosNorthSearch =
+      SmartGcalKey.GmosNorthSearch(
+        SmartGcalKey.GmosCommon(
+          grating.map(_.disperser),
+          filter,
+          fpu.flatMap(_.toOption),
+          common.ccdReadout.xBinning,
+          common.ccdReadout.yBinning,
+          common.ccdReadout.ampGain
+        ),
+        grating.map(_.wavelength)
+      )
+
+  }
+  object GmosN {
+    val Default: GmosN =
+      GmosN(GmosConfig.GmosCommonDynamicConfig.Default, None, None, None)
+  }
+
+  /**
+   * Dynamic configuration for GMOS-S.
+   * @group Constructors
+   */
+  final case class GmosS(
+    common:  GmosConfig.GmosCommonDynamicConfig,
+    grating: Option[GmosConfig.GmosGrating[GmosSouthDisperser]],
+    filter:  Option[GmosSouthFilter],
+    fpu:     Option[Either[GmosConfig.GmosCustomMask, GmosSouthFpu]]
+  ) extends DynamicConfig {
+
+    def toStep(b: Step.Base): Step.GmosS =
+      Step.GmosS(this, b)
+
+    /** Returns the smart gcal search key for this GMOS-S configuration. */
+    def key: SmartGcalKey.GmosSouthSearch =
+      SmartGcalKey.GmosSouthSearch(
+        SmartGcalKey.GmosCommon(
+          grating.map(_.disperser),
+          filter,
+          fpu.flatMap(_.toOption),
+          common.ccdReadout.xBinning,
+          common.ccdReadout.yBinning,
+          common.ccdReadout.ampGain
+        ),
+        grating.map(_.wavelength)
+      )
+  }
+  object GmosS {
+    val Default: GmosS =
+      GmosS(GmosConfig.GmosCommonDynamicConfig.Default, None, None, None)
+  }
+
+  /**
+   * Dynamic configuration for GNIRS.
+   * @group Constructors
+   */
+  final case class Gnirs(
+    acquisitionMirror: GnirsAcquisitionMirror,
+    camera:            GnirsCamera,
+    coadds:            CoAdds,
+    decker:            GnirsDecker,
+    disperser:         GnirsDisperser,
+    exposureTime:      Duration,
+    filter:            GnirsFilter,
+    fpu:               Either[GnirsFpuOther, GnirsFpuSlit],
+    prism:             GnirsPrism,
+    readMode:          GnirsReadMode,
+    wavelength:        Wavelength
+  ) extends DynamicConfig {
+
+    def toStep(b: Step.Base): Step.Gnirs =
+      Step.Gnirs(this, b)
+
+    /** Returns the smart gcal search key for this GNIRS configuration. */
+    def key(s: StaticConfig.Gnirs): SmartGcalKey.GnirsSearch =
+      SmartGcalKey.GnirsSearch(
+        SmartGcalKey.Gnirs(
+          acquisitionMirror,
+          camera.pixelScale,
+          disperser,
+          fpu,
+          prism,
+          s.wellDepth
+        ),
+        wavelength
+      )
+
+  }
+  object Gnirs {
+    val Default: Gnirs = Gnirs(
+      GnirsAcquisitionMirror.Out,
+      GnirsCamera.ShortBlue,
+      CoAdds.One,
+      GnirsDecker.Acquisition,
+      GnirsDisperser.D32,
+      java.time.Duration.ofSeconds(17),
+      GnirsFilter.Order5,
+      Right(GnirsFpuSlit.LongSlit_0_30),
+      GnirsPrism.Mirror,
+      GnirsReadMode.Bright,
+      Wavelength.fromAngstroms.unsafeGet(22000)
+    )
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/config/F2Config.scala
+++ b/modules/core/shared/src/main/scala/gem/config/F2Config.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import cats.Eq
+import gem.enum.F2Fpu
+
+/** Additional type hierarchy over the low-level F2 enums.
+  */
+object F2Config {
+
+  /** Focal plane unit choice, custom or builtin. */
+  sealed trait F2FpuChoice extends Product with Serializable {
+
+    import F2FpuChoice.{ Builtin, Custom }
+
+    /** Extracts the builtin FPU, if any. */
+    def toBuiltin: Option[F2Fpu] =
+      this match {
+        case Custom       => None
+        case Builtin(fpu) => Some(fpu)
+      }
+  }
+
+  object F2FpuChoice {
+    case object      Custom              extends F2FpuChoice
+    final case class Builtin(fpu: F2Fpu) extends F2FpuChoice
+
+    implicit val EqF2FpuChoice: Eq[F2FpuChoice] =
+      Eq.fromUniversalEquals
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/config/GcalConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/GcalConfig.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package config
+
+import cats.Order
+import cats.data.OneAnd
+import gem.CoAdds
+import gem.enum.{GcalArc, GcalContinuum, GcalDiffuser, GcalFilter, GcalShutter}
+import java.time.Duration
+import GcalConfig.GcalLamp
+
+/**
+ * Additional configuration information for [[gem.Step.Gcal Gcal]] steps.
+ * @group Configurations
+ */
+final case class GcalConfig(lamp: GcalLamp, filter: GcalFilter, diffuser: GcalDiffuser, shutter: GcalShutter, exposureTime: Duration, coadds: CoAdds) {
+  def continuum: Option[GcalContinuum] =
+    lamp.swap.toOption
+
+  def arcs: Set[GcalArc] =
+    lamp.fold(_ => Set.empty[GcalArc], _.toSet)
+}
+
+object GcalConfig {
+  // We make this a sealed abstract case class in order to force usage of the
+  // companion object constructor.  The OneAnd head is guaranteed to always be
+  // the minimum GcalArc in the group.
+  sealed abstract case class GcalArcs(arcs: OneAnd[Set, GcalArc]) {
+    def toList: List[GcalArc] =
+      arcs.head :: arcs.tail.toList
+
+    def toSet: Set[GcalArc] =
+      arcs.tail + arcs.head
+  }
+
+  object GcalArcs {
+    /** Constructs GcalArcs such that the GcalArc instances are always in order.
+      */
+    @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+    def apply(arc0: GcalArc, arcs: List[GcalArc]): GcalArcs = {
+      (arc0 :: arcs).toSet.toList.sorted(Order[GcalArc].toOrdering) match {
+        case h :: t => new GcalArcs(OneAnd(h, t.toSet)) {}
+        case Nil    => sys.error("unpossible")
+      }
+    }
+  }
+
+  type GcalLamp = Either[GcalContinuum, GcalArcs]
+
+  object GcalLamp {
+    def fromConfig(continuum: Option[GcalContinuum], arcs: (GcalArc, Boolean)*): Option[GcalLamp] = {
+      // Extract the arc lamps to include, if any.
+      val as = arcs.filter(_._2).unzip._1.toList
+
+      // Extract the continuum lamp, assuming there are no arcs.
+      val co = continuum.flatMap { c => if (as.isEmpty) Some(Left(c)) else None }
+
+      // Prepare the arc lamps, assuming there is no continuum.
+      val ao = as match {
+        case h :: t if continuum.isEmpty => Some(Right(GcalArcs(h, t)))
+        case _                           => None
+      }
+
+      co orElse ao
+    }
+
+    def fromContinuum(continuum: GcalContinuum): GcalLamp =
+      Left(continuum)
+
+    def fromArcs(arc0: GcalArc, arcs: GcalArc*): GcalLamp =
+      Right(GcalArcs(arc0, arcs.toList))
+
+    def unsafeFromConfig(continuum: Option[GcalContinuum], arcs: (GcalArc, Boolean)*): GcalLamp =
+      fromConfig(continuum, arcs: _*).getOrElse {
+        sys.error(s"misconfigured Gcal lamps: continuum=$continuum, arcs=[${arcs.filter(_._2).unzip._1.mkString(",")}]")
+      }
+  }
+}

--- a/modules/core/shared/src/main/scala/gem/config/GmosConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/GmosConfig.scala
@@ -1,0 +1,262 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import cats.Eq
+import gem.enum._
+import gem.math.{ Offset, Wavelength }
+import java.time.Duration
+import monocle.macros.Lenses
+
+/**
+ * Additional type hierarchy over the low-level GMOS enums.
+ * @group Instrument-Specific Models
+ */
+object GmosConfig {
+
+  /** Nod-and-shuffle offset in detector rows, which must be positive, non-zero.
+    * This class essentially provides a newtype for Int.
+    */
+  sealed abstract case class GmosShuffleOffset(detectorRows: Int) {
+
+    // Enforced by fromRowCount constructor
+    assert(detectorRows > 0, s"detectorRows must be > 0, not $detectorRows")
+  }
+
+  object GmosShuffleOffset {
+
+    /** Constructs the shuffle offset with the given number of detector rows,
+      * provided it is a positive number.
+      *
+      * @return `Some(GmosShuffleOffset(rows))` if `rows` is positive,
+      *         `None` otherwise
+      */
+    def fromRowCount(rows: Int): Option[GmosShuffleOffset] =
+      if (rows > 0) Some(new GmosShuffleOffset(rows) {}) else None
+
+    /** Constructs the shuffle offset with the given number of detector rows
+      * provided `rows` is positive, or throws an exception if zero or negative.
+      */
+    def unsafeFromRowCount(rows: Int): GmosShuffleOffset =
+      fromRowCount(rows).getOrElse(sys.error(s"Expecting positive detector row count, not $rows"))
+
+    /** Constructs a shuffle offset using the default number of detector rows
+      * associated with the detector.
+      */
+    def defaultFromDetector(detector: GmosDetector): GmosShuffleOffset =
+      fromRowCount(detector.shuffleOffset).getOrElse(sys.error(s"Misconfigured GmosDetector $detector"))
+
+    implicit val EqualGmosShuffleOffset: Eq[GmosShuffleOffset] =
+      Eq.fromUniversalEquals
+  }
+
+  /** The number of nod-and-shuffle cycles, which must be at least 1. This class
+    * essentially provides a newtype for Int.
+    */
+  sealed abstract case class GmosShuffleCycles(toInt: Int) {
+
+    // Enforced by fromCycleCount constructor
+    assert(toInt > 0, s"toInt must be > 0, not $toInt")
+  }
+
+  object GmosShuffleCycles {
+
+    /** Default non-and-shuffle cycles, which is 1. */
+    val Default: GmosShuffleCycles =
+      unsafeFromCycleCount(1)
+
+    /** Constructs the shuffle cycles from a count if `cycles` is positive.
+      *
+      * @return `Some(GmosShuffleCycles(cycles))` if `cycles` is positive,
+      *         `None` otherwise
+      */
+    def fromCycleCount(cycles: Int): Option[GmosShuffleCycles] =
+      if (cycles > 0) Some(new GmosShuffleCycles(cycles) {}) else None
+
+    /** Constructs the shuffle cycles with the given `cycles` count provided it
+      * is positive, or else throws an exception if 0 or negative.
+      */
+    def unsafeFromCycleCount(cycles: Int): GmosShuffleCycles =
+      fromCycleCount(cycles).getOrElse(sys.error(s"Expecting positive shuffle cycles, not $cycles"))
+
+    implicit val EqualGmosShuffleCycles: Eq[GmosShuffleCycles] =
+      Eq.fromUniversalEquals
+  }
+
+  // TODO: there are many ways to misconfigure Nod And Shuffle.  Some of these
+  // ways can be caught in a companion object constructor, and some cannot, or
+  // at least cannot easily.  In the first category, we should definitly check
+  // whether posA and posB are close enough together (< 2 arcsecs) to allow
+  // e-offsetting.  In the second category, shuffle offset in detector rows has
+  // to be a multiple of y-binning.  Worse, y-binning is part of the dynamic
+  // configuration so it isn't clear what happens if the shuffle offset isn't
+  // always a multiple of y-binning.
+
+  /** GMOS nod-and-shuffle configuration. */
+  final case class GmosNodAndShuffle(
+    posA:    Offset,
+    posB:    Offset,
+    eOffset: GmosEOffsetting,
+    shuffle: GmosShuffleOffset,
+    cycles:  GmosShuffleCycles
+  )
+
+  object GmosNodAndShuffle {
+    val Default: GmosNodAndShuffle =
+      GmosNodAndShuffle(
+        Offset.Zero,
+        Offset.Zero,
+        GmosEOffsetting.Off,
+        GmosShuffleOffset.defaultFromDetector(GmosDetector.HAMAMATSU),
+        GmosShuffleCycles.Default
+      )
+
+    implicit val EqualGmosNodAndShuffle: Eq[GmosNodAndShuffle] =
+      Eq.fromUniversalEquals
+  }
+
+  /** GMOS custom ROI entry definition. */
+  sealed abstract case class GmosCustomRoiEntry(
+    xMin:   Short,
+    yMin:   Short,
+    xRange: Short,
+    yRange: Short
+  ) {
+
+    // Enforced by fromDescription constructor
+    assert(xMin   > 0, s"xMin must be > 0, not $xMin")
+    assert(yMin   > 0, s"yMin must be > 0, not $yMin")
+    assert(xRange > 0, s"xRange must be > 0, not $xRange")
+    assert(yRange > 0, s"yRange must be > 0, not $yRange")
+
+    /** Columns included in this ROI entry (start, end]. */
+    def columns: (Int, Int) =
+      (xMin.toInt, xMin + xRange)
+
+    /** Rows included in this ROI entry (start, end]. */
+    def rows: (Int, Int) =
+      (yMin.toInt, yMin + yRange)
+
+    /** Returns `true` if the pixels specified by this custom ROI entry overlap
+      * with the pixels specified by `that` entry.
+      */
+    def overlaps(that: GmosCustomRoiEntry): Boolean =
+      columnsOverlap(that) && rowsOverlap(that)
+
+    /** Returns `true` if the columns spanned this custom ROI entry overlap with
+      * the columns spanned by `that` entry.
+      */
+    def columnsOverlap(that: GmosCustomRoiEntry): Boolean =
+      overlapCheck(that, _.columns)
+
+    /** Returns `true` if the rows spanned this custom ROI entry overlap with
+      * the rows spanned by `that` entry.
+      */
+    def rowsOverlap(that: GmosCustomRoiEntry): Boolean =
+      overlapCheck(that, _.rows)
+
+    private def overlapCheck(that: GmosCustomRoiEntry, f: GmosCustomRoiEntry => (Int, Int)): Boolean = {
+      val List((_, end), (start, _)) = List(f(this), f(that)).sortBy(_._1)
+      end > start
+    }
+  }
+
+  object GmosCustomRoiEntry {
+
+    def fromDescription(xMin: Short, yMin: Short, xRange: Short, yRange: Short): Option[GmosCustomRoiEntry] =
+      if ((xMin > 0) && (yMin > 0) && (xRange > 0) && (yRange > 0))
+        Some(new GmosCustomRoiEntry(xMin, yMin, xRange, yRange) {})
+      else
+        None
+
+    def unsafeFromDescription(xMin: Short, yMin: Short, xRange: Short, yRange: Short): GmosCustomRoiEntry =
+      fromDescription(xMin, yMin, xRange, yRange)
+        .getOrElse(sys.error(s"All custom ROI fields must be > 0 in GmosCustomRoi.unsafeFromDefinition($xMin, $yMin, $xRange, $yRange)"))
+
+    implicit val EqualGmosCustomRoiEntry: Eq[GmosCustomRoiEntry] =
+      Eq.fromUniversalEquals
+  }
+
+  /** Shared static configuration for both GMOS-N and GMOS-S.
+    */
+  @Lenses final case class GmosCommonStaticConfig(
+    detector:      GmosDetector,
+    mosPreImaging: MosPreImaging,
+    nodAndShuffle: Option[GmosNodAndShuffle],
+    customRois:    Set[GmosCustomRoiEntry]
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object GmosCommonStaticConfig {
+    val Default: GmosCommonStaticConfig =
+      GmosCommonStaticConfig(
+        GmosDetector.HAMAMATSU,
+        MosPreImaging.IsNotMosPreImaging,
+        None,
+        Set.empty[GmosCustomRoiEntry]
+      )
+  }
+
+  /** Parameters that determine GMOS CCD readout.
+    */
+  final case class GmosCcdReadout(
+    xBinning:    GmosXBinning,
+    yBinning:    GmosYBinning,
+    ampCount:    GmosAmpCount,
+    ampGain:     GmosAmpGain,
+    ampReadMode: GmosAmpReadMode
+  )
+
+  object GmosCcdReadout {
+    val Default: GmosCcdReadout =
+      GmosCcdReadout(
+        GmosXBinning.One,
+        GmosYBinning.One,
+        GmosAmpCount.Twelve,
+        GmosAmpGain.Low,
+        GmosAmpReadMode.Slow
+      )
+  }
+
+  /** Shared dynamic configuration for both GMOS-N and GMOS-S.
+    */
+  final case class GmosCommonDynamicConfig(
+    ccdReadout:   GmosCcdReadout,
+    dtaxOffset:   GmosDtax,
+    exposureTime: Duration,
+    roi:          GmosRoi
+  )
+
+  object GmosCommonDynamicConfig {
+    val Default: GmosCommonDynamicConfig =
+      GmosCommonDynamicConfig(
+        GmosCcdReadout.Default,
+        GmosDtax.Zero,
+        Duration.ofSeconds(300),
+        GmosRoi.FullFrame
+      )
+  }
+
+  /** Custom mask definition, which is available as an alternative to using a
+    * builtin FPU.  Either both these parameters are set or neither are set in a
+    * GMOS observation
+    */
+  final case class GmosCustomMask(
+    maskDefinitionFilename: String,
+    slitWidth:              GmosCustomSlitWidth
+  )
+
+  /** GMOS grating configuration, parameterized on the disperser type.  These
+    * are grouped because they only apply when using a grating.  That is, all
+    * are defined or none or defined in the dynamic config.
+    *
+    * @tparam D disperser type, expected to be `GmosNorthDisperser` or
+    *           `GmosSouthDisperser`
+    */
+  final case class GmosGrating[D](
+    disperser:  D,
+    order:      GmosDisperserOrder,
+    wavelength: Wavelength
+  )
+}

--- a/modules/core/shared/src/main/scala/gem/config/SmartGcal.scala
+++ b/modules/core/shared/src/main/scala/gem/config/SmartGcal.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package config
+
+import gem.enum._
+import gem.math.Wavelength
+
+/** Marker trait for smart gcal search keys used to lookup corresponding gcal
+  * configurations.
+  */
+sealed trait SmartGcalSearchKey
+
+/** Marker trait for smart gcal definition keys used to register entries in
+  * a smart gcal lookup table.
+  */
+sealed trait SmartGcalDefinitionKey
+
+object SmartGcalKey {
+
+  final case class Flamingos2(
+    disperser: Option[F2Disperser],
+    filter:    F2Filter,
+    fpu:       Option[F2Fpu]
+  ) extends SmartGcalSearchKey with SmartGcalDefinitionKey
+
+  final case class GmosCommon[D, F, U](
+    disperser: Option[D],
+    filter:    Option[F],
+    fpu:       Option[U],
+    xBinning:  GmosXBinning,
+    yBinning:  GmosYBinning,
+    ampGain:   GmosAmpGain
+  )
+
+  type GmosNorthCommon = GmosCommon[GmosNorthDisperser, GmosNorthFilter, GmosNorthFpu]
+  type GmosSouthCommon = GmosCommon[GmosSouthDisperser, GmosSouthFilter, GmosSouthFpu]
+
+  final case class GmosNorthSearch(
+    gmos:       GmosNorthCommon,
+    wavelength: Option[Wavelength]
+  ) extends SmartGcalSearchKey
+
+  final case class GmosSouthSearch(
+    gmos:       GmosSouthCommon,
+    wavelength: Option[Wavelength]
+  ) extends SmartGcalSearchKey
+
+  final case class GmosDefinition[D, F, U](
+    gmos:            GmosCommon[D, F, U],
+    wavelengthRange: (Wavelength, Wavelength)
+  )
+
+  type GmosNorthDefinition = GmosDefinition[GmosNorthDisperser, GmosNorthFilter, GmosNorthFpu]
+  type GmosSouthDefinition = GmosDefinition[GmosSouthDisperser, GmosSouthFilter, GmosSouthFpu]
+
+  final case class Gnirs(
+    acquisitionMirror: GnirsAcquisitionMirror,
+    pixelScale:        GnirsPixelScale,
+    disperser:         GnirsDisperser,
+    fpu:               Either[GnirsFpuOther, GnirsFpuSlit],
+    prism:             GnirsPrism,
+    wellDepth:         GnirsWellDepth
+  )
+
+  final case class GnirsSearch(
+    gnirs: Gnirs,
+    wavelength: Wavelength
+  ) extends SmartGcalSearchKey
+
+  final case class GnirsDefinition(
+    gnirs: Gnirs,
+    wavelengthRange: (Wavelength, Wavelength)
+  ) extends SmartGcalDefinitionKey
+
+}

--- a/modules/core/shared/src/main/scala/gem/config/StaticConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/StaticConfig.scala
@@ -1,0 +1,102 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package config
+
+import gem.enum.{GmosNorthStageMode, GmosSouthStageMode, GnirsWellDepth, MosPreImaging}
+import monocle.Lens
+import monocle.macros.Lenses
+
+/**
+ * Instrument configuration that is specified once per [[gem.Observation Observation]] and is thus
+ * the same for every [[gem.Step Step]].
+ * @group Configurations
+ */
+sealed trait StaticConfig
+object StaticConfig {
+
+  final case class AcqCam()     extends StaticConfig
+  final case class Bhros()      extends StaticConfig
+  final case class Ghost()      extends StaticConfig
+  final case class Gpi()        extends StaticConfig
+  final case class Gsaoi()      extends StaticConfig
+  final case class Michelle()   extends StaticConfig
+  final case class Nici()       extends StaticConfig
+  final case class Nifs()       extends StaticConfig
+  final case class Niri()       extends StaticConfig
+  final case class Phoenix()    extends StaticConfig
+  final case class Trecs()      extends StaticConfig
+  final case class Visitor()    extends StaticConfig
+
+  final case class Flamingos2(
+    mosPreImaging: MosPreImaging
+  ) extends StaticConfig
+
+  object Flamingos2 {
+    val Default: Flamingos2 =
+      Flamingos2(MosPreImaging.IsNotMosPreImaging)
+  }
+
+  import GmosConfig._
+
+  @Lenses final case class GmosN(
+    common:    GmosCommonStaticConfig,
+    stageMode: GmosNorthStageMode
+  ) extends StaticConfig
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object GmosN extends GmosNorthLenses {
+
+    val Default: GmosN =
+      GmosN(
+        GmosCommonStaticConfig.Default,
+        GmosNorthStageMode.FollowXy
+      )
+
+  }
+
+  trait GmosNorthLenses { this: GmosN.type =>
+
+    lazy val customRois: Lens[GmosN, Set[GmosCustomRoiEntry]] =
+      common ^|-> GmosCommonStaticConfig.customRois
+
+    lazy val nodAndShuffle: Lens[GmosN, Option[GmosNodAndShuffle]] =
+      common ^|-> GmosCommonStaticConfig.nodAndShuffle
+
+  }
+
+  @Lenses final case class GmosS(
+    common:    GmosCommonStaticConfig,
+    stageMode: GmosSouthStageMode
+  ) extends StaticConfig
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object GmosS extends GmosSouthLenses {
+    val Default: GmosS =
+      GmosS(
+        GmosCommonStaticConfig.Default,
+        GmosSouthStageMode.FollowXyz
+      )
+  }
+
+  trait GmosSouthLenses { this: GmosS.type =>
+
+    lazy val customRois: Lens[GmosS, Set[GmosCustomRoiEntry]] =
+      common ^|-> GmosCommonStaticConfig.customRois
+
+    lazy val nodAndShuffle: Lens[GmosS, Option[GmosNodAndShuffle]] =
+      common ^|-> GmosCommonStaticConfig.nodAndShuffle
+  }
+
+  @Lenses final case class Gnirs(
+    wellDepth: GnirsWellDepth
+  ) extends StaticConfig
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object Gnirs {
+    val Default: Gnirs =
+      Gnirs(GnirsWellDepth.Shallow)
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/config/TelescopeConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/TelescopeConfig.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package config
+
+import gem.math.Offset
+
+/**
+ * Additional configuration information for [[gem.Step.Science Science]] steps.
+ * @group Configurations
+ */
+final case class TelescopeConfig(p: Offset.P, q: Offset.Q) {
+  def offset: Offset = Offset(p, q)
+}
+
+object TelescopeConfig extends ((Offset.P, Offset.Q) => TelescopeConfig) {
+  val Zero: TelescopeConfig = TelescopeConfig(Offset.P.Zero, Offset.Q.Zero)
+}

--- a/modules/core/shared/src/main/scala/gem/config/package.scala
+++ b/modules/core/shared/src/main/scala/gem/config/package.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+/** Data types that define sequences of instructions consumed and executed by the SeqExec. */
+package object config

--- a/modules/core/shared/src/main/scala/gem/enum/AsterismType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/AsterismType.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for asterism types.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class AsterismType(
+  val tag: String
+) extends Product with Serializable
+
+object AsterismType {
+
+  /** @group Constructors */ case object GhostDualTarget extends AsterismType("GhostDualTarget")
+  /** @group Constructors */ case object SingleTarget extends AsterismType("SingleTarget")
+
+  /** All members of AsterismType, in canonical order. */
+  val all: List[AsterismType] =
+    List(GhostDualTarget, SingleTarget)
+
+  /** Select the member of AsterismType with the given tag, if any. */
+  def fromTag(s: String): Option[AsterismType] =
+    all.find(_.tag === s)
+
+  /** Select the member of AsterismType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): AsterismType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val AsterismTypeEnumerated: Enumerated[AsterismType] =
+    new Enumerated[AsterismType] {
+      def all = AsterismType.all
+      def tag(a: AsterismType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/DailyProgramType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/DailyProgramType.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.syntax.eq._
+import cats.instances.string._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for the subset of [[ProgramType]] allowed for daily science programs.
+ * @group Enumerations
+ */
+sealed abstract class DailyProgramType(
+  val toProgramType: ProgramType
+) {
+  val tag:       String  = toProgramType.tag
+  val shortName: String  = toProgramType.shortName
+  val longName:  String  = toProgramType.longName
+  val obsolete:  Boolean = toProgramType.obsolete
+}
+
+object DailyProgramType {
+
+  /** @group Constructors */ case object CAL extends DailyProgramType(ProgramType.CAL)
+  /** @group Constructors */ case object ENG extends DailyProgramType(ProgramType.ENG)
+
+  val all: List[DailyProgramType] =
+    List(CAL, ENG)
+
+  def fromTag(s: String): Option[DailyProgramType] =
+    all.find(_.tag === s)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): DailyProgramType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val ProgramTypeEnumerated: Enumerated[DailyProgramType] =
+    new Enumerated[DailyProgramType] {
+      def all = DailyProgramType.all
+      def tag(a: DailyProgramType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/EphemerisKeyType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/EphemerisKeyType.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for Non-sidereal target lookup type.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class EphemerisKeyType(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object EphemerisKeyType {
+
+  /** @group Constructors */ case object Comet extends EphemerisKeyType("Comet", "Comet", "Horizons Comet")
+  /** @group Constructors */ case object AsteroidNew extends EphemerisKeyType("AsteroidNew", "Asteroid New", "Horizons Asteroid (New Format)")
+  /** @group Constructors */ case object AsteroidOld extends EphemerisKeyType("AsteroidOld", "Asteroid Old", "Horizons Asteroid (Old Format)")
+  /** @group Constructors */ case object MajorBody extends EphemerisKeyType("MajorBody", "Major Body", "Horizons Major Body")
+  /** @group Constructors */ case object UserSupplied extends EphemerisKeyType("UserSupplied", "User Supplied", "User Supplied")
+
+  /** All members of EphemerisKeyType, in canonical order. */
+  val all: List[EphemerisKeyType] =
+    List(Comet, AsteroidNew, AsteroidOld, MajorBody, UserSupplied)
+
+  /** Select the member of EphemerisKeyType with the given tag, if any. */
+  def fromTag(s: String): Option[EphemerisKeyType] =
+    all.find(_.tag === s)
+
+  /** Select the member of EphemerisKeyType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): EphemerisKeyType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val EphemerisKeyTypeEnumerated: Enumerated[EphemerisKeyType] =
+    new Enumerated[EphemerisKeyType] {
+      def all = EphemerisKeyType.all
+      def tag(a: EphemerisKeyType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/EventType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/EventType.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for observe [[gem.Event Event]]) types.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class EventType(
+  val tag: String
+) extends Product with Serializable
+
+object EventType {
+
+  /** @group Constructors */ case object StartSequence extends EventType("StartSequence")
+  /** @group Constructors */ case object EndSequence extends EventType("EndSequence")
+  /** @group Constructors */ case object StartSlew extends EventType("StartSlew")
+  /** @group Constructors */ case object EndSlew extends EventType("EndSlew")
+  /** @group Constructors */ case object StartVisit extends EventType("StartVisit")
+  /** @group Constructors */ case object EndVisit extends EventType("EndVisit")
+  /** @group Constructors */ case object StartIntegration extends EventType("StartIntegration")
+  /** @group Constructors */ case object EndIntegration extends EventType("EndIntegration")
+  /** @group Constructors */ case object Abort extends EventType("Abort")
+  /** @group Constructors */ case object Continue extends EventType("Continue")
+  /** @group Constructors */ case object Pause extends EventType("Pause")
+  /** @group Constructors */ case object Stop extends EventType("Stop")
+
+  /** All members of EventType, in canonical order. */
+  val all: List[EventType] =
+    List(StartSequence, EndSequence, StartSlew, EndSlew, StartVisit, EndVisit, StartIntegration, EndIntegration, Abort, Continue, Pause, Stop)
+
+  /** Select the member of EventType with the given tag, if any. */
+  def fromTag(s: String): Option[EventType] =
+    all.find(_.tag === s)
+
+  /** Select the member of EventType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): EventType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val EventTypeEnumerated: Enumerated[EventType] =
+    new Enumerated[EventType] {
+      def all = EventType.all
+      def tag(a: EventType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/F2Disperser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2Disperser.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Wavelength
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for Flamingos2 dispersers.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class F2Disperser(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val wavelength: Wavelength
+) extends Product with Serializable
+
+object F2Disperser {
+
+  /** @group Constructors */ case object R1200JH extends F2Disperser("R1200JH", "R1200JH", "R=1200 (J + H) grism", Wavelength.fromAngstroms.unsafeGet(13900))
+  /** @group Constructors */ case object R1200HK extends F2Disperser("R1200HK", "R1200HK", "R=1200 (H + K) grism", Wavelength.fromAngstroms.unsafeGet(18710))
+  /** @group Constructors */ case object R3000 extends F2Disperser("R3000", "R3000", "R=3000 (J or H or K) grism", Wavelength.fromAngstroms.unsafeGet(16500))
+
+  /** All members of F2Disperser, in canonical order. */
+  val all: List[F2Disperser] =
+    List(R1200JH, R1200HK, R3000)
+
+  /** Select the member of F2Disperser with the given tag, if any. */
+  def fromTag(s: String): Option[F2Disperser] =
+    all.find(_.tag === s)
+
+  /** Select the member of F2Disperser with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): F2Disperser =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val F2DisperserEnumerated: Enumerated[F2Disperser] =
+    new Enumerated[F2Disperser] {
+      def all = F2Disperser.all
+      def tag(a: F2Disperser) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/F2Filter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2Filter.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Wavelength
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for Flamingos2 filters.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class F2Filter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val wavelength: Option[Wavelength],
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object F2Filter {
+
+  /** @group Constructors */ case object Y extends F2Filter("Y", "Y", "Y (1.02 um)", Some(Wavelength.fromAngstroms.unsafeGet(10200)), false)
+  /** @group Constructors */ case object F1056 extends F2Filter("F1056", "F1056", "F1056 (1.056 um)", Some(Wavelength.fromAngstroms.unsafeGet(10560)), false)
+  /** @group Constructors */ case object J extends F2Filter("J", "J", "J (1.25 um)", Some(Wavelength.fromAngstroms.unsafeGet(12500)), false)
+  /** @group Constructors */ case object H extends F2Filter("H", "H", "H (1.65 um)", Some(Wavelength.fromAngstroms.unsafeGet(16500)), false)
+  /** @group Constructors */ case object JH extends F2Filter("JH", "JH", "JH (spectroscopic)", Some(Wavelength.fromAngstroms.unsafeGet(13900)), false)
+  /** @group Constructors */ case object HK extends F2Filter("HK", "HK", "HK (spectroscopic)", Some(Wavelength.fromAngstroms.unsafeGet(18710)), false)
+  /** @group Constructors */ case object JLow extends F2Filter("JLow", "J-low", "J-low (1.15 um)", Some(Wavelength.fromAngstroms.unsafeGet(11500)), false)
+  /** @group Constructors */ case object KLong extends F2Filter("KLong", "K-long", "K-long (2.20 um)", Some(Wavelength.fromAngstroms.unsafeGet(22000)), false)
+  /** @group Constructors */ case object KShort extends F2Filter("KShort", "K-short", "K-short (2.15 um)", Some(Wavelength.fromAngstroms.unsafeGet(21500)), false)
+  /** @group Constructors */ case object F1063 extends F2Filter("F1063", "F1063", "F1063 (1.063 um)", Some(Wavelength.fromAngstroms.unsafeGet(10630)), false)
+  /** @group Constructors */ case object KBlue extends F2Filter("KBlue", "K-blue", "K-blue (2.06 um)", Some(Wavelength.fromAngstroms.unsafeGet(20600)), false)
+  /** @group Constructors */ case object KRed extends F2Filter("KRed", "K-red", "K-red (2.31 um)", Some(Wavelength.fromAngstroms.unsafeGet(23100)), false)
+  /** @group Constructors */ case object Open extends F2Filter("Open", "Open", "Open", Some(Wavelength.fromAngstroms.unsafeGet(16000)), true)
+  /** @group Constructors */ case object Dark extends F2Filter("Dark", "Dark", "Dark", Option.empty[Wavelength], true)
+
+  /** All members of F2Filter, in canonical order. */
+  val all: List[F2Filter] =
+    List(Y, F1056, J, H, JH, HK, JLow, KLong, KShort, F1063, KBlue, KRed, Open, Dark)
+
+  /** Select the member of F2Filter with the given tag, if any. */
+  def fromTag(s: String): Option[F2Filter] =
+    all.find(_.tag === s)
+
+  /** Select the member of F2Filter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): F2Filter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val F2FilterEnumerated: Enumerated[F2Filter] =
+    new Enumerated[F2Filter] {
+      def all = F2Filter.all
+      def tag(a: F2Filter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/F2Fpu.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2Fpu.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for Flamingos2 focal plane units.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class F2Fpu(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val slitWidth: Int,
+  val decker: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object F2Fpu {
+
+  /** @group Constructors */ case object Pinhole extends F2Fpu("Pinhole", "Pinhole", "2-Pixel Pinhole Grid", 0, "Imaging", false)
+  /** @group Constructors */ case object SubPixPinhole extends F2Fpu("SubPixPinhole", "Sub-Pix Pinhole", "Sub-Pixel Pinhole Gr", 0, "Imaging", false)
+  /** @group Constructors */ case object LongSlit1 extends F2Fpu("LongSlit1", "Long Slit 1px", "1-Pixel Long Slit", 1, "Long Slit", false)
+  /** @group Constructors */ case object LongSlit2 extends F2Fpu("LongSlit2", "Long Slit 2px", "2-Pixel Long Slit", 2, "Long Slit", false)
+  /** @group Constructors */ case object LongSlit3 extends F2Fpu("LongSlit3", "Long Slit 3px", "3-Pixel Long Slit", 3, "Long Slit", false)
+  /** @group Constructors */ case object LongSlit4 extends F2Fpu("LongSlit4", "Long Slit 4px", "4-Pixel Long Slit", 4, "Long Slit", false)
+  /** @group Constructors */ case object LongSlit6 extends F2Fpu("LongSlit6", "Long Slit 6px", "6-Pixel Long Slit", 6, "Long Slit", false)
+  /** @group Constructors */ case object LongSlit8 extends F2Fpu("LongSlit8", "Long Slit 8px", "8-Pixel Long Slit", 8, "Long Slit", false)
+
+  /** All members of F2Fpu, in canonical order. */
+  val all: List[F2Fpu] =
+    List(Pinhole, SubPixPinhole, LongSlit1, LongSlit2, LongSlit3, LongSlit4, LongSlit6, LongSlit8)
+
+  /** Select the member of F2Fpu with the given tag, if any. */
+  def fromTag(s: String): Option[F2Fpu] =
+    all.find(_.tag === s)
+
+  /** Select the member of F2Fpu with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): F2Fpu =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val F2FpuEnumerated: Enumerated[F2Fpu] =
+    new Enumerated[F2Fpu] {
+      def all = F2Fpu.all
+      def tag(a: F2Fpu) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/F2LyotWheel.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2LyotWheel.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for Flamingos2 Lyot wheel.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class F2LyotWheel(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val plateScale: Double,
+  val pixelScale: Double,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object F2LyotWheel {
+
+  /** @group Constructors */ case object F16 extends F2LyotWheel("F16", "f/16", "f/16 (Open)", 1.61, 0.18, false)
+  /** @group Constructors */ case object F32High extends F2LyotWheel("F32High", "f/32 High", "f/32 MCAO high background", 0.805, 0.09, true)
+  /** @group Constructors */ case object F32Low extends F2LyotWheel("F32Low", "f/32 Low", "f/32 MCAO low background", 0.805, 0.09, true)
+  /** @group Constructors */ case object F33Gems extends F2LyotWheel("F33Gems", "f/33 GeMS", "f/33 (GeMS)", 0.784, 0.09, true)
+  /** @group Constructors */ case object GemsUnder extends F2LyotWheel("GemsUnder", "GeMS Under", "f/33 (GeMS under-sized)", 0.784, 0.09, false)
+  /** @group Constructors */ case object GemsOver extends F2LyotWheel("GemsOver", "GeMS Over", "f/33 (GeMS over-sized)", 0.784, 0.09, false)
+  /** @group Constructors */ case object HartmannA extends F2LyotWheel("HartmannA", "Hartmann A (H1)", "Hartmann A (H1)", 0.0, 0.0, false)
+  /** @group Constructors */ case object HartmannB extends F2LyotWheel("HartmannB", "Hartmann B (H2)", "Hartmann B (H2)", 0.0, 0.0, false)
+
+  /** All members of F2LyotWheel, in canonical order. */
+  val all: List[F2LyotWheel] =
+    List(F16, F32High, F32Low, F33Gems, GemsUnder, GemsOver, HartmannA, HartmannB)
+
+  /** Select the member of F2LyotWheel with the given tag, if any. */
+  def fromTag(s: String): Option[F2LyotWheel] =
+    all.find(_.tag === s)
+
+  /** Select the member of F2LyotWheel with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): F2LyotWheel =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val F2LyotWheelEnumerated: Enumerated[F2LyotWheel] =
+    new Enumerated[F2LyotWheel] {
+      def all = F2LyotWheel.all
+      def tag(a: F2LyotWheel) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/F2ReadMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2ReadMode.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+import java.time.Duration
+
+/**
+ * Enumerated type for Flamingos2 read modes.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class F2ReadMode(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val description: String,
+  val minimumExposureTime: Duration,
+  val recommendedExposureTime: Duration,
+  val readoutTime: Duration,
+  val readCount: Int,
+  val readNoise: Double
+) extends Product with Serializable
+
+object F2ReadMode {
+
+  /** @group Constructors */ case object Bright extends F2ReadMode("Bright", "bright", "Bright Object", "Strong Source", Duration.ofMillis(1500), Duration.ofMillis(5000), Duration.ofMillis(8000), 1, 11.7)
+  /** @group Constructors */ case object Medium extends F2ReadMode("Medium", "medium", "Medium Object", "Medium Source", Duration.ofMillis(6000), Duration.ofMillis(21000), Duration.ofMillis(14000), 4, 6.0)
+  /** @group Constructors */ case object Faint extends F2ReadMode("Faint", "faint", "Faint Object", "Weak Source", Duration.ofMillis(12000), Duration.ofMillis(85000), Duration.ofMillis(20000), 8, 5.0)
+
+  /** All members of F2ReadMode, in canonical order. */
+  val all: List[F2ReadMode] =
+    List(Bright, Medium, Faint)
+
+  /** Select the member of F2ReadMode with the given tag, if any. */
+  def fromTag(s: String): Option[F2ReadMode] =
+    all.find(_.tag === s)
+
+  /** Select the member of F2ReadMode with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): F2ReadMode =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val F2ReadModeEnumerated: Enumerated[F2ReadMode] =
+    new Enumerated[F2ReadMode] {
+      def all = F2ReadMode.all
+      def tag(a: F2ReadMode) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/F2WindowCover.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/F2WindowCover.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for Flamingos2 window cover state.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class F2WindowCover(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object F2WindowCover {
+
+  /** @group Constructors */ case object Open extends F2WindowCover("Open", "Open", "Open")
+  /** @group Constructors */ case object Close extends F2WindowCover("Close", "Close", "Close")
+
+  /** All members of F2WindowCover, in canonical order. */
+  val all: List[F2WindowCover] =
+    List(Open, Close)
+
+  /** Select the member of F2WindowCover with the given tag, if any. */
+  def fromTag(s: String): Option[F2WindowCover] =
+    all.find(_.tag === s)
+
+  /** Select the member of F2WindowCover with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): F2WindowCover =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val F2WindowCoverEnumerated: Enumerated[F2WindowCover] =
+    new Enumerated[F2WindowCover] {
+      def all = F2WindowCover.all
+      def tag(a: F2WindowCover) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GcalArc.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalArc.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for calibration unit arc lamps.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GcalArc(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GcalArc {
+
+  /** @group Constructors */ case object ArArc extends GcalArc("ArArc", "Ar arc", "Ar arc", false)
+  /** @group Constructors */ case object ThArArc extends GcalArc("ThArArc", "ThAr arc", "ThAr arc", false)
+  /** @group Constructors */ case object CuArArc extends GcalArc("CuArArc", "CuAr arc", "CuAr arc", false)
+  /** @group Constructors */ case object XeArc extends GcalArc("XeArc", "Xe arc", "Xe arc", false)
+
+  /** All members of GcalArc, in canonical order. */
+  val all: List[GcalArc] =
+    List(ArArc, ThArArc, CuArArc, XeArc)
+
+  /** Select the member of GcalArc with the given tag, if any. */
+  def fromTag(s: String): Option[GcalArc] =
+    all.find(_.tag === s)
+
+  /** Select the member of GcalArc with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GcalArc =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GcalArcEnumerated: Enumerated[GcalArc] =
+    new Enumerated[GcalArc] {
+      def all = GcalArc.all
+      def tag(a: GcalArc) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GcalBaselineType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalBaselineType.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for calibration baseline type.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GcalBaselineType(
+  val tag: String
+) extends Product with Serializable
+
+object GcalBaselineType {
+
+  /** @group Constructors */ case object Day extends GcalBaselineType("Day")
+  /** @group Constructors */ case object Night extends GcalBaselineType("Night")
+
+  /** All members of GcalBaselineType, in canonical order. */
+  val all: List[GcalBaselineType] =
+    List(Day, Night)
+
+  /** Select the member of GcalBaselineType with the given tag, if any. */
+  def fromTag(s: String): Option[GcalBaselineType] =
+    all.find(_.tag === s)
+
+  /** Select the member of GcalBaselineType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GcalBaselineType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GcalBaselineTypeEnumerated: Enumerated[GcalBaselineType] =
+    new Enumerated[GcalBaselineType] {
+      def all = GcalBaselineType.all
+      def tag(a: GcalBaselineType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GcalContinuum.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalContinuum.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for calibration unit continuum lamps.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GcalContinuum(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GcalContinuum {
+
+  /** @group Constructors */ case object IrGreyBodyLow extends GcalContinuum("IrGreyBodyLow", "IR grey body - low", "IR grey body - low", false)
+  /** @group Constructors */ case object IrGreyBodyHigh extends GcalContinuum("IrGreyBodyHigh", "IR grey body - high", "IR grey body - high", false)
+  /** @group Constructors */ case object QuartzHalogen extends GcalContinuum("QuartzHalogen", "Quartz Halogen", "Quartz Halogen", false)
+
+  /** All members of GcalContinuum, in canonical order. */
+  val all: List[GcalContinuum] =
+    List(IrGreyBodyLow, IrGreyBodyHigh, QuartzHalogen)
+
+  /** Select the member of GcalContinuum with the given tag, if any. */
+  def fromTag(s: String): Option[GcalContinuum] =
+    all.find(_.tag === s)
+
+  /** Select the member of GcalContinuum with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GcalContinuum =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GcalContinuumEnumerated: Enumerated[GcalContinuum] =
+    new Enumerated[GcalContinuum] {
+      def all = GcalContinuum.all
+      def tag(a: GcalContinuum) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GcalDiffuser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalDiffuser.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for calibration unit diffusers.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GcalDiffuser(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GcalDiffuser {
+
+  /** @group Constructors */ case object Ir extends GcalDiffuser("Ir", "IR", "IR", false)
+  /** @group Constructors */ case object Visible extends GcalDiffuser("Visible", "Visible", "Visible", false)
+
+  /** All members of GcalDiffuser, in canonical order. */
+  val all: List[GcalDiffuser] =
+    List(Ir, Visible)
+
+  /** Select the member of GcalDiffuser with the given tag, if any. */
+  def fromTag(s: String): Option[GcalDiffuser] =
+    all.find(_.tag === s)
+
+  /** Select the member of GcalDiffuser with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GcalDiffuser =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GcalDiffuserEnumerated: Enumerated[GcalDiffuser] =
+    new Enumerated[GcalDiffuser] {
+      def all = GcalDiffuser.all
+      def tag(a: GcalDiffuser) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GcalFilter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalFilter.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for calibration unit filter.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GcalFilter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GcalFilter {
+
+  /** @group Constructors */ case object None extends GcalFilter("None", "none", "none", false)
+  /** @group Constructors */ case object Gmos extends GcalFilter("Gmos", "GMOS balance", "GMOS balance", false)
+  /** @group Constructors */ case object Hros extends GcalFilter("Hros", "HROS balance", "HROS balance", true)
+  /** @group Constructors */ case object Nir extends GcalFilter("Nir", "NIR balance", "NIR balance", false)
+  /** @group Constructors */ case object Nd10 extends GcalFilter("Nd10", "ND1.0", "ND1.0", false)
+  /** @group Constructors */ case object Nd16 extends GcalFilter("Nd16", "ND1.6", "ND1.6", true)
+  /** @group Constructors */ case object Nd20 extends GcalFilter("Nd20", "ND2.0", "ND2.0", false)
+  /** @group Constructors */ case object Nd30 extends GcalFilter("Nd30", "ND3.0", "ND3.0", false)
+  /** @group Constructors */ case object Nd40 extends GcalFilter("Nd40", "ND4.0", "ND4.0", false)
+  /** @group Constructors */ case object Nd45 extends GcalFilter("Nd45", "ND4-5", "ND4-5", false)
+  /** @group Constructors */ case object Nd50 extends GcalFilter("Nd50", "ND5.0", "ND5.0", true)
+
+  /** All members of GcalFilter, in canonical order. */
+  val all: List[GcalFilter] =
+    List(None, Gmos, Hros, Nir, Nd10, Nd16, Nd20, Nd30, Nd40, Nd45, Nd50)
+
+  /** Select the member of GcalFilter with the given tag, if any. */
+  def fromTag(s: String): Option[GcalFilter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GcalFilter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GcalFilter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GcalFilterEnumerated: Enumerated[GcalFilter] =
+    new Enumerated[GcalFilter] {
+      def all = GcalFilter.all
+      def tag(a: GcalFilter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GcalLampType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalLampType.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for calibration lamp type.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GcalLampType(
+  val tag: String
+) extends Product with Serializable
+
+object GcalLampType {
+
+  /** @group Constructors */ case object Arc extends GcalLampType("Arc")
+  /** @group Constructors */ case object Flat extends GcalLampType("Flat")
+
+  /** All members of GcalLampType, in canonical order. */
+  val all: List[GcalLampType] =
+    List(Arc, Flat)
+
+  /** Select the member of GcalLampType with the given tag, if any. */
+  def fromTag(s: String): Option[GcalLampType] =
+    all.find(_.tag === s)
+
+  /** Select the member of GcalLampType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GcalLampType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GcalLampTypeEnumerated: Enumerated[GcalLampType] =
+    new Enumerated[GcalLampType] {
+      def all = GcalLampType.all
+      def tag(a: GcalLampType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GcalShutter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GcalShutter.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for calibration unit shutter states.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GcalShutter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GcalShutter {
+
+  /** @group Constructors */ case object Open extends GcalShutter("Open", "Open", "Open", false)
+  /** @group Constructors */ case object Closed extends GcalShutter("Closed", "Closed", "Closed", false)
+
+  /** All members of GcalShutter, in canonical order. */
+  val all: List[GcalShutter] =
+    List(Open, Closed)
+
+  /** Select the member of GcalShutter with the given tag, if any. */
+  def fromTag(s: String): Option[GcalShutter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GcalShutter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GcalShutter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GcalShutterEnumerated: Enumerated[GcalShutter] =
+    new Enumerated[GcalShutter] {
+      def all = GcalShutter.all
+      def tag(a: GcalShutter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosAdc.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosAdc.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS ADC.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosAdc(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object GmosAdc {
+
+  /** @group Constructors */ case object BestStatic extends GmosAdc("BestStatic", "Best Static", "Best Static Correction")
+  /** @group Constructors */ case object Follow extends GmosAdc("Follow", "Follow", "Follow During Exposure")
+
+  /** All members of GmosAdc, in canonical order. */
+  val all: List[GmosAdc] =
+    List(BestStatic, Follow)
+
+  /** Select the member of GmosAdc with the given tag, if any. */
+  def fromTag(s: String): Option[GmosAdc] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosAdc with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosAdc =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosAdcEnumerated: Enumerated[GmosAdc] =
+    new Enumerated[GmosAdc] {
+      def all = GmosAdc.all
+      def tag(a: GmosAdc) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosAmpCount.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosAmpCount.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS amp count.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosAmpCount(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object GmosAmpCount {
+
+  /** @group Constructors */ case object Three extends GmosAmpCount("Three", "Three", "Three")
+  /** @group Constructors */ case object Six extends GmosAmpCount("Six", "Six", "Six")
+  /** @group Constructors */ case object Twelve extends GmosAmpCount("Twelve", "Twelve", "Twelve")
+
+  /** All members of GmosAmpCount, in canonical order. */
+  val all: List[GmosAmpCount] =
+    List(Three, Six, Twelve)
+
+  /** Select the member of GmosAmpCount with the given tag, if any. */
+  def fromTag(s: String): Option[GmosAmpCount] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosAmpCount with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosAmpCount =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosAmpCountEnumerated: Enumerated[GmosAmpCount] =
+    new Enumerated[GmosAmpCount] {
+      def all = GmosAmpCount.all
+      def tag(a: GmosAmpCount) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosAmpGain.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosAmpGain.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS amp gain.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosAmpGain(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object GmosAmpGain {
+
+  /** @group Constructors */ case object Low extends GmosAmpGain("Low", "Low", "Low")
+  /** @group Constructors */ case object High extends GmosAmpGain("High", "High", "High")
+
+  /** All members of GmosAmpGain, in canonical order. */
+  val all: List[GmosAmpGain] =
+    List(Low, High)
+
+  /** Select the member of GmosAmpGain with the given tag, if any. */
+  def fromTag(s: String): Option[GmosAmpGain] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosAmpGain with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosAmpGain =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosAmpGainEnumerated: Enumerated[GmosAmpGain] =
+    new Enumerated[GmosAmpGain] {
+      def all = GmosAmpGain.all
+      def tag(a: GmosAmpGain) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosAmpReadMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosAmpReadMode.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS amp read mode.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosAmpReadMode(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object GmosAmpReadMode {
+
+  /** @group Constructors */ case object Slow extends GmosAmpReadMode("Slow", "slow", "Slow")
+  /** @group Constructors */ case object Fast extends GmosAmpReadMode("Fast", "fast", "Fast")
+
+  /** All members of GmosAmpReadMode, in canonical order. */
+  val all: List[GmosAmpReadMode] =
+    List(Slow, Fast)
+
+  /** Select the member of GmosAmpReadMode with the given tag, if any. */
+  def fromTag(s: String): Option[GmosAmpReadMode] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosAmpReadMode with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosAmpReadMode =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosAmpReadModeEnumerated: Enumerated[GmosAmpReadMode] =
+    new Enumerated[GmosAmpReadMode] {
+      def all = GmosAmpReadMode.all
+      def tag(a: GmosAmpReadMode) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosCustomSlitWidth.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosCustomSlitWidth.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Angle
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS custom slit width.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosCustomSlitWidth(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val width: Angle
+) extends Product with Serializable
+
+object GmosCustomSlitWidth {
+
+  /** @group Constructors */ case object CustomWidth_0_25 extends GmosCustomSlitWidth("CustomWidth_0_25", "0.25", "0.25 arcsec", Angle.fromDoubleArcseconds(0.25))
+  /** @group Constructors */ case object CustomWidth_0_50 extends GmosCustomSlitWidth("CustomWidth_0_50", "0.50", "0.50 arcsec", Angle.fromDoubleArcseconds(0.50))
+  /** @group Constructors */ case object CustomWidth_0_75 extends GmosCustomSlitWidth("CustomWidth_0_75", "0.75", "0.75 arcsec", Angle.fromDoubleArcseconds(0.75))
+  /** @group Constructors */ case object CustomWidth_1_00 extends GmosCustomSlitWidth("CustomWidth_1_00", "1.00", "1.00 arcsec", Angle.fromDoubleArcseconds(1.00))
+  /** @group Constructors */ case object CustomWidth_1_50 extends GmosCustomSlitWidth("CustomWidth_1_50", "1.50", "1.50 arcsec", Angle.fromDoubleArcseconds(1.50))
+  /** @group Constructors */ case object CustomWidth_2_00 extends GmosCustomSlitWidth("CustomWidth_2_00", "2.00", "2.00 arcsec", Angle.fromDoubleArcseconds(2.00))
+  /** @group Constructors */ case object CustomWidth_5_00 extends GmosCustomSlitWidth("CustomWidth_5_00", "5.00", "5.00 arcsec", Angle.fromDoubleArcseconds(5.00))
+
+  /** All members of GmosCustomSlitWidth, in canonical order. */
+  val all: List[GmosCustomSlitWidth] =
+    List(CustomWidth_0_25, CustomWidth_0_50, CustomWidth_0_75, CustomWidth_1_00, CustomWidth_1_50, CustomWidth_2_00, CustomWidth_5_00)
+
+  /** Select the member of GmosCustomSlitWidth with the given tag, if any. */
+  def fromTag(s: String): Option[GmosCustomSlitWidth] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosCustomSlitWidth with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosCustomSlitWidth =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosCustomSlitWidthEnumerated: Enumerated[GmosCustomSlitWidth] =
+    new Enumerated[GmosCustomSlitWidth] {
+      def all = GmosCustomSlitWidth.all
+      def tag(a: GmosCustomSlitWidth) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosDetector.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosDetector.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Angle
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS detector.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosDetector(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val northPixelSize: Angle,
+  val southPixelSize: Angle,
+  val shuffleOffset: Int,
+  val xSize: Int,
+  val ySize: Int,
+  val maxRois: Int
+) extends Product with Serializable
+
+object GmosDetector {
+
+  /** @group Constructors */ case object E2V extends GmosDetector("E2V", "E2V", "E2V", Angle.fromDoubleArcseconds(0.0727), Angle.fromDoubleArcseconds(0.0730), 1536, 6144, 4608, 4)
+  /** @group Constructors */ case object HAMAMATSU extends GmosDetector("HAMAMATSU", "Hamamatsu", "Hamamatsu", Angle.fromDoubleArcseconds(0.0809), Angle.fromDoubleArcseconds(0.0809), 1392, 6144, 4224, 5)
+
+  /** All members of GmosDetector, in canonical order. */
+  val all: List[GmosDetector] =
+    List(E2V, HAMAMATSU)
+
+  /** Select the member of GmosDetector with the given tag, if any. */
+  def fromTag(s: String): Option[GmosDetector] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosDetector with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosDetector =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosDetectorEnumerated: Enumerated[GmosDetector] =
+    new Enumerated[GmosDetector] {
+      def all = GmosDetector.all
+      def tag(a: GmosDetector) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosDisperserOrder.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosDisperserOrder.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS disperser order.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosDisperserOrder(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val count: Int
+) extends Product with Serializable
+
+object GmosDisperserOrder {
+
+  /** @group Constructors */ case object Zero extends GmosDisperserOrder("Zero", "0", "Zero", 0)
+  /** @group Constructors */ case object One extends GmosDisperserOrder("One", "1", "One", 1)
+  /** @group Constructors */ case object Two extends GmosDisperserOrder("Two", "2", "Two", 2)
+
+  /** All members of GmosDisperserOrder, in canonical order. */
+  val all: List[GmosDisperserOrder] =
+    List(Zero, One, Two)
+
+  /** Select the member of GmosDisperserOrder with the given tag, if any. */
+  def fromTag(s: String): Option[GmosDisperserOrder] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosDisperserOrder with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosDisperserOrder =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosDisperserOrderEnumerated: Enumerated[GmosDisperserOrder] =
+    new Enumerated[GmosDisperserOrder] {
+      def all = GmosDisperserOrder.all
+      def tag(a: GmosDisperserOrder) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosDtax.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosDtax.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS detector translation X offset.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosDtax(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val dtax: Int
+) extends Product with Serializable
+
+object GmosDtax {
+
+  /** @group Constructors */ case object MinusSix extends GmosDtax("MinusSix", "-6", "-6", -6)
+  /** @group Constructors */ case object MinusFive extends GmosDtax("MinusFive", "-5", "-5", -5)
+  /** @group Constructors */ case object MinusFour extends GmosDtax("MinusFour", "-4", "-4", -4)
+  /** @group Constructors */ case object MinusThree extends GmosDtax("MinusThree", "-3", "-3", -3)
+  /** @group Constructors */ case object MinusTwo extends GmosDtax("MinusTwo", "-2", "-2", -2)
+  /** @group Constructors */ case object MinusOne extends GmosDtax("MinusOne", "-1", "-1", -1)
+  /** @group Constructors */ case object Zero extends GmosDtax("Zero", "0", "0", 0)
+  /** @group Constructors */ case object One extends GmosDtax("One", "1", "1", 1)
+  /** @group Constructors */ case object Two extends GmosDtax("Two", "2", "2", 2)
+  /** @group Constructors */ case object Three extends GmosDtax("Three", "3", "3", 3)
+  /** @group Constructors */ case object Four extends GmosDtax("Four", "4", "4", 4)
+  /** @group Constructors */ case object Five extends GmosDtax("Five", "5", "5", 5)
+  /** @group Constructors */ case object Six extends GmosDtax("Six", "6", "6", 6)
+
+  /** All members of GmosDtax, in canonical order. */
+  val all: List[GmosDtax] =
+    List(MinusSix, MinusFive, MinusFour, MinusThree, MinusTwo, MinusOne, Zero, One, Two, Three, Four, Five, Six)
+
+  /** Select the member of GmosDtax with the given tag, if any. */
+  def fromTag(s: String): Option[GmosDtax] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosDtax with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosDtax =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosDtaxEnumerated: Enumerated[GmosDtax] =
+    new Enumerated[GmosDtax] {
+      def all = GmosDtax.all
+      def tag(a: GmosDtax) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosEOffsetting.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosEOffsetting.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS Electric Offsetting.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosEOffsetting(
+  val tag: String,
+  val description: String,
+  val toBoolean: Boolean
+) extends Product with Serializable
+
+object GmosEOffsetting {
+
+  /** @group Constructors */ case object On extends GmosEOffsetting("On", "Electronic Offsetting On", true)
+  /** @group Constructors */ case object Off extends GmosEOffsetting("Off", "Electronic Offsetting Off", false)
+
+  /** All members of GmosEOffsetting, in canonical order. */
+  val all: List[GmosEOffsetting] =
+    List(On, Off)
+
+  /** Select the member of GmosEOffsetting with the given tag, if any. */
+  def fromTag(s: String): Option[GmosEOffsetting] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosEOffsetting with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosEOffsetting =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosEOffsettingEnumerated: Enumerated[GmosEOffsetting] =
+    new Enumerated[GmosEOffsetting] {
+      def all = GmosEOffsetting.all
+      def tag(a: GmosEOffsetting) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthDisperser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthDisperser.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS North dispersers.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosNorthDisperser(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val rulingDensity: Int,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GmosNorthDisperser {
+
+  /** @group Constructors */ case object B1200_G5301 extends GmosNorthDisperser("B1200_G5301", "B1200", "B1200_G5301", 1200, false)
+  /** @group Constructors */ case object R831_G5302 extends GmosNorthDisperser("R831_G5302", "R831", "R831_G5302", 831, false)
+  /** @group Constructors */ case object B600_G5303 extends GmosNorthDisperser("B600_G5303", "B600", "B600_G5303", 600, true)
+  /** @group Constructors */ case object B600_G5307 extends GmosNorthDisperser("B600_G5307", "B600", "B600_G5307", 600, false)
+  /** @group Constructors */ case object R600_G5304 extends GmosNorthDisperser("R600_G5304", "R600", "R600_G5304", 600, false)
+  /** @group Constructors */ case object R400_G5305 extends GmosNorthDisperser("R400_G5305", "R400", "R400_G5305", 400, false)
+  /** @group Constructors */ case object R150_G5306 extends GmosNorthDisperser("R150_G5306", "R150", "R150_G5306", 150, false)
+  /** @group Constructors */ case object R150_G5308 extends GmosNorthDisperser("R150_G5308", "R150", "R150_G5308", 150, false)
+
+  /** All members of GmosNorthDisperser, in canonical order. */
+  val all: List[GmosNorthDisperser] =
+    List(B1200_G5301, R831_G5302, B600_G5303, B600_G5307, R600_G5304, R400_G5305, R150_G5306, R150_G5308)
+
+  /** Select the member of GmosNorthDisperser with the given tag, if any. */
+  def fromTag(s: String): Option[GmosNorthDisperser] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosNorthDisperser with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosNorthDisperser =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosNorthDisperserEnumerated: Enumerated[GmosNorthDisperser] =
+    new Enumerated[GmosNorthDisperser] {
+      def all = GmosNorthDisperser.all
+      def tag(a: GmosNorthDisperser) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthFilter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthFilter.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Wavelength
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS North filters.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosNorthFilter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val wavelength: Wavelength,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GmosNorthFilter {
+
+  /** @group Constructors */ case object GPrime extends GmosNorthFilter("GPrime", "g", "g_G0301", Wavelength.fromAngstroms.unsafeGet(4750), false)
+  /** @group Constructors */ case object RPrime extends GmosNorthFilter("RPrime", "r", "r_G0303", Wavelength.fromAngstroms.unsafeGet(6300), false)
+  /** @group Constructors */ case object IPrime extends GmosNorthFilter("IPrime", "i", "i_G0302", Wavelength.fromAngstroms.unsafeGet(7800), false)
+  /** @group Constructors */ case object ZPrime extends GmosNorthFilter("ZPrime", "z", "z_G0304", Wavelength.fromAngstroms.unsafeGet(9250), false)
+  /** @group Constructors */ case object Z extends GmosNorthFilter("Z", "Z", "Z_G0322", Wavelength.fromAngstroms.unsafeGet(8760), false)
+  /** @group Constructors */ case object Y extends GmosNorthFilter("Y", "Y", "Y_G0323", Wavelength.fromAngstroms.unsafeGet(10100), false)
+  /** @group Constructors */ case object GG455 extends GmosNorthFilter("GG455", "GG455", "GG455_G0305", Wavelength.fromAngstroms.unsafeGet(6800), false)
+  /** @group Constructors */ case object OG515 extends GmosNorthFilter("OG515", "OG515", "OG515_G0306", Wavelength.fromAngstroms.unsafeGet(7100), false)
+  /** @group Constructors */ case object RG610 extends GmosNorthFilter("RG610", "RG610", "RG610_G0307", Wavelength.fromAngstroms.unsafeGet(7500), false)
+  /** @group Constructors */ case object CaT extends GmosNorthFilter("CaT", "CaT", "CaT_G0309", Wavelength.fromAngstroms.unsafeGet(8600), false)
+  /** @group Constructors */ case object Ha extends GmosNorthFilter("Ha", "Ha", "Ha_G0310", Wavelength.fromAngstroms.unsafeGet(6550), false)
+  /** @group Constructors */ case object HaC extends GmosNorthFilter("HaC", "HaC", "HaC_G0311", Wavelength.fromAngstroms.unsafeGet(6620), false)
+  /** @group Constructors */ case object DS920 extends GmosNorthFilter("DS920", "DS920", "DS920_G0312", Wavelength.fromAngstroms.unsafeGet(9200), false)
+  /** @group Constructors */ case object SII extends GmosNorthFilter("SII", "SII", "SII_G0317", Wavelength.fromAngstroms.unsafeGet(6720), false)
+  /** @group Constructors */ case object OIII extends GmosNorthFilter("OIII", "OIII", "OIII_G0318", Wavelength.fromAngstroms.unsafeGet(4990), false)
+  /** @group Constructors */ case object OIIIC extends GmosNorthFilter("OIIIC", "OIIIC", "OIIIC_G0319", Wavelength.fromAngstroms.unsafeGet(5140), false)
+  /** @group Constructors */ case object HeII extends GmosNorthFilter("HeII", "HeII", "HeII_G0320", Wavelength.fromAngstroms.unsafeGet(4680), false)
+  /** @group Constructors */ case object HeIIC extends GmosNorthFilter("HeIIC", "HeIIC", "HeIIC_G0321", Wavelength.fromAngstroms.unsafeGet(4780), false)
+  /** @group Constructors */ case object HartmannA_RPrime extends GmosNorthFilter("HartmannA_RPrime", "r+HartA", "HartmannA_G0313 + r_G0303", Wavelength.fromAngstroms.unsafeGet(6300), false)
+  /** @group Constructors */ case object HartmannB_RPrime extends GmosNorthFilter("HartmannB_RPrime", "r+HartB", "HartmannB_G0314 + r_G0303", Wavelength.fromAngstroms.unsafeGet(6300), false)
+  /** @group Constructors */ case object GPrime_GG455 extends GmosNorthFilter("GPrime_GG455", "g+GG455", "g_G0301 + GG455_G0305", Wavelength.fromAngstroms.unsafeGet(5060), false)
+  /** @group Constructors */ case object GPrime_OG515 extends GmosNorthFilter("GPrime_OG515", "g+OG515", "g_G0301 + OG515_G0306", Wavelength.fromAngstroms.unsafeGet(5360), false)
+  /** @group Constructors */ case object RPrime_RG610 extends GmosNorthFilter("RPrime_RG610", "r+RG610", "r_G0303 + RG610_G0307", Wavelength.fromAngstroms.unsafeGet(6570), false)
+  /** @group Constructors */ case object IPrime_CaT extends GmosNorthFilter("IPrime_CaT", "i+CaT", "i_G0302 + CaT_G0309", Wavelength.fromAngstroms.unsafeGet(8150), false)
+  /** @group Constructors */ case object ZPrime_CaT extends GmosNorthFilter("ZPrime_CaT", "z+CaT", "z_G0304 + CaT_G0309", Wavelength.fromAngstroms.unsafeGet(8900), false)
+  /** @group Constructors */ case object UPrime extends GmosNorthFilter("UPrime", "u", "u_G0308", Wavelength.fromAngstroms.unsafeGet(3500), true)
+
+  /** All members of GmosNorthFilter, in canonical order. */
+  val all: List[GmosNorthFilter] =
+    List(GPrime, RPrime, IPrime, ZPrime, Z, Y, GG455, OG515, RG610, CaT, Ha, HaC, DS920, SII, OIII, OIIIC, HeII, HeIIC, HartmannA_RPrime, HartmannB_RPrime, GPrime_GG455, GPrime_OG515, RPrime_RG610, IPrime_CaT, ZPrime_CaT, UPrime)
+
+  /** Select the member of GmosNorthFilter with the given tag, if any. */
+  def fromTag(s: String): Option[GmosNorthFilter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosNorthFilter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosNorthFilter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosNorthFilterEnumerated: Enumerated[GmosNorthFilter] =
+    new Enumerated[GmosNorthFilter] {
+      def all = GmosNorthFilter.all
+      def tag(a: GmosNorthFilter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthFpu.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthFpu.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Angle
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS North focal plane units.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosNorthFpu(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val slitWidth: Option[Angle]
+) extends Product with Serializable
+
+object GmosNorthFpu {
+
+  /** @group Constructors */ case object Ifu1 extends GmosNorthFpu("Ifu1", "IFU-2", "IFU 2 Slits", Option.empty[Angle])
+  /** @group Constructors */ case object Ifu2 extends GmosNorthFpu("Ifu2", "IFU-B", "IFU Left Slit (blue)", Option.empty[Angle])
+  /** @group Constructors */ case object Ifu3 extends GmosNorthFpu("Ifu3", "IFU-R", "IFU Right Slit (red)", Option.empty[Angle])
+  /** @group Constructors */ case object Ns0 extends GmosNorthFpu("Ns0", "NS0.25arcsec", "N and S 0.25 arcsec", Some(Angle.fromDoubleArcseconds(0.25)))
+  /** @group Constructors */ case object Ns1 extends GmosNorthFpu("Ns1", "NS0.5arcsec", "N and S 0.50 arcsec", Some(Angle.fromDoubleArcseconds(0.50)))
+  /** @group Constructors */ case object Ns2 extends GmosNorthFpu("Ns2", "NS0.75arcsec", "N and S 0.75 arcsec", Some(Angle.fromDoubleArcseconds(0.75)))
+  /** @group Constructors */ case object Ns3 extends GmosNorthFpu("Ns3", "NS1.0arcsec", "N and S 1.00 arcsec", Some(Angle.fromDoubleArcseconds(1.00)))
+  /** @group Constructors */ case object Ns4 extends GmosNorthFpu("Ns4", "NS1.5arcsec", "N and S 1.50 arcsec", Some(Angle.fromDoubleArcseconds(1.50)))
+  /** @group Constructors */ case object Ns5 extends GmosNorthFpu("Ns5", "NS2.0arcsec", "N and S 2.00 arcsec", Some(Angle.fromDoubleArcseconds(2.00)))
+  /** @group Constructors */ case object LongSlit_0_25 extends GmosNorthFpu("LongSlit_0_25", "0.25arcsec", "Longslit 0.25 arcsec", Some(Angle.fromDoubleArcseconds(0.25)))
+  /** @group Constructors */ case object LongSlit_0_50 extends GmosNorthFpu("LongSlit_0_50", "0.50arcsec", "Longslit 0.50 arcsec", Some(Angle.fromDoubleArcseconds(0.50)))
+  /** @group Constructors */ case object LongSlit_0_75 extends GmosNorthFpu("LongSlit_0_75", "0.75arcsec", "Longslit 0.75 arcsec", Some(Angle.fromDoubleArcseconds(0.75)))
+  /** @group Constructors */ case object LongSlit_1_00 extends GmosNorthFpu("LongSlit_1_00", "1.0arcsec", "Longslit 1.00 arcsec", Some(Angle.fromDoubleArcseconds(1.00)))
+  /** @group Constructors */ case object LongSlit_1_50 extends GmosNorthFpu("LongSlit_1_50", "1.5arcsec", "Longslit 1.50 arcsec", Some(Angle.fromDoubleArcseconds(1.50)))
+  /** @group Constructors */ case object LongSlit_2_00 extends GmosNorthFpu("LongSlit_2_00", "2.0arcsec", "Longslit 2.00 arcsec", Some(Angle.fromDoubleArcseconds(2.00)))
+  /** @group Constructors */ case object LongSlit_5_00 extends GmosNorthFpu("LongSlit_5_00", "5.0arcsec", "Longslit 5.00 arcsec", Some(Angle.fromDoubleArcseconds(5.00)))
+
+  /** All members of GmosNorthFpu, in canonical order. */
+  val all: List[GmosNorthFpu] =
+    List(Ifu1, Ifu2, Ifu3, Ns0, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00)
+
+  /** Select the member of GmosNorthFpu with the given tag, if any. */
+  def fromTag(s: String): Option[GmosNorthFpu] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosNorthFpu with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosNorthFpu =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosNorthFpuEnumerated: Enumerated[GmosNorthFpu] =
+    new Enumerated[GmosNorthFpu] {
+      def all = GmosNorthFpu.all
+      def tag(a: GmosNorthFpu) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosNorthStageMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosNorthStageMode.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS North stage modes.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosNorthStageMode(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GmosNorthStageMode {
+
+  /** @group Constructors */ case object NoFollow extends GmosNorthStageMode("NoFollow", "No Follow", "Do Not Follow", false)
+  /** @group Constructors */ case object FollowXyz extends GmosNorthStageMode("FollowXyz", "Follow XYZ", "Follow in XYZ(focus)", true)
+  /** @group Constructors */ case object FollowXy extends GmosNorthStageMode("FollowXy", "Follow XY", "Follow in XY", false)
+  /** @group Constructors */ case object FollowZ extends GmosNorthStageMode("FollowZ", "Follow Z", "Follow in Z Only", true)
+
+  /** All members of GmosNorthStageMode, in canonical order. */
+  val all: List[GmosNorthStageMode] =
+    List(NoFollow, FollowXyz, FollowXy, FollowZ)
+
+  /** Select the member of GmosNorthStageMode with the given tag, if any. */
+  def fromTag(s: String): Option[GmosNorthStageMode] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosNorthStageMode with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosNorthStageMode =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosNorthStageModeEnumerated: Enumerated[GmosNorthStageMode] =
+    new Enumerated[GmosNorthStageMode] {
+      def all = GmosNorthStageMode.all
+      def tag(a: GmosNorthStageMode) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosRoi.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosRoi.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS ROI (region of interest).
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosRoi(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GmosRoi {
+
+  /** @group Constructors */ case object FullFrame extends GmosRoi("FullFrame", "full", "Full Frame Readout", false)
+  /** @group Constructors */ case object Ccd2 extends GmosRoi("Ccd2", "ccd2", "CCD 2", false)
+  /** @group Constructors */ case object CentralSpectrum extends GmosRoi("CentralSpectrum", "cspec", "Central Spectrum", false)
+  /** @group Constructors */ case object CentralStamp extends GmosRoi("CentralStamp", "stamp", "Central Stamp", false)
+  /** @group Constructors */ case object TopSpectrum extends GmosRoi("TopSpectrum", "tspec", "Top Spectrum", true)
+  /** @group Constructors */ case object BottomSpectrum extends GmosRoi("BottomSpectrum", "bspec", "Bottom Spectrum", true)
+  /** @group Constructors */ case object Custom extends GmosRoi("Custom", "custom", "Custom ROI", false)
+
+  /** All members of GmosRoi, in canonical order. */
+  val all: List[GmosRoi] =
+    List(FullFrame, Ccd2, CentralSpectrum, CentralStamp, TopSpectrum, BottomSpectrum, Custom)
+
+  /** Select the member of GmosRoi with the given tag, if any. */
+  def fromTag(s: String): Option[GmosRoi] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosRoi with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosRoi =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosRoiEnumerated: Enumerated[GmosRoi] =
+    new Enumerated[GmosRoi] {
+      def all = GmosRoi.all
+      def tag(a: GmosRoi) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthDisperser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthDisperser.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS South dispersers.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosSouthDisperser(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val rulingDensity: Int,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GmosSouthDisperser {
+
+  /** @group Constructors */ case object B1200_G5321 extends GmosSouthDisperser("B1200_G5321", "B1200", "B1200_G5321", 1200, false)
+  /** @group Constructors */ case object R831_G5322 extends GmosSouthDisperser("R831_G5322", "R831", "R831_G5322", 831, false)
+  /** @group Constructors */ case object B600_G5323 extends GmosSouthDisperser("B600_G5323", "B600", "B600_G5323", 600, false)
+  /** @group Constructors */ case object R600_G5324 extends GmosSouthDisperser("R600_G5324", "R600", "R600_G5324", 600, false)
+  /** @group Constructors */ case object R400_G5325 extends GmosSouthDisperser("R400_G5325", "R400", "R400_G5325", 400, false)
+  /** @group Constructors */ case object R150_G5326 extends GmosSouthDisperser("R150_G5326", "R150", "R150_G5326", 150, false)
+
+  /** All members of GmosSouthDisperser, in canonical order. */
+  val all: List[GmosSouthDisperser] =
+    List(B1200_G5321, R831_G5322, B600_G5323, R600_G5324, R400_G5325, R150_G5326)
+
+  /** Select the member of GmosSouthDisperser with the given tag, if any. */
+  def fromTag(s: String): Option[GmosSouthDisperser] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosSouthDisperser with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosSouthDisperser =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosSouthDisperserEnumerated: Enumerated[GmosSouthDisperser] =
+    new Enumerated[GmosSouthDisperser] {
+      def all = GmosSouthDisperser.all
+      def tag(a: GmosSouthDisperser) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthFilter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthFilter.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Wavelength
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS South filters.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosSouthFilter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val wavelength: Wavelength,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GmosSouthFilter {
+
+  /** @group Constructors */ case object UPrime extends GmosSouthFilter("UPrime", "u", "u_G0332", Wavelength.fromAngstroms.unsafeGet(3500), false)
+  /** @group Constructors */ case object GPrime extends GmosSouthFilter("GPrime", "g", "g_G0325", Wavelength.fromAngstroms.unsafeGet(4750), false)
+  /** @group Constructors */ case object RPrime extends GmosSouthFilter("RPrime", "r", "r_G0326", Wavelength.fromAngstroms.unsafeGet(6300), false)
+  /** @group Constructors */ case object IPrime extends GmosSouthFilter("IPrime", "i", "i_G0327", Wavelength.fromAngstroms.unsafeGet(7800), false)
+  /** @group Constructors */ case object ZPrime extends GmosSouthFilter("ZPrime", "z", "z_G0328", Wavelength.fromAngstroms.unsafeGet(9250), false)
+  /** @group Constructors */ case object Z extends GmosSouthFilter("Z", "Z", "Z_G0343", Wavelength.fromAngstroms.unsafeGet(8760), false)
+  /** @group Constructors */ case object Y extends GmosSouthFilter("Y", "Y", "Y_G0344", Wavelength.fromAngstroms.unsafeGet(10100), false)
+  /** @group Constructors */ case object GG455 extends GmosSouthFilter("GG455", "GG455", "GG455_G0329", Wavelength.fromAngstroms.unsafeGet(6800), false)
+  /** @group Constructors */ case object OG515 extends GmosSouthFilter("OG515", "OG515", "OG515_G0330", Wavelength.fromAngstroms.unsafeGet(7100), false)
+  /** @group Constructors */ case object RG610 extends GmosSouthFilter("RG610", "RG610", "RG610_G0331", Wavelength.fromAngstroms.unsafeGet(7500), false)
+  /** @group Constructors */ case object RG780 extends GmosSouthFilter("RG780", "RG780", "RG780_G0334", Wavelength.fromAngstroms.unsafeGet(8500), false)
+  /** @group Constructors */ case object CaT extends GmosSouthFilter("CaT", "CaT", "CaT_G0333", Wavelength.fromAngstroms.unsafeGet(8600), false)
+  /** @group Constructors */ case object HartmannA_RPrime extends GmosSouthFilter("HartmannA_RPrime", "r+HartA", "HartmannA_G0337 + r_G0326", Wavelength.fromAngstroms.unsafeGet(6300), false)
+  /** @group Constructors */ case object HartmannB_RPrime extends GmosSouthFilter("HartmannB_RPrime", "r+HartB", "HartmannB_G0338 + r_G0326", Wavelength.fromAngstroms.unsafeGet(6300), false)
+  /** @group Constructors */ case object GPrime_GG455 extends GmosSouthFilter("GPrime_GG455", "g+GG455", "g_G0325 + GG455_G0329", Wavelength.fromAngstroms.unsafeGet(5060), false)
+  /** @group Constructors */ case object GPrime_OG515 extends GmosSouthFilter("GPrime_OG515", "g+OG515", "g_G0325 + OG515_G0330", Wavelength.fromAngstroms.unsafeGet(5360), false)
+  /** @group Constructors */ case object RPrime_RG610 extends GmosSouthFilter("RPrime_RG610", "r+RG610", "r_G0326 + RG610_G0331", Wavelength.fromAngstroms.unsafeGet(6570), false)
+  /** @group Constructors */ case object IPrime_RG780 extends GmosSouthFilter("IPrime_RG780", "i+RG780", "i_G0327 + RG780_G0334", Wavelength.fromAngstroms.unsafeGet(8190), false)
+  /** @group Constructors */ case object IPrime_CaT extends GmosSouthFilter("IPrime_CaT", "i+CaT", "i_G0327 + CaT_G0333", Wavelength.fromAngstroms.unsafeGet(8150), false)
+  /** @group Constructors */ case object ZPrime_CaT extends GmosSouthFilter("ZPrime_CaT", "z+Cat", "z_G0328 + CaT_G0333", Wavelength.fromAngstroms.unsafeGet(8900), false)
+  /** @group Constructors */ case object Ha extends GmosSouthFilter("Ha", "Ha", "Ha_G0336", Wavelength.fromAngstroms.unsafeGet(6560), false)
+  /** @group Constructors */ case object SII extends GmosSouthFilter("SII", "SII", "SII_G0335", Wavelength.fromAngstroms.unsafeGet(6720), false)
+  /** @group Constructors */ case object HaC extends GmosSouthFilter("HaC", "HaC", "HaC_G0337", Wavelength.fromAngstroms.unsafeGet(6620), false)
+  /** @group Constructors */ case object OIII extends GmosSouthFilter("OIII", "OIII", "OIII_G0338", Wavelength.fromAngstroms.unsafeGet(4990), false)
+  /** @group Constructors */ case object OIIIC extends GmosSouthFilter("OIIIC", "OIIIC", "OIIIC_G0339", Wavelength.fromAngstroms.unsafeGet(5140), false)
+  /** @group Constructors */ case object HeII extends GmosSouthFilter("HeII", "HeII", "HeII_G0340", Wavelength.fromAngstroms.unsafeGet(4680), false)
+  /** @group Constructors */ case object HeIIC extends GmosSouthFilter("HeIIC", "HeIIC", "HeIIC_G0341", Wavelength.fromAngstroms.unsafeGet(4780), false)
+  /** @group Constructors */ case object Lya395 extends GmosSouthFilter("Lya395", "Lya395", "Lya395_G0342", Wavelength.fromAngstroms.unsafeGet(3960), false)
+
+  /** All members of GmosSouthFilter, in canonical order. */
+  val all: List[GmosSouthFilter] =
+    List(UPrime, GPrime, RPrime, IPrime, ZPrime, Z, Y, GG455, OG515, RG610, RG780, CaT, HartmannA_RPrime, HartmannB_RPrime, GPrime_GG455, GPrime_OG515, RPrime_RG610, IPrime_RG780, IPrime_CaT, ZPrime_CaT, Ha, SII, HaC, OIII, OIIIC, HeII, HeIIC, Lya395)
+
+  /** Select the member of GmosSouthFilter with the given tag, if any. */
+  def fromTag(s: String): Option[GmosSouthFilter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosSouthFilter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosSouthFilter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosSouthFilterEnumerated: Enumerated[GmosSouthFilter] =
+    new Enumerated[GmosSouthFilter] {
+      def all = GmosSouthFilter.all
+      def tag(a: GmosSouthFilter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthFpu.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthFpu.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Angle
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS South focal plane units.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosSouthFpu(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val slitWidth: Option[Angle]
+) extends Product with Serializable
+
+object GmosSouthFpu {
+
+  /** @group Constructors */ case object Ifu1 extends GmosSouthFpu("Ifu1", "IFU-2", "IFU 2 Slits", Option.empty[Angle])
+  /** @group Constructors */ case object Ifu2 extends GmosSouthFpu("Ifu2", "IFU-B", "IFU Left Slit (blue)", Option.empty[Angle])
+  /** @group Constructors */ case object Ifu3 extends GmosSouthFpu("Ifu3", "IFU-R", "IFU Right Slit (red)", Option.empty[Angle])
+  /** @group Constructors */ case object Bhros extends GmosSouthFpu("Bhros", "bHROS", "bHROS", Option.empty[Angle])
+  /** @group Constructors */ case object IfuN extends GmosSouthFpu("IfuN", "IFU-NS-2", "IFU N and S 2 Slits", Option.empty[Angle])
+  /** @group Constructors */ case object IfuNB extends GmosSouthFpu("IfuNB", "IFU-NS-B", "IFU N and S Left Slit (blue)", Option.empty[Angle])
+  /** @group Constructors */ case object IfuNR extends GmosSouthFpu("IfuNR", "IFU-NS-R", "IFU N and S Right Slit (red)", Option.empty[Angle])
+  /** @group Constructors */ case object Ns1 extends GmosSouthFpu("Ns1", "NS0.5arcsec", "N and S 0.50 arcsec", Some(Angle.fromDoubleArcseconds(0.50)))
+  /** @group Constructors */ case object Ns2 extends GmosSouthFpu("Ns2", "NS0.75arcsec", "N and S 0.75 arcsec", Some(Angle.fromDoubleArcseconds(0.75)))
+  /** @group Constructors */ case object Ns3 extends GmosSouthFpu("Ns3", "NS1.0arcsec", "N and S 1.00 arcsec", Some(Angle.fromDoubleArcseconds(1.00)))
+  /** @group Constructors */ case object Ns4 extends GmosSouthFpu("Ns4", "NS1.5arcsec", "N and S 1.50 arcsec", Some(Angle.fromDoubleArcseconds(1.50)))
+  /** @group Constructors */ case object Ns5 extends GmosSouthFpu("Ns5", "NS2.0arcsec", "N and S 2.00 arcsec", Some(Angle.fromDoubleArcseconds(2.00)))
+  /** @group Constructors */ case object LongSlit_0_25 extends GmosSouthFpu("LongSlit_0_25", "0.25arcsec", "Longslit 0.25 arcsec", Some(Angle.fromDoubleArcseconds(0.25)))
+  /** @group Constructors */ case object LongSlit_0_50 extends GmosSouthFpu("LongSlit_0_50", "0.50arcsec", "Longslit 0.50 arcsec", Some(Angle.fromDoubleArcseconds(0.50)))
+  /** @group Constructors */ case object LongSlit_0_75 extends GmosSouthFpu("LongSlit_0_75", "0.75arcsec", "Longslit 0.75 arcsec", Some(Angle.fromDoubleArcseconds(0.75)))
+  /** @group Constructors */ case object LongSlit_1_00 extends GmosSouthFpu("LongSlit_1_00", "1.0arcsec", "Longslit 1.00 arcsec", Some(Angle.fromDoubleArcseconds(1.00)))
+  /** @group Constructors */ case object LongSlit_1_50 extends GmosSouthFpu("LongSlit_1_50", "1.5arcsec", "Longslit 1.50 arcsec", Some(Angle.fromDoubleArcseconds(1.50)))
+  /** @group Constructors */ case object LongSlit_2_00 extends GmosSouthFpu("LongSlit_2_00", "2.0arcsec", "Longslit 2.00 arcsec", Some(Angle.fromDoubleArcseconds(2.00)))
+  /** @group Constructors */ case object LongSlit_5_00 extends GmosSouthFpu("LongSlit_5_00", "5.0arcsec", "Longslit 5.00 arcsec", Some(Angle.fromDoubleArcseconds(5.00)))
+
+  /** All members of GmosSouthFpu, in canonical order. */
+  val all: List[GmosSouthFpu] =
+    List(Ifu1, Ifu2, Ifu3, Bhros, IfuN, IfuNB, IfuNR, Ns1, Ns2, Ns3, Ns4, Ns5, LongSlit_0_25, LongSlit_0_50, LongSlit_0_75, LongSlit_1_00, LongSlit_1_50, LongSlit_2_00, LongSlit_5_00)
+
+  /** Select the member of GmosSouthFpu with the given tag, if any. */
+  def fromTag(s: String): Option[GmosSouthFpu] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosSouthFpu with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosSouthFpu =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosSouthFpuEnumerated: Enumerated[GmosSouthFpu] =
+    new Enumerated[GmosSouthFpu] {
+      def all = GmosSouthFpu.all
+      def tag(a: GmosSouthFpu) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosSouthStageMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosSouthStageMode.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS South stage mode.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosSouthStageMode(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GmosSouthStageMode {
+
+  /** @group Constructors */ case object NoFollow extends GmosSouthStageMode("NoFollow", "No Follow", "Do Not Follow", false)
+  /** @group Constructors */ case object FollowXyz extends GmosSouthStageMode("FollowXyz", "Follow XYZ", "Follow in XYZ(focus)", false)
+  /** @group Constructors */ case object FollowXy extends GmosSouthStageMode("FollowXy", "Follow XY", "Follow in XY", true)
+  /** @group Constructors */ case object FollowZ extends GmosSouthStageMode("FollowZ", "Follow Z", "Follow in Z Only", false)
+
+  /** All members of GmosSouthStageMode, in canonical order. */
+  val all: List[GmosSouthStageMode] =
+    List(NoFollow, FollowXyz, FollowXy, FollowZ)
+
+  /** Select the member of GmosSouthStageMode with the given tag, if any. */
+  def fromTag(s: String): Option[GmosSouthStageMode] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosSouthStageMode with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosSouthStageMode =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosSouthStageModeEnumerated: Enumerated[GmosSouthStageMode] =
+    new Enumerated[GmosSouthStageMode] {
+      def all = GmosSouthStageMode.all
+      def tag(a: GmosSouthStageMode) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosXBinning.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosXBinning.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS X-binning.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosXBinning(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val count: Int
+) extends Product with Serializable
+
+object GmosXBinning {
+
+  /** @group Constructors */ case object One extends GmosXBinning("One", "1", "One", 1)
+  /** @group Constructors */ case object Two extends GmosXBinning("Two", "2", "Two", 2)
+  /** @group Constructors */ case object Four extends GmosXBinning("Four", "4", "Four", 4)
+
+  /** All members of GmosXBinning, in canonical order. */
+  val all: List[GmosXBinning] =
+    List(One, Two, Four)
+
+  /** Select the member of GmosXBinning with the given tag, if any. */
+  def fromTag(s: String): Option[GmosXBinning] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosXBinning with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosXBinning =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosXBinningEnumerated: Enumerated[GmosXBinning] =
+    new Enumerated[GmosXBinning] {
+      def all = GmosXBinning.all
+      def tag(a: GmosXBinning) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GmosYBinning.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GmosYBinning.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GMOS Y-binning.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GmosYBinning(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val count: Int
+) extends Product with Serializable
+
+object GmosYBinning {
+
+  /** @group Constructors */ case object One extends GmosYBinning("One", "1", "One", 1)
+  /** @group Constructors */ case object Two extends GmosYBinning("Two", "2", "Two", 2)
+  /** @group Constructors */ case object Four extends GmosYBinning("Four", "4", "Four", 4)
+
+  /** All members of GmosYBinning, in canonical order. */
+  val all: List[GmosYBinning] =
+    List(One, Two, Four)
+
+  /** Select the member of GmosYBinning with the given tag, if any. */
+  def fromTag(s: String): Option[GmosYBinning] =
+    all.find(_.tag === s)
+
+  /** Select the member of GmosYBinning with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GmosYBinning =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GmosYBinningEnumerated: Enumerated[GmosYBinning] =
+    new Enumerated[GmosYBinning] {
+      def all = GmosYBinning.all
+      def tag(a: GmosYBinning) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsAcquisitionMirror.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsAcquisitionMirror.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Acquisition Mirror.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsAcquisitionMirror(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object GnirsAcquisitionMirror {
+
+  /** @group Constructors */ case object In extends GnirsAcquisitionMirror("In", "In", "In")
+  /** @group Constructors */ case object Out extends GnirsAcquisitionMirror("Out", "Out", "Out")
+
+  /** All members of GnirsAcquisitionMirror, in canonical order. */
+  val all: List[GnirsAcquisitionMirror] =
+    List(In, Out)
+
+  /** Select the member of GnirsAcquisitionMirror with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsAcquisitionMirror] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsAcquisitionMirror with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsAcquisitionMirror =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsAcquisitionMirrorEnumerated: Enumerated[GnirsAcquisitionMirror] =
+    new Enumerated[GnirsAcquisitionMirror] {
+      def all = GnirsAcquisitionMirror.all
+      def tag(a: GnirsAcquisitionMirror) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsCamera.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsCamera.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Camera.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsCamera(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val pixelScale: GnirsPixelScale
+) extends Product with Serializable
+
+object GnirsCamera {
+
+  /** @group Constructors */ case object LongBlue extends GnirsCamera("LongBlue", "Long blue", "Long blue camera", GnirsPixelScale.PixelScale_0_05)
+  /** @group Constructors */ case object LongRed extends GnirsCamera("LongRed", "Long red", "Long red camera", GnirsPixelScale.PixelScale_0_05)
+  /** @group Constructors */ case object ShortBlue extends GnirsCamera("ShortBlue", "Short blue", "Short blue camera", GnirsPixelScale.PixelScale_0_15)
+  /** @group Constructors */ case object ShortRed extends GnirsCamera("ShortRed", "Short red", "Short red camera", GnirsPixelScale.PixelScale_0_15)
+
+  /** All members of GnirsCamera, in canonical order. */
+  val all: List[GnirsCamera] =
+    List(LongBlue, LongRed, ShortBlue, ShortRed)
+
+  /** Select the member of GnirsCamera with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsCamera] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsCamera with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsCamera =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsCameraEnumerated: Enumerated[GnirsCamera] =
+    new Enumerated[GnirsCamera] {
+      def all = GnirsCamera.all
+      def tag(a: GnirsCamera) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsDecker.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsDecker.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNRIS Decker.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsDecker(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GnirsDecker {
+
+  /** @group Constructors */ case object Acquisition extends GnirsDecker("Acquisition", "Acquisition", "Acquisition", false)
+  /** @group Constructors */ case object PupilViewer extends GnirsDecker("PupilViewer", "Pupil", "Pupil viewer", false)
+  /** @group Constructors */ case object ShortCamCrossDispersed extends GnirsDecker("ShortCamCrossDispersed", "Short camera XD", "Short camera cross dispersed", false)
+  /** @group Constructors */ case object Ifu extends GnirsDecker("Ifu", "IFU", "Integral field unit", true)
+  /** @group Constructors */ case object LongCamLongSlit extends GnirsDecker("LongCamLongSlit", "Long camera slit", "Long camera long slit", false)
+  /** @group Constructors */ case object Wollaston extends GnirsDecker("Wollaston", "Wollaston", "Wollaston", true)
+  /** @group Constructors */ case object ShortCamLongSlit extends GnirsDecker("ShortCamLongSlit", "Short camera slit", "Short camera long slit", false)
+  /** @group Constructors */ case object LongCamCrossDispersed extends GnirsDecker("LongCamCrossDispersed", "Long camera XD", "Long camera cross dispersed", false)
+
+  /** All members of GnirsDecker, in canonical order. */
+  val all: List[GnirsDecker] =
+    List(Acquisition, PupilViewer, ShortCamCrossDispersed, Ifu, LongCamLongSlit, Wollaston, ShortCamLongSlit, LongCamCrossDispersed)
+
+  /** Select the member of GnirsDecker with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsDecker] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsDecker with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsDecker =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsDeckerEnumerated: Enumerated[GnirsDecker] =
+    new Enumerated[GnirsDecker] {
+      def all = GnirsDecker.all
+      def tag(a: GnirsDecker) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsDisperser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsDisperser.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Disperser.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsDisperser(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val rulingDensity: Int
+) extends Product with Serializable
+
+object GnirsDisperser {
+
+  /** @group Constructors */ case object D10 extends GnirsDisperser("D10", "10", "10 l/mm grating", 10)
+  /** @group Constructors */ case object D32 extends GnirsDisperser("D32", "32", "32 l/mm grating", 32)
+  /** @group Constructors */ case object D111 extends GnirsDisperser("D111", "111", "111 l/mm grating", 111)
+
+  /** All members of GnirsDisperser, in canonical order. */
+  val all: List[GnirsDisperser] =
+    List(D10, D32, D111)
+
+  /** Select the member of GnirsDisperser with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsDisperser] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsDisperser with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsDisperser =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsDisperserEnumerated: Enumerated[GnirsDisperser] =
+    new Enumerated[GnirsDisperser] {
+      def all = GnirsDisperser.all
+      def tag(a: GnirsDisperser) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsDisperserOrder.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsDisperserOrder.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Wavelength
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Disperser Order.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsDisperserOrder(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val count: Int,
+  val defaultWavelength: Wavelength,
+  val minWavelength: Wavelength,
+  val maxWavelength: Wavelength,
+  val deltaWavelength: Wavelength,
+  val band: Option[MagnitudeBand],
+  val cross_dispersed: Boolean
+) extends Product with Serializable
+
+object GnirsDisperserOrder {
+
+  /** @group Constructors */ case object One extends GnirsDisperserOrder("One", "1", "One", 1, Wavelength.fromAngstroms.unsafeGet(48500), Wavelength.fromAngstroms.unsafeGet(43000), Wavelength.fromAngstroms.unsafeGet(60000), Wavelength.fromAngstroms.unsafeGet(0), Some(MagnitudeBand.M), false)
+  /** @group Constructors */ case object Two extends GnirsDisperserOrder("Two", "2", "Two", 2, Wavelength.fromAngstroms.unsafeGet(34000), Wavelength.fromAngstroms.unsafeGet(27000), Wavelength.fromAngstroms.unsafeGet(43000), Wavelength.fromAngstroms.unsafeGet(0), Some(MagnitudeBand.L), false)
+  /** @group Constructors */ case object Three extends GnirsDisperserOrder("Three", "3", "Three", 3, Wavelength.fromAngstroms.unsafeGet(22200), Wavelength.fromAngstroms.unsafeGet(18600), Wavelength.fromAngstroms.unsafeGet(27000), Wavelength.fromAngstroms.unsafeGet(6), Some(MagnitudeBand.K), true)
+  /** @group Constructors */ case object FourXD extends GnirsDisperserOrder("FourXD", "4XD", "FourXD", 4, Wavelength.fromAngstroms.unsafeGet(16500), Wavelength.fromAngstroms.unsafeGet(14200), Wavelength.fromAngstroms.unsafeGet(18600), Wavelength.fromAngstroms.unsafeGet(5), Some(MagnitudeBand.H), true)
+  /** @group Constructors */ case object Four extends GnirsDisperserOrder("Four", "4", "Four", 4, Wavelength.fromAngstroms.unsafeGet(16300), Wavelength.fromAngstroms.unsafeGet(14200), Wavelength.fromAngstroms.unsafeGet(18600), Wavelength.fromAngstroms.unsafeGet(5), Some(MagnitudeBand.H), true)
+  /** @group Constructors */ case object Five extends GnirsDisperserOrder("Five", "5", "Five", 5, Wavelength.fromAngstroms.unsafeGet(12500), Wavelength.fromAngstroms.unsafeGet(11700), Wavelength.fromAngstroms.unsafeGet(14200), Wavelength.fromAngstroms.unsafeGet(4), Some(MagnitudeBand.J), true)
+  /** @group Constructors */ case object Six extends GnirsDisperserOrder("Six", "6", "Six", 6, Wavelength.fromAngstroms.unsafeGet(11000), Wavelength.fromAngstroms.unsafeGet(10300), Wavelength.fromAngstroms.unsafeGet(11700), Wavelength.fromAngstroms.unsafeGet(3), None, true)
+  /** @group Constructors */ case object Seven extends GnirsDisperserOrder("Seven", "7", "Seven", 7, Wavelength.fromAngstroms.unsafeGet(9510), Wavelength.fromAngstroms.unsafeGet(8800), Wavelength.fromAngstroms.unsafeGet(10300), Wavelength.fromAngstroms.unsafeGet(3), None, true)
+  /** @group Constructors */ case object Eight extends GnirsDisperserOrder("Eight", "8", "Eight", 8, Wavelength.fromAngstroms.unsafeGet(8320), Wavelength.fromAngstroms.unsafeGet(7800), Wavelength.fromAngstroms.unsafeGet(8800), Wavelength.fromAngstroms.unsafeGet(2), None, true)
+
+  /** All members of GnirsDisperserOrder, in canonical order. */
+  val all: List[GnirsDisperserOrder] =
+    List(One, Two, Three, FourXD, Four, Five, Six, Seven, Eight)
+
+  /** Select the member of GnirsDisperserOrder with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsDisperserOrder] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsDisperserOrder with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsDisperserOrder =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsDisperserOrderEnumerated: Enumerated[GnirsDisperserOrder] =
+    new Enumerated[GnirsDisperserOrder] {
+      def all = GnirsDisperserOrder.all
+      def tag(a: GnirsDisperserOrder) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsFilter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsFilter.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Wavelength
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Filter.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsFilter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val waveLength: Option[Wavelength]
+) extends Product with Serializable
+
+object GnirsFilter {
+
+  /** @group Constructors */ case object CrossDispersed extends GnirsFilter("CrossDispersed", "XD", "Cross dispersed", Option.empty[Wavelength])
+  /** @group Constructors */ case object Order6 extends GnirsFilter("Order6", "X", "Order 6 (X)", Some(Wavelength.fromAngstroms.unsafeGet(11000)))
+  /** @group Constructors */ case object Order5 extends GnirsFilter("Order5", "J", "Order 5 (J)", Some(Wavelength.fromAngstroms.unsafeGet(12500)))
+  /** @group Constructors */ case object Order4 extends GnirsFilter("Order4", "H", "Order 4 (H: 1.65µm)", Some(Wavelength.fromAngstroms.unsafeGet(16500)))
+  /** @group Constructors */ case object Order3 extends GnirsFilter("Order3", "K", "Order 3 (K)", Some(Wavelength.fromAngstroms.unsafeGet(22000)))
+  /** @group Constructors */ case object Order2 extends GnirsFilter("Order2", "L", "Order 2 (L)", Some(Wavelength.fromAngstroms.unsafeGet(35000)))
+  /** @group Constructors */ case object Order1 extends GnirsFilter("Order1", "M", "Order 1 (M)", Some(Wavelength.fromAngstroms.unsafeGet(48000)))
+  /** @group Constructors */ case object H2 extends GnirsFilter("H2", "H2", "H2: 2.12µm", Some(Wavelength.fromAngstroms.unsafeGet(21200)))
+  /** @group Constructors */ case object HNd100x extends GnirsFilter("HNd100x", "H+ND100X", "H + ND100X", Some(Wavelength.fromAngstroms.unsafeGet(16500)))
+  /** @group Constructors */ case object H2Nd100x extends GnirsFilter("H2Nd100x", "H2+ND100X", "H2 + ND100X", Some(Wavelength.fromAngstroms.unsafeGet(21200)))
+  /** @group Constructors */ case object PAH extends GnirsFilter("PAH", "PAH", "PAH: 3.3µm", Some(Wavelength.fromAngstroms.unsafeGet(33000)))
+  /** @group Constructors */ case object Y extends GnirsFilter("Y", "Y", "Y: 1.03µm", Some(Wavelength.fromAngstroms.unsafeGet(10300)))
+  /** @group Constructors */ case object J extends GnirsFilter("J", "J", "J: 1.25µm", Some(Wavelength.fromAngstroms.unsafeGet(12500)))
+  /** @group Constructors */ case object K extends GnirsFilter("K", "K", "K: 2.20µm", Some(Wavelength.fromAngstroms.unsafeGet(22000)))
+
+  /** All members of GnirsFilter, in canonical order. */
+  val all: List[GnirsFilter] =
+    List(CrossDispersed, Order6, Order5, Order4, Order3, Order2, Order1, H2, HNd100x, H2Nd100x, PAH, Y, J, K)
+
+  /** Select the member of GnirsFilter with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsFilter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsFilter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsFilter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsFilterEnumerated: Enumerated[GnirsFilter] =
+    new Enumerated[GnirsFilter] {
+      def all = GnirsFilter.all
+      def tag(a: GnirsFilter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsFpuOther.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsFpuOther.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS FPU Other.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsFpuOther(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GnirsFpuOther {
+
+  /** @group Constructors */ case object Ifu extends GnirsFpuOther("Ifu", "IFU", "Integral Field Unit", true)
+  /** @group Constructors */ case object Acquisition extends GnirsFpuOther("Acquisition", "Acquisition", "Acquisition", false)
+  /** @group Constructors */ case object PupilViewer extends GnirsFpuOther("PupilViewer", "Pupil", "Pupil viewer", false)
+  /** @group Constructors */ case object Pinhole1 extends GnirsFpuOther("Pinhole1", "Small pin", "pinhole 0.1", false)
+  /** @group Constructors */ case object Pinhole3 extends GnirsFpuOther("Pinhole3", "Large pin", "pinhole 0.3", false)
+
+  /** All members of GnirsFpuOther, in canonical order. */
+  val all: List[GnirsFpuOther] =
+    List(Ifu, Acquisition, PupilViewer, Pinhole1, Pinhole3)
+
+  /** Select the member of GnirsFpuOther with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsFpuOther] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsFpuOther with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsFpuOther =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsFpuOtherEnumerated: Enumerated[GnirsFpuOther] =
+    new Enumerated[GnirsFpuOther] {
+      def all = GnirsFpuOther.all
+      def tag(a: GnirsFpuOther) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsFpuSlit.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsFpuSlit.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Angle
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS FPU Slit.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsFpuSlit(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val slitWidth: Angle,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GnirsFpuSlit {
+
+  /** @group Constructors */ case object LongSlit_0_10 extends GnirsFpuSlit("LongSlit_0_10", "0.10 arcsec", "0.10 arcsec", Angle.fromDoubleArcseconds(0.100), false)
+  /** @group Constructors */ case object LongSlit_0_15 extends GnirsFpuSlit("LongSlit_0_15", "0.15 arcsec", "0.15 arcsec", Angle.fromDoubleArcseconds(0.150), false)
+  /** @group Constructors */ case object LongSlit_0_20 extends GnirsFpuSlit("LongSlit_0_20", "0.20 arcsec", "0.20 arcsec", Angle.fromDoubleArcseconds(0.200), false)
+  /** @group Constructors */ case object LongSlit_0_30 extends GnirsFpuSlit("LongSlit_0_30", "0.30 arcsec", "0.30 arcsec", Angle.fromDoubleArcseconds(0.300), false)
+  /** @group Constructors */ case object LongSlit_0_45 extends GnirsFpuSlit("LongSlit_0_45", "0.45 arcsec", "0.45 arcsec", Angle.fromDoubleArcseconds(0.450), false)
+  /** @group Constructors */ case object LongSlit_0_675 extends GnirsFpuSlit("LongSlit_0_675", "0.675 arcsec", "0.675 arcsec", Angle.fromDoubleArcseconds(0.675), false)
+  /** @group Constructors */ case object LongSlit_1_00 extends GnirsFpuSlit("LongSlit_1_00", "1.0 arcsec", "1.0 arcsec", Angle.fromDoubleArcseconds(1.000), false)
+  /** @group Constructors */ case object LongSlit_3_00 extends GnirsFpuSlit("LongSlit_3_00", "3.0 arcsec", "3.0 arcsec", Angle.fromDoubleArcseconds(3.000), true)
+
+  /** All members of GnirsFpuSlit, in canonical order. */
+  val all: List[GnirsFpuSlit] =
+    List(LongSlit_0_10, LongSlit_0_15, LongSlit_0_20, LongSlit_0_30, LongSlit_0_45, LongSlit_0_675, LongSlit_1_00, LongSlit_3_00)
+
+  /** Select the member of GnirsFpuSlit with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsFpuSlit] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsFpuSlit with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsFpuSlit =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsFpuSlitEnumerated: Enumerated[GnirsFpuSlit] =
+    new Enumerated[GnirsFpuSlit] {
+      def all = GnirsFpuSlit.all
+      def tag(a: GnirsFpuSlit) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsPixelScale.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsPixelScale.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Pixel Scale.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsPixelScale(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: BigDecimal
+) extends Product with Serializable
+
+object GnirsPixelScale {
+
+  /** @group Constructors */ case object PixelScale_0_05 extends GnirsPixelScale("PixelScale_0_05", "0.05 as/pix", "Pixel scale for short cameras", 0.05)
+  /** @group Constructors */ case object PixelScale_0_15 extends GnirsPixelScale("PixelScale_0_15", "0.15 as/pix", "Pixel scale for long cameras", 0.15)
+
+  /** All members of GnirsPixelScale, in canonical order. */
+  val all: List[GnirsPixelScale] =
+    List(PixelScale_0_05, PixelScale_0_15)
+
+  /** Select the member of GnirsPixelScale with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsPixelScale] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsPixelScale with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsPixelScale =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsPixelScaleEnumerated: Enumerated[GnirsPixelScale] =
+    new Enumerated[GnirsPixelScale] {
+      def all = GnirsPixelScale.all
+      def tag(a: GnirsPixelScale) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsPrism.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsPrism.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Prism Turret.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsPrism(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable {
+  type Self = this.type
+}
+
+object GnirsPrism {
+
+  type Aux[A] = GnirsPrism { type Self = A }
+
+  /** @group Constructors */ case object Mirror extends GnirsPrism("Mirror", "Mirror", "Mirror")
+  /** @group Constructors */ case object Sxd extends GnirsPrism("Sxd", "Short XD", "Short cross dispersion")
+  /** @group Constructors */ case object Lxd extends GnirsPrism("Lxd", "Long XD", "Long cross dispersion")
+
+  /** All members of GnirsPrism, in canonical order. */
+  val all: List[GnirsPrism] =
+    List(Mirror, Sxd, Lxd)
+
+  /** Select the member of GnirsPrism with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsPrism] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsPrism with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsPrism =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsPrismEnumerated: Enumerated[GnirsPrism] =
+    new Enumerated[GnirsPrism] {
+      def all = GnirsPrism.all
+      def tag(a: GnirsPrism) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsReadMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsReadMode.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNIRS Read Mode.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsReadMode(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val count: Int,
+  val minimumExposureTime: Int,
+  val readNoise: Int,
+  val readNoiseLow: Int
+) extends Product with Serializable {
+  type Self = this.type
+}
+
+object GnirsReadMode {
+
+  type Aux[A] = GnirsReadMode { type Self = A }
+
+  /** @group Constructors */ case object VeryBright extends GnirsReadMode("VeryBright", "Very bright", "Very Bright Acquisition or High Background", 200, 1, 155, 1)
+  /** @group Constructors */ case object Bright extends GnirsReadMode("Bright", "Bright", "Bright objects", 600, 2, 30, 1)
+  /** @group Constructors */ case object Faint extends GnirsReadMode("Faint", "Faint", "Faint objects", 3, 9000, 10, 16)
+  /** @group Constructors */ case object VeryFaint extends GnirsReadMode("VeryFaint", "Very faint", "Very faint objects", 18000, 4, 7, 32)
+
+  /** All members of GnirsReadMode, in canonical order. */
+  val all: List[GnirsReadMode] =
+    List(VeryBright, Bright, Faint, VeryFaint)
+
+  /** Select the member of GnirsReadMode with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsReadMode] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsReadMode with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsReadMode =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsReadModeEnumerated: Enumerated[GnirsReadMode] =
+    new Enumerated[GnirsReadMode] {
+      def all = GnirsReadMode.all
+      def tag(a: GnirsReadMode) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GnirsWellDepth.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GnirsWellDepth.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GNRIS Well Depth.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GnirsWellDepth(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val bias_level: Int
+) extends Product with Serializable
+
+object GnirsWellDepth {
+
+  /** @group Constructors */ case object Shallow extends GnirsWellDepth("Shallow", "Shallow", "Shallow", 300)
+  /** @group Constructors */ case object Deep extends GnirsWellDepth("Deep", "Deep", "Deep", 600)
+
+  /** All members of GnirsWellDepth, in canonical order. */
+  val all: List[GnirsWellDepth] =
+    List(Shallow, Deep)
+
+  /** Select the member of GnirsWellDepth with the given tag, if any. */
+  def fromTag(s: String): Option[GnirsWellDepth] =
+    all.find(_.tag === s)
+
+  /** Select the member of GnirsWellDepth with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GnirsWellDepth =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GnirsWellDepthEnumerated: Enumerated[GnirsWellDepth] =
+    new Enumerated[GnirsWellDepth] {
+      def all = GnirsWellDepth.all
+      def tag(a: GnirsWellDepth) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiASU.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiASU.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Artificial Source Unit.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiASU(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: Boolean
+) extends Product with Serializable
+
+object GpiASU {
+
+  /** @group Constructors */ case object On extends GpiASU("On", "On", "On", true)
+  /** @group Constructors */ case object Off extends GpiASU("Off", "Off", "Off", false)
+
+  /** All members of GpiASU, in canonical order. */
+  val all: List[GpiASU] =
+    List(On, Off)
+
+  /** Select the member of GpiASU with the given tag, if any. */
+  def fromTag(s: String): Option[GpiASU] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiASU with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiASU =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiASUEnumerated: Enumerated[GpiASU] =
+    new Enumerated[GpiASU] {
+      def all = GpiASU.all
+      def tag(a: GpiASU) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiAdc.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiAdc.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI ADC.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiAdc(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: Boolean
+) extends Product with Serializable
+
+object GpiAdc {
+
+  /** @group Constructors */ case object In extends GpiAdc("In", "In", "In", true)
+  /** @group Constructors */ case object Out extends GpiAdc("Out", "Out", "Out", false)
+
+  /** All members of GpiAdc, in canonical order. */
+  val all: List[GpiAdc] =
+    List(In, Out)
+
+  /** Select the member of GpiAdc with the given tag, if any. */
+  def fromTag(s: String): Option[GpiAdc] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiAdc with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiAdc =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiAdcEnumerated: Enumerated[GpiAdc] =
+    new Enumerated[GpiAdc] {
+      def all = GpiAdc.all
+      def tag(a: GpiAdc) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiApodizer.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiApodizer.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Apodizer.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiApodizer(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GpiApodizer {
+
+  /** @group Constructors */ case object CLEAR extends GpiApodizer("CLEAR", "Clear", "Clear", false)
+  /** @group Constructors */ case object CLEARGP extends GpiApodizer("CLEARGP", "CLEAR GP", "CLEAR GP", false)
+  /** @group Constructors */ case object APOD_Y extends GpiApodizer("APOD_Y", "APOD_Y_56", "APOD_Y_56", false)
+  /** @group Constructors */ case object APOD_J extends GpiApodizer("APOD_J", "APOD_J_56", "APOD_J_56", false)
+  /** @group Constructors */ case object APOD_H extends GpiApodizer("APOD_H", "APOD_H_56", "APOD_H_56", false)
+  /** @group Constructors */ case object APOD_K1 extends GpiApodizer("APOD_K1", "APOD_K1_56", "APOD_K1_56", false)
+  /** @group Constructors */ case object APOD_K2 extends GpiApodizer("APOD_K2", "APOD_K2_56", "APOD_K2_56", false)
+  /** @group Constructors */ case object NRM extends GpiApodizer("NRM", "NRM", "NRM", false)
+  /** @group Constructors */ case object APOD_HL extends GpiApodizer("APOD_HL", "APOD_HL", "APOD_HL", false)
+  /** @group Constructors */ case object APOD_STAR extends GpiApodizer("APOD_STAR", "APOD_star", "APOD_star", true)
+  /** @group Constructors */ case object ND3 extends GpiApodizer("ND3", "ND3", "ND3", false)
+
+  /** All members of GpiApodizer, in canonical order. */
+  val all: List[GpiApodizer] =
+    List(CLEAR, CLEARGP, APOD_Y, APOD_J, APOD_H, APOD_K1, APOD_K2, NRM, APOD_HL, APOD_STAR, ND3)
+
+  /** Select the member of GpiApodizer with the given tag, if any. */
+  def fromTag(s: String): Option[GpiApodizer] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiApodizer with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiApodizer =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiApodizerEnumerated: Enumerated[GpiApodizer] =
+    new Enumerated[GpiApodizer] {
+      def all = GpiApodizer.all
+      def tag(a: GpiApodizer) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiCalEntranceShutter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiCalEntranceShutter.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Cal Entrance Shutter.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiCalEntranceShutter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: Boolean
+) extends Product with Serializable
+
+object GpiCalEntranceShutter {
+
+  /** @group Constructors */ case object Open extends GpiCalEntranceShutter("Open", "Open", "Open", true)
+  /** @group Constructors */ case object Close extends GpiCalEntranceShutter("Close", "Close", "Close", false)
+
+  /** All members of GpiCalEntranceShutter, in canonical order. */
+  val all: List[GpiCalEntranceShutter] =
+    List(Open, Close)
+
+  /** Select the member of GpiCalEntranceShutter with the given tag, if any. */
+  def fromTag(s: String): Option[GpiCalEntranceShutter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiCalEntranceShutter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiCalEntranceShutter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiCalEntranceShutterEnumerated: Enumerated[GpiCalEntranceShutter] =
+    new Enumerated[GpiCalEntranceShutter] {
+      def all = GpiCalEntranceShutter.all
+      def tag(a: GpiCalEntranceShutter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiCassegrain.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiCassegrain.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Cassegrain.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiCassegrain(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: Int
+) extends Product with Serializable
+
+object GpiCassegrain {
+
+  /** @group Constructors */ case object A0 extends GpiCassegrain("A0", "0", "0", 0)
+  /** @group Constructors */ case object A180 extends GpiCassegrain("A180", "180", "180", 180)
+
+  /** All members of GpiCassegrain, in canonical order. */
+  val all: List[GpiCassegrain] =
+    List(A0, A180)
+
+  /** Select the member of GpiCassegrain with the given tag, if any. */
+  def fromTag(s: String): Option[GpiCassegrain] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiCassegrain with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiCassegrain =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiCassegrainEnumerated: Enumerated[GpiCassegrain] =
+    new Enumerated[GpiCassegrain] {
+      def all = GpiCassegrain.all
+      def tag(a: GpiCassegrain) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiDisperser.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiDisperser.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Disperser.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiDisperser(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object GpiDisperser {
+
+  /** @group Constructors */ case object PRISM extends GpiDisperser("PRISM", "Prism", "Prism")
+  /** @group Constructors */ case object WOLLASTON extends GpiDisperser("WOLLASTON", "Wollaston", "Prism")
+
+  /** All members of GpiDisperser, in canonical order. */
+  val all: List[GpiDisperser] =
+    List(PRISM, WOLLASTON)
+
+  /** Select the member of GpiDisperser with the given tag, if any. */
+  def fromTag(s: String): Option[GpiDisperser] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiDisperser with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiDisperser =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiDisperserEnumerated: Enumerated[GpiDisperser] =
+    new Enumerated[GpiDisperser] {
+      def all = GpiDisperser.all
+      def tag(a: GpiDisperser) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiEntranceShutter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiEntranceShutter.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Entrance Shutter.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiEntranceShutter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: Boolean
+) extends Product with Serializable
+
+object GpiEntranceShutter {
+
+  /** @group Constructors */ case object Open extends GpiEntranceShutter("Open", "Open", "Open", true)
+  /** @group Constructors */ case object Close extends GpiEntranceShutter("Close", "Close", "Close", false)
+
+  /** All members of GpiEntranceShutter, in canonical order. */
+  val all: List[GpiEntranceShutter] =
+    List(Open, Close)
+
+  /** Select the member of GpiEntranceShutter with the given tag, if any. */
+  def fromTag(s: String): Option[GpiEntranceShutter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiEntranceShutter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiEntranceShutter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiEntranceShutterEnumerated: Enumerated[GpiEntranceShutter] =
+    new Enumerated[GpiEntranceShutter] {
+      def all = GpiEntranceShutter.all
+      def tag(a: GpiEntranceShutter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiFPM.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiFPM.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI FPM.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiFPM(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GpiFPM {
+
+  /** @group Constructors */ case object OPEN extends GpiFPM("OPEN", "Open", "Open", false)
+  /** @group Constructors */ case object F50umPIN extends GpiFPM("F50umPIN", "50umPIN", "50umPIN", false)
+  /** @group Constructors */ case object WITH_DOT extends GpiFPM("WITH_DOT", "WITH_DOT", "WITH_DOT", false)
+  /** @group Constructors */ case object SCIENCE extends GpiFPM("SCIENCE", "SCIENCE", "SCIENCE", false)
+  /** @group Constructors */ case object FPM_K1 extends GpiFPM("FPM_K1", "FPM_K1", "FPM_K1", false)
+  /** @group Constructors */ case object FPM_H extends GpiFPM("FPM_H", "FPM_H", "FPM_H", false)
+  /** @group Constructors */ case object FPM_J extends GpiFPM("FPM_J", "FPM_J", "FPM_J", false)
+  /** @group Constructors */ case object FPM_Y extends GpiFPM("FPM_Y", "FPM_Y", "FPM_Y", false)
+
+  /** All members of GpiFPM, in canonical order. */
+  val all: List[GpiFPM] =
+    List(OPEN, F50umPIN, WITH_DOT, SCIENCE, FPM_K1, FPM_H, FPM_J, FPM_Y)
+
+  /** Select the member of GpiFPM with the given tag, if any. */
+  def fromTag(s: String): Option[GpiFPM] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiFPM with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiFPM =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiFPMEnumerated: Enumerated[GpiFPM] =
+    new Enumerated[GpiFPM] {
+      def all = GpiFPM.all
+      def tag(a: GpiFPM) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiFilter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiFilter.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Filter.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiFilter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val band: MagnitudeBand,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GpiFilter {
+
+  /** @group Constructors */ case object Y extends GpiFilter("Y", "Y", "Y", MagnitudeBand.Y, false)
+  /** @group Constructors */ case object J extends GpiFilter("J", "J", "J", MagnitudeBand.J, false)
+  /** @group Constructors */ case object H extends GpiFilter("H", "H", "H", MagnitudeBand.H, false)
+  /** @group Constructors */ case object K1 extends GpiFilter("K1", "K1", "K1", MagnitudeBand.K, false)
+  /** @group Constructors */ case object K2 extends GpiFilter("K2", "K2", "K2", MagnitudeBand.K, false)
+
+  /** All members of GpiFilter, in canonical order. */
+  val all: List[GpiFilter] =
+    List(Y, J, H, K1, K2)
+
+  /** Select the member of GpiFilter with the given tag, if any. */
+  def fromTag(s: String): Option[GpiFilter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiFilter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiFilter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiFilterEnumerated: Enumerated[GpiFilter] =
+    new Enumerated[GpiFilter] {
+      def all = GpiFilter.all
+      def tag(a: GpiFilter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiLyot.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiLyot.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Lyot.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiLyot(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GpiLyot {
+
+  /** @group Constructors */ case object BLANK extends GpiLyot("BLANK", "Blank", "Blank", false)
+  /** @group Constructors */ case object LYOT_080m12_03 extends GpiLyot("LYOT_080m12_03", "080m12_03", "080m12_03", false)
+  /** @group Constructors */ case object LYOT_080m12_04 extends GpiLyot("LYOT_080m12_04", "080m12_04", "080m12_04", false)
+  /** @group Constructors */ case object LYOT_080_04 extends GpiLyot("LYOT_080_04", "080_04", "080_04", false)
+  /** @group Constructors */ case object LYOT_080m12_06 extends GpiLyot("LYOT_080m12_06", "080m12_06", "080m12_06", false)
+  /** @group Constructors */ case object LYOT_080m12_04_c extends GpiLyot("LYOT_080m12_04_c", "080m12_04_c", "080m12_04_c", false)
+  /** @group Constructors */ case object LYOT_080m12_06_03 extends GpiLyot("LYOT_080m12_06_03", "080m12_06_03", "080m12_06_03", false)
+  /** @group Constructors */ case object LYOT_080m12_07 extends GpiLyot("LYOT_080m12_07", "080m12_07", "080m12_07", false)
+  /** @group Constructors */ case object LYOT_080m12_10 extends GpiLyot("LYOT_080m12_10", "080m12_10", "080m12_10", false)
+  /** @group Constructors */ case object OPEN extends GpiLyot("OPEN", "Open", "Open", false)
+
+  /** All members of GpiLyot, in canonical order. */
+  val all: List[GpiLyot] =
+    List(BLANK, LYOT_080m12_03, LYOT_080m12_04, LYOT_080_04, LYOT_080m12_06, LYOT_080m12_04_c, LYOT_080m12_06_03, LYOT_080m12_07, LYOT_080m12_10, OPEN)
+
+  /** Select the member of GpiLyot with the given tag, if any. */
+  def fromTag(s: String): Option[GpiLyot] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiLyot with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiLyot =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiLyotEnumerated: Enumerated[GpiLyot] =
+    new Enumerated[GpiLyot] {
+      def all = GpiLyot.all
+      def tag(a: GpiLyot) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiObservingMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiObservingMode.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.Eval
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.MagnitudeValue
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI ObservingMode.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiObservingMode(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val filter: Option[GpiFilter],
+  val filterIterable: Boolean,
+  val apodizer: Option[GpiApodizer],
+  val fpm: Option[GpiFPM],
+  val lyot: Option[GpiLyot],
+  val brightLimitPrism: Option[MagnitudeValue],
+  val brightLimitWollaston: Option[MagnitudeValue],
+  val correspondingHMode: Eval[GpiObservingMode],
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GpiObservingMode {
+
+  /** @group Constructors */ case object CORON_Y_BAND extends GpiObservingMode("CORON_Y_BAND", "Coronograph Y-band", "Coronograph Y-band", Some(GpiFilter.Y), false, Some(GpiApodizer.APOD_Y), Some(GpiFPM.FPM_Y), Some(GpiLyot.LYOT_080m12_03), Some(MagnitudeValue(50)), Some(MagnitudeValue(300)), cats.Eval.later(GpiObservingMode.unsafeFromTag("CORON_H_BAND")), false)
+  /** @group Constructors */ case object CORON_J_BAND extends GpiObservingMode("CORON_J_BAND", "Coronograph J-band", "Coronograph J-band", Some(GpiFilter.J), false, Some(GpiApodizer.APOD_J), Some(GpiFPM.FPM_J), Some(GpiLyot.LYOT_080m12_04), Some(MagnitudeValue(50)), Some(MagnitudeValue(300)), cats.Eval.later(GpiObservingMode.unsafeFromTag("CORON_H_BAND")), false)
+  /** @group Constructors */ case object CORON_H_BAND extends GpiObservingMode("CORON_H_BAND", "Coronograph H-band", "Coronograph H-band", Some(GpiFilter.H), false, Some(GpiApodizer.APOD_H), Some(GpiFPM.FPM_H), Some(GpiLyot.LYOT_080m12_04), Some(MagnitudeValue(50)), Some(MagnitudeValue(300)), cats.Eval.later(GpiObservingMode.unsafeFromTag("CORON_H_BAND")), false)
+  /** @group Constructors */ case object CORON_K1_BAND extends GpiObservingMode("CORON_K1_BAND", "Coronograph K1-band", "Coronograph K1-band", Some(GpiFilter.K1), false, Some(GpiApodizer.APOD_K1), Some(GpiFPM.FPM_K1), Some(GpiLyot.LYOT_080m12_06_03), Some(MagnitudeValue(50)), Some(MagnitudeValue(300)), cats.Eval.later(GpiObservingMode.unsafeFromTag("CORON_H_BAND")), false)
+  /** @group Constructors */ case object CORON_K2_BAND extends GpiObservingMode("CORON_K2_BAND", "Coronograph K2-band", "Coronograph K2-band", Some(GpiFilter.K2), false, Some(GpiApodizer.APOD_K2), Some(GpiFPM.FPM_K1), Some(GpiLyot.LYOT_080m12_07), Some(MagnitudeValue(50)), Some(MagnitudeValue(300)), cats.Eval.later(GpiObservingMode.unsafeFromTag("CORON_H_BAND")), false)
+  /** @group Constructors */ case object H_STAR extends GpiObservingMode("H_STAR", "H_STAR", "H_STAR", Some(GpiFilter.H), false, Some(GpiApodizer.APOD_STAR), Some(GpiFPM.FPM_H), Some(GpiLyot.LYOT_080m12_03), Option.empty[MagnitudeValue], Option.empty[MagnitudeValue], cats.Eval.later(GpiObservingMode.unsafeFromTag("H_STAR")), true)
+  /** @group Constructors */ case object H_LIWA extends GpiObservingMode("H_LIWA", "H_LIWA", "H_LIWA", Some(GpiFilter.H), false, Some(GpiApodizer.APOD_HL), Some(GpiFPM.FPM_K1), Some(GpiLyot.LYOT_080m12_04), Option.empty[MagnitudeValue], Option.empty[MagnitudeValue], cats.Eval.later(GpiObservingMode.unsafeFromTag("H_LIWA")), false)
+  /** @group Constructors */ case object DIRECT_Y_BAND extends GpiObservingMode("DIRECT_Y_BAND", "Y direct", "Y direct", Some(GpiFilter.Y), true, Some(GpiApodizer.CLEAR), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Some(MagnitudeValue(550)), Some(MagnitudeValue(750)), cats.Eval.later(GpiObservingMode.unsafeFromTag("DIRECT_H_BAND")), false)
+  /** @group Constructors */ case object DIRECT_J_BAND extends GpiObservingMode("DIRECT_J_BAND", "J direct", "J direct", Some(GpiFilter.J), true, Some(GpiApodizer.CLEAR), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Some(MagnitudeValue(550)), Some(MagnitudeValue(750)), cats.Eval.later(GpiObservingMode.unsafeFromTag("DIRECT_H_BAND")), false)
+  /** @group Constructors */ case object DIRECT_H_BAND extends GpiObservingMode("DIRECT_H_BAND", "H direct", "H direct", Some(GpiFilter.H), true, Some(GpiApodizer.CLEAR), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Some(MagnitudeValue(550)), Some(MagnitudeValue(750)), cats.Eval.later(GpiObservingMode.unsafeFromTag("DIRECT_H_BAND")), false)
+  /** @group Constructors */ case object DIRECT_K1_BAND extends GpiObservingMode("DIRECT_K1_BAND", "K1 direct", "K1 direct", Some(GpiFilter.K1), true, Some(GpiApodizer.CLEAR), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Some(MagnitudeValue(550)), Some(MagnitudeValue(750)), cats.Eval.later(GpiObservingMode.unsafeFromTag("DIRECT_H_BAND")), false)
+  /** @group Constructors */ case object DIRECT_K2_BAND extends GpiObservingMode("DIRECT_K2_BAND", "K2 direct", "K2 direct", Some(GpiFilter.K2), true, Some(GpiApodizer.CLEAR), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Some(MagnitudeValue(550)), Some(MagnitudeValue(750)), cats.Eval.later(GpiObservingMode.unsafeFromTag("DIRECT_H_BAND")), false)
+  /** @group Constructors */ case object NRM_Y extends GpiObservingMode("NRM_Y", "Non Redundant Mask Y", "Non Redundant Mask Y", Some(GpiFilter.Y), true, Some(GpiApodizer.NRM), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Option.empty[MagnitudeValue], Option.empty[MagnitudeValue], cats.Eval.later(GpiObservingMode.unsafeFromTag("NRM_H")), false)
+  /** @group Constructors */ case object NRM_J extends GpiObservingMode("NRM_J", "Non Redundant Mask J", "Non Redundant Mask J", Some(GpiFilter.J), true, Some(GpiApodizer.NRM), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Option.empty[MagnitudeValue], Option.empty[MagnitudeValue], cats.Eval.later(GpiObservingMode.unsafeFromTag("NRM_H")), false)
+  /** @group Constructors */ case object NRM_H extends GpiObservingMode("NRM_H", "Non Redundant Mask H", "Non Redundant Mask H", Some(GpiFilter.H), true, Some(GpiApodizer.NRM), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Option.empty[MagnitudeValue], Option.empty[MagnitudeValue], cats.Eval.later(GpiObservingMode.unsafeFromTag("NRM_H")), false)
+  /** @group Constructors */ case object NRM_K1 extends GpiObservingMode("NRM_K1", "Non Redundant Mask K1", "Non Redundant Mask K1", Some(GpiFilter.K1), true, Some(GpiApodizer.NRM), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Option.empty[MagnitudeValue], Option.empty[MagnitudeValue], cats.Eval.later(GpiObservingMode.unsafeFromTag("NRM_H")), false)
+  /** @group Constructors */ case object NRM_K2 extends GpiObservingMode("NRM_K2", "Non Redundant Mask K2", "Non Redundant Mask K2", Some(GpiFilter.K2), true, Some(GpiApodizer.NRM), Some(GpiFPM.SCIENCE), Some(GpiLyot.OPEN), Option.empty[MagnitudeValue], Option.empty[MagnitudeValue], cats.Eval.later(GpiObservingMode.unsafeFromTag("NRM_H")), false)
+  /** @group Constructors */ case object DARK extends GpiObservingMode("DARK", "Dark", "Dark", Some(GpiFilter.H), false, Some(GpiApodizer.APOD_H), Some(GpiFPM.FPM_H), Some(GpiLyot.BLANK), Some(MagnitudeValue(50)), Some(MagnitudeValue(300)), cats.Eval.later(GpiObservingMode.unsafeFromTag("DARK")), false)
+  /** @group Constructors */ case object UNBLOCKED_Y extends GpiObservingMode("UNBLOCKED_Y", "Y Unblocked", "Y Unblocked", Some(GpiFilter.Y), false, Some(GpiApodizer.APOD_Y), Some(GpiFPM.SCIENCE), Some(GpiLyot.LYOT_080m12_03), Some(MagnitudeValue(400)), Some(MagnitudeValue(650)), cats.Eval.later(GpiObservingMode.unsafeFromTag("UNBLOCKED_Y")), false)
+  /** @group Constructors */ case object UNBLOCKED_J extends GpiObservingMode("UNBLOCKED_J", "J Unblocked", "J Unblocked", Some(GpiFilter.J), false, Some(GpiApodizer.APOD_J), Some(GpiFPM.SCIENCE), Some(GpiLyot.LYOT_080m12_04), Some(MagnitudeValue(400)), Some(MagnitudeValue(650)), cats.Eval.later(GpiObservingMode.unsafeFromTag("UNBLOCKED_J")), false)
+  /** @group Constructors */ case object UNBLOCKED_H extends GpiObservingMode("UNBLOCKED_H", "H Unblocked", "H Unblocked", Some(GpiFilter.H), false, Some(GpiApodizer.APOD_H), Some(GpiFPM.SCIENCE), Some(GpiLyot.LYOT_080m12_04), Some(MagnitudeValue(400)), Some(MagnitudeValue(650)), cats.Eval.later(GpiObservingMode.unsafeFromTag("UNBLOCKED_H")), false)
+  /** @group Constructors */ case object UNBLOCKED_K1 extends GpiObservingMode("UNBLOCKED_K1", "K1 Unblocked", "K1 Unblocked", Some(GpiFilter.K1), false, Some(GpiApodizer.APOD_K1), Some(GpiFPM.SCIENCE), Some(GpiLyot.LYOT_080m12_06_03), Some(MagnitudeValue(400)), Some(MagnitudeValue(650)), cats.Eval.later(GpiObservingMode.unsafeFromTag("UNBLOCKED_K1")), false)
+  /** @group Constructors */ case object UNBLOCKED_K2 extends GpiObservingMode("UNBLOCKED_K2", "K2 Unblocked", "K2 Unblocked", Some(GpiFilter.K2), false, Some(GpiApodizer.APOD_K2), Some(GpiFPM.SCIENCE), Some(GpiLyot.LYOT_080m12_07), Some(MagnitudeValue(400)), Some(MagnitudeValue(650)), cats.Eval.later(GpiObservingMode.unsafeFromTag("UNBLOCKED_K2")), false)
+  /** @group Constructors */ case object NONSTANDARD extends GpiObservingMode("NONSTANDARD", "Nonstandard", "Nonstandard", Option.empty[GpiFilter], false, Option.empty[GpiApodizer], Option.empty[GpiFPM], Option.empty[GpiLyot], Option.empty[MagnitudeValue], Option.empty[MagnitudeValue], cats.Eval.later(GpiObservingMode.unsafeFromTag("NONSTANDARD")), false)
+
+  /** All members of GpiObservingMode, in canonical order. */
+  val all: List[GpiObservingMode] =
+    List(CORON_Y_BAND, CORON_J_BAND, CORON_H_BAND, CORON_K1_BAND, CORON_K2_BAND, H_STAR, H_LIWA, DIRECT_Y_BAND, DIRECT_J_BAND, DIRECT_H_BAND, DIRECT_K1_BAND, DIRECT_K2_BAND, NRM_Y, NRM_J, NRM_H, NRM_K1, NRM_K2, DARK, UNBLOCKED_Y, UNBLOCKED_J, UNBLOCKED_H, UNBLOCKED_K1, UNBLOCKED_K2, NONSTANDARD)
+
+  /** Select the member of GpiObservingMode with the given tag, if any. */
+  def fromTag(s: String): Option[GpiObservingMode] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiObservingMode with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiObservingMode =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiObservingModeEnumerated: Enumerated[GpiObservingMode] =
+    new Enumerated[GpiObservingMode] {
+      def all = GpiObservingMode.all
+      def tag(a: GpiObservingMode) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiPupilCamera.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiPupilCamera.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Pupil Camera.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiPupilCamera(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: Boolean
+) extends Product with Serializable
+
+object GpiPupilCamera {
+
+  /** @group Constructors */ case object In extends GpiPupilCamera("In", "In", "In", true)
+  /** @group Constructors */ case object Out extends GpiPupilCamera("Out", "Out", "Out", false)
+
+  /** All members of GpiPupilCamera, in canonical order. */
+  val all: List[GpiPupilCamera] =
+    List(In, Out)
+
+  /** Select the member of GpiPupilCamera with the given tag, if any. */
+  def fromTag(s: String): Option[GpiPupilCamera] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiPupilCamera with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiPupilCamera =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiPupilCameraEnumerated: Enumerated[GpiPupilCamera] =
+    new Enumerated[GpiPupilCamera] {
+      def all = GpiPupilCamera.all
+      def tag(a: GpiPupilCamera) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiReferenceArmShutter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiReferenceArmShutter.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Reference Arm Shutter.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiReferenceArmShutter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: Boolean
+) extends Product with Serializable
+
+object GpiReferenceArmShutter {
+
+  /** @group Constructors */ case object Open extends GpiReferenceArmShutter("Open", "Open", "Open", true)
+  /** @group Constructors */ case object Close extends GpiReferenceArmShutter("Close", "Close", "Close", false)
+
+  /** All members of GpiReferenceArmShutter, in canonical order. */
+  val all: List[GpiReferenceArmShutter] =
+    List(Open, Close)
+
+  /** Select the member of GpiReferenceArmShutter with the given tag, if any. */
+  def fromTag(s: String): Option[GpiReferenceArmShutter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiReferenceArmShutter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiReferenceArmShutter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiReferenceArmShutterEnumerated: Enumerated[GpiReferenceArmShutter] =
+    new Enumerated[GpiReferenceArmShutter] {
+      def all = GpiReferenceArmShutter.all
+      def tag(a: GpiReferenceArmShutter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiSamplingMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiSamplingMode.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Sampling Mode.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiSamplingMode(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object GpiSamplingMode {
+
+  /** @group Constructors */ case object FAST extends GpiSamplingMode("FAST", "Fast", "Fast", false)
+  /** @group Constructors */ case object SINGLE_CDS extends GpiSamplingMode("SINGLE_CDS", "Single CDS", "Single CDS", false)
+  /** @group Constructors */ case object MULTIPLE_CDS extends GpiSamplingMode("MULTIPLE_CDS", "Multiple CDS", "Multiple CDS", false)
+  /** @group Constructors */ case object UTR extends GpiSamplingMode("UTR", "UTR", "UTR", false)
+
+  /** All members of GpiSamplingMode, in canonical order. */
+  val all: List[GpiSamplingMode] =
+    List(FAST, SINGLE_CDS, MULTIPLE_CDS, UTR)
+
+  /** Select the member of GpiSamplingMode with the given tag, if any. */
+  def fromTag(s: String): Option[GpiSamplingMode] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiSamplingMode with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiSamplingMode =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiSamplingModeEnumerated: Enumerated[GpiSamplingMode] =
+    new Enumerated[GpiSamplingMode] {
+      def all = GpiSamplingMode.all
+      def tag(a: GpiSamplingMode) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiScienceArmShutter.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiScienceArmShutter.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI Science Arm Shutter.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiScienceArmShutter(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val value: Boolean
+) extends Product with Serializable
+
+object GpiScienceArmShutter {
+
+  /** @group Constructors */ case object Open extends GpiScienceArmShutter("Open", "Open", "Open", true)
+  /** @group Constructors */ case object Close extends GpiScienceArmShutter("Close", "Close", "Close", false)
+
+  /** All members of GpiScienceArmShutter, in canonical order. */
+  val all: List[GpiScienceArmShutter] =
+    List(Open, Close)
+
+  /** Select the member of GpiScienceArmShutter with the given tag, if any. */
+  def fromTag(s: String): Option[GpiScienceArmShutter] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiScienceArmShutter with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GpiScienceArmShutter =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GpiScienceArmShutterEnumerated: Enumerated[GpiScienceArmShutter] =
+    new Enumerated[GpiScienceArmShutter] {
+      def all = GpiScienceArmShutter.all
+      def tag(a: GpiScienceArmShutter) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/Half.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/Half.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for semester half.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class Half(
+  val tag: String,
+  val toInt: Int
+) extends Product with Serializable
+
+object Half {
+
+  /** @group Constructors */ case object A extends Half("A", 0)
+  /** @group Constructors */ case object B extends Half("B", 1)
+
+  /** All members of Half, in canonical order. */
+  val all: List[Half] =
+    List(A, B)
+
+  /** Select the member of Half with the given tag, if any. */
+  def fromTag(s: String): Option[Half] =
+    all.find(_.tag === s)
+
+  /** Select the member of Half with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): Half =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val HalfEnumerated: Enumerated[Half] =
+    new Enumerated[Half] {
+      def all = Half.all
+      def tag(a: Half) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/Instrument.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/Instrument.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for instruments.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class Instrument(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object Instrument {
+
+  /** @group Constructors */ case object Phoenix extends Instrument("Phoenix", "Phoenix", "Phoenix", false)
+  /** @group Constructors */ case object Michelle extends Instrument("Michelle", "Michelle", "Michelle", false)
+  /** @group Constructors */ case object Gnirs extends Instrument("Gnirs", "GNIRS", "GNIRS", false)
+  /** @group Constructors */ case object Niri extends Instrument("Niri", "NIRI", "NIRI", false)
+  /** @group Constructors */ case object Trecs extends Instrument("Trecs", "TReCS", "TReCS", false)
+  /** @group Constructors */ case object Nici extends Instrument("Nici", "NICI", "NICI", false)
+  /** @group Constructors */ case object Nifs extends Instrument("Nifs", "NIFS", "NIFS", false)
+  /** @group Constructors */ case object Gpi extends Instrument("Gpi", "GPI", "GPI", false)
+  /** @group Constructors */ case object Gsaoi extends Instrument("Gsaoi", "GSAOI", "GSAOI", false)
+  /** @group Constructors */ case object GmosS extends Instrument("GmosS", "GMOS-S", "GMOS South", false)
+  /** @group Constructors */ case object AcqCam extends Instrument("AcqCam", "AcqCam", "Acquisition Camera", false)
+  /** @group Constructors */ case object GmosN extends Instrument("GmosN", "GMOS-N", "GMOS North", false)
+  /** @group Constructors */ case object Bhros extends Instrument("Bhros", "bHROS", "bHROS", true)
+  /** @group Constructors */ case object Visitor extends Instrument("Visitor", "Visitor Instrument", "Visitor Instrument", false)
+  /** @group Constructors */ case object Flamingos2 extends Instrument("Flamingos2", "Flamingos2", "Flamingos 2", false)
+  /** @group Constructors */ case object Ghost extends Instrument("Ghost", "GHOST", "GHOST", false)
+
+  /** All members of Instrument, in canonical order. */
+  val all: List[Instrument] =
+    List(Phoenix, Michelle, Gnirs, Niri, Trecs, Nici, Nifs, Gpi, Gsaoi, GmosS, AcqCam, GmosN, Bhros, Visitor, Flamingos2, Ghost)
+
+  /** Select the member of Instrument with the given tag, if any. */
+  def fromTag(s: String): Option[Instrument] =
+    all.find(_.tag === s)
+
+  /** Select the member of Instrument with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): Instrument =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val InstrumentEnumerated: Enumerated[Instrument] =
+    new Enumerated[Instrument] {
+      def all = Instrument.all
+      def tag(a: Instrument) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/MagnitudeBand.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/MagnitudeBand.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Wavelength
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for magnitude band.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class MagnitudeBand(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val center: Wavelength,
+  val width: Int,
+  val magnitudeSystem: MagnitudeSystem
+) extends Product with Serializable
+
+object MagnitudeBand {
+
+  /** @group Constructors */ case object SloanU extends MagnitudeBand("SloanU", "u", "UV", Wavelength.fromAngstroms.unsafeGet(3560), 46, MagnitudeSystem.AB)
+  /** @group Constructors */ case object SloanG extends MagnitudeBand("SloanG", "g", "Green", Wavelength.fromAngstroms.unsafeGet(4830), 99, MagnitudeSystem.AB)
+  /** @group Constructors */ case object SloanR extends MagnitudeBand("SloanR", "r", "Red", Wavelength.fromAngstroms.unsafeGet(6260), 96, MagnitudeSystem.AB)
+  /** @group Constructors */ case object SloanI extends MagnitudeBand("SloanI", "i", "Far red", Wavelength.fromAngstroms.unsafeGet(7670), 106, MagnitudeSystem.AB)
+  /** @group Constructors */ case object SloanZ extends MagnitudeBand("SloanZ", "z", "Near infrared", Wavelength.fromAngstroms.unsafeGet(9100), 125, MagnitudeSystem.AB)
+  /** @group Constructors */ case object U extends MagnitudeBand("U", "U", "Ultraviolet", Wavelength.fromAngstroms.unsafeGet(3600), 75, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object B extends MagnitudeBand("B", "B", "Blue", Wavelength.fromAngstroms.unsafeGet(4400), 90, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object V extends MagnitudeBand("V", "V", "Visual", Wavelength.fromAngstroms.unsafeGet(5500), 85, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object Uc extends MagnitudeBand("Uc", "UC", "UCAC", Wavelength.fromAngstroms.unsafeGet(6100), 63, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object R extends MagnitudeBand("R", "R", "Red", Wavelength.fromAngstroms.unsafeGet(6700), 100, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object I extends MagnitudeBand("I", "I", "Infrared", Wavelength.fromAngstroms.unsafeGet(8700), 100, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object Y extends MagnitudeBand("Y", "Y", "Y", Wavelength.fromAngstroms.unsafeGet(10200), 120, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object J extends MagnitudeBand("J", "J", "J", Wavelength.fromAngstroms.unsafeGet(12500), 240, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object H extends MagnitudeBand("H", "H", "H", Wavelength.fromAngstroms.unsafeGet(16500), 300, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object K extends MagnitudeBand("K", "K", "K", Wavelength.fromAngstroms.unsafeGet(22000), 410, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object L extends MagnitudeBand("L", "L", "L", Wavelength.fromAngstroms.unsafeGet(37600), 700, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object M extends MagnitudeBand("M", "M", "M", Wavelength.fromAngstroms.unsafeGet(47700), 240, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object N extends MagnitudeBand("N", "N", "N", Wavelength.fromAngstroms.unsafeGet(104700), 5230, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object Q extends MagnitudeBand("Q", "Q", "Q", Wavelength.fromAngstroms.unsafeGet(201300), 1650, MagnitudeSystem.Vega)
+  /** @group Constructors */ case object Ap extends MagnitudeBand("Ap", "AP", "Apparent", Wavelength.fromAngstroms.unsafeGet(5500), 85, MagnitudeSystem.Vega)
+
+  /** All members of MagnitudeBand, in canonical order. */
+  val all: List[MagnitudeBand] =
+    List(SloanU, SloanG, SloanR, SloanI, SloanZ, U, B, V, Uc, R, I, Y, J, H, K, L, M, N, Q, Ap)
+
+  /** Select the member of MagnitudeBand with the given tag, if any. */
+  def fromTag(s: String): Option[MagnitudeBand] =
+    all.find(_.tag === s)
+
+  /** Select the member of MagnitudeBand with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): MagnitudeBand =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val MagnitudeBandEnumerated: Enumerated[MagnitudeBand] =
+    new Enumerated[MagnitudeBand] {
+      def all = MagnitudeBand.all
+      def tag(a: MagnitudeBand) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/MagnitudeSystem.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/MagnitudeSystem.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for magnitude system.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class MagnitudeSystem(
+  val tag: String
+) extends Product with Serializable
+
+object MagnitudeSystem {
+
+  /** @group Constructors */ case object Vega extends MagnitudeSystem("Vega")
+  /** @group Constructors */ case object AB extends MagnitudeSystem("AB")
+  /** @group Constructors */ case object Jy extends MagnitudeSystem("Jy")
+
+  /** All members of MagnitudeSystem, in canonical order. */
+  val all: List[MagnitudeSystem] =
+    List(Vega, AB, Jy)
+
+  /** Select the member of MagnitudeSystem with the given tag, if any. */
+  def fromTag(s: String): Option[MagnitudeSystem] =
+    all.find(_.tag === s)
+
+  /** Select the member of MagnitudeSystem with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): MagnitudeSystem =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val MagnitudeSystemEnumerated: Enumerated[MagnitudeSystem] =
+    new Enumerated[MagnitudeSystem] {
+      def all = MagnitudeSystem.all
+      def tag(a: MagnitudeSystem) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/MosPreImaging.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/MosPreImaging.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for MOS pre-imaging category.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class MosPreImaging(
+  val tag: String,
+  val description: String,
+  val toBoolean: Boolean
+) extends Product with Serializable
+
+object MosPreImaging {
+
+  /** @group Constructors */ case object IsMosPreImaging extends MosPreImaging("IsMosPreImaging", "Is MOS Pre-imaging", true)
+  /** @group Constructors */ case object IsNotMosPreImaging extends MosPreImaging("IsNotMosPreImaging", "Is Not MOS Pre-Imaging", false)
+
+  /** All members of MosPreImaging, in canonical order. */
+  val all: List[MosPreImaging] =
+    List(IsMosPreImaging, IsNotMosPreImaging)
+
+  /** Select the member of MosPreImaging with the given tag, if any. */
+  def fromTag(s: String): Option[MosPreImaging] =
+    all.find(_.tag === s)
+
+  /** Select the member of MosPreImaging with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): MosPreImaging =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val MosPreImagingEnumerated: Enumerated[MosPreImaging] =
+    new Enumerated[MosPreImaging] {
+      def all = MosPreImaging.all
+      def tag(a: MosPreImaging) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/ProgramRole.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/ProgramRole.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for user roles with respect to a given program.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class ProgramRole(
+  val tag: String,
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object ProgramRole {
+
+  /** @group Constructors */ case object PI extends ProgramRole("PI", "PI", "Principal Investigator")
+  /** @group Constructors */ case object GEM extends ProgramRole("GEM", "GEM", "Gemini Contact")
+  /** @group Constructors */ case object NGO extends ProgramRole("NGO", "NGO", "NGO Contact")
+
+  /** All members of ProgramRole, in canonical order. */
+  val all: List[ProgramRole] =
+    List(PI, GEM, NGO)
+
+  /** Select the member of ProgramRole with the given tag, if any. */
+  def fromTag(s: String): Option[ProgramRole] =
+    all.find(_.tag === s)
+
+  /** Select the member of ProgramRole with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): ProgramRole =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val ProgramRoleEnumerated: Enumerated[ProgramRole] =
+    new Enumerated[ProgramRole] {
+      def all = ProgramRole.all
+      def tag(a: ProgramRole) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/ProgramType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/ProgramType.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for program types (see [[gem.ProgramId ProgramId]]).
+ * @group Enumerations (Generated)
+ */
+sealed abstract class ProgramType(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object ProgramType {
+
+  /** @group Constructors */ case object CAL extends ProgramType("CAL", "CAL", "Calibration", false)
+  /** @group Constructors */ case object C extends ProgramType("C", "C", "Classical", false)
+  /** @group Constructors */ case object DS extends ProgramType("DS", "DS", "Demo Science", false)
+  /** @group Constructors */ case object DD extends ProgramType("DD", "DD", "Director's Time", false)
+  /** @group Constructors */ case object ENG extends ProgramType("ENG", "ENG", "Engineering", false)
+  /** @group Constructors */ case object FT extends ProgramType("FT", "FT", "Fast Turnaround", false)
+  /** @group Constructors */ case object LP extends ProgramType("LP", "LP", "Large Program", false)
+  /** @group Constructors */ case object Q extends ProgramType("Q", "Q", "Queue", false)
+  /** @group Constructors */ case object SV extends ProgramType("SV", "SV", "System Verification", false)
+
+  /** All members of ProgramType, in canonical order. */
+  val all: List[ProgramType] =
+    List(CAL, C, DS, DD, ENG, FT, LP, Q, SV)
+
+  /** Select the member of ProgramType with the given tag, if any. */
+  def fromTag(s: String): Option[ProgramType] =
+    all.find(_.tag === s)
+
+  /** Select the member of ProgramType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): ProgramType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val ProgramTypeEnumerated: Enumerated[ProgramType] =
+    new Enumerated[ProgramType] {
+      def all = ProgramType.all
+      def tag(a: ProgramType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/Site.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/Site.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.math.Angle
+import gem.util.Enumerated
+import java.time.ZoneId
+
+/**
+ * Enumerated type for Gemini observing sites.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class Site(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val mountain: String,
+  val latitude: Angle,
+  val longitude: Angle,
+  val altitude: Int,
+  val timezone: ZoneId
+) extends Product with Serializable
+
+object Site {
+
+  /** @group Constructors */ case object GN extends Site("GN", "GN", "Gemini North", "Mauna Kea", Angle.fromDoubleDegrees(19.8238068), Angle.fromDoubleDegrees(-155.4690550), 4213, ZoneId.of("Pacific/Honolulu"))
+  /** @group Constructors */ case object GS extends Site("GS", "GS", "Gemini South", "Cerro Pachon", Angle.fromDoubleDegrees(-30.2407494), Angle.fromDoubleDegrees(-70.7366867), 2722, ZoneId.of("America/Santiago"))
+
+  /** All members of Site, in canonical order. */
+  val all: List[Site] =
+    List(GN, GS)
+
+  /** Select the member of Site with the given tag, if any. */
+  def fromTag(s: String): Option[Site] =
+    all.find(_.tag === s)
+
+  /** Select the member of Site with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): Site =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val SiteEnumerated: Enumerated[Site] =
+    new Enumerated[Site] {
+      def all = Site.all
+      def tag(a: Site) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/SmartGcalType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/SmartGcalType.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for "smart" calibration sequence tpes.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class SmartGcalType(
+  val tag: String
+) extends Product with Serializable
+
+object SmartGcalType {
+
+  /** @group Constructors */ case object Arc extends SmartGcalType("Arc")
+  /** @group Constructors */ case object Flat extends SmartGcalType("Flat")
+  /** @group Constructors */ case object DayBaseline extends SmartGcalType("DayBaseline")
+  /** @group Constructors */ case object NightBaseline extends SmartGcalType("NightBaseline")
+
+  /** All members of SmartGcalType, in canonical order. */
+  val all: List[SmartGcalType] =
+    List(Arc, Flat, DayBaseline, NightBaseline)
+
+  /** Select the member of SmartGcalType with the given tag, if any. */
+  def fromTag(s: String): Option[SmartGcalType] =
+    all.find(_.tag === s)
+
+  /** Select the member of SmartGcalType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): SmartGcalType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val SmartGcalTypeEnumerated: Enumerated[SmartGcalType] =
+    new Enumerated[SmartGcalType] {
+      def all = SmartGcalType.all
+      def tag(a: SmartGcalType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/StepType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/StepType.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for step types.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class StepType(
+  val tag: String
+) extends Product with Serializable
+
+object StepType {
+
+  /** @group Constructors */ case object Bias extends StepType("Bias")
+  /** @group Constructors */ case object Dark extends StepType("Dark")
+  /** @group Constructors */ case object Gcal extends StepType("Gcal")
+  /** @group Constructors */ case object Science extends StepType("Science")
+  /** @group Constructors */ case object SmartGcal extends StepType("SmartGcal")
+
+  /** All members of StepType, in canonical order. */
+  val all: List[StepType] =
+    List(Bias, Dark, Gcal, Science, SmartGcal)
+
+  /** Select the member of StepType with the given tag, if any. */
+  def fromTag(s: String): Option[StepType] =
+    all.find(_.tag === s)
+
+  /** Select the member of StepType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): StepType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val StepTypeEnumerated: Enumerated[StepType] =
+    new Enumerated[StepType] {
+      def all = StepType.all
+      def tag(a: StepType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/TrackType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/TrackType.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for track types.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class TrackType(
+  val tag: String
+) extends Product with Serializable
+
+object TrackType {
+
+  /** @group Constructors */ case object Sidereal extends TrackType("Sidereal")
+  /** @group Constructors */ case object Nonsidereal extends TrackType("Nonsidereal")
+
+  /** All members of TrackType, in canonical order. */
+  val all: List[TrackType] =
+    List(Sidereal, Nonsidereal)
+
+  /** Select the member of TrackType with the given tag, if any. */
+  def fromTag(s: String): Option[TrackType] =
+    all.find(_.tag === s)
+
+  /** Select the member of TrackType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): TrackType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val TrackTypeEnumerated: Enumerated[TrackType] =
+    new Enumerated[TrackType] {
+      def all = TrackType.all
+      def tag(a: TrackType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/UserTargetType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/UserTargetType.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for user target type.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class UserTargetType(
+  val tag: String,
+  val shortName: String,
+  val longName: String,
+  val obsolete: Boolean
+) extends Product with Serializable
+
+object UserTargetType {
+
+  /** @group Constructors */ case object BlindOffset extends UserTargetType("BlindOffset", "Blind Offset", "Blind Offset", false)
+  /** @group Constructors */ case object OffAxis extends UserTargetType("OffAxis", "Off Axis", "Off Axis", false)
+  /** @group Constructors */ case object TuningStar extends UserTargetType("TuningStar", "Tuning Star", "Tuning Star", false)
+  /** @group Constructors */ case object Other extends UserTargetType("Other", "Other", "Other", false)
+
+  /** All members of UserTargetType, in canonical order. */
+  val all: List[UserTargetType] =
+    List(BlindOffset, OffAxis, TuningStar, Other)
+
+  /** Select the member of UserTargetType with the given tag, if any. */
+  def fromTag(s: String): Option[UserTargetType] =
+    all.find(_.tag === s)
+
+  /** Select the member of UserTargetType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): UserTargetType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val UserTargetTypeEnumerated: Enumerated[UserTargetType] =
+    new Enumerated[UserTargetType] {
+      def all = UserTargetType.all
+      def tag(a: UserTargetType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/package.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/package.scala
@@ -1,0 +1,192 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import java.time.Month
+import java.time.Month._
+import cats.implicits._
+import gem.config.StaticConfig
+import gem.syntax.ToPrismOps
+
+// The members of this package are generated from database tables, which are the source of truth.
+// See project/gen2.scala for details. Associations with other model types, as needed, are provided
+// here as implicit classes wrapping val the generated companion object extends AnyVals.
+
+/**
+ * Enumerated types (normally generated from database tables) and related syntactic enrichments.
+ */
+package object enum extends ToPrismOps {
+
+  /**
+   * Enrichment methods for the [[StepType]] companion object.
+   * @group Enrichments
+   */
+  implicit class StepTypeCompanionOps(val value: StepType.type) extends AnyVal {
+    def forStep(s: Step): StepType =
+      s.base match {
+        case Step.Base.Bias         => StepType.Bias
+        case Step.Base.Dark         => StepType.Dark
+        case Step.Base.Gcal(_)      => StepType.Gcal
+        case Step.Base.Science(_)   => StepType.Science
+        case Step.Base.SmartGcal(_) => StepType.SmartGcal
+      }
+  }
+
+  /**
+   * Enrichment methods for [[SmartGcalType]].
+   * @group Enrichments
+   */
+  implicit class SmartGcalTypeOps(val value: SmartGcalType) extends AnyVal {
+    def fold[X](lamp: GcalLampType => X, baseline: GcalBaselineType => X): X =
+      value match {
+        case SmartGcalType.Arc           => lamp(GcalLampType.Arc)
+        case SmartGcalType.Flat          => lamp(GcalLampType.Flat)
+        case SmartGcalType.DayBaseline   => baseline(GcalBaselineType.Day)
+        case SmartGcalType.NightBaseline => baseline(GcalBaselineType.Night)
+      }
+  }
+
+  /**
+   * Enrichment methods for the [[Half]] companion object.
+   * @group Enrichments
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  implicit class HalfCompanionOps(val value: Half.type) extends AnyVal {
+
+    def unsafeFromInt(n: Int): Half =
+      fromInt(n).getOrElse(throw new NoSuchElementException(n.toString))
+
+    def fromInt(n: Int): Option[Half] =
+      value.all.find(_.toInt === n)
+
+    def fromMonth(m: Month): Half =
+      m match {
+        case FEBRUARY | MARCH     | APRIL   | MAY      | JUNE     | JULY    => Half.A
+        case AUGUST   | SEPTEMBER | OCTOBER | NOVEMBER | DECEMBER | JANUARY => Half.B
+      }
+
+  }
+
+  /**
+   * Enrichment methods for [[Half]].
+   * @group Enrichments
+   */
+  implicit class HalfOps(val value: Half) extends AnyVal {
+
+    def startMonth: Month =
+      value match {
+        case Half.A => FEBRUARY
+        case Half.B => AUGUST
+      }
+
+    def endMonth: Month =
+      value match {
+        case Half.A => JULY
+        case Half.B => JANUARY
+      }
+
+  }
+
+  /**
+   * Enrichment methods for [[AsterismType]].
+   * @group Enrichment
+   */
+  implicit class AsterismTypeOps(val value: AsterismType.type) extends AnyVal {
+    def of(a: Asterism): AsterismType =
+      a match {
+        case _: Asterism.SingleTarget    => AsterismType.SingleTarget
+        case _: Asterism.GhostDualTarget => AsterismType.GhostDualTarget
+      }
+  }
+
+  /**
+   * Enrichment methods for [[Instrument]].
+   * @group Enrichment
+   */
+  implicit class InstrumentOps(val value: Instrument.type) extends AnyVal {
+
+    def forStep(s: Step): Instrument =
+      s match {
+        case Step.Phoenix(_, _)    => Instrument.Phoenix
+        case Step.Michelle(_, _)   => Instrument.Michelle
+        case Step.Gnirs(_, _)      => Instrument.Gnirs
+        case Step.Niri(_, _)       => Instrument.Niri
+        case Step.Trecs(_, _)      => Instrument.Trecs
+        case Step.Nici(_, _)       => Instrument.Nici
+        case Step.Nifs(_, _)       => Instrument.Nifs
+        case Step.Gpi(_, _)        => Instrument.Gpi
+        case Step.Gsaoi(_, _)      => Instrument.Gsaoi
+        case Step.GmosS(_, _)      => Instrument.GmosS
+        case Step.AcqCam(_, _)     => Instrument.AcqCam
+        case Step.GmosN(_, _)      => Instrument.GmosN
+        case Step.Bhros(_, _)      => Instrument.Bhros
+        case Step.Visitor(_, _)    => Instrument.Visitor
+        case Step.Flamingos2(_, _) => Instrument.Flamingos2
+        case Step.Ghost(_, _)      => Instrument.Ghost
+      }
+
+
+    def forStaticConfig(s: StaticConfig): Instrument =
+      s match {
+        case _: StaticConfig.Phoenix    => Instrument.Phoenix
+        case _: StaticConfig.Michelle   => Instrument.Michelle
+        case _: StaticConfig.Gnirs      => Instrument.Gnirs
+        case _: StaticConfig.Niri       => Instrument.Niri
+        case _: StaticConfig.Trecs      => Instrument.Trecs
+        case _: StaticConfig.Nici       => Instrument.Nici
+        case _: StaticConfig.Nifs       => Instrument.Nifs
+        case _: StaticConfig.Gpi        => Instrument.Gpi
+        case _: StaticConfig.Gsaoi      => Instrument.Gsaoi
+        case _: StaticConfig.GmosS      => Instrument.GmosS
+        case _: StaticConfig.AcqCam     => Instrument.AcqCam
+        case _: StaticConfig.GmosN      => Instrument.GmosN
+        case _: StaticConfig.Bhros      => Instrument.Bhros
+        case _: StaticConfig.Visitor    => Instrument.Visitor
+        case _: StaticConfig.Flamingos2 => Instrument.Flamingos2
+        case _: StaticConfig.Ghost      => Instrument.Ghost
+      }
+
+    def forAsterism(a: Asterism): Instrument =
+      a match {
+        case Asterism.Phoenix(_)            => Instrument.Phoenix
+        case Asterism.Michelle(_)           => Instrument.Michelle
+        case Asterism.Gnirs(_)              => Instrument.Gnirs
+        case Asterism.Niri(_)               => Instrument.Niri
+        case Asterism.Trecs(_)              => Instrument.Trecs
+        case Asterism.Nici(_)               => Instrument.Nici
+        case Asterism.Nifs(_)               => Instrument.Nifs
+        case Asterism.Gpi(_)                => Instrument.Gpi
+        case Asterism.Gsaoi(_)              => Instrument.Gsaoi
+        case Asterism.GmosS(_)              => Instrument.GmosS
+        case Asterism.AcqCam(_)             => Instrument.AcqCam
+        case Asterism.GmosN(_)              => Instrument.GmosN
+        case Asterism.Bhros(_)              => Instrument.Bhros
+        case Asterism.Visitor(_)            => Instrument.Visitor
+        case Asterism.Flamingos2(_)         => Instrument.Flamingos2
+        case Asterism.GhostDualTarget(_, _) => Instrument.Ghost
+      }
+
+    def forObservation(a: Observation): Instrument =
+      a match {
+        case Observation.Phoenix(_, _, _, _)    => Instrument.Phoenix
+        case Observation.Michelle(_, _, _, _)   => Instrument.Michelle
+        case Observation.Gnirs(_, _, _, _)      => Instrument.Gnirs
+        case Observation.Niri(_, _, _, _)       => Instrument.Niri
+        case Observation.Trecs(_, _, _, _)      => Instrument.Trecs
+        case Observation.Nici(_, _, _, _)       => Instrument.Nici
+        case Observation.Nifs(_, _, _, _)       => Instrument.Nifs
+        case Observation.Gpi(_, _, _, _)        => Instrument.Gpi
+        case Observation.Gsaoi(_, _, _, _)      => Instrument.Gsaoi
+        case Observation.GmosS(_, _, _, _)      => Instrument.GmosS
+        case Observation.AcqCam(_, _, _, _)     => Instrument.AcqCam
+        case Observation.GmosN(_, _, _, _)      => Instrument.GmosN
+        case Observation.Bhros(_, _, _, _)      => Instrument.Bhros
+        case Observation.Visitor(_, _, _, _)    => Instrument.Visitor
+        case Observation.Flamingos2(_, _, _, _) => Instrument.Flamingos2
+        case Observation.Ghost(_, _, _, _)      => Instrument.Ghost
+      }
+
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/instances/TimeInstances.scala
+++ b/modules/core/shared/src/main/scala/gem/instances/TimeInstances.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.instances
+
+import java.time._
+import cats.Order
+
+/** Instances for java.time data types. */
+trait TimeInstances {
+
+  // The java.time types all follow this pattern.
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  private def naturalOrder[A](before: (A, A) => Boolean): Order[A] =
+    Order.from { (a, b) =>
+             if (a == b)        0
+        else if (before(a, b)) -1
+        else                    1
+    }
+
+  // This looks like repetition but it's not. The isBefore methods have the same name but are
+  // unrelated by any common supertype.
+  implicit val InstantOrder:       Order[Instant]       = naturalOrder(_ isBefore _)
+  implicit val YearOrder:          Order[Year]          = naturalOrder(_ isBefore _)
+  implicit val LocalTimeOrder:     Order[LocalTime]     = naturalOrder(_ isBefore _)
+  implicit val LocalDateOrder:     Order[LocalDate]     = naturalOrder(_ isBefore _)
+  implicit val LocalDateTimeOrder: Order[LocalDateTime] = naturalOrder(_ isBefore _)
+
+}
+object time extends TimeInstances

--- a/modules/core/shared/src/main/scala/gem/instances/TreeMapInstances.scala
+++ b/modules/core/shared/src/main/scala/gem/instances/TreeMapInstances.scala
@@ -1,0 +1,179 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.instances
+
+import cats.{Always, Applicative, Eval, FlatMap, Foldable, Monoid, Show, Traverse}
+import cats.kernel._
+import cats.kernel.instances.StaticMethods
+import scala.annotation.tailrec
+import scala.collection.immutable.TreeMap
+
+// This redefines all the cats SortedMap instances for TreeMap. It's a copy/paste from the cats
+// source. We may want to go back and do everything in terms of SortedMap … not sure we need
+// TreeMap specifically. TBD.
+trait TreeMapInstances extends TreeMapInstances2 {
+
+  implicit def catsStdHashForTreeMap[K: Hash: Order, V: Hash]: Hash[TreeMap[K, V]] =
+    new TreeMapHash[K, V]
+
+  implicit def catsStdCommutativeMonoidForTreeMap[K: Order, V: CommutativeSemigroup]: CommutativeMonoid[TreeMap[K, V]] =
+    new TreeMapCommutativeMonoid[K, V]
+
+  implicit def catsStdShowForTreeMap[A: Order, B](implicit showA: Show[A], showB: Show[B]): Show[TreeMap[A, B]] =
+    new Show[TreeMap[A, B]] {
+      def show(m: TreeMap[A, B]): String =
+        m.iterator
+          .map { case (a, b) => showA.show(a) + " -> " + showB.show(b) }
+          .mkString("TreeMap(", ", ", ")")
+    }
+
+  // scalastyle:off method.length
+  @SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
+  implicit def catsStdInstancesForTreeMap[K: Order]: Traverse[TreeMap[K, ?]] with FlatMap[TreeMap[K, ?]] =
+    new Traverse[TreeMap[K, ?]] with FlatMap[TreeMap[K, ?]] {
+
+      implicit val orderingK: Ordering[K] = Order[K].toOrdering
+
+      def traverse[G[_], A, B](fa: TreeMap[K, A])(f: A => G[B])(implicit G: Applicative[G]): G[TreeMap[K, B]] = {
+        val gba: Eval[G[TreeMap[K, B]]] = Always(G.pure(TreeMap.empty(Order[K].toOrdering)))
+        Foldable.iterateRight(fa, gba){ (kv, lbuf) =>
+          G.map2Eval(f(kv._2), lbuf)({ (b, buf) => buf + (kv._1 -> b)})
+        }.value
+      }
+
+      def flatMap[A, B](fa: TreeMap[K, A])(f: A => TreeMap[K, B]): TreeMap[K, B] =
+        fa.flatMap { case (k, a) => f(a).get(k).map((k, _)) }
+
+      override def map[A, B](fa: TreeMap[K, A])(f: A => B): TreeMap[K, B] =
+        fa.map { case (k, a) => (k, f(a)) }
+
+
+      override def map2Eval[A, B, Z](fa: TreeMap[K, A], fb: Eval[TreeMap[K, B]])(f: (A, B) => Z): Eval[TreeMap[K, Z]] =
+        if (fa.isEmpty) Eval.now(TreeMap.empty(Order[K].toOrdering)) // no need to evaluate fb
+        else fb.map(fb => map2(fa, fb)(f))
+
+      override def ap2[A, B, Z](f: TreeMap[K, (A, B) => Z])(fa: TreeMap[K, A], fb: TreeMap[K, B]): TreeMap[K, Z] =
+        f.flatMap { case (k, f) =>
+          for { a <- fa.get(k); b <- fb.get(k) } yield (k, f(a, b))
+        }
+
+      def foldLeft[A, B](fa: TreeMap[K, A], b: B)(f: (B, A) => B): B =
+        fa.foldLeft(b) { case (x, (_, a)) => f(x, a)}
+
+      def foldRight[A, B](fa: TreeMap[K, A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+        Foldable.iterateRight(fa.values, lb)(f)
+
+      def tailRecM[A, B](a: A)(f: A => TreeMap[K, Either[A, B]]): TreeMap[K, B] = {
+        val bldr = TreeMap.newBuilder[K, B](Order[K].toOrdering)
+
+        @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+        @tailrec def descend(k: K, either: Either[A, B]): Unit =
+          either match {
+            case Left(a) =>
+              f(a).get(k) match {
+                case Some(x) => descend(k, x)
+                case None => ()
+              }
+            case Right(b) =>
+              bldr += ((k, b))
+              ()
+          }
+
+        f(a).foreach { case (k, a) => descend(k, a) }
+        bldr.result
+      }
+
+      override def size[A](fa: TreeMap[K, A]): Long = fa.size.toLong
+
+      override def get[A](fa: TreeMap[K, A])(idx: Long): Option[A] =
+        if (idx < 0L || Int.MaxValue < idx) None
+        else {
+          val n = idx.toInt
+          if (n >= fa.size) None
+          else Some(fa.valuesIterator.drop(n).next)
+        }
+
+      override def isEmpty[A](fa: TreeMap[K, A]): Boolean = fa.isEmpty
+
+      override def fold[A](fa: TreeMap[K, A])(implicit A: Monoid[A]): A =
+        A.combineAll(fa.values)
+
+      override def toList[A](fa: TreeMap[K, A]): List[A] = fa.values.toList
+
+      override def collectFirst[A, B](fa: TreeMap[K, A])(pf: PartialFunction[A, B]): Option[B] = fa.collectFirst(new PartialFunction[(K, A), B] {
+        override def isDefinedAt(x: (K, A)) = pf.isDefinedAt(x._2)
+        override def apply(v1: (K, A)) = pf(v1._2)
+      })
+
+      override def collectFirstSome[A, B](fa: TreeMap[K, A])(f: A => Option[B]): Option[B] = collectFirst(fa)(Function.unlift(f))
+    }
+
+}
+
+trait TreeMapInstances1 {
+  implicit def catsStdEqForTreeMap[K: Order, V: Eq]: Eq[TreeMap[K, V]] =
+    new TreeMapEq[K, V]
+}
+
+trait TreeMapInstances2 extends TreeMapInstances1 {
+  implicit def catsStdMonoidForTreeMap[K: Order, V: Semigroup]: Monoid[TreeMap[K, V]] =
+    new TreeMapMonoid[K, V]
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Equals"))
+class TreeMapHash[K, V](implicit V: Hash[V], O: Order[K], K: Hash[K]) extends TreeMapEq[K, V]()(V, O) with Hash[TreeMap[K, V]] {
+  // adapted from [[scala.util.hashing.MurmurHash3]],
+  // but modified standard `Any#hashCode` to `ev.hash`.
+  import scala.util.hashing.MurmurHash3._
+  def hash(x: TreeMap[K, V]): Int = {
+    var a, b, n = 0
+    var c = 1;
+    x foreach { case (k, v) =>
+      val h = StaticMethods.product2Hash(K.hash(k), V.hash(v))
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+      n += 1
+    }
+    var h = mapSeed
+    h = mix(h, a)
+    h = mix(h, b)
+    h = mixLast(h, c)
+    finalizeHash(h, n)
+  }
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals"))
+class TreeMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends Eq[TreeMap[K, V]] {
+  def eqv(x: TreeMap[K, V], y: TreeMap[K, V]): Boolean =
+    if (x eq y) (O, true)._2
+    else x.size == y.size && x.forall { case (k, v1) =>
+      y.get(k) match {
+        case Some(v2) => V.eqv(v1, v2)
+        case None => false
+      }
+    }
+}
+
+class TreeMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: Order[K])
+  extends TreeMapMonoid[K, V] with CommutativeMonoid[TreeMap[K, V]]
+
+class TreeMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends Monoid[TreeMap[K, V]]  {
+
+  def empty: TreeMap[K, V] = TreeMap.empty(O.toOrdering)
+
+  def combine(xs: TreeMap[K, V], ys: TreeMap[K, V]): TreeMap[K, V] =
+    if (xs.size <= ys.size) {
+      xs.foldLeft(ys) { case (my, (k, x)) =>
+        my.updated(k, Semigroup.maybeCombine(x, my.get(k)))
+      }
+    } else {
+      ys.foldLeft(xs) { case (mx, (k, y)) =>
+        mx.updated(k, Semigroup.maybeCombine(mx.get(k), y))
+      }
+    }
+
+}
+
+object treemap extends TreeMapInstances

--- a/modules/core/shared/src/main/scala/gem/instances/TreeSetInstances.scala
+++ b/modules/core/shared/src/main/scala/gem/instances/TreeSetInstances.scala
@@ -1,0 +1,133 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.instances
+
+import cats._
+import cats.kernel.{BoundedSemilattice, Hash, Order}
+import scala.collection.immutable.TreeSet
+import scala.annotation.tailrec
+import cats.implicits._
+
+trait TreeSetInstances extends TreeSetInstances1 {
+
+  implicit val catsStdInstancesForTreeSet: Foldable[TreeSet] with SemigroupK[TreeSet] =
+    new Foldable[TreeSet] with SemigroupK[TreeSet] {
+
+      def combineK[A](x: TreeSet[A], y: TreeSet[A]): TreeSet[A] = x | y
+
+      def foldLeft[A, B](fa: TreeSet[A], b: B)(f: (B, A) => B): B =
+        fa.foldLeft(b)(f)
+
+      def foldRight[A, B](fa: TreeSet[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+        Foldable.iterateRight(fa, lb)(f)
+
+      override def foldMap[A, B](fa: TreeSet[A])(f: A => B)(implicit B: Monoid[B]): B =
+        B.combineAll(fa.iterator.map(f))
+
+      @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+      override def get[A](fa: TreeSet[A])(idx: Long): Option[A] = {
+        @tailrec
+        def go(idx: Int, it: Iterator[A]): Option[A] = {
+          if (it.hasNext) {
+            if (idx == 0) Some(it.next) else {
+              it.next
+              go(idx - 1, it)
+            }
+          } else None
+        }
+        if (idx < Int.MaxValue && idx >= 0L)  go(idx.toInt, fa.toIterator) else None
+      }
+
+      override def size[A](fa: TreeSet[A]): Long = fa.size.toLong
+
+      override def exists[A](fa: TreeSet[A])(p: A => Boolean): Boolean =
+        fa.exists(p)
+
+      override def forall[A](fa: TreeSet[A])(p: A => Boolean): Boolean =
+        fa.forall(p)
+
+      override def isEmpty[A](fa: TreeSet[A]): Boolean = fa.isEmpty
+
+      override def fold[A](fa: TreeSet[A])(implicit A: Monoid[A]): A = A.combineAll(fa)
+
+      override def toList[A](fa: TreeSet[A]): List[A] = fa.toList
+
+      override def reduceLeftOption[A](fa: TreeSet[A])(f: (A, A) => A): Option[A] =
+        fa.reduceLeftOption(f)
+
+      override def find[A](fa: TreeSet[A])(f: A => Boolean): Option[A] = fa.find(f)
+
+      override def collectFirst[A, B](fa: TreeSet[A])(pf: PartialFunction[A, B]): Option[B] =
+        fa.collectFirst(pf)
+
+      override def collectFirstSome[A, B](fa: TreeSet[A])(f: A => Option[B]): Option[B] =
+        fa.collectFirst(Function.unlift(f))
+    }
+
+  implicit def catsStdShowForTreeSet[A: Show]: Show[TreeSet[A]] = new Show[TreeSet[A]] {
+    def show(fa: TreeSet[A]): String =
+      fa.toIterator.map(_.show).mkString("TreeSet(", ", ", ")")
+  }
+
+  implicit def catsKernelStdOrderForTreeSet[A: Order]: Order[TreeSet[A]] =
+    new TreeSetOrder[A]
+}
+
+trait TreeSetInstances1 {
+  implicit def catsKernelStdHashForTreeSet[A: Order: Hash]: Hash[TreeSet[A]] =
+    new TreeSetHash[A]
+
+  implicit def catsKernelStdSemilatticeForTreeSet[A: Order]: BoundedSemilattice[TreeSet[A]] =
+    new TreeSetSemilattice[A]
+}
+
+class TreeSetOrder[A: Order] extends Order[TreeSet[A]] {
+  def compare(a1: TreeSet[A], a2: TreeSet[A]): Int = {
+
+    Order[Int].compare(a1.size, a2.size) match {
+      case 0 => Order.compare(a1.toStream, a2.toStream)
+      case x => x
+    }
+  }
+
+  override def eqv(s1: TreeSet[A], s2: TreeSet[A]): Boolean = {
+    // implicit val x = Order[A].toOrdering
+    s1.toStream.corresponds(s2.toStream)(Order[A].eqv)
+  }
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Equals"))
+class TreeSetHash[A: Order: Hash] extends Hash[TreeSet[A]] {
+  import scala.util.hashing.MurmurHash3._
+
+  // adapted from [[scala.util.hashing.MurmurHash3]],
+  // but modified standard `Any#hashCode` to `ev.hash`.
+  def hash(xs: TreeSet[A]): Int = {
+    var a, b, n = 0
+    var c = 1
+    xs foreach { x =>
+      val h = Hash[A].hash(x)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+      n += 1
+    }
+    var h = setSeed
+    h = mix(h, a)
+    h = mix(h, b)
+    h = mixLast(h, c)
+    finalizeHash(h, n)
+  }
+  override def eqv(s1: TreeSet[A], s2: TreeSet[A]): Boolean = {
+    // implicit val x = Order[A].toOrdering
+    s1.toStream.corresponds(s2.toStream)(Order[A].eqv)
+  }
+}
+
+class TreeSetSemilattice[A: Order] extends BoundedSemilattice[TreeSet[A]] {
+  def empty: TreeSet[A] = TreeSet.empty(implicitly[Order[A]].toOrdering)
+  def combine(x: TreeSet[A], y: TreeSet[A]): TreeSet[A] = x | y
+}
+
+object treeset extends TreeSetInstances

--- a/modules/core/shared/src/main/scala/gem/instances/package.scala
+++ b/modules/core/shared/src/main/scala/gem/instances/package.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+/**
+ * Implicit instances for types defined outside of Gen. Each set of instances is provided as a
+ * trait that can be extended and as a module whose members can be imported (preferred).
+ */
+package object instances {
+
+  object all extends TimeInstances
+                with TreeMapInstances
+                with TreeSetInstances
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Angle.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Angle.scala
@@ -1,0 +1,555 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package math
+
+import cats.{ Eq, Order, Show }
+import cats.kernel.CommutativeGroup
+import cats.instances.long._
+import cats.syntax.eq._
+import gem.parser.AngleParsers
+import gem.syntax.parser._
+import gem.optics._
+import monocle.{ Iso, Prism }
+
+/**
+ * Exact angles represented as integral microarcseconds. These values form a commutative group over
+ * addition, where the inverse is reflection around the 0-180° axis. The subgroup of angles where
+ * integral microarcseconds correspond with clock microseconds (i.e., where they are evenly
+ * divisible by 15 microarcseconds) is represented by the HourAgle subtype.
+ *
+ * Lawful conversion to and from other types/scales is provided by optics defined on the companion
+ * object. Floating-point conversions are provided directly
+ * @param toMicroarcseconds This angle in microarcseconds. Exact.
+ */
+sealed class Angle protected (val toMicroarcseconds: Long) {
+
+  // Sanity checks … should be correct via the companion constructor.
+  assert(toMicroarcseconds >= 0, s"Invariant violated. $toMicroarcseconds is negative.")
+  assert(toMicroarcseconds < 360L * 60L * 60L * 1000L * 1000L, s"Invariant violated. $toMicroarcseconds is >= 360°.")
+
+  /**
+   * Flip this angle 180°. Equivalent to `mirrorBy(this + Angle90)`. Exact, invertible.
+   * @group Transformations
+   */
+  def flip: Angle =
+    this + Angle.Angle180
+
+  /**
+   * Additive inverse of this angle, equvalent to `mirrorBy Angle0`. Exact, invertible.
+   * @group Transformations
+   */
+  def unary_- : Angle =
+    Angle.fromMicroarcseconds(-toMicroarcseconds.toLong)
+
+  /**
+   * Mirror image of this angle, when the mirror stands at angle `a`; or picture picking up the
+   * circle and flipping it over, around a line drawn from the center going off in direction `a`.
+   * So `(88° mirrorBy 90°) = 92°` for instance, as is `88° mirrorBy 270°` since it's the same
+   * line. This operation is specified completely by the identity `b - a = (a mirrorBy b) - b`.
+   * @group Transformations
+   */
+  def mirrorBy(a: Angle): Angle = {
+    val Δ = a.toMicroarcseconds - toMicroarcseconds
+    Angle.fromMicroarcseconds(toMicroarcseconds + Δ * 2L)
+  }
+
+  /**
+   * This angle in decimal degrees. Approximate, non-invertible.
+   * @group Conversions
+   */
+  def toDoubleDegrees: Double =
+    toMicroarcseconds.toDouble / (60.0 * 60.0 * 1000.0 * 1000.0)
+
+  /**
+   * This angle in signed decimal degrees. Approximate, non-invertible
+   * @group Conversions
+   */
+  def toSignedDoubleDegrees: Double =
+    Angle.signedMicroarcseconds.get(this).toDouble / (60.0 * 60.0 * 1000.0 * 1000.0)
+
+  /**
+   * This angle in decimal radian, [0 .. 2π) Approximate, non-invertible
+   * @group Conversions
+   */
+  def toDoubleRadians: Double =
+    toDoubleDegrees.toRadians
+
+  /**
+   * This angle in signed decimal radians, [-π .. π) Approximate, non-invertible
+   * @group Conversions
+   */
+  def toSignedDoubleRadians: Double =
+    toSignedDoubleDegrees.toRadians
+
+  /**
+   * Sum of this angle and `a`. Exact, commutative, invertible.
+   * @group Operations
+   */
+  def +(a: Angle): Angle =
+    Angle.fromMicroarcseconds(toMicroarcseconds + a.toMicroarcseconds)
+
+  /**
+   * Difference of this angle and `a`. Exact, invertible.
+   * @group Operations
+   */
+  def -(a: Angle): Angle =
+    Angle.fromMicroarcseconds(toMicroarcseconds - a.toMicroarcseconds)
+
+  /** String representation of this Angle, for debugging purposes only. */
+  override def toString =
+    f"Angle(${Angle.dms.get(this)}, $toDoubleDegrees%1.10f°)"
+
+  /** Angles are equal if their magnitudes are equal. Exact. */
+  override final def equals(a: Any) =
+    a match {
+      case a: Angle => a.toMicroarcseconds === toMicroarcseconds
+      case _        => false
+    }
+
+  override final def hashCode =
+    toMicroarcseconds.toInt
+
+}
+
+object Angle extends AngleOptics {
+
+  /** @group Constants */ lazy val Angle0:   Angle = degrees.reverseGet(0)
+  /** @group Constants */ lazy val Angle90:  Angle = degrees.reverseGet(90)
+  /** @group Constants */ lazy val Angle180: Angle = degrees.reverseGet(180)
+  /** @group Constants */ lazy val Angle270: Angle = degrees.reverseGet(270)
+
+  /**
+   * Construct a new Angle of the given magnitude in integral microarcseconds, modulo 360°. Exact.
+   * @group Constructors
+   */
+  def fromMicroarcseconds(µas: Long): Angle = {
+    val µasPer360 = 360L * 60L * 60L * 1000L * 1000L
+    val µasʹ = (((µas % µasPer360) + µasPer360) % µasPer360)
+    new Angle(µasʹ)
+  }
+
+  /**
+   * Construct a new Angle of the given magnitude in double degrees, modulo 360°. Approximate.
+   * @group Constructors
+   */
+  def fromDoubleDegrees(ds: Double): Angle =
+    fromMicroarcseconds((ds * 60 * 60 * 1000 * 1000).toLong)
+
+  /**
+   * Construct a new Angle of the given magnitude in double arcseconds, modulo 360°. Approximate.
+   * @group Constructors
+   */
+  def fromDoubleArcseconds(as: Double): Angle =
+    fromMicroarcseconds((as * 1000 * 1000).toLong)
+
+  /**
+   * Construct a new Angle of the given magnitude in radians, modulo 2π. Approximate.
+   * @group Constructors
+   */
+  def fromDoubleRadians(rad: Double): Angle =
+    fromDoubleDegrees(rad.toDegrees)
+
+  /**
+   * Angle forms a commutative group.
+   * @group Typeclass Instances
+   */
+  implicit val AngleCommutativeGroup: CommutativeGroup[Angle] =
+    new CommutativeGroup[Angle] {
+      val empty: Angle = Angle0
+      def combine(a: Angle, b: Angle) = a + b
+      def inverse(a: Angle) = -a
+    }
+
+  /** @group Typeclass Instances */
+  implicit val AngleShow: Show[Angle] =
+    Show.fromToString
+
+  /**
+   * Angles are equal if their magnitudes are equal.
+   * @group Typeclass Instances
+   */
+  implicit val AngleEqual: Eq[Angle] =
+    Eq.fromUniversalEquals
+
+  /**
+   * Sorts Angle by magnitude [0, 360) degrees. Not implicit.
+   * @group Typeclass Instances
+   */
+  val AngleOrder: Order[Angle] =
+    Order.by(_.toMicroarcseconds)
+
+  /**
+   * Sorts Angle by signed angle, so [-180, 180).  Not implicit.
+   * @group Typeclass Instances
+   */
+  val SignedAngleOrder: Order[Angle] =
+    Order.by(signedMicroarcseconds.get)
+
+  // This works for both DMS and HMS so let's just do it once.
+  protected[math] def toMicrosexigesimal(micros: Long): (Int, Int, Int, Int, Int) = {
+    val µs =  micros                               % 1000L
+    val ms = (micros / (1000L))                    % 1000L
+    val s  = (micros / (1000L * 1000L))            % 60L
+    val m  = (micros / (1000L * 1000L * 60L))      % 60L
+    val d  = (micros / (1000L * 1000L * 60L * 60L))
+    (d.toInt, m.toInt, s.toInt, ms.toInt, µs.toInt)
+  }
+
+  /**
+   * Integral angle represented as a sum of degrees, arcminutes, arcseconds, milliarcseconds and
+   * microarcseconds. This type is exact and isomorphic to Angle.
+   */
+  final case class DMS(toAngle: Angle) {
+    val (
+      degrees: Int,
+      arcminutes: Int,
+      arcseconds: Int,
+      milliarcseconds: Int,
+      microarcseconds: Int
+    ) = Angle.toMicrosexigesimal(toAngle.toMicroarcseconds)
+    def format: String = f"$degrees%02d:$arcminutes%02d:$arcseconds%02d.$milliarcseconds%03d$microarcseconds%03d"
+    override final def toString = s"DMS($format)"
+  }
+  object DMS {
+    implicit val eqDMS: Eq[DMS] =
+      Eq.by(_.toAngle)
+  }
+
+  /**
+   * Construct a new Angle of the given magnitude as a sum of degrees, arcminutes, arcseconds,
+   * milliarcseconds, and microarcseconds. Exact modulo 360°.
+   * @group Constructors
+   */
+  def fromDMS(
+    degrees:         Int,
+    arcminutes:      Int,
+    arcseconds:      Int,
+    milliarcseconds: Int,
+    microarcseconds: Int
+  ): Angle =
+    fromMicroarcseconds(
+      microarcseconds.toLong +
+      milliarcseconds.toLong * 1000 +
+      arcseconds.toLong      * 1000 * 1000 +
+      arcminutes.toLong      * 1000 * 1000 * 60 +
+      degrees.toLong         * 1000 * 1000 * 60 * 60
+    )
+
+}
+
+trait AngleOptics extends OpticsHelpers { this: Angle.type =>
+
+  /**
+   * Microarcseconds, in [0, 360°).
+   * @group Optics
+   */
+  lazy val microarcseconds: SplitMono[Angle, Long] =
+    SplitMono(_.toMicroarcseconds, Angle.fromMicroarcseconds)
+
+  /**
+   * Signed microarcseconds, in [-180°, 180°).
+   * @group Optics
+   */
+  lazy val signedMicroarcseconds: SplitMono[Angle, Long] = {
+    lazy val µas360 = Angle.Angle180.toMicroarcseconds * 2L
+    microarcseconds.imapB[Long](
+      identity,
+      µas => if (µas >= Angle.Angle180.toMicroarcseconds) µas - µas360  else µas
+    )
+  }
+
+  /**
+   * Milliarcseconds, in [0, 360°).
+   * @group Optics
+   */
+  lazy val milliarcseconds: Wedge[Angle, Int] =
+    microarcseconds.scaled(1000L)
+
+  /**
+   * Arcseconds, in [0, 360°).
+   * @group Optics
+   */
+  lazy val arcseconds: Wedge[Angle, Int] =
+    microarcseconds.scaled(1000L * 1000L)
+
+  /**
+   * Arcminutes, in [0, 360°).
+   * @group Optics
+   */
+  lazy val arcminutes: Wedge[Angle, Int] =
+      microarcseconds.scaled(1000L * 1000L * 60L)
+
+  /**
+   * Degrees, in [0, 360).
+   * @group Optics
+   */
+  lazy val degrees: Wedge[Angle, Int] = microarcseconds.scaled(1000L * 1000L * 60L * 60L)
+
+  /**
+   * This angle, rounded down to the nearest HourAngle.
+   * @group Optics
+   */
+  lazy val hourAngle: SplitEpi[Angle, HourAngle] =
+    SplitEpi(a => HourAngle.microseconds.reverseGet(a.toMicroarcseconds.toLong / 15L), identity)
+
+  /**
+   * This angle as an HourAngle, where defined.
+   * @group Optics
+   */
+  lazy val hourAngleExact: Prism[Angle, HourAngle] =
+    Prism((a: Angle) => if (a.toMicroarcseconds % 15L === 0L) Some(hourAngle.get(a)) else None)(identity)
+
+  /**
+   * This angle as an DMS.
+   * @group Optics
+   */
+  lazy val dms: Iso[Angle, DMS] =
+    Iso(DMS(_))(_.toAngle)
+
+  /**
+   * String parsed as unsigned DMS.
+   * @see [[gem.parser.AngleParsers]]
+   * @group Optics
+   */
+  lazy val fromStringDMS: Format[String, Angle] =
+    Format(AngleParsers.dms.parseExact, dms.get(_).format)
+
+  /**
+   * String parsed as signed DMS.
+   * @see [[gem.parser.AngleParsers]]
+   * @group Optics
+   */
+  lazy val fromStringSignedDMS: Format[String, Angle] =
+    Format(fromStringDMS.getOption, { a =>
+      if (signedMicroarcseconds.get(a) < 0) "-" + fromStringDMS.reverseGet(-a)
+      else "+" + fromStringDMS.reverseGet(a)
+    })
+
+}
+
+
+/**
+ * Exact hour angles represented as integral microseconds. These values form a commutative group
+ * over addition, where the inverse is reflection around the 0-12h axis. This is a subgroup of the
+ * integral Angles where microarcseconds are evenly divisible by 15.
+ *
+ * Lawful conversion to and from other types/scales is provided by optics defined on the companion
+ * object. Floating-point conversions are provided directly
+ * @see The helpful [[https://en.wikipedia.org/wiki/Hour_angle Wikipedia]] article.
+ */
+final class HourAngle private (µas: Long) extends Angle(µas) {
+
+  // Sanity checks … should be correct via the companion constructor.
+  assert(toMicroarcseconds %  15 === 0, s"Invariant violated. $µas isn't divisible by 15.")
+
+  /**
+   * Flip this HourAngle by 12h. This is logically identical to the superclass implementation
+   * and serves only to refine the return type. Exact, invertible.
+   * @group Transformations
+   */
+  override def flip: HourAngle =
+    this + HourAngle.HourAngle12
+
+  /**
+   * Additive inverse of this HourAngle (by mirroring around the 0-12h axis). This is logically
+   * identical to the superclass implementation and serves only to refine the return type. Exact,
+   * invertible.
+   * @group Transformations
+   */
+  override def unary_- : HourAngle =
+    HourAngle.fromMicroseconds(-toMicroseconds.toLong)
+
+  /**
+   * This `HourAngle` in microseconds. Exact.
+   * @group Conversions
+   */
+  def toMicroseconds: Long =
+    toMicroarcseconds / 15
+
+  /**
+   * This `HourAngle` in decimal hours. Approximate.
+   * @group Conversions
+   */
+  def toDoubleHours: Double =
+    toMicroseconds.toDouble / HourAngle.µsPerHour
+
+  /**
+   * Sum of this HourAngle and `ha`. Exact, commutative, invertible.
+   * @group Operations
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  def +(ha: HourAngle): HourAngle =
+    HourAngle.fromMicroseconds(toMicroseconds.toLong + ha.toMicroseconds.toLong)
+
+  /**
+   * Difference of this HourAngle and `ha`. Exact, invertible.
+   * @group Operations
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  def -(ha: HourAngle): HourAngle =
+    HourAngle.fromMicroseconds(toMicroseconds.toLong - ha.toMicroseconds.toLong)
+
+  /** String representation of this HourAngle, for debugging purposes only. */
+  override def toString =
+    HourAngle.fromStringHMS.taggedToString("HourAngle", this)
+
+}
+
+object HourAngle extends HourAngleOptics {
+
+  private val µsPerHour: Long = 60L * 60L * 1000L * 1000L
+
+  /** @group Constants */ lazy val HourAngle0 : HourAngle = microseconds.reverseGet(0)
+  /** @group Constants */ lazy val HourAngle12: HourAngle = hours.reverseGet(12)
+
+  /**
+   * Construct a new Angle of the given magnitude in integral microseconds, modulo 24h. Exact.
+   * @group Constructors
+   */
+  def fromMicroseconds(µs: Long): HourAngle = {
+    val µsPer24 = 24L * µsPerHour
+    val µsʹ = (((µs % µsPer24) + µsPer24) % µsPer24)
+    new HourAngle(µsʹ * 15L)
+  }
+
+  /**
+   * Construct a new Angle of the given magnitude in floating point hours, modulo 24h. Approximate.
+   * @group Constructors
+   */
+  def fromDoubleHours(hs: Double): HourAngle =
+    fromMicroseconds((hs * µsPerHour).round)
+
+  /**
+   * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,
+   * milliseconds, and microseconds. Exact modulo 24h.
+   * @group Constructors
+   */
+  def fromHMS(hours: Int, minutes: Int, seconds: Int, milliseconds: Int, microseconds: Int): HourAngle =
+    fromMicroseconds(
+      microseconds.toLong +
+      milliseconds.toLong * 1000L +
+      seconds.toLong      * 1000L * 1000L +
+      minutes.toLong      * 1000L * 1000L * 60L +
+      hours.toLong        * 1000L * 1000L * 60L * 60L
+    )
+
+  /**
+   * HourAngle forms a commutative group.
+   * @group Typeclass Instances
+   */
+  implicit val AngleCommutativeGroup: CommutativeGroup[HourAngle] =
+    new CommutativeGroup[HourAngle] {
+      val empty: HourAngle = HourAngle0
+      def combine(a: HourAngle, b: HourAngle) = a + b
+      def inverse(a: HourAngle) = -a
+    }
+
+  /** @group Typeclass Instances */
+  implicit val HourAngleShow: Show[HourAngle] =
+    Show.fromToString
+
+  /**
+   * Angles are equal if their magnitudes are equal.
+   * @group Typeclass Instances
+   */
+  implicit val HourAngleEqual: Eq[HourAngle] =
+    Eq.by(_.toMicroarcseconds)
+
+  /**
+   * Integral hour angle represented as a sum of hours, minutes, seconds, milliseconds, and
+   * microseconds. This type is exact and isomorphic to HourAngle.
+   */
+  final case class HMS(toHourAngle: HourAngle) {
+    def toAngle: Angle = toHourAngle // forget it's an hour angle
+    val (
+      hours: Int,
+      minutes: Int,
+      seconds: Int,
+      milliseconds: Int,
+      microseconds: Int
+    ) = Angle.toMicrosexigesimal(toHourAngle.toMicroseconds)
+    def format: String = f"$hours%02d:$minutes%02d:$seconds%02d.$milliseconds%03d$microseconds%03d"
+    override final def toString = format
+  }
+  object HMS {
+    implicit val eqHMS: Eq[HMS] =
+      Eq.by(_.toHourAngle)
+  }
+
+}
+
+trait HourAngleOptics extends OpticsHelpers { this: HourAngle.type =>
+
+  /**
+   * This `HourAngle` as an `Angle`.
+   * @group Optics
+   */
+  lazy val angle: SplitMono[HourAngle, Angle] = Angle.hourAngle.reverse
+
+  /**
+   * This `HourAngle` in microseconds.
+   * @group Optics
+   */
+  lazy val microseconds: SplitMono[HourAngle, Long] =
+    SplitMono(_.toMicroseconds, HourAngle.fromMicroseconds)
+
+  /**
+   * This `HourAngle` in milliseconds.
+   * @group Optics
+   */
+  lazy val milliseconds: Wedge[HourAngle, Int] =
+    microseconds.scaled(1000L)
+
+  /**
+   * This `HourAngle` in seconds.
+   * @group Optics
+   */
+  lazy val seconds: Wedge[HourAngle, Int] =
+    microseconds.scaled(1000L * 1000L)
+
+  /**
+   * This `HourAngle` in minutes.
+   * @group Optics
+   */
+  lazy val minutes: Wedge[HourAngle, Int] =
+    microseconds.scaled(1000L * 1000L * 60L)
+
+  /**
+   * This `HourAngle` in hours.
+   * @group Optics
+   */
+  lazy val hours: Wedge[HourAngle, Int] =
+    microseconds.scaled(1000L * 1000L * 60L * 60L)
+
+  /**
+   * This `HourAngle` as an `HMS`.
+   * @group Optics
+   */
+  lazy val hms: Iso[HourAngle, HMS] =
+    Iso(HMS(_))(_.toHourAngle)
+
+  /**
+   * String in HMS as an `HourAngle`/
+   * @group Optics
+   */
+  lazy val fromStringHMS: Format[String, HourAngle] =
+    Format(AngleParsers.hms.parseExact, HMS(_).format)
+
+}
+
+trait OpticsHelpers {
+
+  // Syntax to scale down and squeeze into Int
+  protected implicit class SplitMonoOps[A](self: SplitMono[A, Long]) {
+
+    private val longToInt: SplitEpi[Long, Int] =
+      SplitEpi(_.toInt, _.toLong)
+
+    def scaled(n: Long): Wedge[A, Int] =
+      self.imapB[Long](_ * n, _ / n) composeSplitEpi longToInt
+
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Coordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Coordinates.scala
@@ -1,0 +1,138 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package math
+
+import cats._, cats.implicits._
+import gem.parser.CoordinateParsers
+import gem.optics.Format
+import gem.syntax.all._
+import monocle.Lens
+import monocle.macros._
+import scala.math.{ sin, cos, atan2, sqrt }
+
+/** A point in the sky, given right ascension and declination. */
+final case class Coordinates(ra: RightAscension, dec: Declination) {
+
+  /**
+   * Offset these `Coordinates` by the given deltas, and indicate whether the declination crossed
+   * a pole; if so the right ascension will have been flipped 180°.
+   * @group Operations
+   */
+  def offsetWithCarry(dRA: HourAngle, dDec: Angle): (Coordinates, Boolean) =
+    dec.offset(dDec) match {
+      case (decʹ, false) => (Coordinates(ra.offset(dRA),      decʹ), false)
+      case (decʹ, true)  => (Coordinates(ra.flip.offset(dRA), decʹ), true)
+    }
+
+  /**
+   * Offset these `Coordinates` by the given deltas. If the declination crossed a pole the right
+   * ascension will have been flipped 180°.
+   * @group Operations
+   */
+  def offset(dRA: HourAngle, dDec: Angle): Coordinates =
+    offsetWithCarry(dRA, dDec)._1
+
+  /**
+   * Compute the offset between points, such that `a offset (a diff b) = b`.
+   * @group Operations
+   */
+  def diff(c: Coordinates): (HourAngle, Angle) =
+    (c.ra.toHourAngle - ra.toHourAngle, c.dec.toAngle - dec.toAngle)
+
+  /**
+   * Angular distance from `this` to `that`, always a positive angle in [0, 180]). Approximate.
+   * @see Algorithm at [[http://www.movable-type.co.uk/scripts/latlong.html Movable Type Scripts]].
+   */
+  def angularDistance(that: Coordinates): Angle = {
+    val φ1 = this.dec.toAngle.toDoubleRadians
+    val φ2 = that.dec.toAngle.toDoubleRadians
+    val Δφ = (that.dec.toAngle - this.dec.toAngle).toDoubleRadians
+    val Δλ = (that.ra.toAngle  - this.ra.toAngle) .toDoubleRadians
+    val a  = sin(Δφ / 2) * sin(Δφ / 2) +
+             cos(φ1)     * cos(φ2)     *
+             sin(Δλ / 2) * sin(Δλ / 2)
+    Angle.fromDoubleRadians(2 * atan2(sqrt(a), sqrt(1 - a)))
+  }
+
+  /**
+   * Interpolate between `this` and `that` at a position specified by `f`, where `0.0` is `this`,
+   * `1.0` is `other`, and `0.5` is halfway along the great circle connecting them. Note that this
+   * computation is undefined where `f` is `NaN` or `Infinity`. Approximate.
+   * @see Algorithm at [[http://www.movable-type.co.uk/scripts/latlong.html Movable Type Scripts]].
+   */
+  def interpolate(that: Coordinates, f: Double): Coordinates = {
+    val δ = angularDistance(that).toDoubleRadians
+    if (δ === 0) this
+    else {
+      val φ1 = this.dec.toAngle.toDoubleRadians
+      val φ2 = that.dec.toAngle.toDoubleRadians
+      val λ1 = this.ra.toAngle.toDoubleRadians
+      val λ2 = that.ra.toAngle.toDoubleRadians
+      val a  = sin((1 - f) * δ) / sin(δ) // n.b. this line is wrong on the web page
+      val b  = sin(f * δ) / sin(δ)
+      val x  = a * cos(φ1) * cos(λ1) + b * cos(φ2) * cos(λ2)
+      val y  = a * cos(φ1) * sin(λ1) + b * cos(φ2) * sin(λ2)
+      val z  = a * sin(φ1) + b * sin(φ2)
+      val φi = atan2(z, sqrt(x * x + y * y))
+      val λi = atan2(y, x)
+      Coordinates(
+        RA.fromHourAngle.get(Angle.hourAngle.get(Angle.fromDoubleRadians(λi))),
+        Dec.fromAngle.unsafeGet(Angle.fromDoubleRadians(φi))
+      )
+    }
+  }
+
+  /** These coordinates in radians, [0 .. 2π) and [-π/2 .. π/2]. */
+  def toRadians: (Double, Double) =
+    (ra.toRadians, dec.toRadians)
+
+  override def toString =
+    Coordinates.fromHmsDms.productToString(this)
+
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object Coordinates extends CoordinatesOptics {
+
+  /* @group Constructors */ val Zero:      Coordinates = Coordinates(RA.Zero, Dec.Zero)
+  /* @group Constructors */ val SouthPole: Coordinates = Coordinates(RA.Zero, Dec.Min)
+  /* @group Constructors */ val NorthPole: Coordinates = Coordinates(RA.Zero, Dec.Max)
+
+  def fromRadians(ra: Double, dec: Double): Option[Coordinates] =
+    Declination.fromRadians(dec).map(Coordinates(RA.fromRadians(ra), _))
+
+  def unsafeFromRadians(ra: Double, dec: Double): Coordinates =
+    Coordinates(RA.fromRadians(ra), Declination.unsafeFromRadians(dec))
+
+  /** @group Typeclass Instances */
+  implicit val CoordinatesOrder: Order[Coordinates] =
+    Order.by(c => (c.ra, c.dec))
+
+  /** @group Typeclass Instances. */
+  implicit val ShowCoordinates: Show[Coordinates] =
+    Show.fromToString
+
+}
+
+trait CoordinatesOptics { this: Coordinates.type =>
+
+  /**
+   * Format as a String like "17 57 48.49803 +04 41 36.2072".
+   * @group Optics
+   */
+  val fromHmsDms: Format[String, Coordinates] = Format(
+    CoordinateParsers.coordinates.parseExact,
+    cs => s"${RightAscension.fromStringHMS.reverseGet(cs.ra)} ${Declination.fromStringSignedDMS.reverseGet(cs.dec)}"
+  )
+
+  /** @group Optics */
+  val rightAscension: Lens[Coordinates, RightAscension] =
+    GenLens[Coordinates](_.ra)
+
+  /** @group Optics */
+  val declination: Lens[Coordinates, Declination] =
+    GenLens[Coordinates](_.dec)
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Declination.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Declination.scala
@@ -1,0 +1,98 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package math
+
+import cats.{ Order, Show }
+import cats.instances.long._
+import gem.parser.CoordinateParsers
+import gem.syntax.all._
+import gem.optics.Format
+import monocle.Prism
+
+/**
+ * Celestial latitude, measured in angular distance from the celestial equator. Points north of the
+ * celestial equator have positive declinations, while those south have negative declinations. This
+ * is a newtype wrapper for an `Angle` constrainted to the range [-90°, 90°], or [270 - 360) +
+ * [0 - 90] in terms of the underlying `Angle`. Note that the range is *inclusive* of both poles.
+ * @see The helpful [[https://en.wikipedia.org/wiki/Declination Wikipedia]] article.
+ */
+sealed abstract case class Declination protected (toAngle: Angle) {
+
+  // Sanity check … should be correct via the companion constructor.
+  assert(
+    toAngle.toMicroarcseconds >= Angle.Angle270.toMicroarcseconds ||
+    toAngle.toMicroarcseconds <= Angle.Angle90.toMicroarcseconds,
+    s"Invariant violated. $toAngle is outside the range [270 - 360) + [0 - 90]"
+  )
+
+  /**
+   * Offset this [[Declination]] by the given angle, returning the result and a carry bit. A carry
+   * of `true` indicates that the result lies on the opposite side of the sphere and the
+   * associated [[RightAscension]] (if any) must be flipped by around the 90° axis. Exact,
+   * invertible by offseting again by `-a` if carry is false, or by `a` if true; new carry will be
+   * the same.
+   * @group Operations
+   */
+  def offset(a: Angle): (Declination, Boolean) =
+    Declination.fromAngleWithCarry(toAngle + a)
+
+  /** This declination in signed radians in [-π/2 .. π/2] */
+  def toRadians: Double =
+    toAngle.toSignedDoubleRadians
+
+  final override def toString: String =
+    Declination.fromStringSignedDMS.taggedToString("Dec", this)
+
+}
+
+object Declination extends DeclinationOptics {
+
+  val Min:  Declination = fromAngle.unsafeGet(Angle.Angle270)
+  val Max:  Declination = fromAngle.unsafeGet(Angle.Angle90)
+  val Zero: Declination = fromAngle.unsafeGet(Angle.Angle0)
+
+  /**
+   * Construct a `Declination` from an `Angle`, mirroring about the 90° axis if out of range and
+   * reporting whether or not mirroring was required. This operation is useful when offsetting might
+   * cause coordinates to cross the pole, in which case the associated RA will need to be flipped
+   * 180°.
+   * @group Constructors
+   */
+  def fromAngleWithCarry(a: Angle): (Declination, Boolean) =
+    fromAngle.getOption(a).map((_, false)) getOrElse {
+      (fromAngle.unsafeGet(a mirrorBy Angle.Angle90), true)
+    }
+
+  def fromRadians(rad: Double): Option[Declination] =
+    fromAngle.getOption(Angle.fromDoubleRadians(rad))
+
+  def unsafeFromRadians(rad: Double): Declination =
+    fromAngle.unsafeGet(Angle.fromDoubleRadians(rad))
+
+  /**
+   * Declinations are ordered from south to north.
+   * @group Typeclass Instances
+   */
+  implicit val DeclinationOrder: Order[Declination] =
+    Order.by(dec => Angle.signedMicroarcseconds.get(dec.toAngle))
+
+  implicit val DeclinationShow: Show[Declination] =
+    Show.fromToString
+
+}
+
+trait DeclinationOptics { this: Declination.type =>
+
+  val fromAngle: Prism[Angle, Declination] =
+    Prism((a: Angle) => {
+      if (a.toMicroarcseconds >= Angle.Angle270.toMicroarcseconds ||
+          a.toMicroarcseconds <= Angle.Angle90.toMicroarcseconds) Some(new Declination(a) {})
+      else None
+    })(_.toAngle)
+
+  val fromStringSignedDMS: Format[String, Declination] =
+    Format(CoordinateParsers.dec.parseExact, d => Angle.fromStringSignedDMS.reverseGet(d.toAngle))
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Ephemeris.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Ephemeris.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.syntax.treemap._
+import gem.util.Timestamp
+
+import cats.{ Eq, Foldable, Monoid }
+import cats.implicits._
+
+import scala.collection.immutable.TreeMap
+
+/**
+ * Time-parameterized coordinates over a fixed interval, defined pairwise. Coordinates that fall
+ * between known instants are interpolated.
+ */
+sealed abstract case class Ephemeris private (toMap: TreeMap[Timestamp, EphemerisCoordinates]) {
+  import Ephemeris.Element
+
+  // N.B. this case class is abstract and has a private ctor because we want to keep construction of
+  // the TreeMap private to ensure that the correct ordering is used and remains consistent.
+
+  /** First element in this ephemeris, if any. */
+  def first: Option[Element] =
+    toMap.headOption
+
+  /** Last element in this ephemeris, if any. */
+  def last: Option[Element] =
+    toMap.lastOption
+
+  /** Coordinates at time `t`, exact if known, interpolated if `bracket(t)` is known. */
+  def get(t: Timestamp): Option[EphemerisCoordinates] =
+    toMap.get(t) orElse bracket(t).map { case ((a, ca), (b, cb)) =>
+      val (iʹ, aʹ, bʹ) = (t.toEpochMilli, a.toEpochMilli, b.toEpochMilli)
+      val factor = (iʹ - aʹ).toDouble / (bʹ - aʹ).toDouble
+      ca.interpolate(cb, factor)
+    }
+
+  /**
+   * Greatest lower and least upper bounds of `t`; i.e., the closest elements on either side,
+   * inclusive (so if `t` is present then `bracket(t) = (t, t)`).
+   */
+  def bracket(t: Timestamp): Option[(Element, Element)] =
+    (toMap.to(t).lastOption, toMap.from(t).headOption).tupled
+
+  /** The sum of this ephemeris and `e`, taking values from `e` in the case of overlap. */
+  def ++(e: Ephemeris): Ephemeris =
+    new Ephemeris(toMap ++ e.toMap) {}
+
+}
+object Ephemeris {
+
+  /** An ephemeris element. */
+  type Element = (Timestamp, EphemerisCoordinates)
+
+  /** The empty ephemeris. */
+  val empty: Ephemeris = apply()
+
+  /** Construct an ephemeris from a sequence of literal elements. */
+  def apply(es: Element*): Ephemeris =
+    fromList(es.toList)
+
+  /** Construct an ephemeris from a `List` of elements. */
+  def fromList(es: List[Element]): Ephemeris =
+    new Ephemeris(TreeMap.fromList(es)) {}
+
+  /** Construct an ephemeris from a foldable of elements. */
+  def fromFoldable[F[_]: Foldable](fa: F[Element]): Ephemeris =
+    fromList(fa.toList)
+
+  /** Ephemerides form a monoid, using `++` as the combining operation. */
+  implicit val MonoidEphemeris: Monoid[Ephemeris] =
+    new Monoid[Ephemeris] {
+      val empty: Ephemeris = Ephemeris.empty
+      def combine(a: Ephemeris, b: Ephemeris) = a ++ b
+    }
+
+  implicit val EqEphemeris: Eq[Ephemeris] =
+    Eq.fromUniversalEquals
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/EphemerisCoordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/math/EphemerisCoordinates.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats._
+import monocle.Lens
+import monocle.macros.GenLens
+
+/** A coordinate along with a rate of change in RA and Dec for some time unit,
+  * expressed as an offset in p and q.  In reality the velocity information
+  * comes from horizons and is always arcseconds per hour in horizons data.
+  *
+  * @param coord coordinates
+  * @param delta rate of change in RA and dec, where the delta(RA)/time has been
+  *              multiplied by the cosine of the dec
+  */
+final case class EphemerisCoordinates(
+                   coord: Coordinates,
+                   delta: Offset /* per time unit */) {
+
+  /** Interpolates the position and rate of change at a point between this
+    * coordinate and the given coordinate.
+    */
+  def interpolate(that: EphemerisCoordinates, f: Double): EphemerisCoordinates = {
+    def interpolateAngle(a: Angle, b: Angle): Angle =
+      Angle.fromMicroarcseconds(
+        (Angle.signedMicroarcseconds.get(a).toDouble * (1 - f) + Angle.signedMicroarcseconds.get(b) * f).round
+      )
+
+    val coordʹ = coord.interpolate(that.coord, f)
+    val pʹ     = interpolateAngle(delta.p.toAngle, that.delta.p.toAngle)
+    val qʹ     = interpolateAngle(delta.q.toAngle, that.delta.q.toAngle)
+
+    EphemerisCoordinates(coordʹ, Offset(Offset.P(pʹ), Offset.Q(qʹ)))
+  }
+
+}
+
+object EphemerisCoordinates extends EphemerisCoordinatesOptics {
+
+  val Zero: EphemerisCoordinates =
+    EphemerisCoordinates(Coordinates.Zero, Offset.Zero)
+
+  /** @group Typeclass Instances */
+  implicit val EphemerisCoordinatesEqual: Eq[EphemerisCoordinates] =
+    Eq.fromUniversalEquals
+
+  /** @group Typeclass Instances */
+  implicit val ShowEphemerisCoordinates: Show[EphemerisCoordinates] =
+    Show.fromToString
+
+}
+
+trait EphemerisCoordinatesOptics {
+
+  /** @group Optics */
+  val coordinates: Lens[EphemerisCoordinates, Coordinates] =
+    GenLens[EphemerisCoordinates](_.coord)
+
+  /** @group Optics */
+  val delta: Lens[EphemerisCoordinates, Offset] =
+    GenLens[EphemerisCoordinates](_.delta)
+
+  /** @group Optics */
+  val rightAscension: Lens[EphemerisCoordinates, RightAscension] =
+    coordinates composeLens Coordinates.rightAscension
+
+  /** @group Optics */
+  val declination: Lens[EphemerisCoordinates, Declination] =
+    coordinates composeLens Coordinates.declination
+
+  /** @group Optics */
+  val deltaP: Lens[EphemerisCoordinates, Offset.P] =
+    delta composeLens Offset.p
+
+  /** @group Optics */
+  val deltaQ: Lens[EphemerisCoordinates, Offset.Q] =
+    delta composeLens Offset.q
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Epoch.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Epoch.scala
@@ -1,0 +1,148 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package math
+
+import cats.{ Order, Show }
+import cats.implicits._
+import gem.parser.EpochParsers
+import gem.syntax.parser._
+import gem.optics.Format
+import java.time._
+
+/**
+ * An epoch, the astronomer's equivalent of `Instant`, based on a fractional year in some temporal
+ * scheme (Julian or Besselian) that determines year zero and the length of a year. The only
+ * meaningful operation for an `Epoch` is to ask the elapsed epoch-years between it and some other
+ * point in time. We need this for proper motion corrections because velocities are measured in
+ * motion per epoch-year. The epoch year is stored internally as integral milliyears.
+ * @param scheme This `Epoch`'s temporal scheme.
+ * @see The Wikipedia [[https://en.wikipedia.org/wiki/Epoch_(astronomy) article]]
+ */
+final class Epoch private (val scheme: Epoch.Scheme, private[math] val toMilliyears: Int) {
+
+  /** This `Epoch`'s year. Note that this value is not very useful without the `Scheme`. */
+  def epochYear: Double =
+    toMilliyears.toDouble * 1000.0
+
+  /** Offset in epoch-years from this `Epoch` to the given `Instant`. */
+  def untilInstant(i: Instant): Double =
+    untilLocalDateTime(LocalDateTime.ofInstant(i, ZoneOffset.UTC))
+
+  /** Offset in epoch-years from this `Epoch` to the given `LocalDateTime`. */
+  def untilLocalDateTime(ldt: LocalDateTime): Double =
+    untilJulianDay(Epoch.Scheme.toJulianDay(ldt))
+
+  /** Offset in epoch-years from this `Epoch` to the given fractional Julian day. */
+  def untilJulianDay(jd: Double): Double =
+    untilEpochYear(scheme.fromJulianDay(jd).epochYear)
+
+  /** Offset in epoch-years from this `Epoch` to the given epoch year under the same scheme. */
+  def untilEpochYear(epochYear: Double): Double =
+    epochYear - this.epochYear
+
+  def plusYears(y: Double): Epoch =
+    scheme.fromEpochYears(epochYear + y)
+
+  override def equals(a: Any): Boolean =
+    a match {
+      case e: Epoch => (scheme === e.scheme) && toMilliyears === e.toMilliyears
+      case _ => false
+    }
+
+  override def hashCode: Int =
+    scheme.hashCode ^ toMilliyears
+
+  override def toString =
+    Epoch.fromString.taggedToString("Epoch", this)
+
+}
+
+object Epoch extends EpochOptics {
+
+  /**
+   * Standard epoch.
+   * @group Constructors
+   */
+  val J2000: Epoch = Julian.fromIntegralYears(2000)
+
+  /**
+   * Standard epoch prior to J2000. Obsolete but still in use.
+   * @group Constructors
+   */
+  val B1950: Epoch = Besselian.fromIntegralYears(1950)
+
+  /**
+   * The scheme defines year zero and length of a year in terms of Julian days. There are two
+   * common schemes that we support here.
+   */
+  sealed abstract class Scheme(
+    val prefix:       Char,
+    val yearBasis:    Double,
+    val julianBasis:  Double,
+    val lengthOfYear: Double
+  ) {
+
+    def fromIntegralYears(years: Int): Epoch =
+      fromMilliyears(years * 1000)
+
+    def fromMilliyears(mys: Int): Epoch =
+      new Epoch(this, mys)
+
+    def fromLocalDateTime(ldt: LocalDateTime): Epoch =
+      fromJulianDay(Scheme.toJulianDay(ldt))
+
+    def fromJulianDay(jd: Double): Epoch =
+      fromEpochYears(yearBasis + (jd - julianBasis) / lengthOfYear)
+
+    def fromEpochYears(epochYear: Double): Epoch =
+      fromMilliyears((epochYear * 1000.0).toInt)
+
+  }
+  object Scheme {
+
+    /**
+     * Convert a `LocalDateTime` to a fractional Julian day.
+     * @see The Wikipedia [[https://en.wikipedia.org/wiki/Julian_day article]]
+     */
+    def toJulianDay(dt: LocalDateTime): Double =
+      JulianDate.ofLocalDateTime(dt).dayNumber.toDouble
+
+    implicit val SchemeOrder: Order[Scheme] =
+      Order.by(s => (s.prefix, s.yearBasis, s.julianBasis, s.lengthOfYear))
+
+    implicit val SchemeShow: Show[Scheme] =
+      Show.fromToString
+
+  }
+
+  /**
+   * Module of constructors for Besselian epochs.
+   * @group Constructors
+   */
+  case object Besselian extends Scheme('B', 1900.0, 2415020.31352, 365.242198781)
+
+  /**
+   * Module of constructors for Julian epochs.
+   * @group Constructors
+   */
+  case object Julian extends Scheme('J', 2000.0, 2451545.0, 365.25)
+
+  implicit val EpochOrder: Order[Epoch] =
+    Order.by(e => (e.scheme, e.toMilliyears))
+
+  implicit val EpochShow: Show[Epoch] =
+    Show.fromToString
+
+}
+
+trait EpochOptics { this: Epoch.type =>
+
+  val fromString: Format[String, Epoch] =
+    Format(
+      s => EpochParsers.epoch.parseExact(s),
+      e => f"${e.scheme.prefix}%s${e.toMilliyears / 1000}%d.${e.toMilliyears % 1000}%03d"
+    )
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Index.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Index.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.{ Order, Show }
+import cats.instances.short._
+import mouse.boolean._
+import gem.parser.MiscParsers
+import gem.syntax.all._
+import monocle.Prism
+
+/** A positive, non-zero value for numbered identifiers. */
+sealed abstract case class Index(toShort: Short)
+object Index extends IndexOptics {
+
+  val One: Index =
+    fromShort.unsafeGet(1)
+
+  implicit val OrderIndex: Order[Index] =
+    Order.by(_.toShort)
+
+  implicit val OrderingIndex: scala.math.Ordering[Index] =
+    OrderIndex.toOrdering
+
+  implicit val showIndex: Show[Index] =
+    Show.fromToString
+
+}
+
+trait IndexOptics {
+
+  /** @group Optics */
+  val fromShort: Prism[Short, Index] =
+    Prism((i: Short) => (i > 0) option new Index(i) {})(_.toShort)
+
+  /** @group Optics */
+  val fromString: Prism[String, Index] =
+    Prism(MiscParsers.index.parseExact)(_.toShort.toString)
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/JulianDate.scala
+++ b/modules/core/shared/src/main/scala/gem/math/JulianDate.scala
@@ -1,0 +1,119 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.{Order, Show}
+import cats.implicits._
+
+import java.time.{Instant, LocalDateTime}
+import java.time.ZoneOffset.UTC
+
+/** Astronomical time representation of continuous days since noon, November 24,
+  * 4714 BC.
+  *
+  * @param dayNumber      whole Julian Day number
+  * @param nanoAdjustment fraction of a day adjustment in nanoseconds
+  *
+  * @see The Wikipedia [[https://en.wikipedia.org/wiki/Julian_day article]]
+  */
+sealed abstract case class JulianDate(
+  dayNumber:      Int,
+  nanoAdjustment: Long
+) {
+
+  import JulianDate._
+
+  // Guaranteed by the JulianDate constructors, double checked here.
+  assert(dayNumber      >= 0,             s"dayNumber >= 0")
+  assert(nanoAdjustment >= MinAdjustment, s"nanoAdjustment >= $MinAdjustment")
+  assert(nanoAdjustment <= MaxAdjustment, s"nanoAdjustment <= $MaxAdjustment")
+
+
+  /** Julian date value as a Double, including Julian Day Number and fractional
+    * day since the preceding noon.
+    */
+  val toDouble: Double =
+    dayNumber + nanoAdjustment.toDouble / NanoPerDay.toDouble
+
+  /** Modified Julian Date (MJD) double.  This is logically the same as
+    * `toDouble - 2400000.5`. MJD was introduced to preserve a bit of floating
+    * point decimal precision in calculations that use Julian dates.  It also
+    * makes it easier to directly implement algorithms that work with MJD.
+    *
+    * @see http://tycho.usno.navy.mil/mjd.html
+    */
+  def toModifiedDouble: Double = {
+    val h = SecondsPerHalfDay.toLong * Billion.toLong
+    val d = dayNumber      - 2400000
+    val n = nanoAdjustment - h
+
+    val (dʹ,nʹ) = if (n >= MinAdjustment) (d, n)
+                  else (d - 1, n + SecondsPerDay.toLong * Billion.toLong)
+
+    dʹ + nʹ.toDouble / NanoPerDay.toDouble
+  }
+}
+
+
+object JulianDate {
+
+  /** Seconds per Julian day. */
+  val SecondsPerDay: Int =               // 86400
+    24 * 60 * 60
+
+  private val SecondsPerHalfDay: Int  =  // 43200
+    SecondsPerDay / 2
+
+  private val Billion: Int        = 1000000000
+  private val NanoPerDay: Long    = SecondsPerDay.toLong * Billion.toLong
+
+  private val MinAdjustment: Long = -SecondsPerHalfDay.toLong * Billion.toLong
+  private val MaxAdjustment: Long =  SecondsPerHalfDay.toLong * Billion.toLong - 1
+
+  /** J2000 reference epoch as Julian Date. */
+  val J2000: JulianDate =                // JulianDate(2451545,0)
+    JulianDate.ofLocalDateTime(
+      LocalDateTime.of(2000, 1, 1, 12, 0, 0)
+    )
+
+  /** Convert an `Instant` to a Julian Date.
+    */
+  def ofInstant(i: Instant): JulianDate =
+    ofLocalDateTime(LocalDateTime.ofInstant(i, UTC))
+
+  /** JulianDate from a `LocalDateTime` assumed to represent a time at UTC.
+    */
+  def ofLocalDateTime(ldt: LocalDateTime): JulianDate = {
+    val y   = ldt.getYear
+    val m   = ldt.getMonthValue
+    val d   = ldt.getDayOfMonth
+
+    // Julian Day Number algorithm from:
+    // Fliegel, H.F. and Van Flandern, T.C. (1968). "A Machine Algorithm for
+    // Processing Calendar Dates" Communications of the Association of Computing
+    // Machines ll, 6sT.
+
+    // Yes, integer division.  -1 for Jan and Feb. 0 for Mar - Dec.
+    val t   = (m - 14) / 12
+
+    // Julian Day Number (integer division).
+    val jdn = (1461 * (y + 4800 + t))       /  4 +
+              ( 367 * (m - 2 - 12 * t))     / 12 -
+              (   3 * ((y + 4900 + t)/100)) /  4 +
+              d - 32075
+
+    // Whole seconds since midnight
+    val secs = ldt.getHour * 3600 + ldt.getMinute * 60 + ldt.getSecond
+    val adj  = (secs - SecondsPerHalfDay).toLong * Billion + ldt.getNano
+
+    new JulianDate(jdn, adj) {}
+  }
+
+  implicit val JulianDateOrder: Order[JulianDate] =
+    Order.by(jd => (jd.dayNumber, jd.nanoAdjustment))
+
+  implicit val JulianDateShow: Show[JulianDate] =
+    Show.fromToString
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/LocalObservingNight.scala
+++ b/modules/core/shared/src/main/scala/gem/math/LocalObservingNight.scala
@@ -1,0 +1,147 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats._
+import cats.data.Validated
+import cats.effect.Sync
+import cats.implicits._
+import gem.enum.Site
+import gem.instances.time._
+import java.time._
+import java.time.format.DateTimeFormatter
+import monocle.Iso
+import monocle.macros.GenIso
+
+/** A local observing night is defined as the period of time starting at 14:00
+  * (inclusive) on one day and ending at 14:00 (exclusive) the next day.
+  *
+  * A `LocalObservingNight` is site-agnostic.  Use `atSite` to obtain precise
+  * start / end times in an `ObservingNight`.
+  */
+final case class LocalObservingNight(toLocalDate: LocalDate) {
+
+  /** Constructs an ObservingNight associated with a particular Site. */
+  def atSite(site: Site): ObservingNight =
+    ObservingNight(site, this)
+
+  /** The start time (inclusive) of the local observing night. */
+  def start: LocalDateTime =
+    end.minusDays(1L)
+
+  /** The end time (exclusive) of the local observing night. */
+  def end: LocalDateTime =
+    LocalDateTime.of(toLocalDate, LocalObservingNight.Start)
+
+  /** The previous local observing night. */
+  def previous: LocalObservingNight =
+    LocalObservingNight(toLocalDate.minusDays(1L))
+
+  /** The next local observing night. */
+  def next: LocalObservingNight =
+    LocalObservingNight(toLocalDate.plusDays(1L))
+
+  /** Returns `true` if the local date time is included in this night, but
+    * `false` otherwise.
+    */
+  def includes(d: LocalDateTime): Boolean =
+    (start <= d) && (d < end)
+
+  /** Formats the LocalObservingNight to a String `YYYYMMDD` that is readable by
+    * `LocalObservingNight.fromString`.
+    */
+  def format: String =
+    LocalObservingNight.Formatter.format(toLocalDate)
+}
+
+object LocalObservingNight extends LocalObservingNightOptics {
+
+  /** The hour, in the local time zone, at which the night is considered to
+    * officially start.
+    *
+    * @group Constants
+    */
+  val StartHour: Int =
+    14
+
+  /** The local time at which the night is considered to officially start.
+    *
+    * @group Constants
+    */
+  val Start: LocalTime =
+    LocalTime.of(StartHour, 0)
+
+  /** Formatter for nights.  The night string representation corresponds to the
+    * date YYYYMMDD for which the night ends in UTC.
+    *
+    * @group Constants
+    */
+  val Formatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyyMMdd")
+
+  /** Constructs the LocalObservingNight corresponding to the given date and
+    * time, taking into account the 2PM switchover hour.
+    *
+    * @group Constructors
+    */
+  def fromLocalDateTime(d: LocalDateTime): LocalObservingNight =
+    LocalObservingNight(
+      d.toLocalDate.plusDays(if (d.toLocalTime >= Start) 1L else 0L)
+    )
+
+  /** Constructs the LocalObservingNight corresponding to the given time, taking
+    * into account the 2PM switchover hour.
+    *
+    * @group Constructors
+    */
+  def fromZonedDateTime(d: ZonedDateTime): LocalObservingNight =
+    fromLocalDateTime(d.toLocalDateTime)
+
+  /** Constructs the LocalObservingNight corresponding to the given time, taking
+    * into account the 2PM switchover hour.
+    *
+    * @group Constructors
+    */
+  def fromSiteAndInstant(s: Site, i: Instant): LocalObservingNight =
+    fromZonedDateTime(ZonedDateTime.ofInstant(i, s.timezone))
+
+  /** Returns a program in M that computes the LocalObservingNight for the
+    * instant it is executed.
+    *
+    * @group Constructors
+    */
+  def current[M[_]: Sync]: M[LocalObservingNight] =
+    Sync[M].delay(LocalDateTime.now).map(fromLocalDateTime)
+
+  /** Parse a LocalObservingNight like `20180307` from a String, if possible. */
+  def fromString(s: String): Option[LocalObservingNight] =
+    Validated.catchNonFatal { LocalDate.parse(s, Formatter) }
+             .toOption
+             .map(LocalObservingNight(_))
+
+  /** Parse a LocalObservingNight like `20180307` from a String, throwing on
+    * failure.
+    */
+  def unsafeFromString(s: String): LocalObservingNight =
+    fromString(s).getOrElse(sys.error(s"Invalid night: $s"))
+
+  /** @group Typeclass Instances. */
+  implicit val ShowLocalObservingNight: Show[LocalObservingNight] =
+    Show.fromToString
+
+  /** LocalObservingNight is ordered by local date.
+    *
+    * @group Typeclass Instances
+    */
+  implicit val OrderLocalObservingNight: Order[LocalObservingNight] =
+    Order.by(_.toLocalDate)
+}
+
+trait LocalObservingNightOptics {
+
+  /** @group Optics */
+  val localDate: Iso[LocalObservingNight, LocalDate] =
+    GenIso[LocalObservingNight, LocalDate]
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/MagnitudeValue.scala
+++ b/modules/core/shared/src/main/scala/gem/math/MagnitudeValue.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.{ Order, Show }
+import cats.instances.int._
+
+/**
+ * Exact magnitude value represented as an int with the original value scaled up
+ *
+ * @param scaledValue This magnitude integral value, as the original multiplied by 100. value is dimensionless
+ * @see The Wikipedia [[https://en.wikipedia.org/wiki/Apparent_magnitude]]
+ */
+final case class MagnitudeValue(private[gem] val scaledValue: Int) extends Product with Serializable {
+  def toDoubleValue: Double = scaledValue / 100.0
+}
+
+object MagnitudeValue {
+
+  final lazy val ZeroMagnitude = MagnitudeValue(0)
+
+  /** @group Typeclass Instances */
+  implicit val MagnitudeValueShow: Show[MagnitudeValue] =
+    Show.fromToString
+
+  /** @group Typeclass Instances */
+  implicit val MagnitudeValueOrder: Order[MagnitudeValue] =
+    Order.by(_.scaledValue)
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Night.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Night.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.enum.Site
+
+import cats.implicits._
+
+import java.time.{ Duration, Instant }
+import scala.math.Ordering.Implicits._
+
+
+/** Description of the start/end times for a night according to some criterion.
+  * For example, the official observing night begins and ends at 2PM local time
+  * while twilight bounded nights start and end according to defined angles of
+  * the sun below the horizon.
+  */
+trait Night {
+
+  /** Location at which the times described by this night are valid. */
+  def site: Site
+
+  /** Start instant of the night (inclusive). */
+  def start: Instant
+
+  /** End instant of the night (exclusive). */
+  def end: Instant
+
+  /** Duration of the night. */
+  def duration: Duration =
+    Duration.between(start, end)
+
+  /** Returns `true` if the night includes the given `Instant`. */
+  def includes(time: Instant): Boolean =
+    (start <= time) && (time < end)
+}

--- a/modules/core/shared/src/main/scala/gem/math/ObservingNight.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ObservingNight.scala
@@ -1,0 +1,110 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.enum.Site
+
+import cats._
+import cats.effect.Sync
+import cats.implicits._
+import java.time._
+import monocle.Lens
+import monocle.macros.GenLens
+
+/** An observing night is defined as the period of time from 14:00 on one day
+  * until 14:00 on the following day.  In a timezone that honors daylight saving,
+  * it is sometimes longer and sometimes shorter than a period of 24 hours.
+  *
+  * An `ObservingNight` pairs a `Site` with a `LocalObservingNight` to obtain
+  * precise start/end `Instant`s.
+  */
+final case class ObservingNight(site: Site, toLocalObservingNight: LocalObservingNight) extends Night {
+
+  /** The `Instant` at which the observing night starts (inclusive) for the
+    * associated site.
+    */
+  override val start: Instant =
+    toLocalObservingNight.start.atZone(site.timezone).toInstant
+
+  /** The `Instant` at which the observing night ends (exclusive) for the
+    * associated site.
+    */
+  override val end: Instant =
+    toLocalObservingNight.end.atZone(site.timezone).toInstant
+
+  /** The previous observing night. */
+  def previous: ObservingNight =
+    ObservingNight(site, toLocalObservingNight.previous)
+
+  /** The next observing night. */
+  def next: ObservingNight =
+    ObservingNight(site, toLocalObservingNight.next)
+
+  /** Returns the local date on which this observing night ends. */
+  def toLocalDate: LocalDate =
+    toLocalObservingNight.toLocalDate
+
+}
+
+object ObservingNight extends ObservingNightOptics {
+
+  /** Constructs the observing night that ends on the given local date for
+    * for the given site.
+    *
+    * @group Constructors
+    */
+  def fromSiteAndLocalDate(s: Site, d: LocalDate): ObservingNight =
+    ObservingNight(s, LocalObservingNight(d))
+
+  /** Constructs the observing night for the given site and local date time.
+    *
+    * @group Constructors
+    */
+  def fromSiteAndLocalDateTime(s: Site, d: LocalDateTime): ObservingNight =
+    ObservingNight(s, LocalObservingNight.fromLocalDateTime(d))
+
+  /** Constructs the observing night that includes the given time at the
+    * specified site.
+    *
+    * @group Constructors
+    */
+  def fromSiteAndInstant(s: Site, i: Instant): ObservingNight =
+    ObservingNight(s, LocalObservingNight.fromSiteAndInstant(s, i))
+
+  /** Returns a program in M that computes the ObservingNight for the instant it
+    * is executed.
+    *
+    * @group Constructors
+    */
+  def current[M[_]: Sync](s: Site): M[ObservingNight] =
+    LocalObservingNight.current.map(_.atSite(s))
+
+  /** @group Typeclass Instances. */
+  implicit val ShowObservingNight: Show[ObservingNight] =
+    Show.fromToString
+
+  /** ObservingNight is ordered by site and local observing night.
+    *
+    * @group Typeclass Instances
+    */
+  implicit val OrderObservingNight: Order[ObservingNight] =
+    Order.by(n => (n.site, n.toLocalObservingNight))
+
+}
+
+trait ObservingNightOptics {
+
+  /** @group Optics */
+  val site: Lens[ObservingNight, Site] =
+    GenLens[ObservingNight](_.site)
+
+  /** @group Optics */
+  val localObservingNight: Lens[ObservingNight, LocalObservingNight] =
+    GenLens[ObservingNight](_.toLocalObservingNight)
+
+  /** @group Optics */
+  val localDate: Lens[ObservingNight, LocalDate] =
+    localObservingNight composeIso LocalObservingNight.localDate
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Offset.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Offset.scala
@@ -1,0 +1,164 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package math
+
+import cats.{ Order, Show }
+import cats.kernel.CommutativeGroup
+import cats.implicits._
+import monocle.{ Iso, Lens }
+import monocle.macros.{ GenIso, GenLens }
+
+/** Angular offset with P and Q components. */
+final case class Offset(p: Offset.P, q: Offset.Q) {
+
+  /** This offset, with both components reflected around the 0 .. 180° axis. Exact, invertable. */
+  def unary_- : Offset =
+    Offset(-p, -q)
+
+  /** Componentwise sum of this offset and `o`. Exact. */
+  def +(o: Offset): Offset =
+    Offset(p + o.p, q + o.q)
+
+  /** This offset pair in radians. */
+  def toRadians: (Double, Double) =
+    (p.toRadians, q.toRadians)
+
+}
+
+object Offset extends OffsetOptics {
+
+  /** The zero offset. */
+  val Zero: Offset =
+    Offset(P.Zero, Q.Zero)
+
+  /** Offset forms a commutative group. */
+  implicit val CommutativeGroupOffset: CommutativeGroup[Offset] =
+    new CommutativeGroup[Offset] {
+      val empty: Offset = Zero
+      def combine(a: Offset, b: Offset) = a + b
+      def inverse(a: Offset) = -a
+    }
+
+  implicit val ShowOffset: Show[Offset] =
+    Show.fromToString
+
+  /** Offsets are ordered by p, then q. */
+  implicit val OrderOffset: Order[Offset] =
+    Order.by(o => (o.p, o.q))
+
+  /** P component of an angular offset.. */
+  final case class P(toAngle: Angle) {
+
+    /** This P component, reflected around the 0 .. 180° axis. Exact, invertable. */
+    def unary_- : P =
+      P(-toAngle)
+
+    /** Some of this P component and `p`. Exact. */
+    def +(p: P): P =
+      P(toAngle + p.toAngle)
+
+    /** This P component in signed radians. */
+    def toRadians: Double =
+      toAngle.toSignedDoubleRadians
+
+  }
+  object P extends POptics {
+
+    /** The zero P component. */
+    val Zero: P =
+      P(Angle.Angle0)
+
+    /** P forms a commutative group. */
+    implicit val CommutativeGroupP: CommutativeGroup[P] =
+      new CommutativeGroup[P] {
+        val empty: P = Zero
+        def combine(a: P, b: P) = a + b
+        def inverse(a: P) = -a
+      }
+
+    implicit val ShowP: Show[P] =
+      Show.fromToString
+
+    /** P components are by signed angle. */
+    implicit val OrderP: Order[P] =
+      Angle.SignedAngleOrder.contramap(_.toAngle)
+
+  }
+  trait POptics {
+
+    /** @Group Optics */
+    val angle: Iso[P, Angle] =
+      GenIso[P, Angle]
+
+  }
+
+  /** Q component of an angular offset.. */
+  final case class Q(toAngle: Angle) {
+
+    /** This Q component, reflected around the 0 .. 180° axis. Exact, invertable. */
+    def unary_- : Q =
+      Q(-toAngle)
+
+    /** Some of this Q component and `p`. Exact. */
+    def +(p: Q): Q =
+      Q(toAngle + p.toAngle)
+
+    /** This Q component in signed radians. */
+    def toRadians: Double =
+      toAngle.toSignedDoubleRadians
+
+  }
+  object Q extends QOptics {
+
+    /** The zero Q component. */
+    val Zero: Q =
+      Q(Angle.Angle0)
+
+    /** Q forms a commutative group. */
+    implicit val CommutativeGroupQ: CommutativeGroup[Q] =
+      new CommutativeGroup[Q] {
+        val empty: Q = Zero
+        def combine(a: Q, b: Q) = a + b
+        def inverse(a: Q) = -a
+      }
+
+    implicit val ShowQ: Show[Q] =
+      Show.fromToString
+
+    /** Q components are ordered by signed angle. */
+    implicit val OrderQ: Order[Q] =
+      Angle.SignedAngleOrder.contramap(_.toAngle)
+
+  }
+  trait QOptics {
+
+    /** @Group Optics */
+    val angle: Iso[Q, Angle] =
+      GenIso[Q, Angle]
+
+  }
+
+
+}
+
+trait OffsetOptics {
+
+  /** @group Optics */
+  val p: Lens[Offset, Offset.P] =
+    GenLens[Offset](_.p)
+
+  /** @group Optics */
+  val q: Lens[Offset, Offset.Q] =
+    GenLens[Offset](_.q)
+
+  /** @group Optics */
+  val pAngle: Lens[Offset, Angle] =
+    p composeIso Offset.P.angle
+
+  /** @group Optics */
+  val qAngle: Lens[Offset, Angle] =
+    q composeIso Offset.Q.angle
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/PhysicalConstants.scala
+++ b/modules/core/shared/src/main/scala/gem/math/PhysicalConstants.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+object PhysicalConstants {
+
+  /** One AU in meters. */
+  val AstronomicalUnit: Long = 149597870660L
+
+  /** Speed of light in meters per second. Exact. */
+  val SpeedOfLight: Int = 299792458
+
+  /** 2π, to higher precision than what you get in stdlib. */
+  val TwoPi: Double = 6.283185307179586476925286766559
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
@@ -225,28 +225,3 @@ trait ProperMotionOptics {
     GenLens[ProperMotion](_.parallax)
 
 }
-
-
-object ProperMotionExample {
-
-  /** Proper motion of Barnard's Star, for reference. */
-  val Barnard: ProperMotion =
-    ProperMotion(
-      Coordinates.fromHmsDms.getOption("17 57 48.49803 +04 41 36.2072").getOrElse(sys.error("oops")),
-      Epoch.J2000,
-      Some(Offset(
-        Offset.P(Angle.fromMicroarcseconds( -798580L)),
-        Offset.Q(Angle.fromMicroarcseconds(10328120L))
-      )),
-      Some(RadialVelocity.fromKilometersPerSecond(-110.6)),
-      Some(Angle.fromMicroarcseconds(545620L))
-    )
-
-  def main(args: Array[String]): Unit = {
-    (0.0 to 10.0 by 1.0) foreach { y =>
-      val cs = Barnard.plusYears(y).baseCoordinates
-      println(s"${2000 + y} -> $cs") // scalastyle:off console.io
-    }
-  }
-
-}

--- a/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
+++ b/modules/core/shared/src/main/scala/gem/math/ProperMotion.scala
@@ -1,0 +1,252 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats._
+import cats.implicits._
+import java.time.Instant
+import monocle.Lens
+import monocle.macros.GenLens
+import scala.math.{ sin, cos, hypot, atan2 }
+
+/**
+ * Time-parameterized coordinates, based on an observed position at some point in time (called
+ * the `epoch`) and measured velocities in distance (`radialVelocity`; i.e., doppler shift) and
+ * position (`properVelocity`) per year. Given this information we can compute the position at any
+ * instant in time. The references below are ''extremely'' helpful, so do check them out if you're
+  * trying to understand the implementation.
+ * @see The pretty good [[https://en.wikipedia.org/wiki/Proper_motion wikipedia]] article
+ * @see Astronomical Almanac 1984 [[https://babel.hathitrust.org/cgi/pt?id=uc1.b3754036;view=1up;seq=141 p.B39]]
+ * @see Astronomy and Astrophysics 134 (1984) [[http://articles.adsabs.harvard.edu/cgi-bin/nph-iarticle_query?bibcode=1984A%26A...134....1L&db_key=AST&page_ind=0&data_type=GIF&type=SCREEN_VIEW&classic=YES p.1-6]]
+ * @param baseCoordinates observed coordinates at `epoch`
+ * @param epoch           time of the base observation; typically `Epoch.J2000`
+ * @param properVelocity  proper velocity '''per year''' in [[RightAscension]] and [[Declination]], if any
+ * @param radialVelocity  radial velocity (km/y, positive if receding), if any
+ * @param parallax        parallax, if any
+ */
+final case class ProperMotion(
+  baseCoordinates: Coordinates,
+  epoch:           Epoch,
+  properVelocity:  Option[Offset],
+  radialVelocity:  Option[RadialVelocity],
+  parallax:        Option[Angle]
+) {
+
+  def at(i: Instant): ProperMotion =
+    plusYears(epoch.untilInstant(i))
+
+  /** Coordinates `elapsedYears` fractional epoch-years after `epoch`. */
+  def plusYears(elapsedYears: Double): ProperMotion =
+    ProperMotion(
+      ProperMotion.properMotion(
+        baseCoordinates,
+        epoch,
+        properVelocity.orEmpty,
+        radialVelocity.getOrElse(RadialVelocity.Zero).toKilometersPerSecond,
+        parallax.orEmpty,
+        elapsedYears
+      ),
+      epoch.plusYears(elapsedYears),
+      properVelocity,
+      radialVelocity,
+      parallax
+    )
+
+}
+
+
+object ProperMotion extends ProperMotionOptics {
+  import PhysicalConstants.{ AstronomicalUnit, TwoPi }
+
+  def const(cs: Coordinates): ProperMotion =
+    ProperMotion(cs, Epoch.J2000, None, None, None)
+
+  /**
+   * Proper motion correction in model units.
+   * @param baseCoordinates base coordinates
+   * @param epoch           the epoch
+   * @param properVelocity  proper velocity per epoch year
+   * @param radialVelocity  radial velocity (km/sec, positive if receding)
+   * @param parallax        parallax
+   * @param elapsedYears    elapsed time in epoch years
+   * @return Coordinates corrected for proper motion
+   */
+  def properMotion(
+    baseCoordinates: Coordinates,
+    epoch:           Epoch,
+    properVelocity:  Offset,
+    radialVelocity:  Double,
+    parallax:        Angle,
+    elapsedYears:    Double
+  ): Coordinates = {
+    val (ra, dec) = properMotionʹ(
+      baseCoordinates.toRadians,
+      epoch.scheme.lengthOfYear,
+      properVelocity.toRadians,
+      radialVelocity,
+      parallax.toMicroarcseconds.toDouble / 1000000.0,
+      elapsedYears
+    )
+    Coordinates.unsafeFromRadians(ra, dec)
+  }
+
+  // Some constants we need
+  private val secsPerDay  = 86400.0
+  private val auPerKm     = 1000.0 / AstronomicalUnit.toDouble
+  private val radsPerAsec = Angle.arcseconds.reverseGet(1).toDoubleRadians
+
+  // We need to do things with little vectors of doubles
+  private type Vec2 = (Double, Double)
+  private type Vec3 = (Double, Double, Double)
+
+  // |+| gives us addition for VecN, but we also need scalar multiplication
+  private implicit class Vec3Ops(a: Vec3) {
+    def *(d: Double): Vec3 =
+      (a._1 * d, a._2 * d, a._3 * d)
+  }
+
+  /**
+   * Proper motion correction in base units.
+   * @param baseCoordinates base (ra, dec) in radians, [0 … 2π) and (-π/2 … π/2)
+   * @param daysPerYear     length of epoch year in fractonal days
+   * @param properVelocity  proper velocity in (ra, dec) in radians per epoch year
+   * @param radialVelocity  radial velocity (km/sec, positive means away from earth)
+   * @param parallax        parallax in arcseconds (!)
+   * @param elapsedYears    elapsed time in epoch years
+   * @return (ra, dec) in radians, corrected for proper motion
+   */
+  // scalastyle:off method.length
+  private def properMotionʹ(
+    baseCoordinates: Vec2,
+    daysPerYear:     Double,
+    properVelocity:  Vec2,
+    parallax:        Double,
+    radialVelocity:  Double,
+    elapsedYears:    Double
+  ): Vec2 = {
+
+    // Break out our components
+    val (ra,   dec) = baseCoordinates
+    val (dRa, dDec) = properVelocity
+
+    // Convert to cartesian
+    val pos: Vec3 = {
+      val cd = cos(dec)
+      (cos(ra) * cd, sin(ra) * cd, sin(dec))
+    }
+
+    // Change per year due to radial velocity and parallax. The units work out to asec/y.
+    val dPos1: Vec3 =
+      pos            *
+      daysPerYear    *
+      secsPerDay     *
+      radsPerAsec    *
+      auPerKm        *
+      radialVelocity *
+      parallax
+
+    // Change per year due to proper velocity
+    val dPos2 = (
+      -dRa * pos._2 - dDec * cos(ra) * sin(dec),
+       dRa * pos._1 - dDec * sin(ra) * sin(dec),
+                      dDec *           cos(dec)
+    )
+
+    // Our new position (still in polar coordinates). `|+|` here is scalar addition provided by
+    // cats … unlike scalaz it does give you Semigroup[Double] even though it's not strictly lawful.
+    val pʹ = pos |+| ((dPos1 |+| dPos2) * elapsedYears)
+
+    // Back to spherical
+    val (x, y, z) = pʹ
+    val r    = hypot(x, y)
+    val raʹ  = if (r === 0.0) 0.0 else atan2(y, x)
+    val decʹ = if (z === 0.0) 0.0 else atan2(z, r)
+    val raʹʹ = {
+      // Normalize to [0 .. 2π)
+      val rem = raʹ % TwoPi
+      if (rem < 0.0) rem + TwoPi else rem
+    }
+    (raʹʹ, decʹ)
+
+  }
+  // scalastyle:on method.length
+
+  implicit val OrderProperMotion: Order[ProperMotion] = {
+
+    implicit val MonoidOrder: Monoid[Order[ProperMotion]] =
+      Order.whenEqualMonoid[ProperMotion]
+
+    implicit val AngleOrder: Order[Angle] =
+      Angle.SignedAngleOrder
+
+    def order[A: Order](f: ProperMotion => A): Order[ProperMotion] =
+      Order.by(f)
+
+    // This could be done with:
+    //
+    //   Order.by(p => (p.baseCoordinates, p.epoch, ...))
+    //
+    // but that would always perform comparisons for all the fields (and all
+    // their contained fields down to the leaves of the tree) all of the time.
+    // The Monoid approach on the other hand will stop at the first difference.
+    // This is premature optimization perhaps but it seems like it might make a
+    // difference when sorting a long list of targets.
+
+    order(_.baseCoordinates)  |+|
+      order(_.epoch)          |+|
+      order(_.properVelocity) |+|
+      order(_.radialVelocity) |+|
+      order(_.parallax)
+
+  }
+}
+
+trait ProperMotionOptics {
+
+  /** @group Optics */
+  val baseCoordinates: Lens[ProperMotion, Coordinates] =
+    GenLens[ProperMotion](_.baseCoordinates)
+
+  /** @group Optics */
+  val epoch: Lens[ProperMotion, Epoch] =
+    GenLens[ProperMotion](_.epoch)
+
+  /** @group Optics */
+  val properVelocity: Lens[ProperMotion, Option[Offset]] =
+    GenLens[ProperMotion](_.properVelocity)
+
+  /** @group Optics */
+  val radialVelocity: Lens[ProperMotion, Option[RadialVelocity]] =
+    GenLens[ProperMotion](_.radialVelocity)
+
+  /** @group Optics */
+  val parallax: Lens[ProperMotion, Option[Angle]] =
+    GenLens[ProperMotion](_.parallax)
+
+}
+
+
+object ProperMotionExample {
+
+  /** Proper motion of Barnard's Star, for reference. */
+  val Barnard: ProperMotion =
+    ProperMotion(
+      Coordinates.fromHmsDms.getOption("17 57 48.49803 +04 41 36.2072").getOrElse(sys.error("oops")),
+      Epoch.J2000,
+      Some(Offset(
+        Offset.P(Angle.fromMicroarcseconds( -798580L)),
+        Offset.Q(Angle.fromMicroarcseconds(10328120L))
+      )),
+      Some(RadialVelocity.fromKilometersPerSecond(-110.6)),
+      Some(Angle.fromMicroarcseconds(545620L))
+    )
+
+  def main(args: Array[String]): Unit = {
+    (0.0 to 10.0 by 1.0) foreach { y =>
+      val cs = Barnard.plusYears(y).baseCoordinates
+      println(s"${2000 + y} -> $cs") // scalastyle:off console.io
+    }
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/RadialVelocity.scala
+++ b/modules/core/shared/src/main/scala/gem/math/RadialVelocity.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.{ Order, Show }
+import cats.implicits._
+import gem.math.PhysicalConstants.SpeedOfLight
+import scala.math.sqrt
+
+/**
+ * Radial Velocity represented as integral meters per second, positive if receding. We can also
+ * view velocity in terms of redshift (a dimensionless value called '''z''').
+ * @see Wikipedia on [[https://en.wikipedia.org/wiki/Radial_velocity Radial Velocity]]
+ * @see Wikipedia on [[https://en.wikipedia.org/wiki/Redshift Redshift]]
+ */
+final case class RadialVelocity(toMetersPerSecond: Int) {
+
+  // Sanity check
+  assert(toMetersPerSecond.abs <= SpeedOfLight, "Radial velocity exceeds the speed of light.")
+
+  def toKilometersPerSecond: Double =
+    toMetersPerSecond.toDouble / 1000.0
+
+  def toRedshift: Double = {
+    val v = toMetersPerSecond.toDouble
+    val C = SpeedOfLight.toDouble
+    val t = (1.0 + v / C) / (1.0 - v / C)
+    sqrt(t) - 1.0
+  }
+
+  override def toString =
+    f"RadialVelocity($toKilometersPerSecond%3.3fkm/s)"
+
+}
+
+object RadialVelocity {
+
+  /** Radial velocity of zero. */
+  val Zero: RadialVelocity = RadialVelocity(0)
+
+  /** Construct a [[RadialVelocity]] from floating point kilometers per second. */
+  def fromKilometersPerSecond(kms: Double): RadialVelocity =
+    RadialVelocity((kms * 1000.0).toInt)
+
+  def fromRedshift(z: Double): RadialVelocity = {
+    val C = SpeedOfLight.toDouble
+    val m = C * ((z + 1.0) * (z + 1.0) - 1.0) / ((z + 1.0) * (z + 1.0) + 1.0)
+    RadialVelocity(m.toInt)
+  }
+
+  /** Instances are ordered by their `.toMetersPerSecond` values. */
+  implicit val RadialVelocityOrder: Order[RadialVelocity] =
+    Order.by(_.toMetersPerSecond)
+
+  implicit val RadialVelocityShow: Show[RadialVelocity] =
+    Show.fromToString
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/RightAscension.scala
+++ b/modules/core/shared/src/main/scala/gem/math/RightAscension.scala
@@ -1,0 +1,88 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package math
+
+import cats.{ Order, Show }
+import cats.instances.long._
+import gem.optics.Format
+import monocle._
+
+/**
+ * Celestial longitude, measured eastward along the celestial equator from the vernal equinox to the
+ * hour circle of the point in question. This class is a simple newtype wrapper for an [[HourAngle]].
+ * @see The helpful [[https://en.wikipedia.org/wiki/Right_ascension Wikipedia]] article.
+ * @param toHourAngle the underlying hour angle
+ */
+final case class RightAscension(toHourAngle: HourAngle) {
+
+  /**
+   * Offset this `RightAscension` by the given hour angle.
+   * @group Operations
+   */
+  def offset(ha: HourAngle): RightAscension =
+    RightAscension(toHourAngle + ha)
+
+  /**
+   * Flip this `RightAscension` 180°, as might be required when offsetting coordinates causes the
+   * associated declination to cross a pole.
+   * @group Operations
+   */
+  def flip: RightAscension =
+    RightAscension(toHourAngle.flip)
+
+  /** Forget that this [[RightAscension]] wraps an [[HourAngle]]. */
+  def toAngle: Angle =
+    toHourAngle
+
+  /** This RightAscension in radians [0 .. 2π). Approximate. */
+  def toRadians: Double =
+    toAngle.toDoubleRadians
+
+  override def toString =
+    RightAscension.fromStringHMS.taggedToString("RA", this)
+
+}
+
+object RightAscension extends RightAscensionOptics {
+
+  /**
+   * Construct a `RightAscension` from an angle in radians.
+   * @group Constructors
+   */
+  def fromRadians(rad: Double): RightAscension =
+    RightAscension(Angle.hourAngle.get(Angle.fromDoubleRadians(rad)))
+
+  /**
+   * The `RightAscension` at zero degrees.
+   * @group Constructors
+   */
+  val Zero: RightAscension =
+    RightAscension(HourAngle.HourAngle0)
+
+  /**
+   * Unlike arbitrary angles, it is common to order right asensions starting at zero hours.
+   * @group Typeclass Instances
+   */
+  implicit val RightAscensionOrder: Order[RightAscension] =
+    Order.by(_.toHourAngle.toMicroseconds)
+
+  /* @group Typeclass Instances */
+  implicit val RightAscensionShow: Show[RightAscension] =
+    Show.fromToString
+
+}
+
+trait RightAscensionOptics { this: RightAscension.type =>
+
+  val fromHourAngle: Iso[HourAngle, RightAscension] =
+    Iso(RightAscension(_))(_.toHourAngle)
+
+  val fromStringHMS: Format[String, RightAscension] =
+    HourAngle.fromStringHMS composeIso fromHourAngle
+
+  val fromAngleExact: Prism[Angle, RightAscension] =
+    Angle.hourAngleExact composeIso fromHourAngle
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/Wavelength.scala
+++ b/modules/core/shared/src/main/scala/gem/math/Wavelength.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.{ Order, Show }
+import cats.instances.int._
+import gem.syntax.prism._
+import monocle.Prism
+
+/**
+ * Exact wavelengths represented as unsigned integral angstroms in the range [0 .. Int.MaxValue]
+ * which means the largest representable wavelength is 214.7483647 mm.
+ * @param toAngstroms This wavelength in integral angstroms (10^-10 of a meter).
+ */
+sealed abstract case class Wavelength private (toAngstroms: Int) {
+  // Sanity check … should be correct via the companion constructor.
+  assert(toAngstroms >= 0, s"Invariant violated. $toAngstroms is negative.")
+}
+
+object Wavelength {
+
+  final lazy val Min: Wavelength = fromAngstroms.unsafeGet(0)
+  final lazy val Max: Wavelength = fromAngstroms.unsafeGet(Int.MaxValue)
+
+  /** @group Typeclass Instances */
+  implicit val WavelengthShow: Show[Wavelength] =
+    Show.fromToString
+
+  /** @group Typeclass Instances */
+  implicit val WavelengthOrd: Order[Wavelength] =
+    Order.by(_.toAngstroms)
+
+  /**
+   * Prism from Int into Wavelength and back.
+   * @group Optics
+   */
+  def fromAngstroms: Prism[Int, Wavelength] =
+    Prism((n: Int) => Some(n).filter(_ >= 0).map(new Wavelength(_) {}))(_.toAngstroms)
+
+}

--- a/modules/core/shared/src/main/scala/gem/math/package.scala
+++ b/modules/core/shared/src/main/scala/gem/math/package.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+/** Mathematical data types for general use, not specific to the Gem model. */
+package object math {
+
+  type RA = RightAscension
+  val  RA: RightAscension.type = RightAscension
+
+  type Dec = Declination
+  val  Dec:  Declination.type = Declination
+
+}

--- a/modules/core/shared/src/main/scala/gem/optics/Format.scala
+++ b/modules/core/shared/src/main/scala/gem/optics/Format.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.optics
+
+import cats.arrow._
+import monocle.{ Iso, Prism }
+
+/**
+ * A normalizing optic, isomorphic to Prism but with different laws, specifically `getOption`
+ * need not be injective; i.e., distinct inputs may have the same getOption result, which combined
+ * with a subsequent `reverseGet` yield a normalized form for A. Composition with stronger optics
+ * (`Prism` and `Iso`) yields another `Format`.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+final case class Format[A, B](getOption: A => Option[B], reverseGet: B => A) {
+
+  /** Like getOption, but throws IllegalArgumentException on failure. */
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments", "org.wartremover.warts.Throw"))
+  def unsafeGet(a: A): B =
+    getOption(a).getOrElse {
+      throw new IllegalArgumentException(s"unsafeGet failed: $a")
+    }
+
+  /** Compose with another Format. */
+  def composeFormat[C](f: Format[B, C]): Format[A, C] =
+    Format(getOption(_).flatMap(f.getOption), reverseGet compose f.reverseGet)
+
+  /** Compose with another Format. */
+  def composePrism[C](f: Prism[B, C]): Format[A, C] =
+    Format(getOption(_).flatMap(f.getOption), reverseGet compose f.reverseGet)
+
+  /** Compose with another Format. */
+  def composeIso[C](f: Iso[B, C]): Format[A, C] =
+    Format(getOption(_).map(f.get), reverseGet compose f.reverseGet)
+
+  /** Alias to composeFormat. */
+  def ^<-*[C](f: Format[B, C]): Format[A, C] =
+    composeFormat(f)
+
+  /** Alias to composePrism. */
+  def ^<-?[C](f: Prism[B, C]): Format[A, C] =
+    composePrism(f)
+
+  /** Alias to composeIso. */
+  def ^<->[C](f: Iso[B, C]): Format[A, C] =
+    composeIso(f)
+
+  /** Format is an invariant functor over A. */
+  def imapA[C](f: C => B, g: B => C): Format[A, C] =
+    Format(getOption(_).map(g), f andThen reverseGet)
+
+  /** Format is an invariant functor over B. */
+  def imapB[C](f: A => C, g: C => A): Format[C, B] =
+    Format(g andThen getOption, reverseGet andThen f)
+
+  /**
+   * getOption and reverseGet, yielding a normalized formatted value. Subsequent getOption/reverseGet cycles are
+   * idempotent.
+   */
+  def normalize(b: A): Option[A] =
+    getOption(b).map(reverseGet)
+
+  /** If we can reverseGet a Product as a String we can implement a tagged toString like "Foo(stuff)". */
+  def productToString(b: B)(
+    implicit as: A =:= String,
+             bp: B <:< Product
+  ): String =
+    taggedToString(b.productPrefix, b)
+
+  /**
+   * If we provide a tag like "Foo" and reverseGet as a String we can implement a nice toString like
+   * "Foo(stuff)".
+   */
+  def taggedToString(tag: String, b: B)(
+    implicit as: A =:= String
+  ): String =
+    new StringBuilder(tag)
+      .append('(')
+      .append(as(reverseGet(b)))
+      .append(')')
+      .toString
+
+}
+
+object Format {
+
+  /** A Prism is trivially a Format. */
+  def fromPrism[A, B](p: Prism[A, B]): Format[A, B] =
+    Format(p.getOption, p.reverseGet)
+
+  /** An Iso is trivially a Format. */
+  def fromIso[A, B](p: Iso[A, B]): Format[A, B] =
+    Format(a => Some(p.get(a)), p.reverseGet)
+
+  /** Format forms a category. */
+  implicit def FormatCategory: Category[Format] =
+    new Category[Format] {
+      def id[A] = Format(Some(_), identity)
+      def compose[A, B, C](f: Format[B, C], g: Format[A, B]): Format[A, C] = g ^<-* f
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/optics/README.md
+++ b/modules/core/shared/src/main/scala/gem/optics/README.md
@@ -1,0 +1,32 @@
+## Non-Injective Optics
+
+Standard 2-way optics deal with **invertible** mappings. `Iso[A, B]` says that `A` and `B` are equal, so round-trips in either direction are identities. `Prism[A, B]` says that there is some *subset* of `A` that is equal to `B`.
+
+If we loosen the requirement that types be the same size we get a different kind of mapping, where the large type is squeezed into the small type in one direction or the other. An example is `Int ⟺ Byte` by the standard widening/narrowing conversions. Note that the round-trip starting at `Byte` is an identity, but the round-up starting at `Int` is merely **idempotent**: the first round-trip "normalizes" an `Int` into `Byte` range and thereafter the round-trip is an identity.
+
+This [phenomenon](https://ncatlab.org/nlab/show/split+epimorphism) is a thing, called a **split monomorphism** or a **split epimorphism** depending on which side is bigger. Note that every `Iso` is trivially a split where the idempotent round-trip happens to be an identity.
+
+When we compose a split mono and a split epi end-to-end in either direction we end up with a situation where neither round-trip is necessarily an identity but both are idempotent. I'm calling this a `Wedge` for lack of a better idea. Splits are trivially wedges where one of the idempotent round-trips happens to be an identity.
+
+A `Format` is a weaker `Prism` where a *subset* of `A` forms a split epi with `B`. Every `Prism` is a `Format` where the split epi happens to be an `Iso`; and every `SplitEpi` forms a `Prism` where the subset of `A` is `A` itself.
+
+
+```
+               Wedge[A,B]
+                 A ? B
+
+                   │                  Format[A,B]
+          ┌────────┴────────┐       ∃ a ⊂ A | a > B
+          │                 │
+                                           │
+    SplitMono[A,B]     SplitEpi[A,B]  ─────┤
+        A < B             A > B            │
+
+          │                 │         Prism[A,B]
+          └────────┬────────┘       ∃ a ⊂ A | a = B
+                   │                       │
+                                           │
+                Iso[A,B]  ─────────────────┘
+                 A = B
+```
+

--- a/modules/core/shared/src/main/scala/gem/optics/SplitEpi.scala
+++ b/modules/core/shared/src/main/scala/gem/optics/SplitEpi.scala
@@ -1,0 +1,115 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.optics
+
+import cats.arrow.Category
+import monocle.{ Iso, Prism }
+
+/**
+ * A split epimorphism, which we can think of as a weaker `Iso[A, B]` where `B` is a ''smaller''
+ . type. So `reverseGet andThen get` remains an identity but `get andThen reverseGet` is merely
+ * idempotent (i.e., it normalizes values in `A`). The following statements hold:
+ *
+ *  - `reverseGet` is a ''section'' of `get`,
+ *  - `get` is a ''retraction'' of `reverseGet`,
+ *  - `B` is a ''retract'' of `A`,
+ *  - the pair `(get, reverseGet)` is a ''splitting'' of the idempotent `get andThen reverseGet`.
+ *
+ * @param get any function A => B.
+ * @param reverseGet a section of `get` such that `reverseGet andThen get` is an identity.
+ * @see [[https://ncatlab.org/nlab/show/split+epimorphism Split Epimorphism]] at nLab
+ */
+final case class SplitEpi[A, B](get: A => B, reverseGet: B => A) {
+
+  /** Swapping `get` and `reverseGet` yields a `SplitMono. */
+  def reverse: SplitMono[B, A] =
+    SplitMono(reverseGet, get)
+
+  /** Compose with another SplitEpi. */
+  def composeSplitEpi[C](f: SplitEpi[B, C]): SplitEpi[A, C] =
+    SplitEpi(get andThen f.get, reverseGet compose f.reverseGet)
+
+  /** Compose with another SplitEpi. */
+  def composeSplitMono[C](f: SplitMono[B, C]): Wedge[A, C] =
+    Wedge(get andThen f.get, reverseGet compose f.reverseGet)
+
+  /** Compose with an Iso. */
+  def composeIso[C](f: Iso[B, C]): SplitEpi[A, C] =
+    SplitEpi(get andThen f.get, reverseGet compose f.reverseGet)
+
+  /** Compose with a Prism to get a Format. */
+  def composePrism[C](bc: Prism[B, C]): Format[A, C] =
+    Format(a => bc.getOption(get(a)), reverseGet compose bc.reverseGet)
+
+  /** View this SplitEpi as a Format. */
+  def asFormat: Format[A, B] =
+    Format(a => Some(get(a)), reverseGet)
+
+  /** View this SplitEpi as a Wedge. */
+  def asWedge: Wedge[A, B] =
+    Wedge(get, reverseGet)
+
+  /** Alias to composeSplitEpi. */
+  def ^<-![C](f: SplitEpi[B, C]): SplitEpi[A, C] =
+    composeSplitEpi(f)
+
+  /** Alias to composeIso. */
+  def ^<->[C](f: Iso[B, C]): SplitEpi[A, C] =
+    composeIso(f)
+
+  /** Alias to composePrism. */
+  def ^<-?[C](f: Prism[B, C]): Format[A, C] =
+    composePrism(f)
+
+  /** SplitEpi is an invariant functor over A. */
+  def imapA[C](f: C => B, g: B => C): SplitEpi[A, C] =
+    SplitEpi(get andThen g, f andThen reverseGet)
+
+  /** SplitEpi is an invariant functor over B. */
+  def imapB[C](f: A => C, g: C => A): SplitEpi[C, B] =
+    SplitEpi(g andThen get, reverseGet andThen f)
+
+  /**
+   * get and reverseGet, yielding a normalized formatted value. Subsequent get/reverseGet cycles are
+   * idempotent.
+   */
+  def normalize(a: A): A =
+    reverseGet(get(a))
+
+  /** If we can reverseGet a Product as a String we can implement a tagged toString like "Foo(stuff)". */
+  def productToString(b: B)(
+    implicit as: A =:= String,
+             bp: B <:< Product
+  ): String =
+    taggedToString(b.productPrefix, b)
+
+  /**
+   * If we provide a tag like "Foo" and reverseGet as a String we can implement a nice toString like
+   * "Foo(stuff)".
+   */
+  def taggedToString(tag: String, b: B)(
+    implicit as: A =:= String
+  ): String =
+    new StringBuilder(tag)
+      .append('(')
+      .append(as(reverseGet(b)))
+      .append(')')
+      .toString
+
+}
+
+object SplitEpi {
+
+  /** An Iso is trivially a SplitEpi. */
+  def fromIso[A, B](p: Iso[A, B]): SplitEpi[A, B] =
+    SplitEpi(p.get, p.reverseGet)
+
+  /** SplitEpi forms a category. */
+  implicit def SplitEpiCategory: Category[SplitEpi] =
+    new Category[SplitEpi] {
+      def id[A] = SplitEpi(identity, identity)
+      def compose[A, B, C](f: SplitEpi[B, C], g: SplitEpi[A, B]): SplitEpi[A, C] = g ^<-! f
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/optics/SplitMono.scala
+++ b/modules/core/shared/src/main/scala/gem/optics/SplitMono.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.optics
+
+import cats.arrow.Category
+import monocle.{ Fold, Getter, Iso }
+
+/**
+ * A split monomorphism, which we can think of as a weaker `Iso[A, B]` where `A` is a ''smaller''
+ . type. So `get andThen reverseGet andThen` remains an identity but `reverseGet andThen get` is merely
+ * idempotent (i.e., it normalizes values in `B`). The following statements hold:
+ *
+ *  - `reverseGet` is a ''retraction'' of `get`,
+ *  - `get` is a ''section'' of `reverseGet`,
+ *  - `A` is a ''retract'' of `B`,
+ *  - the pair `(reverseGet, get)` is a ''splitting'' of the idempotent `reverseGet andThen get`.
+ *
+ * @param get  section of `reverseGet` such that `get andThen reverseGet` is an identity
+ * @param reverseGet any function B => A
+ * @see [[https://ncatlab.org/nlab/show/split+monomorphism Split Epimorphism]] at nLab
+ */
+final case class SplitMono[A, B](get: A => B, reverseGet: B => A) {
+
+  /** Swapping `get` and `reverseGet` yields a `SplitEpi. */
+  def reverse: SplitEpi[B, A] =
+    SplitEpi(reverseGet, get)
+
+  /** Compose with another SplitMono. */
+  def composeSplitMono[C](f: SplitMono[B, C]): SplitMono[A, C] =
+    SplitMono(get andThen f.get, reverseGet compose f.reverseGet)
+
+  /** Compose with another SplitEpi. */
+  def composeSplitEpi[C](f: SplitEpi[B, C]): Wedge[A, C] =
+    Wedge(get andThen f.get, reverseGet compose f.reverseGet)
+
+  /** Compose with an Iso. */
+  def composeIso[C](f: Iso[B, C]): SplitMono[A, C] =
+    SplitMono(get andThen f.get, reverseGet compose f.reverseGet)
+
+  /** View this SplitEpi as a Fold. */
+  def asFold: Fold[A, B] =
+    asGetter.asFold
+
+  /** View this SplitMono as a Getter. */
+  def asGetter: Getter[A, B] =
+    Getter(get)
+
+  /** View this SplitMono as a Wedge. */
+  def asWedge: Wedge[A, B] =
+    Wedge(get, reverseGet)
+
+  /** Alias to composeSplitMono. */
+  def ^<-![C](f: SplitMono[B, C]): SplitMono[A, C] =
+    composeSplitMono(f)
+
+  /** Alias to composeIso. */
+  def ^<->[C](f: Iso[B, C]): SplitMono[A, C] =
+    composeIso(f)
+
+  /** SplitMono is an invariant functor over A. */
+  def imapA[C](f: A => C, g: C => A): SplitMono[C, B] =
+    SplitMono(g andThen get, reverseGet andThen f)
+
+  /** SplitMono is an invariant functor over B. */
+  def imapB[C](f: C => B, g: B => C): SplitMono[A, C] =
+    SplitMono(get andThen g, f andThen reverseGet)
+
+  /**
+   * reverseGet and get, yielding a normalized formatted value. Subsequent reverseGet/get cycles are
+   * idempotent.
+   */
+  def normalize(b: B): B =
+    get(reverseGet(b))
+
+}
+
+object SplitMono {
+
+  /** An Iso is trivially a SplitMono. */
+  def fromIso[A, B](p: Iso[A, B]): SplitMono[A, B] =
+    SplitMono(p.get, p.reverseGet)
+
+  /** SplitMono forms a category. */
+  implicit def SplitMonoCategory: Category[SplitMono] =
+    new Category[SplitMono] {
+      def id[A] = SplitMono(identity, identity)
+      def compose[A, B, C](f: SplitMono[B, C], g: SplitMono[A, B]): SplitMono[A, C] = g ^<-! f
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/optics/Wedge.scala
+++ b/modules/core/shared/src/main/scala/gem/optics/Wedge.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.optics
+
+import cats.arrow.Category
+import monocle.Iso
+
+/**
+ * Composition of a `SplitMono` and a `SplitEpi`, yielding an even weaker structure where neither
+ * `get andThen reverseGet` and `reverseGet andThen get` is an identity but both are idempotent.
+ */
+final case class Wedge[A, B](get: A => B, reverseGet: B => A) {
+
+  /** Swapping `get` and `reverseGet` yields a `Wedge`. */
+  def reverse: Wedge[B, A] =
+    Wedge(reverseGet, get)
+
+  /** Compose with another Wedge. */
+  def composeWedge[C](f: Wedge[B, C]): Wedge[A, C] =
+    Wedge(get andThen f.get, reverseGet compose f.reverseGet)
+
+  /** Compose with an Iso. */
+  def composeIso[C](f: Iso[B, C]): Wedge[A, C] =
+    Wedge(get andThen f.get, reverseGet compose f.reverseGet)
+
+  /** Alias to composeWedge. */
+  def ^<-![C](f: Wedge[B, C]): Wedge[A, C] =
+    composeWedge(f)
+
+  /** Alias to composeIso. */
+  def ^<->[C](f: Iso[B, C]): Wedge[A, C] =
+    composeIso(f)
+
+  /** Wedge is an invariant functor over A. */
+  def imapA[C](f: A => C, g: C => A): Wedge[C, B] =
+    Wedge(g andThen get, reverseGet andThen f)
+
+  /** Wedge is an invariant functor over B. */
+  def imapB[C](f: C => B, g: B => C): Wedge[A, C] =
+    Wedge(get andThen g, f andThen reverseGet)
+
+  /** Normalize A via a round-trip through B. */
+  def normalizeA(a: A): A =
+    (get andThen reverseGet)(a)
+
+  /** Normalize B via a round-trip through A. */
+  def normalizeB(b: B): B =
+    (get compose reverseGet)(b)
+
+}
+
+object Wedge {
+
+  /** An Iso is trivially a Wedge. */
+  def fromIso[A, B](p: Iso[A, B]): Wedge[A, B] =
+    Wedge(p.get, p.reverseGet)
+
+  /** Wedge forms a category. */
+  implicit def WedgeCategory: Category[Wedge] =
+    new Category[Wedge] {
+      def id[A] = Wedge(identity, identity)
+      def compose[A, B, C](f: Wedge[B, C], g: Wedge[A, B]): Wedge[A, C] = g ^<-! f
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/package.scala
+++ b/modules/core/shared/src/main/scala/gem/package.scala
@@ -1,0 +1,5 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+/** The Gem science model. */
+package object gem

--- a/modules/core/shared/src/main/scala/gem/parser/Angle.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Angle.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package parser
+
+import atto._, Atto._
+import cats.implicits._
+import gem.math.{ Angle, HourAngle }
+
+/** Parsers for `[[gem.math.Angle]].` */
+trait AngleParsers {
+  import MiscParsers._
+
+  /**
+   * Generic parser for the components of an angle in "11 22 33.444555" format, with at least 1
+   * and at most 6 digits following the decimal point, and terminal parsers for each segment.
+   */
+  def genAngle(t1: Parser[_], t2: Parser[_], t3: Parser[_]): Parser[(Int, Int, Int, Int, Int)] =
+    (int <~ t1, int <~ t2, int <~ char('.'), frac(6) <~ t3) mapN { (h, m, s, µs) =>
+      (h, m, s, µs / 1000, µs % 1000)
+    } named s"genAngle($t1, $t2, $t3)"
+
+  /** Generic parser for the components of an HourAngle; see `genAngle`. */
+  def genHMS(t1: Parser[_], t2: Parser[_], t3: Parser[_]): Parser[HourAngle] =
+    genAngle(t1, t2, t3).map((HourAngle.fromHMS _).tupled) named s"genHMS($t1, $t2, $t3)"
+
+  /** 00:00:00.000000 */
+  val hms1: Parser[HourAngle] =
+    genHMS(char(':'), char(':'), void) named "hms1(00:00:00.000000)"
+
+  /** 00 00 00.000000 */
+  val hms2: Parser[HourAngle] =
+    genHMS(spaces1, spaces1, void) named "hms2(00 00 00.000000)"
+
+  /** 00h 00m 00.000000s */
+  val hms3: Parser[HourAngle] =
+    genHMS(token(char('h')), token(char('m')), char('s')) named "hms3(00h 00m 00.000000s)"
+
+  val hms = (hms1 | hms2 | hms3) named "hms"
+
+  /** Generic parser for the components of a DMS Angle, which is optionally prefixed by a sign. */
+  def genDMS(t1: Parser[_], t2: Parser[_], t3: Parser[_]): Parser[Angle] =
+    (neg, genAngle(t1, t2, t3).map((Angle.fromDMS _).tupled)).mapN {
+      case (true,  a) => -a
+      case (false, a) =>  a
+    } named s"genDMS($t2, $t2, $t3)"
+
+  /** +00:00:00.000000 */
+  val dms1: Parser[Angle] =
+    genDMS(char(':'), char(':'), void) named "dms1(+00:00:00.000000)"
+
+  /** +00 00 00.000000 */
+  val dms2: Parser[Angle] =
+    genDMS(spaces1, spaces1, void) named "dms2(+00 00 00.000000)"
+
+  /** +04° 41′ 36.2072″ */
+  val dms3: Parser[Angle] =
+    genDMS(token(char('°')), token(char('′')), char('″')) named "dms3(+04° 41′ 36.2072″)"
+
+  val dms = (dms1 | dms2 | dms3) named "dms"
+
+}
+
+object AngleParsers extends AngleParsers

--- a/modules/core/shared/src/main/scala/gem/parser/Coordinates.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Coordinates.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.parser
+
+import cats.implicits._
+import atto._, Atto._
+import gem.math._
+
+/** Parsers for [[gem.math.Coordinates]] and related types. */
+trait CoordinateParsers {
+  import AngleParsers.{ hms, dms }
+  import MiscParsers.spaces1
+
+  /** Parser for a RightAscension, always a positive angle in HMS. */
+  val ra: Parser[RightAscension] =
+    hms.map(RightAscension(_)) named "ra"
+
+  /** Parser for a RightAscension, always a positive angle in HMS. */
+  val dec: Parser[Declination] =
+    dms.map(Declination.fromAngle.getOption).flatMap {
+      case Some(ra) => ok(ra)
+      case None     => err[Declination]("Invalid Declination")
+    } named "dec"
+
+  /** Parser for coordinates: HMS and DMS separated by spaces. */
+  val coordinates: Parser[Coordinates] =
+    (ra <~ spaces1, dec).mapN(Coordinates(_, _)) named "coordinates"
+
+}
+object CoordinateParsers extends CoordinateParsers

--- a/modules/core/shared/src/main/scala/gem/parser/Enum.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Enum.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.implicits._
+import atto._, Atto._
+import gem.enum._
+import gem.util.Enumerated
+
+/** Parsers for `gem.enum` data types. */
+trait EnumParsers {
+
+  /** Parser for an `Enumerated` type, based on some string property. */
+  def enumBy[A](f: A => String)(implicit ev: Enumerated[A]): Parser[A] =
+    choice(ev.all.map(a => string(f(a)).as(a))) named "enumBy(...)"
+
+  /** Parser for `Site` based on `shortName` like `GS`. */
+  val site: Parser[Site] =
+    enumBy[Site](_.shortName) namedOpaque "Site"
+
+  /** Parser for `ProgramType` based on `shortName` like `SV`. */
+  val programType: Parser[ProgramType] =
+    enumBy[ProgramType](_.shortName) namedOpaque "ProgramType"
+
+  /** Parser for `DailyProgramType` based on `shortName` like `CAL`. */
+  val dailyProgramType: Parser[DailyProgramType] =
+    enumBy[DailyProgramType](_.shortName) namedOpaque "DailyProgramType"
+
+  /** Parser for `Half` based on `tag` like `A`. */
+  val half: Parser[Half] =
+    enumBy[Half](_.tag) namedOpaque "Half"
+
+}
+object EnumParsers extends EnumParsers

--- a/modules/core/shared/src/main/scala/gem/parser/EphemerisKey.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/EphemerisKey.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package parser
+
+import EphemerisKey._
+import atto._
+import Atto._
+import cats.implicits._
+
+/** Parser for [[gem.EphemerisKey]]. */
+trait EphemerisKeyParsers {
+
+  private def des[A](s: String, p: Parser[A]): Parser[A] =
+    string(s"${s}_") ~> p
+
+  private def textDes[A](s: String)(f: String => A): Parser[A] =
+    des(s, takeText.map(f))
+
+  private def numDes[A](s: String)(f: Int => A): Parser[A] =
+    des(s, int.map(f))
+
+  val comet: Parser[Comet] =
+    textDes("Comet")(Comet.apply) namedOpaque "comet"
+
+  val asteroidNew: Parser[AsteroidNew] =
+    textDes("AsteroidNew")(AsteroidNew.apply) namedOpaque "asteroidNew"
+
+  val asteroidOld: Parser[AsteroidOld] =
+    numDes("AsteroidOld")(AsteroidOld.apply) namedOpaque "asteroidOld"
+
+  val majorBody: Parser[MajorBody] =
+    numDes("MajorBody")(MajorBody.apply) namedOpaque "majorBody"
+
+  val userSupplied: Parser[UserSupplied] =
+    numDes("UserSupplied")(UserSupplied.apply) namedOpaque "userSupplied"
+
+  val ephemerisKey: Parser[EphemerisKey] =
+      (comet       .widen[EphemerisKey] |
+       asteroidNew .widen[EphemerisKey] |
+       asteroidOld .widen[EphemerisKey] |
+       majorBody   .widen[EphemerisKey] |
+       userSupplied.widen[EphemerisKey]) named "ephemerisKey"
+
+}
+
+object EphemerisKeyParsers extends EphemerisKeyParsers

--- a/modules/core/shared/src/main/scala/gem/parser/Epoch.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Epoch.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.parser
+
+import cats.implicits._
+import atto._, Atto._
+import gem.math.Epoch
+
+/** Parser for [[gem.math.Epoch]]. */
+trait EpochParsers {
+  import MiscParsers.intN
+
+  val besselian: Parser[Epoch.Scheme] =
+    char('B').as[Epoch.Scheme](Epoch.Besselian) named "besselian"
+
+  val julian: Parser[Epoch.Scheme] =
+    char('J').as[Epoch.Scheme](Epoch.Julian) named "julian"
+
+  /** Parser for an `Epoch.Scheme`. */
+  val epochScheme: Parser[Epoch.Scheme] =
+    (besselian | julian) named "epochScheme"
+
+  /** Parser for an `Epoch`. */
+  val epoch: Parser[Epoch] =
+    (epochScheme, int <~ char('.'), intN(3)) mapN { (s, y, f) =>
+      s.fromMilliyears(y * 1000 + f)
+    } named "epoch"
+
+}
+object EpochParsers extends EpochParsers

--- a/modules/core/shared/src/main/scala/gem/parser/Misc.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Misc.scala
@@ -1,0 +1,121 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.parser
+
+import atto._, Atto._
+import gem.math.Index
+import gem.syntax.prism._
+import scala.annotation.tailrec
+
+/** General-purpose parsers and combinators that aren't provided by atto. */
+trait MiscParsers {
+
+  /** Parser that always succeeds without consuming any input. */
+  val void: Parser[Unit] =
+    ok(()) namedOpaque "void"
+
+  /** Creates a Parser that consumes the given character. */
+  private def matchChar(c: Char, n: String): Parser[Unit] =
+    char(c).void namedOpaque n
+
+  /** Parser for a colon. */
+  val colon: Parser[Unit] =
+    matchChar(':', "colon")
+
+  /** Parser for a dot/period/decimal point. */
+  val dot: Parser[Unit] =
+    matchChar('.', "dot")
+
+  /** Parser for a hyphen. */
+  val hyphen: Parser[Unit] =
+    matchChar('-', "hyphen")
+
+  /** Parser for a single space. */
+  val space: Parser[Unit] =
+    matchChar(' ', "space")
+
+  /** Parser for one or more spaces. */
+  val spaces1: Parser[Unit] =
+    skipMany1(space) namedOpaque "spaces1"
+
+  /** Parser for a non-whitespace string. */
+  val nonWhitespace: Parser[String] =
+    takeWhile(c => !c.isWhitespace) namedOpaque "nonWhitespace"
+
+  /** Parser for a vertical whitespace String. */
+  val verticalWhitespace: Parser[Unit] =
+    skipMany1(char('\n') | char('\r'))
+
+  /** Catch a `NumberFormatException`, useful for flatMap. */
+  def catchNFE[A, B](f: A => B): A => Parser[B] = a =>
+    try ok(f(a)) catch { case e: NumberFormatException => err[B](e.toString) }
+
+  /** Parser for `n` consecutive digits, parsed as an `Int`. */
+  def intN(n:Int): Parser[Int] =
+    count(n, digit).map(_.mkString).flatMap(catchNFE(_.toInt)) namedOpaque s"intN($n)"
+
+  /** Parser for a positive `Int`. */
+  val positiveInt: Parser[Int] =
+    int.filter(_ > 0) namedOpaque "positiveInt"
+
+  /** Parser for an `Index`, which must be a positive Short with no leading zeros. */
+  val index: Parser[Index] =
+    ensure(1).flatMap { s =>
+      val c = s(0) // safe
+      if (c >= '1' && c <= '9') short.map(Index.fromShort.unsafeGet)
+      else err("Expected non-zero leading digit.")
+    }
+
+  /** Parser for an optional sign (+ or -), returned as a boolean indicating whether to negate. */
+  val neg: Parser[Boolean] =
+    opt(char('-').void || char('+').void).map {
+      case Some(Left(()))  => true
+      case Some(Right(())) => false
+      case None            => false
+    } namedOpaque "neg"
+
+  /**
+   * Fractional portion of a decimal value, with up to N places given. So frac(3) parsing "12"
+   * yields 120. Mind the overflow, this only works for small N.
+   */
+  def frac(n: Int): Parser[Int] = {
+
+    def nexp(n: Int, e: Int): Int = {
+      @tailrec def go(e: Int, acc: Int): Int =
+        if (e < 1) acc else go(e - 1, acc * n)
+      go(e, 1)
+    }
+
+    if (n < 1) ok(0)
+    else opt(digit.map(_ - '0')).flatMap {
+      case None    => ok(0)
+      case Some(d) => frac(n - 1).map(_ + d * nexp(10, n - 1))
+    }
+
+  } namedOpaque s"frac($n)"
+
+
+  /** Force and return all remaining input without consuming it. */
+  val force: Parser[String] =
+    get.flatMap { s =>
+      opt(ensure(s.length + 1)) flatMap {
+        case Some(_) => force
+        case None    => ok(s)
+      }
+    }
+
+  /**
+   * Force and examine remaining input and yield the longest prefix up to (but not including) a
+   * char satisfying `p`, which is discarded. Fails if no such char is found.
+   */
+  def takeUntilLast(p: Char => Boolean): Parser[String] =
+    force.flatMap { s =>
+      s.lastIndexWhere(p) match {
+        case -1 => err[String]("not satisfied")
+        case  n => take(n) <~ advance(1)
+      }
+    } named "takeUntilLast(…)"
+
+}
+object MiscParsers extends MiscParsers

--- a/modules/core/shared/src/main/scala/gem/parser/ProgramId.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/ProgramId.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package parser
+
+import atto._, Atto._
+import cats.implicits._
+import gem.enum.{ Site, ProgramType }
+
+/** Parsers for [[gem.ProgramId]]. */
+trait ProgramIdParsers {
+  import MiscParsers._
+  import EnumParsers._
+  import SemesterParsers._
+  import TimeParsers._
+  import ProgramId._
+
+  /** Parser for a standard science program id like `GS-2008A-SV-33`. */
+  val science: Parser[Science] =
+    (site        <~ hyphen,
+     semester    <~ hyphen,
+     programType <~ hyphen,
+     index).mapN(Science.apply) named "science"
+
+  /** Parser for a daily program id like `GS-ENG20120102`. */
+  val daily: Parser[Daily] =
+    (site <~ hyphen, dailyProgramType, yyyymmdd).mapN(Daily.apply) named "daily"
+
+  /**
+   * Parser for the components of a nonstandard program id (which has no public constructor).
+   * This parser is greedy and will read as much structured information as possible rather than
+   * leaving it in the tail.
+   */
+  def nonstandard: Parser[(Option[Site], Option[Semester], Option[ProgramType], String)] =
+    (opt(site        <~ hyphen),
+     opt(semester    <~ hyphen),
+     opt(programType <~ hyphen),
+     nonWhitespace).tupled named "nonstandard"
+
+}
+object ProgramIdParsers extends ProgramIdParsers

--- a/modules/core/shared/src/main/scala/gem/parser/Semester.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Semester.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package parser
+
+import cats.implicits._
+import atto._, Atto._
+
+/** Parser for [[gem.Semester]]. */
+trait SemesterParsers {
+  import TimeParsers._
+  import EnumParsers._
+
+  /** Parser for a full-year `Semester` like `2015A`. */
+  val semester: Parser[Semester] =
+    (year4, half).mapN(Semester.apply) named "semester"
+
+}
+object SemesterParsers extends SemesterParsers

--- a/modules/core/shared/src/main/scala/gem/parser/Time.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/Time.scala
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.parser
+
+import cats.implicits._
+
+import atto._, Atto._
+import java.time.{ DateTimeException, Instant, LocalDate, LocalDateTime, LocalTime, Month, Year, ZoneOffset }
+
+/** Parsers for `java.time` data types. */
+trait TimeParsers {
+
+  import MiscParsers.{ dot, frac, intN, spaces1, void }
+
+  /** Catch a `DateTimeException`, useful for flatMap. */
+  def catchDTE[A, B](f: A => B): A => Parser[B] = a =>
+    try ok(f(a)) catch { case e: DateTimeException => err[B](e.toString) }
+
+  /** Parser for 4 consecutive digits, parsed as a `Year`. */
+  val year4: Parser[Year] =
+    intN(4).flatMap(catchDTE(Year.of)) namedOpaque "year4"
+
+  /** Parser for 2 consecutive digits, parsed as a `Month`. */
+  val month2: Parser[Month] =
+    intN(2).flatMap(catchDTE(Month.of)) namedOpaque "month2"
+
+  /** Parser for 3 letter month strings like "Jan", parsed as a `Month`. */
+  val monthMMM: Parser[Month] = {
+    import Month._
+
+    val months = List(
+      "Jan" -> JANUARY, "Feb" -> FEBRUARY, "Mar" -> MARCH,
+      "Apr" -> APRIL,   "May" -> MAY,      "Jun" -> JUNE,
+      "Jul" -> JULY,    "Aug" -> AUGUST,   "Sep" -> SEPTEMBER,
+      "Oct" -> OCTOBER, "Nov" -> NOVEMBER, "Dec" -> DECEMBER
+    )
+
+    choice(months.map { case (s, m) => string(s).as(m) }) namedOpaque "monthMMM"
+  }
+
+  /** Generic parser for a local date string in the order year, month, day.
+    *
+    * @param month parser for the month component
+    * @param sep   parser for any separator between components
+    */
+  def genYMD(month: Parser[Month], sep: Parser[_]): Parser[LocalDate] =
+    (for {
+      y <- year4 <~ sep
+      m <- month <~ sep
+      d <- intN(2) namedOpaque "2-digit day of month"
+      l <- catchDTE((d: Int) => LocalDate.of(y.getValue, m, d))(d)
+    } yield l) named s"genYMD($month, $sep)"
+
+  /** Parser for a `LocalDate` in the form `20151107`. */
+  def yyyymmdd: Parser[LocalDate] =
+    genYMD(month2, void) named "yyyymmdd"
+
+  /** Generic parser for a `LocalTime` with fractional seconds to nanosecond
+    * precision.
+    *
+    * @param sep parser for any separator between hours, minutes, and seconds
+    */
+  def genLocalTime(sep: Parser[_]): Parser[LocalTime] = {
+    val nano: Parser[Int] =
+      opt(dot ~> frac(9)).flatMap(o => ok(o.getOrElse(0))) namedOpaque "up to 9 digits nanoseconds"
+
+    (for {
+      h  <- (intN(2) namedOpaque "2-digit hour of day")     <~ sep
+      m  <- (intN(2) namedOpaque "2-digit minute of hour")  <~ sep
+      s  <- (intN(2) namedOpaque "2-digit second of minute")
+      ns <- nano
+      t  <- catchDTE((ms: Int) => LocalTime.of(h, m, s, ns))(ns)
+    } yield t) named "00:00:00.000000000"
+  }
+
+  /** Parser for instants in UTC, where the date is followed by the time and
+    * separated by spaces.
+    */
+  def instantUTC(date: Parser[LocalDate], time: Parser[LocalTime]): Parser[Instant] =
+    (date <~ spaces1, time).mapN { case (d, t) =>
+      LocalDateTime.of(d, t).toInstant(ZoneOffset.UTC)
+    }
+}
+object TimeParsers extends TimeParsers

--- a/modules/core/shared/src/main/scala/gem/parser/package.scala
+++ b/modules/core/shared/src/main/scala/gem/parser/package.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+/**
+ * Package of [[https://github.com/tpolecat/atto atto]] parsers, for parsing things in the science
+ * model. The idea here is that parsers compose, so for internal use it's nice to have them together
+ * and so we can share implementations. In end-user code we normally want to expose something
+ * weaker like `String => Option[A]` that delegates to a parser, rather than exposing `Parser[A]`
+ * directly. Each set of parsers is provided as a trait that can be extended and as a module whose
+ * members can be imported (preferred).
+ */
+package object parser

--- a/modules/core/shared/src/main/scala/gem/syntax/Parser.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/Parser.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import atto._, Atto._
+
+final class ParserOps[A](val self: Parser[A]) extends AnyVal {
+
+  /** Parse entire input into an Option. */
+  def parseExact(s: String): Option[A] =
+    phrase(self).parseOnly(s).option
+
+  /** Parse into an Option, discarding unused input. */
+  def parse(s: String): Option[A] =
+    self.parseOnly(s).option
+
+}
+
+trait ToParserOps {
+  implicit def ToParserOps[A](p: Parser[A]): ParserOps[A] = new ParserOps[A](p)
+}
+
+object parser extends ToParserOps

--- a/modules/core/shared/src/main/scala/gem/syntax/Prism.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/Prism.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import gem.optics.Format
+import monocle.Prism
+
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+final class PrismOps[A, B](val self: Prism[A, B]) extends AnyVal {
+
+  /** Weaken to Format. */
+  def asFormat: Format[A, B] =
+    Format.fromPrism(self)
+
+  /** Like getOption, but throws IllegalArgumentException on failure. */
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  def unsafeGet(a: A): B =
+    asFormat.unsafeGet(a)
+
+}
+
+trait ToPrismOps {
+  implicit def ToPrismOps[A, B](p: Prism[A, B]): PrismOps[A, B] =
+    new PrismOps(p)
+}
+
+object prism extends ToPrismOps

--- a/modules/core/shared/src/main/scala/gem/syntax/String.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/String.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+final class StringOps(val self: String) extends AnyVal {
+
+  private def parse[A](f: String => A): Option[A] =
+    try Some(f(self)) catch { case _: IllegalArgumentException => None }
+
+  def parseShortOption:   Option[Short]   = parse(_.toShort)
+  def parseIntOption:     Option[Int]     = parse(_.toInt)
+  def parseLongOption:    Option[Long]    = parse(_.toLong)
+  def parseDoubleOption:  Option[Double]  = parse(_.toDouble)
+  def parseBooleanOption: Option[Boolean] = parse(_.toBoolean)
+  def parseBigDecimalOption: Option[BigDecimal] = parse(BigDecimal(_))
+
+}
+
+trait ToStringOps {
+  implicit def ToStringOps[A](p: String): StringOps = new StringOps(p)
+}
+
+object string extends ToStringOps

--- a/modules/core/shared/src/main/scala/gem/syntax/Time.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/Time.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import java.time.{ Duration, Instant }
+import java.time.temporal.TemporalAmount
+
+// A bit of syntax to make working with Java Instant and Duration a bit less
+// cumbersome / easier to read.
+
+final class InstantOps(val self: Instant) extends AnyVal {
+
+  def +(t: TemporalAmount): Instant =
+    self.plus(t)
+
+  def -(t: TemporalAmount): Instant =
+    self.minus(t)
+
+}
+
+trait ToInstantOps {
+  implicit def ToInstantOps(i: Instant): InstantOps =
+    new InstantOps(i)
+}
+
+final class DurationOps(val self: Duration) extends AnyVal {
+
+  def +(that: Duration): Duration =
+    self.plus(that)
+
+  def -(that: Duration): Duration =
+    self.minus(that)
+
+  def *(m: Long): Duration =
+    self.multipliedBy(m)
+
+  def /(d: Long): Duration =
+    self.dividedBy(d)
+}
+
+trait ToDurationOps {
+  implicit def ToDurationOps(d: Duration): DurationOps =
+    new DurationOps(d)
+}
+
+object time extends ToInstantOps with ToDurationOps

--- a/modules/core/shared/src/main/scala/gem/syntax/TreeMap.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/TreeMap.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import cats.Foldable
+import cats.data.Ior
+
+import scala.collection.immutable.TreeMap
+
+final class TreeMapCompanionOps(val self: TreeMap.type) extends AnyVal {
+
+  /** Creates a `TreeMap` from a `List[(A, B)]`, provided an `Ordering[A]`
+    * is available.
+    */
+  def fromList[A: Ordering, B](lst: List[(A, B)]): TreeMap[A, B] =
+    TreeMap(lst: _*)
+
+  /** Creates a `TreeMap` from a `Foldable[(A, B)]`, provided an `Ordering[A]`
+    * is available.
+    */
+  def fromFoldable[F[_], A, B](fab: F[(A, B)])(implicit F: Foldable[F], A: Ordering[A]): TreeMap[A, B] =
+    fromList(F.toList(fab))
+
+  /** Combines all the given maps into a single map, where keys common to two or
+    * more maps are the value of the last occurrence in the list.
+    */
+  def join[A: Ordering, B](ms: List[TreeMap[A, B]]): TreeMap[A, B] =
+    ms.foldLeft(TreeMap.empty[A, B]) { case (m0, m1) => m0 ++ m1 }
+}
+
+trait ToTreeMapCompanionOps {
+  implicit def ToTreeMapCompanionOps(c: TreeMap.type): TreeMapCompanionOps =
+    new TreeMapCompanionOps(c)
+}
+
+final class TreeMapOps[A, B](val self: TreeMap[A, B]) extends AnyVal {
+
+  /** Combines this map with the values of matching keys from `that` map using
+    * supplied function.  Keys that only exist in `that` are ignored, but the
+    * value of keys that exist in this map but not in `that` map are passed to
+    * the function as None.
+    *
+    * @param that the map to combine with this one
+    * @param f function that combines the values
+    */
+  def mergeMatchingKeys[C, D](that: Map[A, C])(f: (B, Option[C]) => D)(implicit ev: Ordering[A]): TreeMap[A, D] =
+    self.foldLeft(TreeMap.empty[A, D]) { case (m, (a, b)) =>
+      m.updated(a, f(b, that.get(a)))
+    }
+
+  /** Merges two maps together according to the supplied function. The function
+    * takes an `Ior` with the value from this map and/or the value from that map
+    * for each key present in either map.
+    *
+    * @param that the map to merge with this one
+    * @param f function that combines the values
+    */
+  def mergeAll[C, D](that: Map[A, C])(f: Ior[B, C] => D)(implicit ev: Ordering[A]): TreeMap[A, D] =
+    (self.keySet  ++ that.keySet).foldLeft(TreeMap.empty[A, D]) { (m, a) =>
+      Ior.fromOptions(self.get(a), that.get(a)).fold(m) { ior =>
+        m.updated(a, f(ior))
+      }
+    }
+}
+
+trait ToTreeMapOps {
+  implicit def ToTreeMapOps[A: Ordering, B](m: TreeMap[A, B]): TreeMapOps[A, B] =
+    new TreeMapOps(m)
+}
+
+object treemap extends ToTreeMapCompanionOps with ToTreeMapOps

--- a/modules/core/shared/src/main/scala/gem/syntax/TreeSet.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/TreeSet.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import scala.collection.immutable.TreeSet
+
+final class TreeSetCompanionOps(val self: TreeSet.type) extends AnyVal {
+
+  /** Creates a `TreeSet` from a `List`, provided an `Ordering` is available. */
+  def fromList[A: Ordering](lst: List[A]): TreeSet[A] =
+    TreeSet(lst: _*)
+
+}
+
+trait ToTreeSetCompanionOps {
+  implicit def ToTreeSetCompanionOps(c: TreeSet.type): TreeSetCompanionOps =
+    new TreeSetCompanionOps(c)
+}
+
+object treesetcompanion extends ToTreeSetCompanionOps

--- a/modules/core/shared/src/main/scala/gem/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/package.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+/**
+ * Syntax classes for extension methods, organized à la cats. Each syntax class has an associated
+ * conversion trait and module that extends it; and the `all` module which extends all
+ * conversions traits.
+ */
+package object syntax {
+  object all extends ToParserOps
+                with ToPrismOps
+                with ToStringOps
+                with ToInstantOps
+                with ToDurationOps
+                with ToTreeMapCompanionOps
+                with ToTreeMapOps
+                with ToTreeSetCompanionOps
+}

--- a/modules/core/shared/src/main/scala/gem/util/Enumerated.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Enumerated.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.util
+
+import cats.Order
+import cats.implicits._
+
+/**
+ * Typeclass for an enumerated type with unique string tags and a canonical ordering.
+ * @group Typeclasses
+ */
+trait Enumerated[A] extends Order[A] {
+
+  /** All members of this enumeration, in unspecified but canonical order. */
+  def all: List[A]
+
+  /** The tag for a given value. */
+  def tag(a: A): String
+
+  /** Select the member of this enumeration with the given tag, if any. */
+  def fromTag(s: String): Option[A] = all.find(tag(_) === s)
+
+  /** Select the member of this enumeration with the given tag, throwing if absent. */
+  def unsafeFromTag(tag: String): A = fromTag(tag).getOrElse(sys.error("Invalid tag: " + tag))
+
+  def compare(a: A, b: A): Int =
+    Order[Int].compare(indexOfTag(tag(a)), indexOfTag(tag(b)))
+
+  // Hashed index lookup, for efficient use as an `Order`.
+  private lazy val indexOfTag: Map[String, Int] =
+    all.zipWithIndex.map { case (a, n) => (tag(a), n) } (collection.breakOut)
+
+}
+
+object Enumerated {
+  def apply[A](implicit ev: Enumerated[A]): ev.type = ev
+}
+
+/** @group Typeclasses */
+trait Obsoletable[A] {
+  def isActive(a: A): Boolean
+  final def isObsolete(a: A): Boolean = !isActive(a)
+}
+
+
+/**
+ * Typeclass for things that can be shown in a user interface.
+ * @group Typeclasses
+ */
+trait Display[A] {
+  def name(a:A): String         // short name, for labels
+  def elaboration(a:A): Option[String]  // an elaboration on the name, used for computing longname
+  def longName(a: A): String = name(a) + elaboration(a).fold("")(n => s" ($n)")
+}

--- a/modules/core/shared/src/main/scala/gem/util/Location.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Location.scala
@@ -1,0 +1,205 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.util
+
+import cats._, cats.data._, cats.implicits._
+import scala.BigDecimal.RoundingMode.FLOOR
+import scala.annotation.tailrec
+import scala.collection.breakOut
+
+/** A sortable value used to indicate relative positions of a set of associated
+  * elements.  `Location`s may be thought of as lists of arbitrary integers
+  * which are be compared element by element such that the first pair of values
+  * that differ determine the ordering of the `Location`s as a whole.  If one
+  * `Location` is a proper prefex of another, then it sorts ahead of the other
+  * `Location`.
+  * @group Sequence Model
+  */
+sealed trait Location extends Product with Serializable {
+
+  // These functions aren't of any use to clients.  Instead they are involved
+  // in the cacluation of Locations that fall between two other locations.
+
+  /** Infinite Stream of position elements corresponding to this Location. */
+  protected def positions: Stream[Int]
+
+  /** Minimum size required to obtain all the fixed elements in this Location,
+    * if any.  Beginning and End Locations have no fixed elements.
+    */
+  protected def minPrefixLength: Int
+
+  final override def toString: String =
+    this match {
+      case Location.Beginning  => "{α}"
+      case Location.Middle(ps) => "{" + ps.map(_.toString).intercalate(",") + "}"
+      case Location.End        => "{ω}"
+    }
+
+}
+
+object Location {
+
+  /** A marker for the first Location.  No other Location comes before the
+    * Beginning.  Beginning should not be used to order elements unless you
+    * are sure no elements will ever need to be inserted before Beginning.  Use
+    * Beginning to calculate Locations that fall before the first existing
+    * Location (if any).
+    */
+  case object Beginning extends Location {
+    protected def positions: Stream[Int] =
+      Stream.continually(Int.MinValue)
+
+    protected def minPrefixLength: Int =
+      0
+
+  }
+
+  /** A Location that falls somewhere between the Beginning and End.
+    */
+  sealed abstract case class Middle(posList: NonEmptyList[Int]) extends Location {
+    def positions: Stream[Int] =
+      posList.toList.toStream #::: Stream.continually(Int.MinValue)
+
+    def toList: List[Int] =
+      posList.toList
+
+    protected def minPrefixLength: Int =
+      posList.size
+
+  }
+
+  /** A marker for the last Location.  No other Location comes after the End.
+    * End should not be used to order elements unless you are sure no elements
+    * will ever need to be inserted after End.  Use End to calculate new
+    * Locations that fall after the last existing Location (if any).
+    */
+  case object End extends Location {
+    def positions: Stream[Int] =
+      Stream.continually(Int.MaxValue)
+
+    protected def minPrefixLength: Int =
+      0
+
+  }
+
+  val beginning: Location = Beginning
+  val end: Location       = End
+
+  // Constructors
+
+  def apply(is: Int*): Location =
+    fromFoldable(is.toList)
+
+  def fromFoldable[F[_]: Foldable](fi: F[Int]): Location =
+    fi.foldRight(Eval.now(List.empty[Int])) { (i, elst) =>
+      elst.map { lst =>
+        if (lst.isEmpty && i === Int.MinValue) lst else (i :: lst)
+      }
+    }.value match {
+      case h :: t => new Middle(NonEmptyList(h, t)) {}
+      case _      => Beginning
+    }
+
+  /** Assuming not all provided Ints are `Int.MinValue`, produces a `Middle`
+    * `Location`.
+    */
+  def unsafeMiddle(is: Int*): Middle =
+    unsafeMiddleFromFoldable(is.toList)
+
+  /** Assuming not all provided Ints are `Int.MinValue`, produces a `Middle`
+    * `Location`.
+    */
+  def unsafeMiddleFromFoldable[F[_]: Foldable](fi: F[Int]): Middle =
+    fromFoldable(fi) match {
+      case m: Middle => m
+      case _         => sys.error("Location arguments do not form a Middle position: " + fi.toList.mkString(", "))
+    }
+
+
+  // Utility
+
+  private object Base10 {
+    val Zero  = BigInt(0)
+    val One   = BigInt(1)
+    val Max   = BigInt(Int.MaxValue)
+    val Min   = BigInt(Int.MinValue)
+    val Radix = Max + Min.abs + One
+
+    def toBase10(loc: Location, len: Int): BigInt =
+      loc.positions.take(len).foldRight((Zero, One)) { case (i, (acc, pow)) =>
+        (acc + (BigInt(i) + Min.abs) * pow, pow * Radix)
+      }._1
+
+    def fromBase10(bi: BigInt): Middle = {
+      @tailrec
+      def go(rem: BigInt, tail: List[Int]): Middle = {
+        val (a, b) = rem /% Radix
+        val head   = (b + Min).intValue
+        if (a === Zero) new Middle(NonEmptyList(head, tail)) {} else go(a, head +: tail)
+      }
+      go(bi, List.empty)
+    }
+  }
+
+  /** Finds `count` `Location`s that fall evenly distributed between `l0` and
+    * `l1`, assuming these locations are not the same.
+    *
+    * @param count how many locations to find
+    * @param start starting location (exclusive)
+    * @param end ending Location (exclusive)
+    *
+    * @return sorted list of `Location` where every element is GT l0 and LT l1
+    *         (or vice versa if l0 is GT l1)
+    */
+  def find(count: Int, start: Location, end: Location): List[Middle] = {
+    import Base10._
+
+    @tailrec
+    def go(len: Int): List[Middle] = {
+      val start10 = toBase10(start, len)
+      val end10   = toBase10(end, len)
+
+      // (end10 - start10) is the space we have to fill.  We need count + 1
+      // more or less evenly spaced gaps between numbers in that space.  So
+      // total space / gaps needed is the decimal gap size.  It has to be at
+      // least 1.0 or else we don't have enough space to accommodate `count`
+      // new elements and we have to recurse.
+      val gapSize = BigDecimal.exact(end10 - start10) / (count + 1)
+
+      if (gapSize < BigDecimal.exact(1)) go(len + 1)
+      else {
+        // This is the existing start position as a BigDecimal.
+        val startBd = BigDecimal(start10, 0)
+
+        // Calculate count digits separated one from the other by gapSized gaps,
+        // but rounding down to make them integral. Since gapSize is at least
+        // 1.0, this will always advance and never produce duplicates.
+        (1 to count)
+          .scanLeft(startBd) { (sum, _) => sum + gapSize }
+          .drop(1)
+          .map { bd => fromBase10(bd.setScale(0, FLOOR).toBigInt) }(breakOut)
+      }
+    }
+
+    if ((count <= 0) || (start >= end)) Nil
+    else go(start.minPrefixLength max end.minPrefixLength)
+  }
+
+  // Type Classes
+
+  implicit val OrderLocation: Order[Location] = Order.from {
+    case (Beginning,  Beginning )                => 0
+    case (End,        End       )                => 0
+    case (Middle(m0), Middle(m1)) if (m0 === m1) => 0
+    case (l0,         l1        )                =>
+      l0.positions.zip(l1.positions)
+        .find { case (a, b) => a =!= b }
+        .foldMap { case (a, b) => a compare b }
+  }
+
+  implicit val OrderMiddle: Order[Location.Middle] =
+    OrderLocation.contramap[Location.Middle](lm => lm: Location)
+
+  implicit val ShowLocation: Show[Location] = Show.fromToString
+}

--- a/modules/core/shared/src/main/scala/gem/util/Timestamp.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Timestamp.scala
@@ -1,0 +1,134 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.util
+
+import cats._
+import cats.implicits._
+import cats.effect.IO
+
+import java.time.{ Instant, ZonedDateTime }
+import java.time.ZoneOffset.UTC
+import java.time.temporal.ChronoUnit.MICROS
+
+
+/** Timestamp wraps a `java.util.Instant` that is truncated to microsecond
+  * resolution.  This allows Timestamps to roundtrip to/from the database
+  * where only microsecond resolution is supported.  In addition the min
+  * and max instants that are supported are determined by the postgres limit for
+  * timestamps.
+  *
+  * @param toInstant
+  */
+sealed abstract case class Timestamp(toInstant: Instant) {
+
+  import Timestamp.{ MaxInstant, MinInstant }
+
+  // Guaranteed by construction, but verified here.
+  assert(!toInstant.isBefore(MinInstant))
+  assert(!toInstant.isAfter(MaxInstant))
+  assert((toInstant.getNano % 1000L) === 0)
+
+  /** Gets the number of seconds from the Java epoch of 1970-01-01T00:00:00Z. */
+  def epochSecond: Long =
+    toInstant.getEpochSecond
+
+  /** Gets the number of microseconds after the start of the second returned
+    * by `epochSecond`.
+    */
+  def µs: Long =
+    toInstant.getNano / 1000L
+
+  /** Converts this instant to the number of milliseconds from the epoch of
+    * 1970-01-01T00:00:00Z.
+    */
+  def toEpochMilli: Long =
+    toInstant.toEpochMilli
+
+  /** Creates an updated instance of Timestamp by applying the given
+    * function to its wrapped Instant.  The computed Instant is truncated to
+    * microsecond precision and validated.
+    */
+  private def mod(f: Instant => Instant): Option[Timestamp] =
+    Timestamp.fromInstant(f(toInstant))
+
+  def plusMillis(millisToAdd: Long): Option[Timestamp] =
+    mod(_.plusMillis(millisToAdd))
+
+  def plusMicros(microsToAdd: Long): Option[Timestamp] =
+    mod(_.plusNanos(microsToAdd * 1000))
+
+  def plusSeconds(secondsToAdd: Long): Option[Timestamp] =
+    mod(_.plusSeconds(secondsToAdd))
+
+  override def toString: String =
+    toInstant.toString
+}
+
+object Timestamp {
+
+  private val MinInstant: Instant =
+    ZonedDateTime.of( -4712, 1, 1, 0, 0, 0, 0, UTC).toInstant
+
+  private val MaxInstant: Instant =
+    ZonedDateTime.of(294275, 12, 31, 23, 59, 59, 999999000, UTC).toInstant
+
+  /** Minimum time that can be stored in a postgres timestamp. */
+  val Min: Timestamp =
+    unsafeFromInstant(MinInstant)
+
+  /** Maximum time that can be stored in a postgres timestamp. */
+  val Max: Timestamp =
+    unsafeFromInstant(MaxInstant)
+
+  /** `Instant.EPOCH` transformed to `Timestamp`. */
+  val Epoch: Timestamp =
+    unsafeFromInstant(Instant.EPOCH)
+
+  /** Creates a Timestamp from the given Instant, assuring that the time
+    * value recorded has a round number of microseconds and that it is within
+    * the range supported by postgres.
+    *
+    * @group Constructors
+    */
+  def fromInstant(i: Instant): Option[Timestamp] = {
+    val iʹ = i.truncatedTo(MICROS)
+    if (iʹ.isBefore(MinInstant) || iʹ.isAfter(MaxInstant)) None
+    else Some(new Timestamp(iʹ) {})
+  }
+
+  /** Creates a Timestamp from the given Instant if possible, throwing an
+    * exception if the time is out of the valid range `Min` <= time <= `Max`.
+    *
+    * @group Constructors
+    */
+  def unsafeFromInstant(i: Instant): Timestamp =
+    fromInstant(i).getOrElse(sys.error(s"$i out of Timestamp range"))
+
+  /** Creates a Timestamp representing the current time, truncated to the
+    * last integral number of microseconds.
+    *
+    * @group Constructors
+    */
+  def now: IO[Timestamp] =
+    IO {
+      unsafeFromInstant(Instant.now())
+    }
+
+  /** Creates a Timestamp representing the current time using milliseconds
+    * from the Java time epoch.
+    *
+    * @group Constructors
+    */
+  def ofEpochMilli(epochMilli: Long): Option[Timestamp] =
+    fromInstant(Instant.ofEpochMilli(epochMilli))
+
+  implicit val OrderingTimestamp: Ordering[Timestamp] =
+    Ordering.by(_.toInstant)
+
+  implicit val OrderTimestamp: Order[Timestamp] =
+    Order.fromOrdering
+
+  implicit val ShowTimestamp: Show[Timestamp] =
+    Show.fromToString
+}

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.implicits._
+import gem.arb._
+import gem.config.{ GcalConfig, TelescopeConfig }
+import gem.enum.{Instrument, SmartGcalType}
+import gem.math.{ Index, Offset }
+import gem.syntax.all._
+import gem.util.Location
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+import scala.collection.immutable.TreeMap
+
+trait Arbitraries extends gem.config.Arbitraries  {
+  import ArbEnumerated._
+  import ArbTargetEnvironment._
+
+  implicit val arbLocationMiddle: Arbitrary[Location.Middle] =
+    Arbitrary {
+      for {
+        i  <- choose(Int.MinValue + 1, Int.MaxValue)
+        is <- arbitrary[List[Int]]
+      } yield Location.unsafeMiddleFromFoldable(i +: is)
+    }
+
+  implicit val arbLocation: Arbitrary[Location] =
+    Arbitrary {
+      Gen.frequency[Location](
+        (1, Location.Beginning),
+        (8, arbitrary[Location.Middle]),
+        (1, Location.End)
+      )
+    }
+
+  implicit val cogLocation: Cogen[Location] =
+    Cogen[String].contramap(_.toString)
+
+  // Generator of valid observation/program titles.  The schema doesn't support
+  // titles longer than 255 characters and postgres doesn't want to see char 0.
+  val genTitle: Gen[String] =
+    arbitrary[String].map(_.take(255).filter(_ != 0))
+
+
+  // Step and Sequence
+
+  def genBiasStepOf(i: Instrument): Gen[Step] =
+    genDynamicConfigOf(i).map(_.toStep(Step.Base.Bias))
+
+  def genDarkStepOf(i: Instrument): Gen[Step] =
+    genDynamicConfigOf(i).map(_.toStep(Step.Base.Dark))
+
+  def genGcalStepOf(i: Instrument): Gen[Step] =
+    for {
+      d <- genDynamicConfigOf(i)
+      g <- arbitrary[GcalConfig]
+    } yield d.toStep(Step.Base.Gcal(g))
+
+  def genScienceStepOf(i: Instrument): Gen[Step] =
+    genDynamicConfigOf(i).map(_.toStep(Step.Base.Science(TelescopeConfig(Offset.P.Zero, Offset.Q.Zero))))
+
+  def genSmartGcalStepOf(i: Instrument): Gen[Step] =
+    for {
+      d <- genDynamicConfigOf(i)
+      s <- arbitrary[SmartGcalType]
+    } yield d.toStep(Step.Base.SmartGcal(s))
+
+  def genStepOf(i: Instrument): Gen[Step] =
+    Gen.oneOf(
+      genBiasStepOf(i),
+      genDarkStepOf(i),
+      genGcalStepOf(i),
+      genScienceStepOf(i),
+      genSmartGcalStepOf(i)
+    )
+
+  def genSequenceOf(i: Instrument): Gen[List[Step]] =
+    for {
+      n <- Gen.choose(0, 50)
+      s <- Gen.listOfN(n, genStepOf(i))
+    } yield s
+
+  // Observation
+
+  def genObservationOf(i: Instrument): Gen[Observation] =
+    for {
+      t <- genTitle
+      e <- genTargetEnvironment(i)
+      s <- genStaticConfigOf(i)
+      d <- genSequenceOf(i)
+    } yield Observation.unsafeAssemble(t, e, s, d)
+
+  implicit val arbObservation: Arbitrary[Observation] =
+    Arbitrary {
+      for {
+        i <- Gen.oneOf(
+               Instrument.Flamingos2,
+               Instrument.GmosN,
+               Instrument.GmosS,
+             ) // Add more as they become available
+        o <- genObservationOf(i)
+      } yield o
+    }
+
+  def genObservationMap(limit: Int): Gen[TreeMap[Index, Observation]] =
+    for {
+      count   <- Gen.choose(0, limit)
+      obsIdxs <- Gen.listOfN(count, Gen.posNum[Short]).map(_.distinct.map(Index.fromShort.unsafeGet))
+      obsList <- obsIdxs.traverse(_ => arbitrary[Observation])
+    } yield TreeMap.fromList(obsIdxs.zip(obsList))
+
+}

--- a/modules/core/shared/src/test/scala/gem/DatasetLabelSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/DatasetLabelSpec.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import gem.laws.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString"))
+final class DatasetLabelSpec extends CatsSuite {
+  import ArbDataset._
+
+  // Laws
+  checkAll("DatasetLabel", OrderTests[Dataset.Label].order)
+  checkAll("Optics.fromString", FormatTests(Dataset.Label.fromString).formatWith(strings))
+
+  test("Equality must be natural") {
+    forAll { (a: Dataset.Label, b: Dataset.Label) =>
+      a.equals(b) shouldEqual Eq[Dataset.Label].eqv(a, b)
+    }
+  }
+
+  test("Equality must operate pairwise") {
+    forAll { (a: Dataset.Label, b: Dataset.Label) =>
+      Eq[Observation.Id].eqv(a.observationId, b.observationId) &&
+      Eq[Int].eqv(a.index, b.index) shouldEqual Eq[Dataset.Label].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Dataset.Label) =>
+      a.toString shouldEqual Show[Dataset.Label].show(a)
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/DatasetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/DatasetSpec.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import gem.instances.time._
+import java.time.Instant
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString"))
+final class DatasetSpec extends CatsSuite {
+  import ArbDataset._
+
+  // Laws
+  checkAll("DatasetLabel", OrderTests[Dataset].order)
+
+  test("Equality must be natural") {
+    forAll { (a: Dataset, b: Dataset) =>
+      a.equals(b) shouldEqual Eq[Dataset].eqv(a, b)
+    }
+  }
+
+  test("Equality must operate pairwise") {
+    forAll { (a: Dataset, b: Dataset) =>
+      Eq[Dataset.Label].eqv(a.label, b.label) &&
+      Eq[String].eqv(a.filename, b.filename)  &&
+      Eq[Instant].eqv(a.timestamp, b.timestamp) shouldEqual Eq[Dataset].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Dataset) =>
+      a.toString shouldEqual Show[Dataset].show(a)
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/EphemerisKeySpec.scala
+++ b/modules/core/shared/src/test/scala/gem/EphemerisKeySpec.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.arb._
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import gem.laws.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class EphemerisKeySpec extends CatsSuite {
+  import ArbEphemerisKey._
+  import ArbEnumerated._
+
+  // Laws
+  checkAll("EphemerisKey", OrderTests[EphemerisKey].order)
+  checkAll("fromString", FormatTests(EphemerisKey.fromString).formatWith(ArbEphemerisKey.strings))
+  checkAll("fromTypeAndDes", FormatTests(EphemerisKey.fromTypeAndDes).formatWith(ArbEphemerisKey.keyAndDes))
+
+  test("Equality must be natural") {
+    forAll { (a: EphemerisKey, b: EphemerisKey) =>
+      a.equals(b) shouldEqual Eq[EphemerisKey].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: EphemerisKey) =>
+      a.toString shouldEqual Show[EphemerisKey].show(a)
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/ObservationIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ObservationIdSpec.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import gem.arb._
+import gem.math.Index
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class ObservationIdSpec extends CatsSuite {
+  import ArbObservation._
+
+  // Laws
+  checkAll("Observation.Id", OrderTests[Observation.Id].order)
+
+  test("Equality must be natural") {
+    forAll { (a: Observation.Id, b: Observation.Id) =>
+      a.equals(b) shouldEqual Eq[Observation.Id].eqv(a, b)
+    }
+  }
+
+  test("Equalty must act pairwise") {
+    forAll { (a: Observation.Id, b: Observation.Id) =>
+      Eq[Program.Id].eqv(a.pid, b.pid) &&
+      Eq[Index].eqv(a.index, b.index) shouldEqual Eq[Observation.Id].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Observation.Id) =>
+      a.toString shouldEqual Show[Observation.Id].show(a)
+    }
+  }
+
+  test(".format must reparse") {
+    forAll { (a: Observation.Id) =>
+      Observation.Id.fromString(a.format) shouldEqual Some(a)
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/ObservationSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ObservationSpec.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+
+final class ObservationSpec extends CatsSuite {
+
+}

--- a/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/ProgramIdSpec.scala
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import gem.arb._
+import gem.enum.{ Site, DailyProgramType }
+import java.time._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class ProgramIdSpec extends CatsSuite {
+  import ProgramId._
+  import ArbEnumerated._
+  import ArbProgramId._
+  import ArbTime._
+
+  // Laws
+  checkAll("Program.Id", OrderTests[Program.Id].order)
+  checkAll("Program.Id.Science.fromString", PrismTests(Program.Id.Science.fromString))
+  checkAll("Program.Id.Daily.fromString", PrismTests(Program.Id.Daily.fromString))
+  checkAll("Program.Id.Nonstandard.fromString", PrismTests(Program.Id.Nonstandard.fromString))
+  checkAll("Program.Id.fromString", PrismTests(Program.Id.fromString))
+
+  test("Equality must be natural") {
+    forAll { (a: ProgramId, b: ProgramId) =>
+      a.equals(b) shouldEqual Eq[ProgramId].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: ProgramId) =>
+      a.toString shouldEqual Show[ProgramId].show(a)
+    }
+  }
+
+  test("Science should never reparse into a Nonstandard, even if we try") {
+    forAll { (sid: Science) =>
+      Nonstandard.fromString.getOption(ProgramId.fromString.reverseGet(sid)) shouldEqual None
+    }
+  }
+
+  test("Daily should never reparse into a Nonstandard, even if we try") {
+    forAll { (did: Daily) =>
+      Nonstandard.fromString.getOption(ProgramId.fromString.reverseGet(did)) shouldEqual None
+    }
+  }
+
+  test("Daily should find the correct observing day given a site and instant") {
+    forAll { (site: Site, ldt: LocalDateTime, dpt: DailyProgramType) =>
+      val zdt = ZonedDateTime.of(ldt, site.timezone)
+      val did = Daily.fromSiteAndInstant(site, zdt.toInstant, dpt)
+      val end = zdt.`with`(LocalTime.of(14, 0, 0, 0))
+      val exp = if (zdt isBefore end) ldt.toLocalDate else ldt.plusDays(1).toLocalDate
+      did.localDate shouldEqual exp
+    }
+  }
+
+  test("Daily should be consistent re: .start and .fromSiteAndInstant") {
+    forAll { (did: Daily) =>
+      Daily.fromSiteAndInstant(did.site, did.start.toInstant, did.dailyProgramType) shouldEqual did
+    }
+  }
+
+  test("Daily should be consistent re: .end and .fromSiteAndInstant") {
+    forAll { (did: Daily) =>
+      Daily.fromSiteAndInstant(did.site, did.end.toInstant, did.dailyProgramType) shouldEqual did
+    }
+  }
+
+  test("Daily should have a consistent program type and daily program type") {
+    forAll { (did: Daily) =>
+      did.dailyProgramType.toProgramType shouldEqual did.programType
+    }
+  }
+
+  test("Daily should have a consistent date and semester") {
+    forAll { (did: Daily) =>
+      Semester.fromLocalDate(did.localDate) shouldEqual did.semester
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/SemesterSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/SemesterSpec.scala
@@ -1,0 +1,259 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import gem.arb._
+import gem.enum.{ Half, Site }
+import gem.instances.time._
+import java.time.{ Year, ZoneId }
+import java.time.format.DateTimeFormatter
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class SemesterSpec extends CatsSuite {
+  import ArbEnumerated._
+  import ArbSemester._
+  import ArbTime._
+
+  // Laws
+  checkAll("Semester", OrderTests[Semester].order)
+
+  test("Equality must be natural") {
+    forAll { (a: Semester, b: Semester) =>
+      a.equals(b) shouldEqual Eq[Semester].eqv(a, b)
+    }
+  }
+
+  test("Equality must operate pairwise") {
+    forAll { (a: Semester, b: Semester) =>
+      Eq[Year].eqv(a.year, b.year) &&
+      Eq[Half].eqv(a.half, b.half) shouldEqual Eq[Semester].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Semester) =>
+      a.toString shouldEqual Show[Semester].show(a)
+    }
+  }
+
+  test(".fromString must be invertible via .format") {
+    forAll { (y: Year, h: Half) =>
+      val yʹ = DateTimeFormatter.ofPattern("yyyy").format(y)
+      val hʹ = h.tag
+      val sʹ = s"$yʹ$hʹ"
+      Semester.fromString(sʹ).map(_.format) shouldEqual Some(sʹ)
+    }
+  }
+
+  test(".unsafeFromString must be invertible via .format") {
+    forAll { (y: Year, h: Half) =>
+      val yʹ = DateTimeFormatter.ofPattern("yyyy").format(y)
+      val hʹ = h.tag
+      val sʹ = s"$yʹ$hʹ"
+      Semester.unsafeFromString(sʹ).format shouldEqual sʹ
+    }
+  }
+
+  test(".format must be invertible via .fromString") {
+    forAll { (s: Semester) =>
+      Semester.fromString(s.format) shouldEqual Some(s)
+    }
+  }
+
+  test(".format should also be invertible via .unsafeFromString") {
+    forAll { (s: Semester) =>
+      Semester.unsafeFromString(s.format) shouldEqual s
+    }
+  }
+
+  test(".plusYears must result in a properly updated year") {
+    forAll { (s: Semester, n: Short) =>
+      val nʹ = n.toInt
+      val sʹ = s.plusYears(nʹ)
+      sʹ.year.getValue shouldEqual s.year.getValue + nʹ
+    }
+  }
+
+  test(".plusYears should never affect the half") {
+    forAll { (s: Semester, n: Short) =>
+      val nʹ = n.toInt
+      val sʹ = s.plusYears(nʹ)
+      sʹ.half shouldEqual s.half
+    }
+  }
+
+  test(".plusYears should have an identity") {
+    forAll { (s: Semester) =>
+      s.plusYears(0) shouldEqual s
+    }
+  }
+
+  test(".plusYears should be invertible by negation, for reasonable values") {
+    forAll { (s: Semester, n: Short) =>
+      val nʹ = n.toInt
+      s.plusYears(nʹ).plusYears(-nʹ) shouldEqual s
+    }
+  }
+
+  test(".plusYears should be a homomorphism over addition, for reasonable values") {
+    forAll { (s: Semester, n1: Short, n2: Short) =>
+      val (n1ʹ, n2ʹ) = (n1.toInt, n2.toInt)
+      s.plusYears(n1ʹ).plusYears(n2ʹ) shouldEqual s.plusYears(n1ʹ + n2ʹ)
+    }
+  }
+
+  test(".plusSemesters must be consistent with .plusYears, for reasonable values") {
+    forAll { (s: Semester, n: Byte, b: Boolean) =>
+      val nʹ = n.toInt
+      val bʹ = if (b) nʹ.signum else 0
+      val s1 = s.plusYears(nʹ).plusSemesters(bʹ)
+      val s2 = s.plusSemesters(nʹ * 2 + bʹ)
+      s1 shouldEqual s2
+    }
+  }
+
+  test(".plusSemesters should have an identity") {
+    forAll { (s: Semester) =>
+      s.plusSemesters(0) shouldEqual s
+    }
+  }
+
+  test(".plusSemesters should be invertible by negation, for reasonable values") {
+    forAll { (s: Semester, n: Byte) =>
+      val nʹ = n.toInt
+      s.plusSemesters(nʹ).plusSemesters(-nʹ) shouldEqual s
+    }
+  }
+
+  test(".plusSemesters should be a homomorphism over addition, for reasonable values") {
+    forAll { (s: Semester, n1: Byte, n2: Byte) =>
+      val (n1ʹ, n2ʹ) = (n1.toInt, n2.toInt)
+      s.plusSemesters(n1ʹ).plusSemesters(n2ʹ) shouldEqual s.plusSemesters(n1ʹ + n2ʹ)
+    }
+  }
+
+  test(".start round-tripping must be consistent for .yearMonth     ~ .fromYearMonth") {
+    forAll { (s: Semester) =>
+      Semester.fromYearMonth(s.start.yearMonth) shouldEqual s
+    }
+  }
+
+  test(".start should be consistent for .localDate     ~ .fromLocalDate") {
+    forAll { (s: Semester) =>
+      Semester.fromLocalDate(s.start.localDate) shouldEqual s
+    }
+  }
+
+  test(".start should be consistent for .localDateTime ~ .fromLocalDateTime") {
+    forAll { (s: Semester) =>
+      Semester.fromLocalDateTime(s.start.localDateTime) shouldEqual s
+    }
+  }
+
+  test(".start should be consistent for .zonedDateTime ~ .fromZonedDateTime") {
+    forAll { (s: Semester, z: ZoneId) =>
+      Semester.fromZonedDateTime(s.start.zonedDateTime(z)) shouldEqual s
+    }
+  }
+
+  test(".start should be consistent for .atSite        ~ .fromSiteAndInstant") {
+    forAll { (s: Semester, site: Site) =>
+      Semester.fromSiteAndInstant(site, s.start.atSite(site).toInstant) shouldEqual s
+    }
+  }
+
+  test(".start precision must be correct for .yearMonth") {
+    forAll { (s: Semester) =>
+      Semester.fromYearMonth(s.start.yearMonth.minusMonths(1)) shouldEqual s.prev
+    }
+  }
+
+  test(".start should be correct for .localDate") {
+    forAll { (s: Semester) =>
+      Semester.fromLocalDate(s.start.localDate.minusDays(1)) shouldEqual s.prev
+    }
+  }
+
+  test(".start should be correct for .localDateTime") {
+    forAll { (s: Semester) =>
+      Semester.fromLocalDateTime(s.start.localDateTime.minusNanos(1)) shouldEqual s.prev
+    }
+  }
+
+  test(".start should be correct for .zonedDateTime") {
+    forAll { (s: Semester, z: ZoneId) =>
+      Semester.fromZonedDateTime(s.start.zonedDateTime(z).minusNanos(1)) shouldEqual s.prev
+    }
+  }
+
+  test(".start should be correct for .atSite") {
+    forAll { (s: Semester, site: Site) =>
+      Semester.fromSiteAndInstant(site, s.start.atSite(site).minusNanos(1).toInstant) shouldEqual s.prev
+    }
+  }
+
+  test(".end round-tripping must be consistent for .yearMonth     ~ .fromYearMonth") {
+    forAll { (s: Semester) =>
+      Semester.fromYearMonth(s.end.yearMonth) shouldEqual s
+    }
+  }
+
+  test(".end should be consistent for .localDate     ~ .fromLocalDate") {
+    forAll { (s: Semester) =>
+      Semester.fromLocalDate(s.end.localDate) shouldEqual s
+    }
+  }
+
+  test(".end should be consistent for .localDateTime ~ .fromLocalDateTime") {
+    forAll { (s: Semester) =>
+      Semester.fromLocalDateTime(s.end.localDateTime) shouldEqual s
+    }
+  }
+
+  test(".end should be consistent for .zonedDateTime ~ .fromZonedDateTime") {
+    forAll { (s: Semester, z: ZoneId) =>
+      Semester.fromZonedDateTime(s.end.zonedDateTime(z)) shouldEqual s
+    }
+  }
+
+  test(".end should be consistent for .atSite        ~ .fromSiteAndInstant") {
+    forAll { (s: Semester, site: Site) =>
+      Semester.fromSiteAndInstant(site, s.end.atSite(site).toInstant) shouldEqual s
+    }
+  }
+
+  test(".end precisiom must be correct for .yearMonth") {
+    forAll { (s: Semester) =>
+      Semester.fromYearMonth(s.end.yearMonth.plusMonths(1)) shouldEqual s.next
+    }
+  }
+
+  test(".end should be correct for .localDate") {
+    forAll { (s: Semester) =>
+      Semester.fromLocalDate(s.end.localDate.plusDays(1)) shouldEqual s.next
+    }
+  }
+
+  test(".end should be correct for .localDateTime") {
+    forAll { (s: Semester) =>
+      Semester.fromLocalDateTime(s.end.localDateTime.plusNanos(1)) shouldEqual s.next
+    }
+  }
+
+  test(".end should be correct for .zonedDateTime") {
+    forAll { (s: Semester, z: ZoneId) =>
+      Semester.fromZonedDateTime(s.end.zonedDateTime(z).plusNanos(1)) shouldEqual s.next
+    }
+  }
+
+  test(".end should be correct for .atSite") {
+    forAll { (s: Semester, site: Site) =>
+      Semester.fromSiteAndInstant(site, s.end.atSite(site).plusNanos(1).toInstant) shouldEqual s.next
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/TargetEnvironmentSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/TargetEnvironmentSpec.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import gem.arb._
+
+final class TargetEnvironmentSpec extends CatsSuite {
+  import ArbTargetEnvironment._
+  checkAll(s"TargetEnvironment", EqTests[TargetEnvironment].eqv)
+}

--- a/modules/core/shared/src/test/scala/gem/TargetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/TargetSpec.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+
+import gem.arb._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class TargetSpec extends CatsSuite {
+  import ArbTarget._
+
+  // Laws
+  checkAll("Target",     OrderTests[Target].order)
+  checkAll("TargetName", OrderTests[Target](Target.TargetNameOrder).order)
+}

--- a/modules/core/shared/src/test/scala/gem/TrackSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/TrackSpec.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+
+import gem.arb._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class TrackSpec extends CatsSuite {
+  import ArbTrack._
+
+  // Laws
+  checkAll("Track", EqTests[Track].eqv)
+
+}

--- a/modules/core/shared/src/test/scala/gem/UserTargetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/UserTargetSpec.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+
+import gem.arb._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class UserTargetSpec extends CatsSuite {
+  import ArbUserTarget._
+
+  // Laws
+  checkAll("UserTarget", OrderTests[UserTarget].order)
+}

--- a/modules/core/shared/src/test/scala/gem/arb/ArbAngle.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbAngle.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.{ Angle, HourAngle }
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbAngle {
+
+  implicit def arbAngle: Arbitrary[Angle] =
+    Arbitrary(arbitrary[Double].map(Angle.fromDoubleDegrees))
+
+  implicit def arbHourAngle: Arbitrary[HourAngle] =
+    Arbitrary(arbitrary[Double].map(HourAngle.fromDoubleHours))
+
+  implicit def arbDMS: Arbitrary[Angle.DMS] =
+    Arbitrary(arbitrary[Angle].map(Angle.dms.get))
+
+  implicit def arbHMS: Arbitrary[HourAngle.HMS] =
+    Arbitrary(arbitrary[HourAngle].map(HourAngle.hms.get))
+
+  implicit def cogAngle: Cogen[Angle] =
+    Cogen[Double].contramap(_.toDoubleDegrees)
+
+  implicit def cogHourAngle: Cogen[HourAngle] =
+    Cogen[Double].contramap(_.toDoubleDegrees)
+
+  implicit def cogDMS: Cogen[Angle.DMS] =
+    Cogen[Angle].contramap(_.toAngle)
+
+  implicit def cogHMS: Cogen[HourAngle.HMS] =
+    Cogen[HourAngle].contramap(_.toHourAngle)
+
+  private val perturbations: List[String => Gen[String]] =
+    List(
+      s => arbitrary[String],             // swap for a random string
+      s => Gen.const(s.replace(":", " ")) // replace colons with spaces (ok)
+    )
+
+  // Strings that are often parsable as HMS.
+  val stringsHMS: Gen[String] =
+    arbitrary[HourAngle].map(HourAngle.fromStringHMS.reverseGet).flatMapOneOf(Gen.const, perturbations: _*)
+
+  // Strings that are often parsable as DMS.
+  val stringsDMS: Gen[String] =
+    arbitrary[Angle].map(Angle.fromStringDMS.reverseGet).flatMapOneOf(Gen.const, perturbations: _*)
+
+  // Strings that are often parsable as signed DMS.
+  val stringsSignedDMS: Gen[String] =
+    arbitrary[Angle].map(Angle.fromStringSignedDMS.reverseGet).flatMapOneOf(Gen.const, perturbations: _*)
+
+}
+
+object ArbAngle extends ArbAngle

--- a/modules/core/shared/src/test/scala/gem/arb/ArbAsterism.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbAsterism.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.Instrument
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbAsterism {
+
+  import ArbEnumerated._
+  import ArbTarget._
+
+  def genSingleTarget(i: Instrument): Gen[Asterism] =
+    arbitrary[Target].map(Asterism.unsafeFromSingleTarget(_, i))
+
+  val genGhostDualTarget: Gen[Asterism.GhostDualTarget] =
+    for {
+      t1 <- arbitrary[Target]
+      t2 <- arbitrary[Target]
+    } yield Asterism.GhostDualTarget(t1, t2)
+
+  def genAsterism(i: Instrument): Gen[Asterism] =
+    i match {
+      case Instrument.Ghost => genGhostDualTarget
+      case _                => genSingleTarget(i)
+    }
+
+  implicit val arbAsterism: Arbitrary[Asterism] =
+    Arbitrary {
+      for {
+        i <- arbitrary[Instrument]
+        a <- genAsterism(i)
+      } yield a
+    }
+
+  implicit def cogAsterism: Cogen[Asterism] =
+    Cogen[(List[Target], String)].contramap(a => (a.targets.toList, a.productPrefix))
+
+}
+
+object ArbAsterism extends ArbAsterism

--- a/modules/core/shared/src/test/scala/gem/arb/ArbCoordinates.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbCoordinates.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.{ RightAscension, Declination, Coordinates }
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbCoordinates {
+  import ArbAngle._
+  import ArbRightAscension._
+  import ArbDeclination._
+
+  implicit val arbCoordinates: Arbitrary[Coordinates] =
+    Arbitrary {
+      for {
+        ra  <- arbitrary[RightAscension]
+        dec <- arbitrary[Declination]
+      } yield Coordinates(ra, dec)
+    }
+
+  implicit val cogCoordinates: Cogen[Coordinates] =
+    Cogen[(RightAscension, Declination)].contramap(cs => (cs.ra, cs.dec))
+
+  // Strings that are often parsable as Coordinates
+  val strings: Gen[String] =
+    for {
+      hms <- stringsHMS
+      dms <- stringsDMS
+      n   <- Gen.choose(1,5)
+    } yield hms + (" " * n) + dms
+
+}
+
+object ArbCoordinates extends ArbCoordinates

--- a/modules/core/shared/src/test/scala/gem/arb/ArbDataset.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbDataset.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import java.time.Instant
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+trait ArbDataset {
+  import ArbObservation._
+  import ArbTime._
+
+  implicit val arbLabel: Arbitrary[Dataset.Label] =
+    Arbitrary {
+      for {
+        oid <- arbitrary[Observation.Id]
+        idx <- choose(1,1000)
+      } yield Dataset.Label(oid, idx)
+    }
+
+  implicit val arbDataset: Arbitrary[Dataset] =
+    Arbitrary {
+      for {
+        lab <- arbitrary[Dataset.Label]
+        fn  <- arbitrary[String].map(_.take(100).filterNot(_ == 0))
+        ts  <- arbitrary[Instant]
+      } yield Dataset(lab, fn, ts)
+    }
+
+  implicit val cogLabel: Cogen[Dataset.Label] =
+    Cogen[(Observation.Id, Int)].contramap(l => (l.observationId, l.index))
+
+  implicit val cogDataset: Cogen[Dataset] =
+    Cogen[(Dataset.Label, String, Instant)].contramap(ds => (ds.label, ds.filename, ds.timestamp))
+
+  // Strings that are often parsable as Labels
+  val strings: Gen[String] =
+    arbitrary[Dataset.Label].map(Dataset.Label.fromString.reverseGet).flatMapOneOf(
+      Gen.const,                            // Do nothing, or
+      s => arbitrary[String],               // Replace with an arbitrary String, or
+      s => Gen.const(s.replace("-0", "-")), // remove a leading zero.
+    )
+
+}
+
+object ArbDataset extends ArbDataset

--- a/modules/core/shared/src/test/scala/gem/arb/ArbDeclination.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbDeclination.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.{ Angle, Declination }
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbDeclination {
+  import ArbAngle._
+
+  implicit val arbDeclination: Arbitrary[Declination] =
+    Arbitrary(arbitrary[Angle].map(Declination.fromAngleWithCarry(_)._1))
+
+  implicit val cogDeclination: Cogen[Declination] =
+    Cogen[Angle].contramap(_.toAngle)
+
+}
+
+object ArbDeclination extends ArbDeclination

--- a/modules/core/shared/src/test/scala/gem/arb/ArbEnumerated.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbEnumerated.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.util.Enumerated
+import org.scalacheck._
+import org.scalacheck.Gen._
+
+trait ArbEnumerated {
+
+  implicit def arbEnumerated[A](implicit en: Enumerated[A]): Arbitrary[A] =
+    Arbitrary(oneOf(en.all))
+
+  implicit def cogEnumerated[A](implicit en: Enumerated[A]): Cogen[A] =
+    Cogen[String].contramap(en.tag)
+
+}
+
+object ArbEnumerated extends ArbEnumerated

--- a/modules/core/shared/src/test/scala/gem/arb/ArbEphemeris.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbEphemeris.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.{ Coordinates, Ephemeris, EphemerisCoordinates, Offset }
+import gem.util.Timestamp
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+trait ArbEphemeris {
+  import ArbCoordinates._
+  import ArbOffset._
+  import ArbTime._
+  import Ephemeris.Element
+
+  implicit val arbEphemerisCoordinates: Arbitrary[EphemerisCoordinates] =
+    Arbitrary {
+      for {
+        c <- arbitrary[Coordinates]
+        o <- arbitrary[Offset]
+      } yield EphemerisCoordinates(c, o)
+    }
+
+  implicit val arbElement: Arbitrary[Element] =
+    Arbitrary {
+      for {
+        t <- arbitrary[Timestamp]
+        c <- arbitrary[EphemerisCoordinates]
+      } yield (t, c)
+    }
+
+  implicit val arbEphemeris: Arbitrary[Ephemeris] =
+    Arbitrary {
+      for {
+        len <- choose(0, 10)
+        es  <- listOfN(len, arbitrary[Element])
+      } yield Ephemeris(es: _*)
+    }
+
+  implicit val cogEphemerisCoordinates: Cogen[EphemerisCoordinates] =
+    Cogen[(Coordinates, Offset)].contramap(co => (co.coord, co.delta))
+
+  implicit val cogEphemeris: Cogen[Ephemeris] =
+    Cogen[Map[Timestamp, EphemerisCoordinates]].contramap(_.toMap)
+
+}
+
+object ArbEphemeris extends ArbEphemeris

--- a/modules/core/shared/src/test/scala/gem/arb/ArbEphemerisKey.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbEphemerisKey.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import EphemerisKey._
+import gem.enum.EphemerisKeyType
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbEphemerisKey {
+  import ArbEnumerated._
+
+  private def genStringDes[A](f: String => A): Gen[A] =
+    Gen.alphaNumStr.map(s => f(s.take(10)))
+
+  private def genIntDes[A](f: Int => A): Gen[A] =
+    arbitrary[Int].map(f)
+
+  implicit val arbEphemerisKey: Arbitrary[EphemerisKey] =
+    Arbitrary {
+      Gen.oneOf[EphemerisKey](
+        genStringDes(Comet.apply       ),
+        genStringDes(AsteroidNew.apply ),
+        genIntDes   (AsteroidOld.apply ),
+        genIntDes   (MajorBody.apply   ),
+        genIntDes   (UserSupplied.apply)
+      )
+    }
+
+  implicit val CogenEphemerisKey: Cogen[EphemerisKey] =
+    Cogen[String].contramap(EphemerisKey.fromString.reverseGet)
+
+  private val perturbations: List[String => Gen[String]] =
+    List(
+      s => arbitrary[String],             // swap for a random string
+      s => Gen.const(s.replace("2", "0")) // create a leading zero, perhaps
+    )
+
+  // Key and des pairs that are often parsable
+  val keyAndDes: Gen[(EphemerisKeyType, String)] =
+    for {
+      k <- arbitrary[EphemerisKeyType]
+      d <- arbitrary[Int].map(_.abs.toString).flatMapOneOf(Gen.const, perturbations: _*)
+    } yield (k, d)
+
+  // Strings that are often parsable
+  val strings: Gen[String] =
+    arbitrary[EphemerisKey]
+      .map(EphemerisKey.fromString.reverseGet)
+      .flatMapOneOf(Gen.const, perturbations: _*)
+
+}
+
+object ArbEphemerisKey extends ArbEphemerisKey

--- a/modules/core/shared/src/test/scala/gem/arb/ArbEphemerisMeta.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbEphemerisMeta.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.util.Timestamp
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbEphemerisMeta {
+
+  import ArbTime._
+
+  implicit val arbHorizonsSolnRef: Arbitrary[HorizonsSolutionRef] =
+    Arbitrary {
+      Gen.alphaStr.map(HorizonsSolutionRef.apply)
+    }
+
+  implicit val arbEphemerisMeta: Arbitrary[EphemerisMeta] =
+    Arbitrary {
+      for {
+        u <- arbitrary[Timestamp]
+        c <- arbitrary[Timestamp]
+        s <- arbitrary[Option[HorizonsSolutionRef]]
+      } yield EphemerisMeta(u, c, s)
+    }
+
+}
+
+object ArbEphemerisMeta extends ArbEphemerisMeta

--- a/modules/core/shared/src/test/scala/gem/arb/ArbEpoch.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbEpoch.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.Epoch
+import java.time.LocalDateTime
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+trait ArbEpoch {
+  import ArbTime._
+
+  implicit val arbScheme: Arbitrary[Epoch.Scheme] =
+    Arbitrary(oneOf(Epoch.Julian, Epoch.Besselian))
+
+  implicit val arbEpoch: Arbitrary[Epoch] =
+    Arbitrary {
+      for {
+        sch <- arbitrary[Epoch.Scheme]
+        ldt <- arbitrary[LocalDateTime]
+      } yield sch.fromLocalDateTime(ldt)
+    }
+
+  implicit val cogEpoch: Cogen[Epoch] =
+    Cogen[String].contramap(Epoch.fromString.reverseGet)
+
+  private val perturbations: List[String => Gen[String]] =
+    List(
+      s => arbitrary[String],             // swap for a random string
+      s => Gen.const(s.replace("2", "0")) // create a leading zero, maybe (ok)
+    )
+
+  // Strings that are often parsable as DMS.
+  val strings: Gen[String] =
+    arbitrary[Epoch].map(Epoch.fromString.reverseGet).flatMapOneOf(Gen.const, perturbations: _*)
+
+}
+
+object ArbEpoch extends ArbEpoch

--- a/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbIndex.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.Index
+import gem.syntax.prism._
+import org.scalacheck._
+import org.scalacheck.Gen._
+
+trait ArbIndex {
+
+  val genIndex: Gen[Index] =
+    choose[Short](1, Short.MaxValue).map(Index.fromShort.unsafeGet)
+
+  implicit val arbIndex: Arbitrary[Index] =
+    Arbitrary(genIndex)
+
+  implicit val cogIndex: Cogen[Index] =
+    Cogen[Short].contramap(_.toShort)
+
+}
+
+object ArbIndex extends ArbIndex

--- a/modules/core/shared/src/test/scala/gem/arb/ArbJulianDate.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbJulianDate.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.JulianDate
+
+import java.time.LocalDateTime
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+
+trait ArbJulianDate {
+  import ArbTime._
+
+  implicit val arbJulianDate: Arbitrary[JulianDate] =
+    Arbitrary {
+      arbitrary[LocalDateTime].map(JulianDate.ofLocalDateTime)
+    }
+
+  implicit val cogJulianDate: Cogen[JulianDate] =
+    Cogen[(Int, Long)].contramap(jd => (jd.dayNumber, jd.nanoAdjustment))
+}
+
+object ArbJulianDate extends ArbJulianDate

--- a/modules/core/shared/src/test/scala/gem/arb/ArbMagnitudeValue.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbMagnitudeValue.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.MagnitudeValue
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbMagnitudeValue {
+
+  implicit val arbMagnitudeValue: Arbitrary[MagnitudeValue] = Arbitrary {
+    arbitrary[Int].map(MagnitudeValue.apply)
+  }
+
+  implicit val cogMagnitudeValue: Cogen[MagnitudeValue] =
+    Cogen[Int].contramap(_.scaledValue)
+
+}
+
+object ArbMagnitudeValue extends ArbMagnitudeValue

--- a/modules/core/shared/src/test/scala/gem/arb/ArbObservation.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbObservation.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.Instrument
+import gem.math.Index
+import gem.syntax.prism._
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbObservation extends gem.config.Arbitraries {
+  import ArbEnumerated._
+  import ArbIndex._
+  import ArbProgramId._
+  import ArbTargetEnvironment._
+
+  implicit val arbObservationId: Arbitrary[Observation.Id] =
+    Arbitrary {
+      for {
+        pid <- arbitrary[ProgramId]
+        num <- choose[Short](1, 100)
+      } yield Observation.Id(pid, Index.fromShort.unsafeGet(num))
+    }
+
+  def genObservation(i: Instrument): Gen[Observation] =
+    for {
+      t   <- arbitrary[String]
+      te  <- genTargetEnvironment(i)
+      sc  <- genStaticConfigOf(i)
+      dc  <- genDynamicConfigOf(i)
+    } yield Observation.unsafeAssemble(t, te, sc, List(dc.toStep(Step.Base.Bias)))
+
+  implicit val arbObservation: Arbitrary[Observation] =
+    Arbitrary {
+      for {
+        i <- arbitrary[Instrument]
+        o <- genObservation(i)
+      } yield o
+    }
+
+  implicit val cogObservationId: Cogen[Observation.Id] =
+    Cogen[(ProgramId, Index)].contramap(oid => (oid.pid, oid.index))
+
+}
+
+object ArbObservation extends ArbObservation

--- a/modules/core/shared/src/test/scala/gem/arb/ArbObservingNight.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbObservingNight.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.Site
+import gem.math.{ LocalObservingNight, ObservingNight }
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+import java.time.LocalDate
+
+
+trait ArbObservingNight {
+
+  import ArbEnumerated._
+  import ArbTime._
+
+  implicit val arbLocalObservingNight: Arbitrary[LocalObservingNight] =
+    Arbitrary {
+      arbitrary[LocalDate].map(LocalObservingNight(_))
+    }
+
+  implicit val arbObservingNight: Arbitrary[ObservingNight] =
+    Arbitrary {
+      for {
+        n <- arbitrary[LocalObservingNight]
+        s <- arbitrary[Site]
+      } yield n.atSite(s)
+    }
+
+  implicit val cogLocalObservingNight: Cogen[LocalObservingNight] =
+    Cogen[LocalDate].contramap(_.toLocalDate)
+
+  implicit val cogObservingNight: Cogen[ObservingNight] =
+    Cogen[(Site, LocalObservingNight)].contramap(o => (o.site, o.toLocalObservingNight))
+}
+
+object ArbObservingNight extends ArbObservingNight

--- a/modules/core/shared/src/test/scala/gem/arb/ArbOffset.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbOffset.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.{ Angle, Offset }
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbOffset {
+  import ArbAngle._
+
+  implicit val arbOffsetP: Arbitrary[Offset.P] =
+    Arbitrary(
+      Gen.chooseNum(-10000, 10000).map(mas => Offset.P(Angle.milliarcseconds.reverseGet(mas)))
+    )
+
+  implicit val arbOffsetQ: Arbitrary[Offset.Q] =
+    Arbitrary(
+      Gen.chooseNum(-10000, 10000).map(mas => Offset.Q(Angle.milliarcseconds.reverseGet(mas)))
+    )
+
+  implicit val arbOffset: Arbitrary[Offset] =
+    Arbitrary {
+      for {
+        p <- arbitrary[Offset.P]
+        q <- arbitrary[Offset.Q]
+      } yield Offset(p, q)
+    }
+
+  implicit val cogOffsetP: Cogen[Offset.P] =
+    Cogen[Angle].contramap(_.toAngle)
+
+  implicit val cogOffsetQ: Cogen[Offset.Q] =
+    Cogen[Angle].contramap(_.toAngle)
+
+  implicit val cogOffset: Cogen[Offset] =
+    Cogen[(Offset.P, Offset.Q)].contramap(o => (o.p, o.q))
+
+}
+
+object ArbOffset extends ArbOffset

--- a/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbProgramId.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum. { Site, ProgramType, DailyProgramType }
+import gem.math.Index
+import gem.syntax.prism._
+import java.time.LocalDate
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+trait ArbProgramId {
+  import ProgramId._
+  import ArbEnumerated._
+  import ArbSemester._
+  import ArbTime._
+
+  implicit val arbScience: Arbitrary[Science] =
+    Arbitrary {
+      for {
+        site        <- arbitrary[Site]
+        semester    <- arbitrary[Semester]
+        programType <- arbitrary[ProgramType]
+        index       <- choose[Short](1, 200).map(Index.fromShort.unsafeGet)
+      } yield Science(site, semester, programType, index)
+    }
+
+  implicit val arbDaily: Arbitrary[Daily] =
+    Arbitrary {
+      for {
+        site        <- arbitrary[Site]
+        programType <- arbitrary[DailyProgramType]
+        localDate   <- arbitrary[LocalDate]
+      } yield Daily(site, programType, localDate)
+    }
+
+  // This one is a little awkward because the only way we can get a Nonstandard is via parsing.
+  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+  implicit val arbNonstandard: Arbitrary[Nonstandard] =
+    Arbitrary {
+
+      val gen = for {
+        site        <- arbitrary[Option[Site]]
+        semester    <- arbitrary[Option[Semester]]
+        programType <- arbitrary[Option[ProgramType]]
+        tail        <- Gen.alphaNumStr
+      } yield ProgramId.fromString.getOption(Nonstandard.format(site, semester, programType, tail))
+
+      // It's possible that the generated value is actually a valid Science id, so we need to
+      // retry until we get a Nonstandard.
+      gen.collectUntil { case Some(nid: Nonstandard) => nid }
+
+    }
+
+  implicit val arbProgramId: Arbitrary[ProgramId] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[Science]    .map[ProgramId](identity),
+        arbitrary[Daily]      .map[ProgramId](identity),
+        arbitrary[Nonstandard].map[ProgramId](identity)
+      )
+    }
+
+  implicit val cogProgramId: Cogen[ProgramId] =
+    Cogen[String].contramap(ProgramId.fromString.reverseGet)
+
+  implicit val cogScience: Cogen[ProgramId.Science] =
+    Cogen[String].contramap(ProgramId.Science.fromString.reverseGet)
+
+  implicit val cogDaily: Cogen[ProgramId.Daily] =
+    Cogen[String].contramap(ProgramId.Daily.fromString.reverseGet)
+
+  implicit val cogNonstandard: Cogen[ProgramId.Nonstandard] =
+    Cogen[String].contramap(ProgramId.Nonstandard.fromString.reverseGet)
+
+}
+
+object ArbProgramId extends ArbProgramId

--- a/modules/core/shared/src/test/scala/gem/arb/ArbProperMotion.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbProperMotion.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math._
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen.{ chooseNum, const, oneOf }
+import org.scalacheck.Cogen._
+
+trait ArbProperMotion {
+  import ArbEpoch._
+  import ArbCoordinates._
+  import ArbOffset._
+  import ArbRadialVelocity._
+  import ArbAngle._
+
+  implicit val arbProperMotion: Arbitrary[ProperMotion] =
+    Arbitrary {
+      for {
+        cs <- arbitrary[Coordinates]
+        ap <- arbitrary[Epoch]
+        pv <- arbitrary[Option[Offset]]
+        rv <- arbitrary[Option[RadialVelocity]]
+        px <- oneOf(
+                const(Option.empty[Angle]),
+                // Limit to a value that will fit in numeric(9,3) milliseconds.
+                chooseNum(-999999000L, 999999000L).map(µas => Some(Angle.fromMicroarcseconds(µas)))
+              )
+      } yield ProperMotion(cs, ap, pv, rv, px)
+    }
+
+  implicit val cogProperMotion: Cogen[ProperMotion] =
+    Cogen[(Coordinates, Epoch, Option[Offset], Option[RadialVelocity], Option[Angle])].contramap { p =>
+      (p.baseCoordinates, p.epoch, p.properVelocity, p.radialVelocity, p.parallax)
+    }
+
+}
+
+object ArbProperMotion extends ArbProperMotion

--- a/modules/core/shared/src/test/scala/gem/arb/ArbRadialVelocity.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbRadialVelocity.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math._
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+
+trait ArbRadialVelocity {
+
+  implicit val arbRadialVelocity: Arbitrary[RadialVelocity] =
+    Arbitrary(arbitrary[Short].map(n => RadialVelocity(n.toInt)))
+
+  implicit val cogRadialVelocity: Cogen[RadialVelocity] =
+    Cogen[Int].contramap(_.toMetersPerSecond)
+
+}
+
+object ArbRadialVelocity extends ArbRadialVelocity

--- a/modules/core/shared/src/test/scala/gem/arb/ArbRightAscension.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbRightAscension.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.{ HourAngle, RightAscension }
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbRightAscension {
+  import ArbAngle._
+
+  implicit val arbRightAscension: Arbitrary[RightAscension] =
+    Arbitrary(arbitrary[HourAngle].map(RightAscension.fromHourAngle.get))
+
+  implicit val cogRightAscension: Cogen[RightAscension] =
+    Cogen[HourAngle].contramap(RightAscension.fromHourAngle.reverseGet)
+
+}
+
+object ArbRightAscension extends ArbRightAscension

--- a/modules/core/shared/src/test/scala/gem/arb/ArbSemester.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbSemester.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.Half
+import java.time.Year
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbSemester {
+  import ArbTime._
+  import ArbEnumerated._
+
+  implicit val arbSemester: Arbitrary[Semester] =
+    Arbitrary {
+      for {
+        year <- arbitrary[Year]
+        half <- arbitrary[Half]
+      } yield Semester(year, half)
+    }
+
+  implicit val cogSemester: Cogen[Semester] =
+    Cogen[(Year, Half)].contramap(s => (s.year, s.half))
+
+}
+
+object ArbSemester extends ArbSemester

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTarget.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTarget.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.ProperMotion
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbTarget {
+
+  import ArbEphemerisKey._
+  import ArbProperMotion._
+
+  implicit val arbTarget: Arbitrary[Target] =
+    Arbitrary {
+      for {
+        n <- Gen.alphaStr.map(_.take(64))
+        t <- arbitrary[Either[EphemerisKey, ProperMotion]]
+      } yield Target(n, t)
+    }
+
+  implicit val cogTarget: Cogen[Target] =
+    Cogen[(String, Either[EphemerisKey, ProperMotion])].contramap { t =>
+      (t.name, t.track)
+    }
+}
+
+object ArbTarget extends ArbTarget

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTargetEnvironment.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTargetEnvironment.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.Instrument
+import gem.syntax.treesetcompanion._
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+import scala.collection.immutable.TreeSet
+
+trait ArbTargetEnvironment {
+  import ArbAsterism._
+  import ArbEnumerated._
+  import ArbUserTarget._
+
+  def genTargetEnvironment(i: Instrument): Gen[TargetEnvironment] =
+    for {
+      a <- frequency((9, genAsterism(i).map(Option(_))), (1, const(Option.empty[Asterism])))
+      n <- choose(0, 10)
+      u <- listOfN(n, arbitrary[UserTarget]).map(us => TreeSet.fromList(us))
+    } yield a.fold(TargetEnvironment.fromInstrument(i, u))(TargetEnvironment.fromAsterism(_, u))
+
+  implicit val arbTargetEnvironment: Arbitrary[TargetEnvironment] =
+    Arbitrary {
+      for {
+        i <- arbitrary[Instrument]
+        e <- genTargetEnvironment(i)
+      } yield e
+    }
+
+  implicit val cogTargetEnvironment: Cogen[TargetEnvironment] =
+    Cogen[(Option[Asterism], List[UserTarget])].contramap(e => (e.asterism, e.userTargets.toList))
+
+}
+
+object ArbTargetEnvironment extends ArbTargetEnvironment

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTime.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTime.scala
@@ -1,0 +1,101 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.util.Timestamp
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+import scala.collection.JavaConverters._
+import java.time._
+import java.time.temporal.ChronoUnit
+
+// Arbitrary but resonable dates and times.
+trait ArbTime {
+
+  implicit val arbZoneId: Arbitrary[ZoneId] =
+    Arbitrary {
+      oneOf(ZoneId.getAvailableZoneIds.asScala.toSeq).map(ZoneId.of)
+    }
+
+  implicit val arbYear: Arbitrary[Year] =
+    Arbitrary {
+      choose(2000, 2020).map(Year.of(_))
+    }
+
+  implicit val arbLocalDate: Arbitrary[LocalDate] =
+    Arbitrary {
+      for {
+        y <- arbitrary[Year]
+        d <- choose(1, y.length)
+      } yield LocalDate.ofYearDay(y.getValue, d)
+    }
+
+  implicit val arbLocalTime: Arbitrary[LocalTime] =
+    Arbitrary {
+      for {
+        h <- choose(0, 23)
+        m <- choose(0, 59)
+        s <- choose(0, 59)
+        n <- choose(0, 999999999)
+      } yield LocalTime.of(h, m, s, n)
+    }
+
+  implicit val arbLocalDateTime: Arbitrary[LocalDateTime] =
+    Arbitrary {
+      for {
+        d <- arbitrary[LocalDate]
+        t <- arbitrary[LocalTime]
+      } yield LocalDateTime.of(d, t)
+    }
+
+  implicit val arbZonedDateTime: Arbitrary[ZonedDateTime] =
+    Arbitrary {
+      for {
+        ldt <- arbitrary[LocalDateTime]
+        zid <- arbitrary[ZoneId]
+      } yield ZonedDateTime.of(ldt, zid)
+    }
+
+  implicit val arbInstant: Arbitrary[Instant] =
+    Arbitrary(arbitrary[ZonedDateTime].map(_.toInstant))
+
+  /** An arbitrary `Timestamp` from `Timestamp.Epoch` to `Timestamp.Max`. We
+    * don't generate from `Timestamp.Min` due to what appears to be a
+    * `java.sql.Timestamp` formatting issue for ancient dates.  See Issue #241.
+    */
+  implicit val arbTimestamp: Arbitrary[Timestamp] =
+    Arbitrary {
+      for {
+        m <- Gen.choose(0L, Duration.between(Instant.EPOCH, Timestamp.Max.toInstant).toMillis)
+        u <- Gen.choose(0, 999L)
+      } yield Timestamp.Epoch.plusMillis(m).flatMap(_.plusMicros(u)).getOrElse(Timestamp.Epoch)
+    }
+
+  implicit val arbDuration: Arbitrary[Duration] =
+    Arbitrary {
+      for {
+        a <- Gen.choose(-10000L, 10000L)
+        u <- Gen.oneOf(ChronoUnit.values.filterNot(_.isDurationEstimated))
+      } yield Duration.of(a, u)
+    }
+
+  implicit val cogInstant: Cogen[Instant] =
+    Cogen[(Long, Int)].contramap(t => (t.getEpochSecond, t.getNano))
+
+  implicit val cogLocalDate: Cogen[LocalDate] =
+    Cogen[(Int, Int)].contramap(d => (d.getYear, d.getDayOfYear))
+
+  implicit val cogTimestamp: Cogen[Timestamp] =
+    Cogen[Instant].contramap(_.toInstant)
+
+  implicit val cogYear: Cogen[Year] =
+    Cogen[Int].contramap(_.getValue)
+
+}
+
+object ArbTime extends ArbTime

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTrack.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTrack.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.Site
+import gem.math._
+
+import gem.Track.{ Nonsidereal, Sidereal }
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbTrack {
+  import ArbProperMotion._
+  import ArbEnumerated._
+  import ArbEphemeris._
+
+  implicit val arbSidereal: Arbitrary[Track.Sidereal] =
+    Arbitrary {
+      arbitrary[ProperMotion].map(Sidereal(_))
+    }
+
+  implicit val cogSidereal: Cogen[Track.Sidereal] =
+    Cogen[ProperMotion].contramap(_.properMotion)
+
+  implicit val arbNonsidereal: Arbitrary[Track.Nonsidereal] =
+    Arbitrary {
+      for {
+        eph  <- arbitrary[Ephemeris]
+        site <- arbitrary[Site]
+      } yield Nonsidereal(Map(site -> eph))
+    }
+
+  implicit val cogNonsidereal: Cogen[Track.Nonsidereal] =
+    Cogen[Map[Site, Ephemeris]].contramap(_.ephemerides)
+
+  implicit val arbTrack: Arbitrary[Track] =
+    Arbitrary {
+      Gen.oneOf(arbitrary[Sidereal], arbitrary[Nonsidereal])
+    }
+
+  implicit val cogTrack: Cogen[Track] =
+    Cogen[(Option[Sidereal], Option[Nonsidereal])].contramap { t =>
+      (t.sidereal, t.nonsidereal)
+    }
+}
+
+object ArbTrack extends ArbTrack

--- a/modules/core/shared/src/test/scala/gem/arb/ArbUserTarget.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbUserTarget.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.enum.UserTargetType
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbUserTarget {
+
+  import ArbEnumerated._
+  import ArbTarget._
+
+  implicit val arbUserTarget: Arbitrary[UserTarget] =
+    Arbitrary {
+      for {
+        t <- arbitrary[Target]
+        y <- arbitrary[UserTargetType]
+      } yield UserTarget(t, y)
+    }
+
+  implicit val cogUserTarget: Cogen[UserTarget] =
+    Cogen[(Target, UserTargetType)].contramap { u =>
+      (u.target, u.targetType)
+    }
+}
+
+object ArbUserTarget extends ArbUserTarget

--- a/modules/core/shared/src/test/scala/gem/arb/ArbWavelength.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbWavelength.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.math.Wavelength
+import gem.syntax.prism._
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Cogen._
+
+trait ArbWavelength {
+
+  implicit val arbWavelength: Arbitrary[Wavelength] =
+    Arbitrary(choose(0, Int.MaxValue).map(Wavelength.fromAngstroms.unsafeGet(_)))
+
+  implicit val cogWavelength: Cogen[Wavelength] =
+    Cogen[Int].contramap(_.toAngstroms)
+
+}
+
+object ArbWavelength extends ArbWavelength

--- a/modules/core/shared/src/test/scala/gem/arb/package.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/package.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import org.scalacheck._
+
+package object arb {
+
+  implicit class MoreGenOps[A](g: Gen[A]) {
+
+    /** Like `retryUntil` but retries until the specified PartialFunction is defined. */
+    @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+    def collectUntil[B](f: PartialFunction[A, B]): Gen[B] =
+      g.map(a => f.lift(a)).retryUntil(_.isDefined).map(_.get)
+
+    /** Branch randomly. */
+    def flatMapOneOf[B](f: A => Gen[B], fs: (A => Gen[B])*): Gen[B] =
+      Gen.oneOf(f +: fs).flatMap(g.flatMap)
+
+  }
+
+  // This isn't in scalacheck for whatever reason
+  implicit def mapCogen[A: Cogen, B: Cogen]: Cogen[Map[A, B]] =
+    Cogen[List[(A, B)]].contramap(_.toList)
+
+}

--- a/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
@@ -1,0 +1,302 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import cats._
+
+import gem.CoAdds
+import gem.arb._
+import gem.config.F2Config.F2FpuChoice
+import gem.config.GcalConfig.{GcalArcs, GcalLamp}
+import gem.config.GmosConfig._
+import gem.enum._
+import gem.enum.Instrument._
+import gem.math.{ Offset, Wavelength }
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+import java.time.Duration
+
+trait Arbitraries {
+  import ArbEnumerated._
+  import ArbOffset._
+
+
+  // Surely this is already defined somewhere?
+  implicit val functorGen = new Functor[Gen] {
+    def map[A, B](fa: Gen[A])(f: A => B): Gen[B] =
+      fa.map(f)
+  }
+
+  implicit val applicativeGen = new Applicative[Gen] {
+    def ap[A, B](gf: Gen[A => B])(ga: Gen[A]): Gen[B] =
+      for {
+        f <- gf
+        a <- ga
+      } yield f(a)
+
+    def pure[A](a: A): Gen[A] =
+      Gen.const(a)
+  }
+
+  implicit val arbCoAdds: Arbitrary[CoAdds] =
+    Arbitrary(Gen.posNum[Short].map(CoAdds.fromShort.unsafeGet))
+
+  implicit val arbDuration: Arbitrary[Duration] =
+    Arbitrary(Gen.posNum[Long].map(Duration.ofMillis))
+
+  implicit val arbMosPreImaging: Arbitrary[MosPreImaging] =
+    Arbitrary(
+      Gen.oneOf(MosPreImaging.IsMosPreImaging,
+                MosPreImaging.IsNotMosPreImaging)
+    )
+
+  val genAcqCamStatic:   Gen[StaticConfig.AcqCam]    = Gen.const(StaticConfig.AcqCam()  )
+  val genBhrosStatic:    Gen[StaticConfig.Bhros]     = Gen.const(StaticConfig.Bhros()   )
+  val genGhostStatic:    Gen[StaticConfig.Ghost]     = Gen.const(StaticConfig.Ghost()   )
+  val genGpiStatic:      Gen[StaticConfig.Gpi]       = Gen.const(StaticConfig.Gpi()     )
+  val genGsaoiStatic:    Gen[StaticConfig.Gsaoi]     = Gen.const(StaticConfig.Gsaoi()   )
+  val genMichelleStatic: Gen[StaticConfig.Michelle]  = Gen.const(StaticConfig.Michelle())
+  val genNiciStatic:     Gen[StaticConfig.Nici]      = Gen.const(StaticConfig.Nici()    )
+  val genNifsStatic:     Gen[StaticConfig.Nifs]      = Gen.const(StaticConfig.Nifs()    )
+  val genNiriStatic:     Gen[StaticConfig.Niri]      = Gen.const(StaticConfig.Niri()    )
+  val genPhoenixStatic:  Gen[StaticConfig.Phoenix]   = Gen.const(StaticConfig.Phoenix() )
+  val genTrecsStatic:    Gen[StaticConfig.Trecs]     = Gen.const(StaticConfig.Trecs()   )
+  val genVisitorStatic:  Gen[StaticConfig.Visitor]   = Gen.const(StaticConfig.Visitor() )
+
+  val genF2Static: Gen[StaticConfig.Flamingos2] =
+    arbitrary[MosPreImaging].map(StaticConfig.Flamingos2(_))
+
+  implicit val arbGmosShuffleOffset =
+    Arbitrary(Gen.posNum[Int].map(GmosConfig.GmosShuffleOffset.unsafeFromRowCount))
+
+  implicit val arbGmosShuffleCycles =
+    Arbitrary(Gen.posNum[Int].map(GmosConfig.GmosShuffleCycles.unsafeFromCycleCount))
+
+  implicit val arbGmosNodAndShuffle =
+    Arbitrary(
+      for {
+        a <- arbitrary[Offset]
+        b <- arbitrary[Offset]
+        e <- arbitrary[GmosEOffsetting]
+        o <- arbitrary[GmosConfig.GmosShuffleOffset]
+        c <- arbitrary[GmosConfig.GmosShuffleCycles]
+      } yield GmosConfig.GmosNodAndShuffle(a, b, e, o, c)
+    )
+
+  implicit val arbGmosCustomRoiEntry =
+    Arbitrary(
+      for {
+        xMin <- Gen.posNum[Short]
+        yMin <- Gen.posNum[Short]
+        xRng <- Gen.posNum[Short]
+        yRng <- Gen.posNum[Short]
+      } yield GmosConfig.GmosCustomRoiEntry.unsafeFromDescription(xMin, yMin, xRng, yRng)
+    )
+
+  implicit val arbGmosCommonStaticConfig =
+    Arbitrary(
+      for {
+        d <- arbitrary[GmosDetector]
+        p <- arbitrary[MosPreImaging]
+        n <- arbitrary[Option[GmosConfig.GmosNodAndShuffle]]
+        c <- Gen.choose(1, 5)
+        r <- Gen.listOfN(c, arbitrary[GmosConfig.GmosCustomRoiEntry])
+      } yield GmosConfig.GmosCommonStaticConfig(d, p, n, r.toSet)
+    )
+
+  val genGmosNorthStatic: Gen[StaticConfig.GmosN] =
+    for {
+      c <- arbitrary[GmosConfig.GmosCommonStaticConfig]
+      s <- arbitrary[GmosNorthStageMode]
+    } yield StaticConfig.GmosN(c, s)
+
+  val genGmosSouthStatic: Gen[StaticConfig.GmosS] =
+    for {
+      c <- arbitrary[GmosConfig.GmosCommonStaticConfig]
+      s <- arbitrary[GmosSouthStageMode]
+    } yield StaticConfig.GmosS(c, s)
+
+  val genGnirsStatic: Gen[StaticConfig.Gnirs] =
+    arbitrary[GnirsWellDepth].map(StaticConfig.Gnirs(_))
+
+  def genStaticConfigOf(i: Instrument): Gen[StaticConfig] = {
+    i match {
+      case AcqCam     => genAcqCamStatic
+      case Bhros      => genBhrosStatic
+      case Flamingos2 => genF2Static
+      case Ghost      => genGhostStatic
+      case GmosN      => genGmosNorthStatic
+      case GmosS      => genGmosSouthStatic
+      case Gnirs      => genGnirsStatic
+      case Gpi        => genGpiStatic
+      case Gsaoi      => genGsaoiStatic
+      case Michelle   => genMichelleStatic
+      case Nici       => genNiciStatic
+      case Nifs       => genNifsStatic
+      case Niri       => genNiriStatic
+      case Phoenix    => genPhoenixStatic
+      case Trecs      => genTrecsStatic
+      case Visitor    => genVisitorStatic
+    }
+  }
+
+  val genAcqCamDynamic  : Gen[DynamicConfig.AcqCam]   = Gen.const(DynamicConfig.AcqCam()  )
+  val genBhrosDynamic   : Gen[DynamicConfig.Bhros]    = Gen.const(DynamicConfig.Bhros()   )
+  val genGhostDynamic   : Gen[DynamicConfig.Ghost]    = Gen.const(DynamicConfig.Ghost()   )
+  val genGpiDynamic     : Gen[DynamicConfig.Gpi]      = Gen.const(DynamicConfig.Gpi()     )
+  val genGsaoiDynamic   : Gen[DynamicConfig.Gsaoi]    = Gen.const(DynamicConfig.Gsaoi()   )
+  val genMichelleDynamic: Gen[DynamicConfig.Michelle] = Gen.const(DynamicConfig.Michelle())
+  val genNiciDynamic    : Gen[DynamicConfig.Nici]     = Gen.const(DynamicConfig.Nici()    )
+  val genNifsDynamic    : Gen[DynamicConfig.Nifs]     = Gen.const(DynamicConfig.Nifs()    )
+  val genNiriDynamic    : Gen[DynamicConfig.Niri]     = Gen.const(DynamicConfig.Niri()    )
+  val genPhoenixDynamic : Gen[DynamicConfig.Phoenix]  = Gen.const(DynamicConfig.Phoenix() )
+  val genTrecsDynamic   : Gen[DynamicConfig.Trecs]    = Gen.const(DynamicConfig.Trecs()   )
+  val genVisitorDynamic : Gen[DynamicConfig.Visitor]  = Gen.const(DynamicConfig.Visitor() )
+
+  implicit val arbF2FpuChoice      =
+    Arbitrary {
+      Gen.oneOf(Gen.const(F2FpuChoice.Custom),
+                arbitrary[F2Fpu].map(F2FpuChoice.Builtin(_)))
+    }
+
+  val genF2Dynamic: Gen[DynamicConfig.Flamingos2] =
+    for {
+      d <- arbitrary[Option[F2Disperser]]
+      e <- arbitrary[Duration           ]
+      f <- arbitrary[F2Filter           ]
+      u <- arbitrary[Option[F2FpuChoice]]
+      l <- arbitrary[F2LyotWheel        ]
+      r <- arbitrary[F2ReadMode         ]
+      w <- arbitrary[F2WindowCover      ]
+    } yield DynamicConfig.Flamingos2(d, e, f, u, l, r, w)
+
+  implicit val arbGmosCcdReadout =
+    Arbitrary {
+      for {
+        x <- arbitrary[GmosXBinning]
+        y <- arbitrary[GmosYBinning]
+        c <- arbitrary[GmosAmpCount]
+        g <- arbitrary[GmosAmpGain]
+        r <- arbitrary[GmosAmpReadMode]
+      } yield GmosConfig.GmosCcdReadout(x, y, c, g, r)
+    }
+
+  implicit val arbGmosCommonDynamic =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosConfig.GmosCcdReadout]
+        d <- arbitrary[GmosDtax]
+        e <- arbitrary[Duration]
+        r <- arbitrary[GmosRoi]
+      } yield GmosConfig.GmosCommonDynamicConfig(c, d, e, r)
+    }
+
+  implicit val arbGmosCustomMask =
+    Arbitrary {
+      for {
+        m <- Gen.alphaStr.map(_.take(32))
+        w <- arbitrary[GmosCustomSlitWidth]
+      } yield GmosConfig.GmosCustomMask(m, w)
+    }
+
+  implicit val arbGmosNorthGrating =
+    Arbitrary {
+      for {
+        d <- arbitrary[GmosNorthDisperser]
+        o <- arbitrary[GmosDisperserOrder]
+        w <- Gen.choose(3000, 12000).map(Wavelength.fromAngstroms.unsafeGet)
+      } yield GmosConfig.GmosGrating(d, o, w)
+    }
+
+  implicit val arbGmosSouthGrating =
+    Arbitrary {
+      for {
+        d <- arbitrary[GmosSouthDisperser]
+        o <- arbitrary[GmosDisperserOrder]
+        w <- Gen.choose(3000, 12000).map(Wavelength.fromAngstroms.unsafeGet)
+      } yield GmosConfig.GmosGrating(d, o, w)
+    }
+
+  val genGmosNorthDynamic: Gen[DynamicConfig.GmosN] =
+    for {
+      c <- arbitrary[GmosConfig.GmosCommonDynamicConfig]
+      g <- arbitrary[Option[GmosConfig.GmosGrating[GmosNorthDisperser]]]
+      f <- arbitrary[Option[GmosNorthFilter]]
+      u <- arbitrary[Option[Either[GmosCustomMask, GmosNorthFpu]]]
+    } yield DynamicConfig.GmosN(c, g, f, u)
+
+  val genGmosSouthDynamic: Gen[DynamicConfig.GmosS] =
+    for {
+      c <- arbitrary[GmosConfig.GmosCommonDynamicConfig]
+      g <- arbitrary[Option[GmosConfig.GmosGrating[GmosSouthDisperser]]]
+      f <- arbitrary[Option[GmosSouthFilter]]
+      u <- arbitrary[Option[Either[GmosCustomMask, GmosSouthFpu]]]
+    } yield DynamicConfig.GmosS(c, g, f, u)
+
+  val genGnirsDynamic: Gen[DynamicConfig.Gnirs] =
+      for {
+        a <- arbitrary[GnirsAcquisitionMirror             ]
+        b <- arbitrary[GnirsCamera                        ]
+        c <- arbitrary[CoAdds                             ]
+        d <- arbitrary[GnirsDecker                        ]
+        e <- arbitrary[GnirsDisperser                     ]
+        f <- arbitrary[Duration                           ]
+        g <- arbitrary[GnirsFilter                        ]
+        h <- arbitrary[Either[GnirsFpuOther, GnirsFpuSlit]]
+        i <- arbitrary[GnirsPrism                         ]
+        j <- arbitrary[GnirsReadMode                      ]
+        k <- Gen.choose(1000, 120000).map(Wavelength.fromAngstroms.unsafeGet)
+      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j, k)
+
+  def genDynamicConfigOf(i: Instrument): Gen[DynamicConfig] = {
+    i match {
+      case AcqCam     => genAcqCamDynamic
+      case Bhros      => genBhrosDynamic
+      case Flamingos2 => genF2Dynamic
+      case Ghost      => genGhostDynamic
+      case GmosN      => genGmosNorthDynamic
+      case GmosS      => genGmosSouthDynamic
+      case Gnirs      => genGnirsDynamic
+      case Gpi        => genGpiDynamic
+      case Gsaoi      => genGsaoiDynamic
+      case Michelle   => genMichelleDynamic
+      case Nici       => genNiciDynamic
+      case Nifs       => genNifsDynamic
+      case Niri       => genNiriDynamic
+      case Phoenix    => genPhoenixDynamic
+      case Trecs      => genTrecsDynamic
+      case Visitor    => genVisitorDynamic
+    }
+  }
+
+  // GcalConfig
+
+  implicit val arbGcalArcs: Arbitrary[GcalArcs] =
+    Arbitrary {
+      for {
+        a  <- arbitrary[GcalArc]
+        as <- Gen.someOf(GcalArc.all)
+      } yield GcalArcs(a, as.toList)
+    }
+
+  implicit val arbGcalLamp: Arbitrary[GcalLamp] =
+    Arbitrary(Gen.oneOf(
+      arbitrary[GcalContinuum].map(Left(_)),
+      arbitrary[GcalArcs     ].map(Right(_))
+    ))
+
+  implicit val arbGcalConfig: Arbitrary[GcalConfig] =
+    Arbitrary {
+      for {
+        l <- arbitrary[GcalLamp    ]
+        f <- arbitrary[GcalFilter  ]
+        d <- arbitrary[GcalDiffuser]
+        s <- arbitrary[GcalShutter ]
+        e <- arbitrary[Duration    ]
+        c <- arbitrary[CoAdds      ]
+      } yield GcalConfig(l, f, d, s, e, c)
+    }
+}

--- a/modules/core/shared/src/test/scala/gem/laws/FormatLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/FormatLaws.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+import cats.Eq
+import cats.implicits._
+import gem.optics.Format
+
+final case class FormatLaws[A, B](fab: Format[A, B]) {
+
+  def normalize(a: A): IsEq[Option[B]] =
+    fab.normalize(a).flatMap(fab.getOption) <-> fab.getOption(a)
+
+  def parseRoundTrip(a: A): IsEq[Option[A]] = {
+    val oa = fab.normalize(a)
+    oa.flatMap(fab.getOption).map(fab.reverseGet) <-> oa
+  }
+
+  def formatRoundTrip(b: B): IsEq[Option[B]] =
+    fab.getOption(fab.reverseGet(b)) <-> Some(b)
+
+  // True if `a` is parsable but not in normal form. The existence of such a value in our test data
+  // will show that `normalize` and `parseRoundTrup` are actually testing something.
+  def demonstratesNormalization(a: A)(implicit ev: Eq[A]): Boolean =
+    fab.getOption(a).map(fab.reverseGet) match {
+      case None     => false
+      case Some(aʹ) => a =!= aʹ
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/HomomorphismLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/HomomorphismLaws.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+import cats.{ Semigroup, Monoid, Group }
+
+abstract class SemigroupHomomorphismLaws[A, B](f: A => B) {
+  val A: Semigroup[A]
+  val B: Semigroup[B]
+
+  def combine(a: A, b: A): IsEq[B] =
+    f(A.combine(a, b)) <-> B.combine(f(a), f(b))
+
+}
+
+abstract class MonoidHomomorphismLaws[A, B](f: A => B) extends SemigroupHomomorphismLaws[A, B](f) {
+  override val A: Monoid[A]
+  override val B: Monoid[B]
+
+  def empty: IsEq[B] =
+    f(A.empty) <-> B.empty
+
+}
+
+abstract class GroupHomomorphismLaws[A, B](f: A => B) extends MonoidHomomorphismLaws[A, B](f) {
+  override val A: Group[A]
+  override val B: Group[B]
+
+  def inverse(a: A): IsEq[B] =
+    f(A.inverse(a)) <-> B.inverse(f(a))
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/SplitEpiLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/SplitEpiLaws.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+import cats.Eq
+import cats.implicits._
+import gem.optics.SplitEpi
+
+final case class SplitEpiLaws[A, B](fab: SplitEpi[A, B]) {
+
+  def normalize(a: A): IsEq[B] =
+    fab.get(fab.normalize(a)) <-> fab.get(a)
+
+  def normalizedGetRoundTrip(a: A): IsEq[A] = {
+    val aʹ = fab.normalize(a)
+    (fab.get andThen fab.reverseGet)(aʹ) <-> aʹ
+  }
+
+  def reverseGetRoundTrip(b: B): IsEq[B] =
+    (fab.reverseGet andThen fab.get)(b) <-> b
+
+  // True if `a` is parsable but not in normal form. The existence of such a value in our test data
+  // will show that `normalize` and `parseRoundTrup` are actually testing something.
+  def demonstratesNormalization(a: A)(implicit ev: Eq[A]): Boolean =
+    (fab.get andThen fab.reverseGet)(a) =!= a
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/SplitMonoLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/SplitMonoLaws.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+import cats.Eq
+import cats.implicits._
+import gem.optics.SplitMono
+
+final case class SplitMonoLaws[A, B](fab: SplitMono[A, B]) {
+
+  def normalize(b: B): IsEq[A] =
+    fab.reverseGet(fab.normalize(b)) <-> fab.reverseGet(b)
+
+  def normalizedReverseGetRoundTrip(b: B): IsEq[B] = {
+    val bʹ = fab.normalize(b)
+    (fab.reverseGet andThen fab.get)(bʹ) <-> bʹ
+  }
+
+  def getRoundTrip(a: A): IsEq[A] =
+    (fab.get andThen fab.reverseGet)(a) <-> a
+
+  // True if `a` is parsable but not in normal form. The existence of such a value in our test data
+  // will show that `normalize` and `parseRoundTrup` are actually testing something.
+  def demonstratesNormalization(b: B)(implicit ev: Eq[B]): Boolean =
+    (fab.reverseGet andThen fab.get)(b) =!= b
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/SubgroupLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/SubgroupLaws.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+// A is a subgroup of B if covariant widening is a group homomorphism.
+abstract class SubgroupLaws[A, B](f: A <:< B) extends GroupHomomorphismLaws[A, B](f)

--- a/modules/core/shared/src/test/scala/gem/laws/WedgeLaws.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/WedgeLaws.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+import cats.Eq
+import cats.implicits._
+import gem.optics.Wedge
+
+final case class WedgeLaws[A, B](fab: Wedge[A, B]) {
+
+  def normalizeA(a: A): IsEq[B] =
+    fab.get(fab.normalizeA(a)) <-> fab.get(a)
+
+  def normalizeB(b: B): IsEq[A] =
+    fab.reverseGet(fab.normalizeB(b)) <-> fab.reverseGet(b)
+
+  def normalizedReverseGetRoundTrip(b: B): IsEq[B] = {
+    val bʹ = fab.normalizeB(b)
+    (fab.reverseGet andThen fab.get)(bʹ) <-> bʹ
+  }
+
+  def normalizedGetRoundTrip(a: A): IsEq[A] = {
+    val aʹ = fab.normalizeA(a)
+    (fab.reverseGet compose fab.get)(aʹ) <-> aʹ
+  }
+
+  // Demonstrate coverage
+  def demonstratesCoverageA(b: A)(implicit ev: Eq[A]): Boolean =
+    (fab.reverseGet compose fab.get)(b) =!= b
+
+  def demonstratesCoverageB(b: B)(implicit ev: Eq[B]): Boolean =
+    (fab.reverseGet andThen fab.get)(b) =!= b
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/discipline/FormatTests.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/discipline/FormatTests.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+package discipline
+
+import cats.Eq
+import cats.instances.option._
+import gem.optics.Format
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait FormatTests[A, B] extends Laws {
+  val formatLaws: FormatLaws[A, B]
+
+  def format(
+    implicit aa: Arbitrary[A], ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    new SimpleRuleSet("format",
+      "normalize"        -> forAll((a: A) => formatLaws.normalize(a)),
+      "parse roundtrip"  -> forAll((a: A) => formatLaws.parseRoundTrip(a)),
+      "format roundtrip" -> forAll((b: B) => formatLaws.formatRoundTrip(b)),
+      "coverage"         -> exists((a: A) => formatLaws.demonstratesNormalization(a))
+    )
+
+  /** Convenience constructor that allows passing an explicit generator for input values. */
+  def formatWith(ga: Gen[A])(
+    implicit ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    format(Arbitrary(ga), ea, ab, eb)
+
+}
+
+object FormatTests extends Laws {
+
+  def apply[A, B](fab: Format[A, B]): FormatTests[A, B] =
+    new FormatTests[A, B] {
+      val formatLaws = new FormatLaws(fab)
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/discipline/SplitEpiTests.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/discipline/SplitEpiTests.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+package discipline
+
+import cats.Eq
+import gem.optics.SplitEpi
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait SplitEpiTests[A, B] extends FormatTests[A, B] {
+  val splitEpiLaws: SplitEpiLaws[A, B]
+
+  def splitEpi(
+    implicit aa: Arbitrary[A], ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    new DefaultRuleSet("SplitEpi",
+      Some(format),
+      "normalize"                -> forAll((a: A) => splitEpiLaws.normalize(a)),
+      "normalized get roundtrip" -> forAll((a: A) => splitEpiLaws.normalizedGetRoundTrip(a)),
+      "reverseGet roundtrip"     -> forAll((b: B) => splitEpiLaws.reverseGetRoundTrip(b)),
+      "coverage"                 -> exists((a: A) => splitEpiLaws.demonstratesNormalization(a))
+    )
+
+  /** Convenience constructor that allows passing an explicit generator for input values. */
+  def splitEpiWith(ga: Gen[A])(
+    implicit ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    splitEpi(Arbitrary(ga), ea, ab, eb)
+
+}
+
+object SplitEpiTests extends Laws {
+
+  def apply[A, B](fab: SplitEpi[A, B]): SplitEpiTests[A, B] =
+    new SplitEpiTests[A, B] {
+      val formatLaws = new FormatLaws(fab.asFormat)
+      val splitEpiLaws = new SplitEpiLaws(fab)
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/discipline/SplitMonoTests.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/discipline/SplitMonoTests.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+package discipline
+
+import cats.Eq
+import gem.optics.SplitMono
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait SplitMonoTests[A, B] extends Laws {
+  val laws: SplitMonoLaws[A, B]
+
+  def splitMono(
+    implicit aa: Arbitrary[A], ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    new SimpleRuleSet("SplitMono",
+      "normalize"                -> forAll((b: B) => laws.normalize(b)),
+      "normalized get roundtrip" -> forAll((b: B) => laws.normalizedReverseGetRoundTrip(b)),
+      "reverseGet roundtrip"     -> forAll((a: A) => laws.getRoundTrip(a)),
+      "coverage"                 -> exists((b: B) => laws.demonstratesNormalization(b))
+    )
+
+  /** Convenience constructor that allows passing an explicit generator for input values. */
+  def splitMonoWith(ga: Gen[A])(
+    implicit ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    splitMono(Arbitrary(ga), ea, ab, eb)
+
+}
+
+object SplitMonoTests extends Laws {
+
+  def apply[A, B](fab: SplitMono[A, B]): SplitMonoTests[A, B] =
+    new SplitMonoTests[A, B] {
+      val laws = new SplitMonoLaws(fab)
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/discipline/SubgroupTests.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/discipline/SubgroupTests.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+package discipline
+
+import cats._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait SubgroupTests[A, B] extends Laws {
+  val laws: SubgroupLaws[A, B]
+
+  def subgroup(
+    implicit aa: Arbitrary[A],
+             eq: Eq[B]
+  ): SimpleRuleSet = {
+    new SimpleRuleSet("subgroup",
+      "combine"  -> forAll((a: A, b: A) => laws.combine(a, b)),
+      "identity" -> laws.empty,
+      "inverse"  -> forAll((a: A) => laws.inverse(a))
+    )
+  }
+
+}
+
+object SubgroupTests extends Laws {
+
+  def apply[A, B](
+    implicit ev: A <:< B,
+             ia: Group[A],
+             ib: Group[B]
+  ): SubgroupTests[A, B] =
+    new SubgroupTests[A, B] {
+      val laws = new SubgroupLaws[A, B](ev) {
+        val A = ia
+        val B = ib
+      }
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/discipline/WedgeTests.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/discipline/WedgeTests.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+package discipline
+
+import cats.Eq
+import gem.optics.Wedge
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+trait WedgeTests[A, B] extends Laws {
+  val laws: WedgeLaws[A, B]
+
+  def wedge(
+    implicit aa: Arbitrary[A], ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    new SimpleRuleSet("Wedge",
+      "normalize A"                     -> forAll((a: A) => laws.normalizeA(a)),
+      "normalize B"                     -> forAll((b: B) => laws.normalizeB(b)),
+      "reverseGet reverseGet roundtrip" -> forAll((a: A) => laws.normalizedGetRoundTrip(a)),
+      "normalized get roundtrip"        -> forAll((b: B) => laws.normalizedReverseGetRoundTrip(b)),
+      "coverage A"                      -> exists((a: A) => laws.demonstratesCoverageA(a)),
+      "coverage B"                      -> exists((b: B) => laws.demonstratesCoverageB(b))
+    )
+
+  /** Convenience constructor that allows passing an explicit generator for input values. */
+  def splitMonoWith(ga: Gen[A])(
+    implicit ea: Eq[A],
+             ab: Arbitrary[B], eb: Eq[B]
+  ): RuleSet =
+    wedge(Arbitrary(ga), ea, ab, eb)
+
+}
+
+object WedgeTests extends Laws {
+
+  def apply[A, B](fab: Wedge[A, B]): WedgeTests[A, B] =
+    new WedgeTests[A, B] {
+      val laws = new WedgeLaws(fab)
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/discipline/package.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/discipline/package.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.laws
+
+import cats.Eq
+import org.scalacheck.Prop
+
+package object discipline {
+
+  implicit def gemLawsIsEqToProp[A: Eq](isEq: IsEq[A]): Prop =
+    cats.kernel.laws.discipline.catsLawsIsEqToProp[A](isEq)
+
+}

--- a/modules/core/shared/src/test/scala/gem/laws/package.scala
+++ b/modules/core/shared/src/test/scala/gem/laws/package.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+package object laws {
+
+  type IsEq[A] = cats.kernel.laws.IsEq[A]
+  val IsEq: cats.kernel.laws.IsEq.type = cats.kernel.laws.IsEq
+
+  implicit final class IsEqArrow[A](val lhs: A) extends AnyVal {
+    def <->(rhs: A): IsEq[A] = IsEq(lhs, rhs)
+  }
+  
+}

--- a/modules/core/shared/src/test/scala/gem/math/AngleSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/AngleSpec.scala
@@ -1,0 +1,136 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import gem.laws.discipline._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class AngleSpec extends CatsSuite {
+  import ArbAngle._
+
+  // Laws
+  checkAll("Angle", CommutativeGroupTests[Angle].commutativeGroup)
+  checkAll("Angle", EqTests[Angle].eqv)
+  checkAll("Angle", OrderTests[Angle](Angle.AngleOrder).order)
+  checkAll("SignedAngle", OrderTests[Angle](Angle.SignedAngleOrder).order)
+
+  // Optics
+  checkAll("microarcseconds", SplitMonoTests(Angle.microarcseconds).splitMono)
+  checkAll("signedMicroarcseconds", SplitMonoTests(Angle.signedMicroarcseconds).splitMono)
+  checkAll("milliarcseconds", WedgeTests(Angle.milliarcseconds).wedge)
+  checkAll("arcseconds", WedgeTests(Angle.arcseconds).wedge)
+  checkAll("arcminutes", WedgeTests(Angle.arcminutes).wedge)
+  checkAll("degrees", WedgeTests(Angle.degrees).wedge)
+  checkAll("hourAngle", SplitEpiTests(Angle.hourAngle).splitEpi)
+  checkAll("hourAngleExact", PrismTests(Angle.hourAngleExact))
+  checkAll("dms", IsoTests(Angle.dms))
+  checkAll("fromStringDMS", FormatTests(Angle.fromStringDMS).formatWith(ArbAngle.stringsDMS))
+  checkAll("fromStringSignedDMS", FormatTests(Angle.fromStringSignedDMS).formatWith(ArbAngle.stringsSignedDMS))
+
+  test("Equality must be natural") {
+    forAll { (a: Angle, b: Angle) =>
+      a.equals(b) shouldEqual Eq[Angle].eqv(a, b)
+    }
+  }
+
+  test("Equality must be consistent with .toMicroarcseconds") {
+    forAll { (a: Angle, b: Angle) =>
+      Eq[Long].eqv(a.toMicroarcseconds, b.toMicroarcseconds) shouldEqual
+      Eq[Angle].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Angle) =>
+      a.toString shouldEqual Show[Angle].show(a)
+    }
+  }
+
+  // N.B. this is *not* covered by the `dms` Iso test.
+  test("Conversion to DMS must be invertable") {
+    forAll { (a: Angle) =>
+      val dms = Angle.dms.get(a)
+      Angle.fromDMS(
+        dms.degrees,
+        dms.arcminutes,
+        dms.arcseconds,
+        dms.milliarcseconds,
+        dms.microarcseconds
+      ) shouldEqual a
+    }
+  }
+
+  test("Flipping must be invertable") {
+    forAll { (a: Angle) =>
+      a.flip.flip shouldEqual a
+    }
+  }
+
+  test("Construction must normalize [non-pathological] angles") {
+    forAll { (a: Angle, n: Int) =>
+      val factor   = n % 10
+      val masIn360 = 360L * 60L * 60L * 1000L * 1000L
+      val offset   = masIn360 * factor
+      val b = Angle.fromMicroarcseconds(a.toMicroarcseconds + offset)
+      a shouldEqual b
+    }
+  }
+
+  // In principle I think this is the only thing we need to check.
+  test("mirrorBy must obey the mirror law") {
+    forAll { (a: Angle, b: Angle) =>
+      b - a shouldEqual (a mirrorBy b) - b
+    }
+  }
+
+  test("mirrorBy must be reflexive") {
+    forAll { (a: Angle) =>
+      a mirrorBy a shouldEqual a
+    }
+  }
+
+  test("mirrorBy must be invertible") {
+    forAll { (a: Angle, b: Angle) =>
+      a.mirrorBy(b).mirrorBy(b) shouldEqual a
+    }
+  }
+
+  test("mirrorBy must be invariant to flip in mirror angle") {
+    forAll { (a: Angle, b: Angle) =>
+      a.mirrorBy(b) shouldEqual a.mirrorBy(b.flip)
+    }
+  }
+
+  test("mirrorBy must distribute over flip in target angle") {
+    forAll { (a: Angle, b: Angle) =>
+      (a mirrorBy b).flip shouldEqual (a.flip mirrorBy b)
+    }
+  }
+
+  test("mirrorBy must be consistent with flip") {
+    forAll { (a: Angle) =>
+      a.mirrorBy(a + Angle.Angle90) shouldEqual a.flip
+    }
+  }
+
+  test("mirrorBy must be consistent with unary negation") {
+    forAll { (a: Angle) =>
+      a.mirrorBy(Angle.Angle0) shouldEqual -a
+    }
+  }
+
+  test("HourAngle should (almost) round-trip double hours") {
+    forAll { (a: HourAngle) =>
+      val hrs  = a.toDoubleHours
+      val hrsʹ = HourAngle.fromDoubleHours(hrs).toDoubleHours
+      hrs shouldEqual hrsʹ +- 0.000000001
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
@@ -109,7 +109,6 @@ final class CoordinatesSpec extends CatsSuite {
     }
   }
 
-
   test("angularDistance must equal any offset in right ascension along the equator, to within 1µas") {
     forAll { (ra: RA, ha: HourAngle) =>
       val a = Coordinates(ra, Dec.Zero)
@@ -140,8 +139,8 @@ final class CoordinatesSpec extends CatsSuite {
 
     forAll { (c1: Coordinates, c2: Coordinates) =>
       val sep = c1.angularDistance(c2)
-      val Δs  = (-1.0 to 2.0 by 0.1).map { f =>
-        val stepSep  = c1.interpolate(c2, f).angularDistance(c1).toMicroarcseconds
+      val Δs  = (Range.BigDecimal(-1.0, 2.0, 0.1)).map { f =>
+        val stepSep  = c1.interpolate(c2, f.toDouble).angularDistance(c1).toMicroarcseconds
         val fracSep  = (sep.toMicroarcseconds * f.abs).toLong
         val fracSepʹ = if (fracSep <= µas180) fracSep else µas360 - fracSep
         (stepSep - fracSepʹ).abs

--- a/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/CoordinatesSpec.scala
@@ -1,0 +1,154 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.laws.discipline._
+import gem.arb._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class CoordinatesSpec extends CatsSuite {
+  import ArbCoordinates._
+  import ArbRightAscension._
+  import ArbDeclination._
+  import ArbAngle._
+
+  // Laws
+  checkAll("Coordinates", OrderTests[Coordinates].order)
+  checkAll("Coordinates.fromHmsDms", FormatTests(Coordinates.fromHmsDms).formatWith(ArbCoordinates.strings))
+  checkAll("Coordinates.rightAscension", LensTests(Coordinates.rightAscension))
+  checkAll("Coordinates.declination", LensTests(Coordinates.declination))
+
+  test("Equality must be natural") {
+    forAll { (a: Coordinates, b: Coordinates) =>
+      a.equals(b) shouldEqual Eq[Coordinates].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Coordinates) =>
+      a.toString shouldEqual Show[Coordinates].show(a)
+    }
+  }
+
+  test("offsetWithCarry must be consistent with offset") {
+    forAll { (a: Coordinates, dRA: HourAngle, dDec: Angle) =>
+      a.offset(dRA, dDec) shouldEqual a.offsetWithCarry(dRA, dDec)._1
+    }
+  }
+
+  test("offsetWithCarry must be invertable") {
+    forAll { (a: Coordinates, dRA: HourAngle, dDec: Angle) =>
+      a.offsetWithCarry(dRA, dDec) match {
+        case (cs, false) => cs.offset(-dRA, -dDec) shouldEqual a
+        case (cs, true)  => cs.offset(-dRA,  dDec) shouldEqual a
+      }
+    }
+  }
+
+  test("diff must be consistent with offset") {
+    forAll { (a: Coordinates, b: Coordinates) =>
+      val (dRA, dDec) = a diff b
+      a.offset(dRA, dDec) shouldEqual b
+    }
+  }
+
+  test("diff must be consistent with offsetWithCarry, and never carry") {
+    forAll { (a: Coordinates, b: Coordinates) =>
+      val (dRA, dDec) = a diff b
+      a.offsetWithCarry(dRA, dDec).shouldEqual((b, false))
+    }
+  }
+
+  test("angularDistance must be in [0, 180°]") {
+    forAll { (a: Coordinates, b: Coordinates) =>
+      a.angularDistance(b).toMicroarcseconds should be <= Angle.Angle180.toMicroarcseconds
+    }
+  }
+
+  test("angularDistance must be zero between any point and itself") {
+    forAll { (c: Coordinates) =>
+      c.angularDistance(c) shouldEqual Angle.Angle0
+    }
+  }
+
+  test("angularDistance must be symmetric to within 1µas") {
+    forAll { (a: Coordinates, b: Coordinates) =>
+      val Δ = a.angularDistance(b) - b.angularDistance(a)
+      Angle.signedMicroarcseconds.get(Δ).abs should be <= 1L
+    }
+  }
+
+  test("angularDistance must be exactly 180° between the poles, regardless of RA") {
+    forAll { (ra1: RA, ra2: RA) =>
+      val s = Coordinates(ra1, Dec.Min)
+      val n = Coordinates(ra2, Dec.Max)
+      n.angularDistance(s) shouldEqual Angle.Angle180
+    }
+  }
+
+  test("angularDistance must be 90° between either pole and any point on the equator, regardless of RA, within 1µas") {
+    forAll { (ra1: RA, ra2: RA, dec: Dec, b: Boolean) =>
+      val pole  = Coordinates(ra1, if (b) Dec.Min else Dec.Max)
+      val point = Coordinates(ra2, Dec.Zero)
+      val delta = point.angularDistance(pole)
+      (delta.toMicroarcseconds - Angle.Angle90.toMicroarcseconds).abs should be <= 1L
+    }
+  }
+
+  test("angularDistance must equal any offset in declination from either pole, regardless of RA, to within 1µas") {
+    forAll { (ra1: RA, ra2: RA, dec: Dec, b: Boolean) =>
+      val pole = Coordinates(ra1, if (b) Dec.Min else Dec.Max)
+      val Δdec = dec.toAngle + Angle.Angle90 // [0, 180]
+      val Δ    = pole.angularDistance(pole.offset(ra2.toHourAngle, Δdec)) - Δdec
+      Angle.signedMicroarcseconds.get(Δ).abs should be <= 1L
+    }
+  }
+
+
+  test("angularDistance must equal any offset in right ascension along the equator, to within 1µas") {
+    forAll { (ra: RA, ha: HourAngle) =>
+      val a = Coordinates(ra, Dec.Zero)
+      val b = a.offset(ha, Angle.Angle0)
+      val d = a.angularDistance(b)
+      val Δ = Angle.signedMicroarcseconds.get(d).abs - Angle.signedMicroarcseconds.get(ha).abs
+      Δ.abs should be <= 1L
+    }
+  }
+
+  test("interpolate should result in angular distance of 0° from `a` for factor 0.0, within 1µsec (15µas)") {
+    forAll { (a: Coordinates, b: Coordinates) =>
+      val Δ = a.angularDistance(a.interpolate(b, 0.0))
+      Angle.signedMicroarcseconds.get(Δ).abs should be <= 15L
+    }
+  }
+
+  test("interpolate should result in angular distance of 0° from `b` for factor 1.0, within 1µsec (15µas)") {
+    forAll { (a: Coordinates, b: Coordinates) =>
+      val Δ = b.angularDistance(a.interpolate(b, 1.0))
+      Angle.signedMicroarcseconds.get(Δ).abs should be <= 15L
+    }
+  }
+
+  test("interpolate should be consistent with fractional angular separation, to within 20 µas") {
+    val µas180 = Angle.Angle180.toMicroarcseconds
+    val µas360 = µas180 * 2L
+
+    forAll { (c1: Coordinates, c2: Coordinates) =>
+      val sep = c1.angularDistance(c2)
+      val Δs  = (-1.0 to 2.0 by 0.1).map { f =>
+        val stepSep  = c1.interpolate(c2, f).angularDistance(c1).toMicroarcseconds
+        val fracSep  = (sep.toMicroarcseconds * f.abs).toLong
+        val fracSepʹ = if (fracSep <= µas180) fracSep else µas360 - fracSep
+        (stepSep - fracSepʹ).abs
+      }
+      Δs.filter(_ > 20L) shouldBe empty
+    }
+
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/DeclinationSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/DeclinationSpec.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import gem.laws.discipline._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class DeclinationSpec extends CatsSuite {
+  import ArbDeclination._
+  import ArbAngle._
+
+  // Laws
+  checkAll("Declination", OrderTests[Declination].order)
+  checkAll("fromAngle", PrismTests(Declination.fromAngle))
+  checkAll("fromStringHMS", FormatTests(Declination.fromStringSignedDMS).formatWith(ArbAngle.stringsDMS))
+
+  test("Equality must be natural") {
+    forAll { (a: Declination, b: Declination) =>
+      a.equals(b) shouldEqual Eq[Declination].eqv(a, b)
+    }
+  }
+
+  test("Eq must be consistent with .toAngle.toMicroarcseconds") {
+    forAll { (a: Declination, b: Declination) =>
+      Eq[Long].eqv(a.toAngle.toMicroarcseconds, b.toAngle.toMicroarcseconds) shouldEqual
+      Eq[Declination].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Declination) =>
+      a.toString shouldEqual Show[Declination].show(a)
+    }
+  }
+
+  test("Construction must be consistent between fromAngle and fromAngleWithCarry") {
+    forAll { (a: Angle) =>
+      (Declination.fromAngle.getOption(a), Declination.fromAngleWithCarry(a)) match {
+        case (Some(d), (dʹ, false)) => d shouldEqual dʹ
+        case (None,    (d,  true))  => d.toAngle shouldEqual a.mirrorBy(Angle.Angle90)
+        case _                      => fail("Unpossible")
+      }
+    }
+  }
+
+  test("Offsetting must have an identity") {
+    forAll { (a: Declination) =>
+      a.offset(Angle.Angle0).shouldEqual((a, false))
+    }
+  }
+
+  test("Offsetting must be invertible") {
+    forAll { (a: Declination, b: Angle) =>
+      a.offset(b) match {
+        case (aʹ, false) => aʹ.offset(-b).shouldEqual((a, false))
+        case (aʹ, true)  => aʹ.offset(b).shouldEqual((a, true))
+      }
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisCoordinatesSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisCoordinatesSpec.scala
@@ -1,0 +1,102 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.arb._
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import monocle.law.discipline._
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalatest.Assertion
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class EphemerisCoordinatesSpec extends CatsSuite {
+  import ArbCoordinates._
+  import ArbEphemeris._
+  import ArbOffset._
+  import ArbRightAscension._
+  import ArbDeclination._
+  import EphemerisCoordinatesSpec._
+
+  // Laws
+  checkAll("EphemerisCoordinates", EqTests[EphemerisCoordinates].eqv)
+  checkAll("EphemerisCoordinates.coordinates", LensTests(EphemerisCoordinates.coordinates))
+  checkAll("EphemerisCoordinates.rightAscension", LensTests(EphemerisCoordinates.rightAscension))
+  checkAll("EphemerisCoordinates.declination", LensTests(EphemerisCoordinates.declination))
+  checkAll("EphemerisCoordinates.delta", LensTests(EphemerisCoordinates.delta))
+  checkAll("EphemerisCoordinates.deltaP", LensTests(EphemerisCoordinates.deltaP))
+  checkAll("EphemerisCoordinates.deltaQ", LensTests(EphemerisCoordinates.deltaQ))
+
+  test("Equality must be natural") {
+    forAll { (a: EphemerisCoordinates, b: EphemerisCoordinates) =>
+      a.equals(b) shouldEqual Eq[EphemerisCoordinates].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: EphemerisCoordinates) =>
+      a.toString shouldEqual Show[EphemerisCoordinates].show(a)
+    }
+  }
+
+  test("interpolate must be consistent with Coordinates.interpolate") {
+    forAll { (a: EphemerisCoordinates, b: EphemerisCoordinates, r: Ratio) =>
+      a.interpolate(b, r.ratio).coord shouldEqual a.coord.interpolate(b.coord, r.ratio)
+    }
+  }
+
+  test("interpolate velocity between any point and itself must yield the same velocity") {
+    forAll { (a: EphemerisCoordinates, r: Ratio) =>
+      a.interpolate(a, r.ratio).delta shouldEqual a.delta
+    }
+  }
+
+  test("interpolate velocity with factor 0 should yield the first point") {
+    forAll { (a: EphemerisCoordinates, b: EphemerisCoordinates) =>
+      a.interpolate(b, 0.0).delta shouldEqual a.delta
+    }
+  }
+
+  test("interpolate velocity with factor 1 should yield the second point") {
+    forAll { (a: EphemerisCoordinates, b: EphemerisCoordinates) =>
+      a.interpolate(b, 1.0).delta shouldEqual b.delta
+    }
+  }
+
+  private def midpoint(a: EphemerisCoordinates, b: EphemerisCoordinates, f: Offset => Angle): Assertion = {
+    val m  = a.interpolate(b, 0.5).delta
+    val mΔ = Angle.signedMicroarcseconds.get(f(m))
+
+    val aΔ = Angle.signedMicroarcseconds.get(f(a.delta))
+    val bΔ = Angle.signedMicroarcseconds.get(f(b.delta))
+
+    mΔ shouldEqual ((aΔ + bΔ)/2.0).round
+  }
+
+  test("interpolate velocity with factor 0.5 should yield the midpoint p") {
+    forAll { (a: EphemerisCoordinates, b: EphemerisCoordinates) =>
+      midpoint(a, b, _.p.toAngle)
+    }
+  }
+
+  test("interpolate velocity with factor 0.5 should yield the midpoint q") {
+    forAll { (a: EphemerisCoordinates, b: EphemerisCoordinates) =>
+      midpoint(a, b, _.q.toAngle)
+    }
+  }
+
+}
+
+object EphemerisCoordinatesSpec {
+
+  final case class Ratio(ratio: Double)
+
+  implicit val arbRatio: Arbitrary[Ratio] =
+    Arbitrary {
+      Gen.choose(0.0, 1.0).map(Ratio(_))
+    }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EphemerisSpec.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.arb._
+import gem.util.Timestamp
+
+import cats.Eq
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals", "org.wartremover.warts.OptionPartial"))
+final class EphemerisSpec extends CatsSuite {
+  import ArbEphemeris._
+  import ArbTime._
+  import Ephemeris.Element
+
+  // Laws
+  checkAll("Ephemeris", MonoidTests[Ephemeris].monoid)
+  checkAll("Ephemeris", EqTests[Ephemeris].eqv)
+
+  test("Ephemeris.eq.naturality") {
+    forAll { (a: Ephemeris, b: Ephemeris) =>
+      a.equals(b) shouldEqual Eq[Ephemeris].eqv(a, b)
+    }
+  }
+
+  test("Ephemeris.get.exact") {
+    forAll { (a: Ephemeris, e: Element) =>
+      (a ++ Ephemeris(e)).get(e._1) shouldEqual Some(e._2)
+    }
+  }
+
+  test("Ephemeris.get.interpolated") {
+    forAll { (t1: Timestamp, c1: EphemerisCoordinates, c2: EphemerisCoordinates, n: Int) =>
+      val tEnd = t1.plusSeconds(100).getOrElse(Timestamp.Max)
+      val tBeg = tEnd.plusSeconds(-100).get
+      val off  = (n % 100).abs
+      val tMid = tBeg.plusSeconds(off.toLong).get
+
+      val e  = Ephemeris(tBeg -> c1, tEnd -> c2)
+      val c3 = e.get(tMid).getOrElse(sys.error("failed"))
+      val c4 = c1.interpolate(c2, off.toDouble / 100.00)
+      (c3.coord angularDistance c4.coord).toMicroarcseconds should be <= 15L
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/EpochSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/EpochSpec.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import gem.laws.discipline._
+import java.time.LocalDateTime
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class EpochSpec extends CatsSuite {
+  import ArbEpoch._
+  import ArbTime._
+
+  // Laws
+  checkAll("Epoch", OrderTests[Epoch].order)
+  checkAll("fromString", FormatTests(Epoch.fromString).formatWith(ArbEpoch.strings))
+
+  test("Epoch.eq.natural") {
+    forAll { (a: Epoch, b: Epoch) =>
+      a.equals(b) shouldEqual Eq[Epoch].eqv(a, b)
+    }
+  }
+
+  test("Epoch.show.natural") {
+    forAll { (a: Epoch) =>
+      a.toString shouldEqual Show[Epoch].show(a)
+    }
+  }
+
+  test("Epoch.until.identity") {
+    forAll { (a: Epoch) =>
+      a.untilEpochYear(a.epochYear) shouldEqual 0.0
+    }
+  }
+
+  test("Epoch.until.sanity") {
+    forAll { (a: Epoch, s: Short) =>
+      a.untilEpochYear(a.epochYear + s.toDouble) shouldEqual s.toDouble
+    }
+  }
+
+  test("Epoch.until.sanity2") {
+    forAll { (s: Epoch.Scheme, d1: LocalDateTime, d2: LocalDateTime) =>
+      val Δ1 = s.fromLocalDateTime(d1).untilLocalDateTime(d2)
+      val Δ2 = s.fromLocalDateTime(d2).epochYear - s.fromLocalDateTime(d1).epochYear
+      Δ1 shouldEqual Δ2
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/HourAngleSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/HourAngleSpec.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import gem.laws.discipline._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class HourAngleSpec extends CatsSuite {
+  import ArbAngle._
+
+  // Laws
+  checkAll("HourAngle", CommutativeGroupTests[HourAngle].commutativeGroup)
+  checkAll("HourAngle", EqTests[HourAngle].eqv)
+  checkAll("HourAngle <: Angle", SubgroupTests[HourAngle, Angle].subgroup)
+
+  // Optics
+  checkAll("angle", SplitMonoTests(HourAngle.angle).splitMono)
+  checkAll("microseconds", SplitMonoTests(HourAngle.microseconds).splitMono)
+  checkAll("milliseconds", WedgeTests(HourAngle.milliseconds).wedge)
+  checkAll("seconds", WedgeTests(HourAngle.seconds).wedge)
+  checkAll("minutes", WedgeTests(HourAngle.minutes).wedge)
+  checkAll("hours", WedgeTests(HourAngle.hours).wedge)
+  checkAll("hms", IsoTests(HourAngle.hms))
+  checkAll("fromStringHMS", FormatTests(HourAngle.fromStringHMS).formatWith(ArbAngle.stringsHMS))
+
+  test("Equality must be natural") {
+    forAll { (a: HourAngle, b: HourAngle) =>
+      a.equals(b) shouldEqual Eq[HourAngle].eqv(a, b)
+    }
+  }
+
+  test("Equality must be consistent with .toMicroseconds") {
+    forAll { (a: HourAngle, b: HourAngle) =>
+      Eq[Long].eqv(a.toMicroseconds, b.toMicroseconds) shouldEqual
+      Eq[HourAngle].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: HourAngle) =>
+      a.toString shouldEqual Show[HourAngle].show(a)
+    }
+  }
+
+  test("Conversion to HMS must be invertable") {
+    forAll { (a: HourAngle) =>
+      val hms = HourAngle.hms.get(a)
+      HourAngle.fromHMS(
+        hms.hours,
+        hms.minutes,
+        hms.seconds,
+        hms.milliseconds,
+        hms.microseconds
+      ) shouldEqual a
+    }
+  }
+
+  test("Flipping must be invertable") {
+    forAll { (a: HourAngle) =>
+      a.flip.flip shouldEqual a
+    }
+  }
+
+  test("Construction must normalize [non-pathological] angles") {
+    forAll { (a: HourAngle, n: Int) =>
+      val factor   = n % 10
+      val msIn24 = 24L * 60L * 60L * 1000L * 1000L
+      val offset   = msIn24 * factor
+      val b = HourAngle.fromMicroseconds(a.toMicroseconds + offset)
+      a shouldEqual b
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/IndexSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/IndexSpec.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+import gem.arb._
+import monocle.law.discipline._
+
+final class IndexSpec extends CatsSuite {
+  import ArbIndex._
+
+  // Laws
+  checkAll("Index", OrderTests[Index].order)
+  checkAll("Index.fromShort", PrismTests(Index.fromShort))
+  checkAll("Index.fromString", PrismTests(Index.fromString))
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/JulianDateSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/JulianDateSpec.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+
+import gem.arb._
+
+import java.time.LocalDateTime
+
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class JulianDateSpec extends CatsSuite {
+
+  import ArbJulianDate._
+  import ArbTime._
+
+  // Laws
+  checkAll("JulianDate", OrderTests[JulianDate].order)
+
+  test("JulianDate.eq.natural") {
+    forAll { (a: JulianDate, b: JulianDate) =>
+      a.equals(b) shouldEqual Eq[JulianDate].eqv(a, b)
+    }
+  }
+
+  test("JulianDate.show.natural") {
+    forAll { (a: JulianDate) =>
+      a.toString shouldEqual Show[JulianDate].show(a)
+    }
+  }
+
+  // Old Epoch.Scheme.toJulianDay algorithm
+  private def oldEpochSchemeJulianDate(dt: LocalDateTime): Double = {
+    import scala.math.floor
+
+    val a = floor((14.0 - dt.getMonthValue) / 12.0)
+    val y = dt.getYear + 4800.0 - a
+    val m = dt.getMonthValue + 12 * a - 3.0
+    dt.getDayOfMonth +
+    floor((153.0 * m + 2.0) / 5.0) +
+    365 * y +
+    floor(y / 4.0) -
+    floor(y / 100.0) +
+    floor(y / 400.0) -
+    32045.0
+  }
+
+  test("JulianDate.dayNumber matches old calculation") {
+    forAll { (ldt: LocalDateTime) =>
+      val jd0 = oldEpochSchemeJulianDate(ldt)
+      val jd1 = JulianDate.ofLocalDateTime(ldt).dayNumber.toDouble
+
+      jd0 shouldEqual jd1
+    }
+  }
+
+  test("Some specific dates compared to USNO calculations") {
+
+    // See http://aa.usno.navy.mil/data/docs/JulianDate.php
+    val tests = List(
+      (LocalDateTime.of(1918, 11, 11, 11,  0,  0), 2421908.958333),
+      (LocalDateTime.of(1969,  7, 21,  2, 56, 15), 2440423.622396),
+      (LocalDateTime.of(2001,  9, 11,  8, 46,  0), 2452163.865278),
+      (LocalDateTime.of(2345,  6,  7, 12,  0,  0), 2577711.000000)
+    )
+
+    tests.foreach { case (ldt, expected) =>
+      val jd  = JulianDate.ofLocalDateTime(ldt)
+      assert((expected - jd.toDouble).abs <= 0.000001)
+    }
+  }
+
+  test("Modified JulianDate should almost equal JulianDate - 2400000.5") {
+    forAll { (j: JulianDate) =>
+      assert(j.toModifiedDouble === (j.toDouble - 2400000.5) +- 0.000000001)
+    }
+  }
+}

--- a/modules/core/shared/src/test/scala/gem/math/LocalObservingNightSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/LocalObservingNightSpec.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.arb._
+import gem.instances.time._
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class LocalObservingNightSpec extends CatsSuite {
+  import ArbTime._
+  import ArbEnumerated._
+  import ArbObservingNight._
+
+  checkAll("LocalObservingNight", OrderTests[LocalObservingNight].order)
+  checkAll("LocalObservingNight.localDate", IsoTests(LocalObservingNight.localDate))
+
+  test("Equality must be natural") {
+    forAll { (a: LocalObservingNight, b: LocalObservingNight) =>
+      a.equals(b) shouldEqual Eq[LocalObservingNight].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (o: LocalObservingNight) =>
+      o.toString shouldEqual Show[LocalObservingNight].show(o)
+    }
+  }
+
+  test("Always begins at 2PM") {
+    forAll { (o: LocalObservingNight) =>
+      o.start.getHour shouldEqual LocalObservingNight.StartHour
+    }
+  }
+
+  test("Always ends at 2PM") {
+    forAll { (o: LocalObservingNight) =>
+      o.end.getHour shouldEqual LocalObservingNight.StartHour
+    }
+  }
+
+  test("Is contiguous (1)") {
+    forAll { (o: LocalObservingNight) =>
+      o.previous.end shouldEqual o.start
+    }
+  }
+
+  test("Is contiguous (2)") {
+    forAll { (o: LocalObservingNight) =>
+      o.next.start shouldEqual o.end
+    }
+  }
+
+  test("Includes start") {
+    forAll { (o: LocalObservingNight) =>
+      o.includes(o.start) shouldBe true
+    }
+  }
+
+  test("Excludes end") {
+    forAll { (o: LocalObservingNight) =>
+      o.includes(o.end) shouldBe false
+    }
+  }
+
+  test("night.previous.next shouldEqual night") {
+    forAll { (o: LocalObservingNight) =>
+      o.previous.next shouldEqual o
+    }
+  }
+
+  test("can always parse a formatted night") {
+    forAll { (o: LocalObservingNight) =>
+      LocalObservingNight.fromString(o.format) shouldEqual Some(o)
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/MagnitudeValueSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/MagnitudeValueSpec.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show, Order }
+import cats.kernel.laws.discipline._
+import gem.arb._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString"))
+final class MagnitudeValueSpec extends CatsSuite {
+  import ArbMagnitudeValue._
+
+  // Laws
+  checkAll("MagnitudeValue", OrderTests[MagnitudeValue].order)
+
+  test("Equality must be natural") {
+    forAll { (a: MagnitudeValue, b: MagnitudeValue) =>
+      a.equals(b) shouldEqual Eq[MagnitudeValue].eqv(a, b)
+    }
+  }
+
+  test("Order must be consistent with .scaledValue") {
+    forAll { (a: MagnitudeValue, b: MagnitudeValue) =>
+      Order[Int].comparison(a.scaledValue, b.scaledValue) shouldEqual
+      Order[MagnitudeValue].comparison(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: MagnitudeValue) =>
+      a.toString shouldEqual Show[MagnitudeValue].show(a)
+    }
+  }
+
+  test("Can extract the magnitude as a double") {
+    forAll { (a: MagnitudeValue) =>
+      a.toDoubleValue shouldEqual a.scaledValue / 100.0
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/ObservingNightSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/ObservingNightSpec.scala
@@ -1,0 +1,106 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import gem.arb._
+import gem.enum.Site
+import gem.instances.time._
+
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import java.time._
+import monocle.law.discipline._
+
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class ObservingNightSpec extends CatsSuite {
+  import ArbEnumerated._
+  import ArbObservingNight._
+  import ArbTime._
+
+  checkAll("ObservingNight", OrderTests[ObservingNight].order)
+  checkAll("ObservingNight.site", LensTests(ObservingNight.site))
+  checkAll("ObservingNight.localObservingNight", LensTests(ObservingNight.localObservingNight))
+  checkAll("ObservingNight.localDate", LensTests(ObservingNight.localDate))
+
+  test("Equality must be natural") {
+    forAll { (a: ObservingNight, b: ObservingNight) =>
+      a.equals(b) shouldEqual Eq[ObservingNight].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (o: ObservingNight) =>
+      o.toString shouldEqual Show[ObservingNight].show(o)
+    }
+  }
+
+  test("Start time consistent with LocalObservingNight") {
+    forAll { (o: ObservingNight) =>
+      o.start.atZone(o.site.timezone).toLocalDateTime shouldEqual o.toLocalObservingNight.start
+    }
+  }
+
+  test("End time consistent with LocalObservingNight") {
+    forAll { (o: ObservingNight) =>
+      o.end.atZone(o.site.timezone).toLocalDateTime shouldEqual o.toLocalObservingNight.end
+    }
+  }
+
+  test("Is contiguous (1)") {
+    forAll { (o: ObservingNight) =>
+      o.previous.end shouldEqual o.start
+    }
+  }
+
+  test("Is contiguous (2)") {
+    forAll { (o: ObservingNight) =>
+      o.next.start shouldEqual o.end
+    }
+  }
+
+  test("Includes start") {
+    forAll { (o: ObservingNight) =>
+      o.includes(o.start) shouldBe true
+    }
+  }
+
+  test("Excludes end") {
+    forAll { (o: ObservingNight) =>
+      o.includes(o.end) shouldBe false
+    }
+  }
+
+  test("night.previous.next shouldEqual night") {
+    forAll { (o: ObservingNight) =>
+      o.previous.next shouldEqual o
+    }
+  }
+
+  test("handle daylight savings correctly (summer end)") {
+    val h = LocalObservingNight.fromString("20180513").map(_.atSite(Site.GS).duration.toHours)
+    h shouldEqual Some(25)
+  }
+
+  test("handle daylight savings correctly (winter end)") {
+    val h = LocalObservingNight.fromString("20180812").map(_.atSite(Site.GS).duration.toHours)
+    h shouldEqual Some(23)
+  }
+
+  test("fromSiteAndLocalDate consistent") {
+    forAll { (s: Site, l: LocalDate) =>
+      ObservingNight.fromSiteAndLocalDate(s, l).toLocalDate shouldEqual l
+    }
+  }
+
+  test("fromSiteAndLocalDateTime consistent") {
+    forAll { (s: Site, l: LocalDateTime) =>
+      val n  = ObservingNight.fromSiteAndLocalDateTime(s, l)
+      val d  = l.toLocalDate
+      val dʹ = if (l.toLocalTime.isBefore(LocalObservingNight.Start)) d else d.plusDays(1L)
+      n.toLocalDate shouldEqual dʹ
+    }
+  }
+}

--- a/modules/core/shared/src/test/scala/gem/math/OffsetPSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetPSpec.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class OffsetPSpec extends CatsSuite {
+  import ArbAngle._
+  import ArbOffset._
+
+  // Laws
+  checkAll("Offset.P", CommutativeGroupTests[Offset.P].commutativeGroup)
+  checkAll("Offset.P", OrderTests[Offset.P].order)
+  checkAll("Offset.P.angle", IsoTests(Offset.P.angle))
+
+  test("Equality must be natural") {
+    forAll { (a: Offset.P, b: Offset.P) =>
+      a.equals(b) shouldEqual Eq[Offset.P].eqv(a, b)
+    }
+  }
+
+  test("Equality be consistent with .toAngle") {
+    forAll { (a: Offset.P, b: Offset.P) =>
+      Eq[Angle].eqv(a.toAngle, b.toAngle) shouldEqual Eq[Offset.P].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Offset.P) =>
+      a.toString shouldEqual Show[Offset.P].show(a)
+    }
+  }
+
+  test("Conversion to angle must be invertable") {
+    forAll { (p: Offset.P) =>
+      Offset.P(p.toAngle) shouldEqual p
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/OffsetQSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetQSpec.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class OffsetQSpec extends CatsSuite {
+  import ArbAngle._
+  import ArbOffset._
+
+  // Laws
+  checkAll("Offset.Q", CommutativeGroupTests[Offset.Q].commutativeGroup)
+  checkAll("Offset.Q", OrderTests[Offset.Q].order)
+  checkAll("Offset.Q.angle", IsoTests(Offset.Q.angle))
+
+  test("Equality must be natural") {
+    forAll { (a: Offset.Q, b: Offset.Q) =>
+      a.equals(b) shouldEqual Eq[Offset.Q].eqv(a, b)
+    }
+  }
+
+  test("Equality be consistent with .toAngle") {
+    forAll { (a: Offset.Q, b: Offset.Q) =>
+      Eq[Angle].eqv(a.toAngle, b.toAngle) shouldEqual Eq[Offset.Q].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Offset.Q) =>
+      a.toString shouldEqual Show[Offset.Q].show(a)
+    }
+  }
+
+  test("Conversion to angle must be invertable") {
+    forAll { (p: Offset.Q) =>
+      Offset.Q(p.toAngle) shouldEqual p
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/OffsetSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/OffsetSpec.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class OffsetSpec extends CatsSuite {
+  import ArbAngle._
+  import ArbOffset._
+
+  // Laws
+  checkAll("Offset", CommutativeGroupTests[Offset].commutativeGroup)
+  checkAll("Offset", OrderTests[Offset].order)
+  checkAll("Offset.p", LensTests(Offset.p))
+  checkAll("Offset.q", LensTests(Offset.q))
+  checkAll("Offset.pAngle", LensTests(Offset.pAngle))
+  checkAll("Offset.qAngle", LensTests(Offset.qAngle))
+
+  test("Equality must be natural") {
+    forAll { (a: Offset, b: Offset) =>
+      a.equals(b) shouldEqual Eq[Offset].eqv(a, b)
+    }
+  }
+
+  test("it must operate pairwise") {
+    forAll { (a: Offset, b: Offset) =>
+      Eq[Offset.P].eqv(a.p, b.p) &&
+      Eq[Offset.Q].eqv(a.q, b.q) shouldEqual Eq[Offset].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Offset) =>
+      a.toString shouldEqual Show[Offset].show(a)
+    }
+  }
+
+  test("Conversion to components must be invertable") {
+    forAll { (o: Offset) =>
+      val (p, q) = (o.p, o.q)
+      Offset(p, q) shouldEqual o
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/ProperMotionSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/ProperMotionSpec.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+import gem.arb._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class ProperMotionSpec extends CatsSuite {
+  import ArbAngle._
+  import ArbCoordinates._
+  import ArbEpoch._
+  import ArbOffset._
+  import ArbProperMotion._
+  import ArbRadialVelocity._
+
+  // Laws
+  checkAll("ProperMotion", OrderTests[ProperMotion].order)
+  checkAll("ProperMotion.baseCoordinates", LensTests(ProperMotion.baseCoordinates))
+  checkAll("ProperMotion.epoch", LensTests(ProperMotion.epoch))
+  checkAll("ProperMotion.properVelocity", LensTests(ProperMotion.properVelocity))
+  checkAll("ProperMotion.radialVelocity", LensTests(ProperMotion.radialVelocity))
+  checkAll("ProperMotion.parallax", LensTests(ProperMotion.parallax))
+
+  test("ProperMotion.identity") {
+    forAll { (pm: ProperMotion) =>
+      val c1 = pm.baseCoordinates
+      val c2 = pm.plusYears(0.0).baseCoordinates
+      c1.angularDistance(c2).toMicroarcseconds should be <= 20L
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/RightAscensionSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/RightAscensionSpec.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show, Order }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import gem.laws.discipline._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class RightAscensionSpec extends CatsSuite {
+  import ArbRightAscension._
+  import ArbAngle._
+
+  // Laws
+  checkAll("RightAscension", OrderTests[RightAscension].order)
+  checkAll("fromAngleExact", PrismTests(RightAscension.fromAngleExact))
+  checkAll("fromHourAngle", IsoTests(RightAscension.fromHourAngle))
+  checkAll("fromStringHMS", FormatTests(RightAscension.fromStringHMS).formatWith(ArbAngle.stringsHMS))
+
+  test("Equality must be natural") {
+    forAll { (a: RightAscension, b: RightAscension) =>
+      a.equals(b) shouldEqual Eq[RightAscension].eqv(a, b)
+    }
+  }
+
+  test("Order must be consistent with .toHourAngle.toMicroarcseconds") {
+    forAll { (a: RightAscension, b: RightAscension) =>
+      Order[Long].comparison(a.toHourAngle.toMicroarcseconds, b.toHourAngle.toMicroarcseconds) shouldEqual
+      Order[RightAscension].comparison(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: RightAscension) =>
+      a.toString shouldEqual Show[RightAscension].show(a)
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/math/WavelengthSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/math/WavelengthSpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show, Order }
+import cats.kernel.laws.discipline._
+import gem.arb._
+import monocle.law.discipline._
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+final class WavelengthSpec extends CatsSuite {
+  import ArbWavelength._
+
+  // Laws
+  checkAll("Wavelength", OrderTests[Wavelength].order)
+  checkAll("fromAngstroms", PrismTests(Wavelength.fromAngstroms))
+
+  test("Equality must be natural") {
+    forAll { (a: Wavelength, b: Wavelength) =>
+      a.equals(b) shouldEqual Eq[Wavelength].eqv(a, b)
+    }
+  }
+
+  test("Order must be consistent with .toAngstroms") {
+    forAll { (a: Wavelength, b: Wavelength) =>
+      Order[Int].comparison(a.toAngstroms, b.toAngstroms) shouldEqual
+      Order[Wavelength].comparison(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Wavelength) =>
+      a.toString shouldEqual Show[Wavelength].show(a)
+    }
+  }
+
+  test("Construction from an arbitrary Int must not allow negative values") {
+    forAll { (n: Int) =>
+      Wavelength.fromAngstroms.getOption(n).isDefined shouldEqual n >= 0
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/optics/FormatSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/optics/FormatSpec.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package optics
+
+import cats.tests.CatsSuite
+import gem.laws.discipline._
+
+final class FormatSpec extends CatsSuite {
+
+  // Our example Format injects ints into "positive and even"
+  val example: Format[Int, Boolean] =
+    Format(n => if (n > 0) Some(n % 2 == 0) else None, b => if (b) 2 else 1)
+
+  // Ensure it's lawful
+  checkAll("Formats.HmsDms", FormatTests(example).format)
+
+  test("unsafeGet.consistent with getOption") {
+    forAll { (n: Int) =>
+      example.getOption(n) shouldEqual Either.catchNonFatal(example.unsafeGet(n)).toOption
+    }
+  }
+
+  test("unsafeGet.error message") {
+    forAll { (n: Int) =>
+      Either.catchNonFatal(example.unsafeGet(n)) match {
+        case Left(t)  => t.getMessage shouldEqual s"unsafeGet failed: $n"
+        case Right(_) => true
+      }
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/optics/SplitEpiSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/optics/SplitEpiSpec.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package optics
+
+import cats.tests.CatsSuite
+import gem.laws.discipline._
+
+final class SplitEpiSpec extends CatsSuite {
+
+  val ex1: SplitEpi[Long, Int] =
+    SplitEpi(_.toInt, _.toLong)
+
+  val ex2: SplitEpi[Int, Byte] =
+    SplitEpi(_.toByte, _.toInt)
+
+  // Laws
+  checkAll("Long > Int", SplitEpiTests(ex1).splitEpi)
+  checkAll("Int > Byte", SplitEpiTests(ex2).splitEpi)
+  checkAll("Long > Int > Byte", SplitEpiTests(ex1 composeSplitEpi ex2).splitEpi)
+
+}

--- a/modules/core/shared/src/test/scala/gem/optics/SplitMonoSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/optics/SplitMonoSpec.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package optics
+
+import cats.tests.CatsSuite
+import gem.laws.discipline._
+
+final class SplitMonoSpec extends CatsSuite {
+
+  val ex1: SplitMono[Byte, Int] =
+    SplitMono(_.toInt, _.toByte)
+
+  val ex2: SplitMono[Int, Long] =
+    SplitMono(_.toLong, _.toInt)
+
+  // Laws
+  checkAll("Byte < Int", SplitMonoTests(ex1).splitMono)
+  checkAll("Int < Long", SplitMonoTests(ex2).splitMono)
+  checkAll("Byte < Int < Long", SplitMonoTests(ex1 composeSplitMono ex2).splitMono)
+
+}

--- a/modules/core/shared/src/test/scala/gem/optics/WedgeSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/optics/WedgeSpec.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package optics
+
+import cats.tests.CatsSuite
+import gem.laws.discipline._
+
+final class wedgeSpec extends CatsSuite {
+
+  val se: SplitEpi[Long, Short] =
+    SplitEpi(_.toShort, _.toLong)
+
+  val sm: SplitMono[Short, Int] =
+    SplitMono(_.toInt, _.toShort)
+
+  val w: Wedge[Long, Int] =
+    se composeSplitMono sm
+
+  // Laws
+  checkAll("Long > Short", SplitEpiTests(se).splitEpi)
+  checkAll("Short < Int",   SplitMonoTests(sm).splitMono)
+  checkAll("Long > Short < Int",   WedgeTests(w).wedge)
+
+}

--- a/modules/core/shared/src/test/scala/gem/parser/MiscParsersSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/parser/MiscParsersSpec.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.parser
+
+import atto._, Atto._
+import cats.tests.CatsSuite
+import gem.math.Index
+import gem.parser.MiscParsers.index
+
+final class MiscParsersSpec extends CatsSuite {
+
+  test("index parser must be consistent with Index.fromShort") {
+    forAll { (s: Short) =>
+      index.parseOnly(s.toString).option shouldEqual Index.fromShort.getOption(s)
+    }
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/test/RespectIncludeTags.scala
+++ b/modules/core/shared/src/test/scala/gem/test/RespectIncludeTags.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.test
+
+import org.scalatest._
+
+
+/** Reverses the meaning of Scala Test test filters.  The TLDR version of what
+  * this does is:
+  *
+  * - Allows explicit include filters to override exclude filters
+  * - Explicit include filters don't exclude anything
+  *
+  * This makes it possible to specify Tags and apply them to test cases that
+  * usually should not be run but that can be run when desired.
+  *
+  *
+  * Setting up Tests Excluded by Default
+  *
+  * 1. First chose or create a new Tag (see `gem.test.Tags`).  For example,
+  *    `gem.test.Tags.RequiresNetwork` for tests that require an external
+  *    resource.
+  *
+  * 2. Make sure the build contains a setting to exclude the tag.  For example
+  *
+  *        testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork") // by default, ignore network tests
+  *
+  * 3. Now, to turn on tests that are normally excluded use
+  *
+  *        `testOnly testName -- -n gem.test.Tags.RequiresNetwork`
+  *
+  *    Unfortunately this doesn't work with the `test` command itself.  For that
+  *    you must update the setting which can be done on the SBT command line with:
+  *
+  *        set testOptions in ThisBuild += Tests.Argument(TestFrameworks.ScalaTest, "-n", "gem.test.Tags.RequiresNetwork")
+  *
+  *
+  * Background
+  *
+  * ScalaTest provides the concept of test tags that can be used to control
+  * which tests are executed at runtime.  In particular, two filters are
+  * available, an "include" filter and an "exclude" filter.  The include filter
+  * excludes everything except tests tagged with the given tags, provided they
+  * are not also mentioned in the exclude filter.  The exclude filter just lists
+  * tags whose associated tests should not be executed.  Using the SB `testOnly`
+  * command, include tags can be specified with `-n` and exclude tags with `-l`
+  * (that's lowercase L).  See
+  *
+  * http://www.scalatest.org/user_guide/using_scalatest_with_sbt
+  *
+  * for more information.
+  *
+  */
+trait RespectIncludeTags extends Suite {
+
+  override protected def runTests(testName: Option[String], args: Args): Status = {
+
+    val filter     = args.filter
+    val isExcluded = filter.tagsToExclude
+    val isIncluded = filter.tagsToInclude.getOrElse(Set.empty)
+    val exclude    = isIncluded.foldLeft(isExcluded)(_ - _)
+    val newFilter  = Filter(None, exclude, filter.excludeNestedSuites, filter.dynaTags)
+
+    super.runTests(testName, args.copy(filter = newFilter))
+  }
+
+}

--- a/modules/core/shared/src/test/scala/gem/test/Tags.scala
+++ b/modules/core/shared/src/test/scala/gem/test/Tags.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.test
+
+import org.scalatest.Tag
+
+/** Scalatest tags.
+  */
+object Tags {
+
+  /** Tag tests that require network and external services access. */
+  object RequiresNetwork extends Tag("gem.test.Tags.RequiresNetwork")
+
+  /** Tag tests that are unusually slow. */
+  object Slow extends Tag("gem.test.Tags.Slow")
+}

--- a/modules/core/shared/src/test/scala/gem/util/EnumeratedSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/EnumeratedSpec.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package util
+
+import gem.arb._
+import gem.enum._
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+import scala.reflect.ClassTag
+
+final class EnumeratedSpec extends CatsSuite {
+  import ArbEnumerated._
+
+  def checkEnumeration[A](
+    implicit en: Enumerated[A],
+             ct: ClassTag[A]
+  ): Unit = {
+    val name = ct.runtimeClass.getSimpleName
+    checkAll(name, OrderTests[A].order)
+    test(s"$name.enumerated.canonical") {
+      val sorted   = en.all
+      val shuffled = scala.util.Random.shuffle(sorted)
+      shuffled.sorted(en.toOrdering) shouldEqual sorted
+    }
+  }
+
+  // Check a handful of enums.
+  checkEnumeration[EventType]
+  checkEnumeration[F2Disperser]
+  checkEnumeration[GcalArc]
+  checkEnumeration[GmosAdc]
+  checkEnumeration[Half]
+  checkEnumeration[Instrument]
+  checkEnumeration[MosPreImaging]
+  checkEnumeration[ProgramRole]
+  checkEnumeration[ProgramType]
+  checkEnumeration[Site]
+  checkEnumeration[SmartGcalType]
+  checkEnumeration[StepType]
+
+}

--- a/modules/core/shared/src/test/scala/gem/util/LocationSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/LocationSpec.scala
@@ -1,0 +1,145 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package util
+
+import cats.{ Eq, Order }
+import cats.kernel.laws.discipline._
+import cats.kernel.Comparison.{ GreaterThan => GT, LessThan => LT, EqualTo => EQ }
+import cats.tests.CatsSuite
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
+final class LocationSpec extends CatsSuite with Arbitraries {
+
+  // Laws
+  checkAll("Location", OrderTests[Location].order)
+
+  test("Construction should trim trailing min values from Middle") {
+    forAll { (l: Location.Middle) =>
+      val t = l.toList
+      t shouldEqual t.reverse.dropWhile(_ == Int.MinValue).reverse
+    }
+  }
+
+  test("Construction should produce Beginning if given an empty list") {
+    Location.fromFoldable(List.empty[Int]) shouldEqual Location.Beginning
+  }
+
+  test("Construction should produce beginning if given all Int.MinValue") {
+    forAll { (i: Int) =>
+      val count = (i % 10).abs
+      val mins  = List.fill(count)(Int.MinValue)
+      Location.fromFoldable(mins) shouldEqual Location.Beginning
+    }
+  }
+
+  test("EQ should agree with ==") {
+    forAll { (l0: Location, l1: Location) =>
+      Order[Location].eqv(l0, l1) shouldEqual (l0 == l1)
+    }
+  }
+
+  test("Find should return an empty list if the two positions are the same") {
+    forAll { (l: Location) =>
+      Location.find(10, l, l) shouldEqual List.empty[Location.Middle]
+    }
+  }
+
+  test("Find should return an empty list if the first position is >= the second") {
+    forAll { (l0: Location, l1: Location) =>
+      val res = Order[Location].comparison(l0, l1) match {
+        case LT => Location.find(10, l1, l0)
+        case _  => Location.find(10, l0, l1)
+      }
+      res shouldEqual List.empty[Location.Middle]
+    }
+  }
+
+  test("Find should find nothing if asked for a negative or 0 count") {
+    forAll { (i: Int, l0: Location, l1: Location) =>
+      val negOrZero = -(i.abs)
+      Location.find(negOrZero, l0, l1) shouldEqual List.empty[Location.Middle]
+    }
+  }
+
+  test("Find should find an arbitrary number of Locations between unequal positions") {
+    forAll { (i: Int, l0: Location, l1: Location) =>
+      val count = (i % 10000).abs + 1
+      Order[Location].comparison(l0, l1) match {
+        case LT => Location.find(count, l0, l1).length shouldEqual count
+        case GT => Location.find(count, l1, l0).length shouldEqual count
+        case EQ => Location.find(count, l0, l1) should have length 0
+      }
+    }
+  }
+
+  test("Find should produce a sorted list of Location.Middle") {
+    forAll { (i: Int, l0: Location, l1: Location) =>
+      val count = (i % 10000).abs + 1
+      val res   = Order[Location].comparison(l0, l1) match {
+        case LT => l0 +: Location.find(count, l0, l1).widen[Location] :+ l1
+        case _  => l1 +: Location.find(count, l1, l0).widen[Location] :+ l0
+      }
+
+      assert(Eq[List[Location]].eqv(res.sorted, res))
+    }
+  }
+
+  test("Find should grow the position list if necessary") {
+    Location.find(1, Location(1, 2), Location(1,3)) match {
+      case res :: Nil =>
+        res.toList match {
+          case 1 :: 2 :: p :: Nil =>
+            p should not be Int.MinValue
+
+          case l                  =>
+            fail(s"Expectd List(1, 2, p) not ${l.mkString(",")}")
+        }
+
+      case l                =>
+        fail(s"Expected a single result not ${l.mkString(",")}")
+    }
+  }
+
+  test("Find should evenly space values it finds") {
+    val Max   = BigInt(Int.MaxValue)
+    val Min   = BigInt(Int.MinValue)
+    val Radix = Max + Min.abs + BigInt(1)
+
+    def toBase10(loc: Location.Middle, len: Int): BigInt = {
+      val prefix  = loc.posList.toList
+      val posList = prefix ::: List.fill(len - prefix.length)(Int.MinValue)
+
+      posList.foldRight((BigInt(0), BigInt(1))) { case (i, (acc, pow)) =>
+        (acc + (BigInt(i) + Min.abs) * pow, pow * Radix)
+      }._1
+    }
+
+    def positions(locs: List[Location.Middle]): List[BigInt] = {
+      val len = locs match {
+        case Nil => 0
+        case _   => locs.map(_.posList.toList.length).max
+      }
+      locs.map(toBase10(_, len))
+    }
+
+    forAll { (i: Int, l0: Location, l1: Location) =>
+      val count      = (i % 10000).abs + 1
+      val (fst, snd) = if (l0 < l1) (l0, l1) else (l1, l0)
+      val middles    = Location.find(count, fst, snd)
+      val maxDiff    = positions(middles.toList) match {
+        case Nil | _ :: Nil =>
+          BigInt(0)
+        case posList        =>
+          val gapSizes = posList.zip(posList.drop(1)).map { case (a, b) => b - a }
+          gapSizes.max - gapSizes.min
+      }
+
+      // The gap between consecutive locations across all the values found
+      // should never differ one from the other by more than 1.  That is, the
+      // locations should be as evenly spaced as possible.
+      maxDiff shouldBe <= (BigInt(1))
+    }
+  }
+}

--- a/modules/core/shared/src/test/scala/gem/util/TimestampSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/TimestampSpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package util
+
+import gem.arb.ArbTime._
+
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+
+import java.time.ZonedDateTime
+import java.time.ZoneOffset.UTC
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
+final class TimestampSpec extends CatsSuite {
+
+  // Laws
+  checkAll("Timestamp", OrderTests[Timestamp].order)
+
+  test("Construction should truncate Instant nanoseconds to microseconds") {
+    forAll { (i: Timestamp) =>
+      i.toInstant.getNano % 1000L == 0
+    }
+  }
+
+  test("Out of range dates are rejected") {
+    implicit val arbInt: Arbitrary[Int] =
+      Arbitrary {
+        Gen.frequency((1, Gen.choose(-999999999, 999999999)),
+                      (1, Gen.choose(     -4712,    294275)))
+      }
+
+    forAll { (y: Int) =>
+      val i = ZonedDateTime.of(y, 1, 1, 0, 0, 0, 0, UTC).toInstant
+      val t = Timestamp.fromInstant(i)
+
+      assert(t.isEmpty == (i.isBefore(Timestamp.Min.toInstant) || i.isAfter(Timestamp.Max.toInstant)))
+    }
+  }
+
+}

--- a/modules/ctl/src/main/scala/Parsers.scala
+++ b/modules/ctl/src/main/scala/Parsers.scala
@@ -1,0 +1,108 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+
+import cats.implicits._, cats.effect.IO
+import com.monovore.decline.{ Command => Cmd, _ }
+import gem.ctl.free.ctl.{ CtlIO, Server, Host }
+import gem.ctl.free.interpreter.Config
+import gem.ctl.hi._
+
+/** Command-line option parsers for gemctl. */
+object Parsers {
+
+  // Parsers for a Config object that provides global information to the interpreter.
+  private object ConfigParsers {
+
+    private lazy val verbose: Opts[Boolean] =
+      Opts.flag(
+        short = "v",
+        long  = "verbose",
+        help  = "Show details about what we're doing under the hood."
+      ).orFalse
+
+    private lazy val ansi: Opts[Boolean] =
+      Opts.flag(
+        long  = "no-ansi",
+        help  = "Don't use ANSI colors and control codes."
+      ).orTrue
+
+    private lazy val host: Opts[Option[String]] =
+      Opts.option[String](
+        short   = "H",
+        long    = "host",
+        metavar = "HOST",
+        help    = "Remote docker host."
+      ).orNone
+
+    private lazy val user: Opts[Option[String]] =
+      Opts.option[String](
+        short = "u",
+        long  = "user",
+        metavar = "USER",
+        help = "Remote docker user (ignored unless -H is also specified)."
+      ).orNone
+
+    private lazy val server: Opts[Server] =
+      (host, user) mapN {
+        case (Some(h), ou) => Server.Remote(Host(h), ou)
+        case (None,    _ ) => Server.Local
+      }
+
+    lazy val config: Opts[Config] =
+      (verbose, server, ansi).mapN(Config)
+
+  }
+
+  // Parsers for individual commands.
+  private object CommandParsers {
+
+    private lazy val version: Opts[String] =
+      Opts.argument[String](metavar = "VERSION")
+
+    private lazy val deployTest: Opts[CtlIO[Unit]] =
+      version.map(Deploy.deployTest(_).void)
+
+    private lazy val deployProduction: Opts[CtlIO[Unit]] =
+      version.map(Deploy.deployProduction(_).void)
+
+    lazy val deployTestCommand: Opts[CtlIO[Unit]] =
+      Opts.subcommand(
+        name = "deploy-test",
+        help = "Deploy gem, destroying any existing deployment."
+      )(deployTest.widen[CtlIO[Unit]])
+
+    lazy val deployProductionCommand: Opts[CtlIO[Unit]] =
+      Opts.subcommand(
+        name = "deploy-production",
+        help = "Deploy gem, upgrading from any existing deployment, which will be shut down."
+      )(deployProduction.widen[CtlIO[Unit]])
+
+    lazy val impl: Opts[CtlIO[Unit]] =
+      List(
+        deployTestCommand,
+        deployProductionCommand
+      ).foldRight(Opts.never: Opts[CtlIO[Unit]])(_ orElse _)
+
+  }
+
+  // Top-level command parser
+  private def top(progName: String): Cmd[(Config, CtlIO[Unit])] =
+    Cmd(
+      name   = progName,
+      header = "Deploy and control gem."
+    )((ConfigParsers.config, CommandParsers.impl).tupled)
+
+  /**
+  * Construct a program to parse commandline `args` into a `Command`, or show help information if
+  * parsing fails. The `progName` argument is only used for help messages, and should match the
+  * name of the executable ("gemctl" for example).
+  */
+  def parse[A](progName: String, args: List[String]): IO[Option[(Config, CtlIO[Unit])]] =
+    top(progName).parse(args) match {
+      case Right(c) => c.some.pure[IO]
+      case Left(h) => IO(Console.println(Console.BLUE + h.toString + Console.RESET)).as(none[(Config, CtlIO[Unit])]) // scalastyle:ignore
+    }
+
+}

--- a/modules/ctl/src/main/scala/free/ctl.scala
+++ b/modules/ctl/src/main/scala/free/ctl.scala
@@ -1,0 +1,114 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+package free
+
+import interpreter.Config
+import gem.ctl.low.io._
+
+import cats.free.Free, cats.implicits._
+
+/** Module of constructors for the control language. */
+object ctl {
+
+  final case class Host(name: String)
+
+  sealed trait Server {
+    def userAndHost: String =
+      this match {
+        case Server.Local               => "localhost"
+        case Server.Remote(Host(h), u)  => u.map(_ + "@" + h).getOrElse(h)
+      }
+  }
+  object Server {
+    case object Local extends Server
+    final case class Remote(host: Host, user: Option[String]) extends Server
+  }
+
+
+  /** ADT for output log levels. */
+  sealed trait Level
+  object Level {
+    case object Info  extends Level
+    case object Warn  extends Level
+    case object Error extends Level
+    case object Shell extends Level
+  }
+
+  /** ADT of low-level control operations. */
+  sealed trait CtlOp[A]
+  object CtlOp {
+    final case class  Exit[A](exitCode: Int)                                    extends CtlOp[A]
+          case object GetConfig                                                 extends CtlOp[Config]
+    final case class  Gosub[A](level: Level, msg: String, fa: CtlIO[A])         extends CtlOp[A]
+    final case class  Shell(remote: Boolean, cmd: Either[String, List[String]]) extends CtlOp[Output]
+          case object Now                                                       extends CtlOp[Long]
+  }
+
+  /** Combinator that applies a check to command output. */
+  def require[A](shell: CtlIO[Output])(f: PartialFunction[Output, A]): CtlIO[A] =
+    shell.flatMap { o =>
+      f.lift(o) match {
+        case None    =>
+          o.lines.traverse(error(_))      *>
+          error(s"exited (${o.exitCode})") *>
+          exit[A](o.exitCode)
+        case Some(a) => a.pure[CtlIO]
+      }
+    }
+
+  /** Syntax to allow checks on shell command output. */
+  implicit class CtlIOOps[A](fa: CtlIO[A]) {
+    def require[B](f: PartialFunction[Output, B])(implicit ev: A =:= Output): CtlIO[B] =
+      ctl.require(fa.map(ev))(f)
+  }
+
+  /** Free monad over CtlOp. */
+  type CtlIO[A] = Free[CtlOp, A]
+
+  // Constructors
+
+  def serverHostName: CtlIO[String] =
+    server.map {
+      case Server.Local                 => "localhost"
+      case Server.Remote(Host(name), _) => name
+    }
+
+  def shell(c: String, cs: String*): CtlIO[Output] =
+    Free.liftF(CtlOp.Shell(false, Right(c :: cs.toList)))
+
+  def remote(c: String, cs: String*): CtlIO[Output] =
+    Free.liftF(CtlOp.Shell(true, Right(c :: cs.toList)))
+
+  def exit[A](exitCode: Int): CtlIO[A] =
+    Free.liftF(CtlOp.Exit[A](exitCode))
+
+  val config: CtlIO[Config] =
+    Free.liftF(CtlOp.GetConfig)
+
+  val server: CtlIO[Server] =
+    config.map(_.server)
+
+  val isRemote: CtlIO[Boolean] =
+    server.map {
+      case Server.Remote(_, _) => true
+      case Server.Local        => false
+    }
+
+  def gosub[A](msg: String)(fa: CtlIO[A]): CtlIO[A] =
+    Free.liftF(CtlOp.Gosub(Level.Info, msg, fa))
+
+  def logMessage(level: Level, msg: String): CtlIO[Unit] =
+    Free.liftF(CtlOp.Gosub(level, msg, ().pure[CtlIO]))
+
+  def now: CtlIO[Long] =
+    Free.liftF(CtlOp.Now)
+
+  def info (msg: String): CtlIO[Unit] = logMessage(Level.Info,  msg)
+  def warn (msg: String): CtlIO[Unit] = logMessage(Level.Warn,  msg)
+  def error(msg: String): CtlIO[Unit] = logMessage(Level.Error, msg)
+  def text (msg: String): CtlIO[Unit] = logMessage(Level.Shell, msg)
+
+
+}

--- a/modules/ctl/src/main/scala/free/interp.scala
+++ b/modules/ctl/src/main/scala/free/interp.scala
@@ -1,0 +1,111 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+package free
+
+import cats._, cats.data._, cats.implicits._
+import cats.effect._
+
+import gem.ctl.low.io._
+import gem.ctl.free.ctl._
+
+/** An interpreter for the control language. */
+object interpreter {
+
+  /** Configuration for the interpreter. */
+  final case class Config(
+    verbose: Boolean,
+    server:  Server,
+    ansi:    Boolean
+  )
+
+  final case class InterpreterState(indentation: Int) {
+    def indent:  InterpreterState = copy(indentation = indentation + 1)
+    def outdent: InterpreterState = copy(indentation = indentation - 1)
+  }
+  object InterpreterState {
+    val initial: InterpreterState = InterpreterState(0)
+  }
+
+  /**
+   * Construct an interpreter of `CtlIO` given a `Config` and an `IORef` for the initial state. We
+   * carry our state in an `IORef` because it needs to be visible from multiple threads.
+   */
+  def interpreter(c: Config, state: IORef[InterpreterState]): CtlOp ~> EitherT[IO, Int, ?] =
+    λ[CtlOp ~> EitherT[IO, Int, ?]] {
+      case CtlOp.Shell(false, cmd) => doShell(cmd, c.verbose, c.ansi, state)
+      case CtlOp.Shell(true,  cmd) =>
+        c.server match {
+
+          case Server.Local =>
+            doShell(cmd, c.verbose, c.ansi, state)
+
+          case Server.Remote(Host(h), u) =>
+            doRemoteShell(u.map(u =>  s"$u@$h").getOrElse(h), cmd, c, state)
+
+        }
+      case CtlOp.Exit(exitCode)    => EitherT.left(exitCode.pure[IO])
+      case CtlOp.GetConfig         => c.pure[EitherT[IO, Int, ?]]
+      case CtlOp.Gosub(level, msg, fa) =>
+        for {
+          _ <- doLog(c.ansi, level, msg, state)
+          _ <- EitherT.right(state.mod(_.indent))
+          a <- fa.foldMap(this)
+          _ <- EitherT.right(state.mod(_.outdent))
+        } yield a
+      case CtlOp.Now => EitherT.right(IO(System.currentTimeMillis))
+    }
+
+  /**
+   * Construct a program to log a message to the console at the given log level and indentation.
+   * This is where all the colorizing happens.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  private def doLogʹ(ansi: Boolean, level: Level, msg: String, state: IORef[InterpreterState]): IO[Unit] = {
+    lazy val color =
+      if (ansi) {
+        level match {
+          case Level.Error => Console.RED
+          case Level.Warn  => Console.YELLOW
+          case Level.Info  => Console.GREEN
+          case Level.Shell => "\u001B[0;37m" // gray
+        }
+      } else ""
+    val pre  = s"$color[${level.toString.take(4).toLowerCase}] $color"
+    val post = if (ansi) Console.RESET else ""
+    for {
+      i <- state.read.map(_.indentation).map("  " * _)
+      _ <- IO(Console.println(f"$pre$i$msg$post")) // scalastyle:ignore
+    } yield ()
+  }
+
+  /**
+   * Construct a program to log a message to the console at the given log level and indentation.
+   * Convenience for `doLogʹ` lifted into `EitherT`.
+   */
+  private def doLog(ansi: Boolean, level: Level, msg: String, state: IORef[InterpreterState]): EitherT[IO, Int, Unit] =
+    EitherT.right(doLogʹ(ansi, level, msg, state))
+
+  private def doRemoteShell(uh: String, cmd: Either[String, List[String]], c: Config, state: IORef[InterpreterState]): EitherT[IO, Int, Output] =
+    doShell(cmd.bimap(s => s"ssh $uh $s", "ssh" :: uh :: _), c.verbose, c.ansi, state)
+
+  /**
+   * Construct a program to perform a shell operation, optionally logging the output (if verbose),
+   * and gathering the result as an `Output`.
+   */
+  private def doShell(cmd: Either[String, List[String]], verbose: Boolean, ansi: Boolean, state: IORef[InterpreterState]): EitherT[IO, Int, Output] = {
+
+    def handler(s: String): IO[Unit] =
+      if (verbose) doLogʹ(ansi, Level.Shell, s, state)
+      else IO.unit
+
+    for {
+      _ <- doLog(ansi, Level.Shell, s"$$ ${cmd.fold(identity, _.mkString(" "))}", state).whenA(verbose)
+      o <- EitherT.right(exec(cmd, handler))
+      _ <-doLog(ansi, Level.Shell, s"exit(${o.exitCode})", state).whenA(verbose)
+    } yield o
+
+  }
+
+}

--- a/modules/ctl/src/main/scala/hi/Containers.scala
+++ b/modules/ctl/src/main/scala/hi/Containers.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl.hi
+
+import cats.implicits._
+import gem.ctl.free.ctl._
+import gem.ctl.low.io._
+import gem.ctl.low.docker._
+
+object Containers {
+
+  def createDatabaseContainer(version: String, iPg: Image, n: Network): CtlIO[Container] =
+    gosub(s"Creating Postgres container from image ${iPg.hash}") {
+      for {
+        r <- isRemote // irritating … see below
+        c <- docker("run",
+                  "--detach",
+                 s"--net=${n.name}",
+                  "--name", s"$version-P",
+                  "--label", s"gem.version=$version",
+                  "--label", s"gem.role=db",
+                  "--health-cmd", if (r) "\"psql -U postgres -d gem -c 'select 1'\""
+                                  else     "psql -U postgres -d gem -c 'select 1'",
+                  "--health-interval", "10s",
+                  "--health-retries", "2",
+                  "--health-timeout", "2s",
+                  iPg.hash
+             ).require { case Output(0, List(s)) => Container(s) }
+        _ <- info(s"Container name is $version-P")
+        _ <- info(s"Container hash is ${c.hash}.")
+      } yield c
+    }
+
+  def createGemContainer(version: String, iGem: Image, n: Network): CtlIO[Container] =
+    gosub(s"Creating Gem container from image ${iGem.hash}") {
+      for {
+        r  <- isRemote // irritating … see below
+        c  <- docker("run",
+                "--detach",
+                "--tty",
+                "--interactive",
+               s"--net=${n.name}",
+                "--name",  s"$version-G",
+                "--label", s"gem.version=$version",
+                "--label", s"gem.role=gem",
+                // "--health-cmd", if (r) "\"nc -z localhost 6666\""
+                //                 else     "nc -z localhost 6666",
+                "--publish", s"9090:9090",
+                "--publish", s"9091:9091",
+                "--env",     s"GEM_DB_URL=jdbc:postgresql://$version-P/gem",
+                iGem.hash
+              ).require { case Output(0, List(s)) => Container(s) }
+        _ <- info(s"Container name is $version-G")
+        _ <- info(s"Container hash is ${c.hash}.")
+      } yield c
+    }
+
+  def awaitHealthy(k: Container): CtlIO[Unit] =
+    containerHealth(k) >>= {
+      case "starting" => info( s"Waiting for health check.") *> shell("sleep", "2") *> awaitHealthy(k)
+      case "healthy"  => info( s"Container is healthy.")
+      case s          => error(s"Health check failed: $s") *> exit(-1)
+    }
+
+}

--- a/modules/ctl/src/main/scala/hi/Images.scala
+++ b/modules/ctl/src/main/scala/hi/Images.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl.hi
+
+import cats.implicits._
+import gem.ctl.free.ctl._
+import gem.ctl.low.docker._
+
+object Images {
+
+  private val GemRegistry: String = "sbfocsdev-lv1.cl.gemini.edu"
+  private val GemImage: String    = "gem"
+
+  private def requireImage(nameAndVersion: String): CtlIO[Image] = {
+    info(s"Looking for local image $nameAndVersion") *>
+    findImage(nameAndVersion).flatMap {
+      case None    =>
+        warn(s"Cannot find image locally. Pulling (could take a few minutes).") *> pullImage(nameAndVersion).flatMap {
+          case None    => error(s"Image was not found.") *> exit(-1)
+          case Some(i) => info(s"Image is ${i.hash}") as i
+        }
+      case Some(i) => info(s"Image is ${i.hash}") as i
+    }
+  }
+
+  def getGemImage(version: String): CtlIO[Image] =
+    gosub(s"Finding and verifying Gem image for version $version.") {
+      for {
+        i <- requireImage(s"$GemRegistry/$GemImage:$version")
+        _ <- ensureImageLabel("gem.version", version, i)
+        r <- isRemote
+        _ <- ensureImageLabel("gem.unstable", false.toString, i).whenA(r) // remote deploy must be stable
+      } yield i
+    }
+
+  def getPostgresImage(gemImage: Image): CtlIO[Image] =
+    gosub(s"Finding Postgres image specified by Gem image ${gemImage.hash}.") {
+      for {
+        n <- getImageLabel("gem.postgres", gemImage)
+        _ <- info(s"Gem image requires $n")
+        i <- requireImage(n)
+      } yield i
+    }
+
+}

--- a/modules/ctl/src/main/scala/hi/Networks.scala
+++ b/modules/ctl/src/main/scala/hi/Networks.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl.hi
+
+import cats.implicits._
+import gem.ctl.free.ctl._
+import gem.ctl.low.docker._
+
+object Networks {
+
+  private val PrivateNetwork: String  = "gem-net"
+
+  def getPrivateNetwork: CtlIO[Network] =
+    gosub(s"Verifying $PrivateNetwork network.") {
+      findNetwork(PrivateNetwork).flatMap {
+        case Some(n) => info(s"Using existing network ${n.hash}.").as(n)
+        case None    =>
+          for {
+            n <- createNetwork(PrivateNetwork)
+            _ <- info(s"Created network ${n.hash}.")
+          } yield n
+      }
+    }
+
+}

--- a/modules/ctl/src/main/scala/hi/Postgres.scala
+++ b/modules/ctl/src/main/scala/hi/Postgres.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl.hi
+
+import cats.implicits._
+import gem.ctl.free.ctl._
+import gem.ctl.low.io._
+import gem.ctl.low.docker._
+
+object Postgres {
+
+  def createDatabase(version: String, kPg: Container): CtlIO[Unit] =
+    for {
+      r <- isRemote // irritating … see below
+      b <- docker("exec", kPg.hash,
+             "psql", s"--host=$version-P",
+                     if (r) "--command='create database gem'"
+                     else   "--command=create database gem",
+                      "--username=postgres"
+           ).require {
+             case Output(0, List("CREATE DATABASE")) => true
+             case Output(2, _)                       => false
+           }
+      _ <- if (b) info("Created database.")
+           else {
+             info(s"Waiting for Postgres to start up.") *>
+             shell("sleep", "2") *>
+             createDatabase(version, kPg)
+           }
+    } yield ()
+
+  def copyData(from: Container, to: Container): CtlIO[Unit] =
+    getContainerName(from).flatMap { fromName =>
+      gosub(s"Copying data from $fromName") {
+        isRemote.flatMap { r =>
+          docker(
+            "exec", to.hash,
+            "sh", "-c", if (r) s"'pg_dump -h $fromName -U postgres gem | psql -q -U postgres -d gem'"
+                        else    s"pg_dump -h $fromName -U postgres gem | psql -q -U postgres -d gem"
+          ) require {
+            case Output(0, _) => ()
+          }
+        }
+      }
+    }
+
+}

--- a/modules/ctl/src/main/scala/hi/deploy.scala
+++ b/modules/ctl/src/main/scala/hi/deploy.scala
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl.hi
+
+import cats.implicits._
+import gem.ctl.free.ctl._
+import gem.ctl.low.docker._
+
+object Deploy {
+
+  final case class Deployment(gem: Container, postgres: Container)
+
+  private def destroyDeployment: CtlIO[Unit] =
+    gosub("Destroying current deployment, if any.") {
+      findRunningContainersWithLabel("gem.version").flatMap {
+        case Nil => info("None found, nothing to do!")
+        case cs  => cs.traverse { c =>
+          info(s"Stopping and removing ${c.hash}.") *> destroyContainer(c)
+        }.void
+      }
+    }
+
+  private def deployDatabase(version: String, iPg: Image, n: Network): CtlIO[Container] =
+    gosub("Deploying postgres.") {
+      for {
+        kDb <- Containers.createDatabaseContainer(version, iPg, n)
+        _   <- Postgres.createDatabase(version, kDb)
+        _   <- Containers.awaitHealthy(kDb)
+      } yield kDb
+    }
+
+  private def deployGem(version: String, iGem: Image, n: Network): CtlIO[Container] =
+    gosub("Deploying Gem.") {
+      for {
+        kGem <- Containers.createGemContainer(version, iGem, n)
+        // _    <- awaitHealthy(kGem)
+      } yield kGem
+    }
+
+  private def currentDeployment: CtlIO[Option[Deployment]] =
+    gosub("Finding current deployment.") {
+      findRunningContainersWithLabel("gem.version").flatMap {
+        case Nil          => info("No current deployment.").as(None)
+        case List(c1, c2) =>
+          for {
+            r1 <- getLabelValue("gem.role", c1)
+            r2 <- getLabelValue("gem.role", c2)
+            d  <- (r1, r2) match {
+              case ("gem", "db") => Deployment(c1, c2).pure[CtlIO]
+              case ("db", "gem") => Deployment(c2, c1).pure[CtlIO]
+              case p             => error(s"Unexpected 'gem.role' labels: $p") *> exit[Deployment](-1)
+            }
+            _  <- info(s"Current Gem container is ${d.gem.hash}.")
+            _  <- info(s"Current Postgres container is ${d.postgres.hash}.")
+          } yield Some(d)
+        case cs => error(s"Expected exactly zero or two containers; found ${cs.length}.") *> exit(-1)
+      }
+    }
+
+  private def verifyCompatibility(curr: Container, next: Image): CtlIO[Unit] =
+    gosub("Verifying upgrade compatibility.") {
+      for {
+        _  <- info(s"Current gem container is ${curr.hash}")
+        _  <- info(s"New gem image is ${next.hash}")
+        c  <- getLabelValue("gem.commit", curr)
+        cs <- getImageLabel("gem.history", next).map(_.split(",").toSet)
+        _  <- if (cs.contains(c)) info("They are compatible. The schema can be upgraded.")
+              else error(s"New deployment is incompatible; missing commit: $c") *> exit(-1)
+      } yield ()
+    }
+
+  private def verifyNewVersion(current: Deployment, newVersion: String): CtlIO[Unit] =
+    getLabelValue("gem.version", current.gem).flatMap {
+      case `newVersion` => info("The requested version is already deployed here. Nothing to do.") *> exit(0)
+      case _            => ().pure[CtlIO]
+    }
+
+  def deployTest(version: String): CtlIO[Deployment] =
+    for {
+      h  <- serverHostName
+      _  <- info(s"This is a test deployment on $h. Any existing deployment will be destroyed!")
+      n  <- Networks.getPrivateNetwork
+      gi <- Images.getGemImage(version)
+      pi <- Images.getPostgresImage(gi)
+      _  <- destroyDeployment
+      pk <- deployDatabase(version, pi, n)
+      gk <- deployGem(version, gi, n)
+    } yield Deployment(gk, pk)
+
+  def deployProduction(version: String): CtlIO[Deployment] =
+    for {
+      h  <- serverHostName
+      _  <- info(s"This is a production upgrade on $h.")
+      n  <- Networks.getPrivateNetwork
+      gi <- Images.getGemImage(version)
+      pi <- Images.getPostgresImage(gi)
+      od <- currentDeployment
+      d  <- od.fold(error("No current deployment. Use deploy-test to bootstrap.") *> exit[Deployment](-1))(_.pure[CtlIO])
+      _  <- verifyNewVersion(d, version)
+      _  <- verifyCompatibility(d.gem, gi)
+      pk <- deployDatabase(version, pi, n)
+      ms <- now
+      _  <- info("Stopping Gem container. Downtime starting now.") *> stopContainer(d.gem)
+      _  <- Postgres.copyData(d.postgres, pk)
+      _  <- stopContainer(d.postgres)
+      gk <- deployGem(version, gi, n)
+      dt <- now.map(_ - ms)
+      _  <- info(s"Upgrade successful. Total downtime ${dt / 1000} seconds.")
+    } yield Deployment(gk, pk)
+
+}

--- a/modules/ctl/src/main/scala/ioref.scala
+++ b/modules/ctl/src/main/scala/ioref.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+
+import cats.effect.IO
+import java.util.concurrent.atomic.AtomicReference
+
+/** A threadsafe mutable cell. Note that there is no notion of atomicity; all oprations race. */
+final class IORef[A] private (ref: AtomicReference[A]) {
+  // N.B. can't compare and swap here because
+  def mod(f: A => A): IO[Unit] = IO(ref.set(f(ref.get)))
+  def set(a: A): IO[Unit] = IO(ref.set(a))
+  def read: IO[A] = IO(ref.get)
+}
+object IORef {
+  def apply[A](a: A): IO[IORef[A]] =
+    IO(new IORef(new AtomicReference(a)))
+}

--- a/modules/ctl/src/main/scala/low/docker.scala
+++ b/modules/ctl/src/main/scala/low/docker.scala
@@ -1,0 +1,120 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+package low
+
+import gem.ctl.free.ctl._
+import io._
+
+import cats.implicits._
+
+/** Low-level constructors for `CtlIO` operations related to docker. */
+object docker {
+
+  final case class Network(hash: String, name: String)
+  final case class Image(hash: String)
+  final case class Container(hash: String)
+
+  def docker(args: String*): CtlIO[Output] =
+    isRemote.map {
+      case true  => "/usr/bin/docker"
+      case false => "/usr/local/bin/docker"
+    } .flatMap(remote(_, args : _*))
+
+  def containerHealth(k: Container): CtlIO[String] = // for now
+    isRemote.flatMap { r =>
+      docker("inspect", "-f",
+        if (r) "'{{ .State.Health.Status }}'"
+        else    "{{ .State.Health.Status }}", k.hash).require {
+        case Output(0, s :: Nil) => s
+      }
+    }
+
+  def findNetwork(name: String): CtlIO[Option[Network]] =
+    docker("network", "ls", "-q", "--filter", s"name=$name").require {
+      case Output(0, Nil)     => None
+      case Output(0, List(h)) => Some(Network(h, name))
+    }
+
+  def createNetwork(name: String): CtlIO[Network] =
+    docker("network", "create", name).require {
+      case Output(0, List(h)) => Network(h, name)
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.TraversableOps")) // .last below
+  def pullImage(nameAndVersion: String): CtlIO[Option[Image]] =
+    docker("pull", nameAndVersion).require {
+      case Output(0, s :: ss) if (s :: ss).last.contains("not found") => None
+      case Output(0, _) => Some(nameAndVersion)
+    } .flatMap {
+      case None                 => none[Image].pure[CtlIO]
+      case Some(nameAndVersion) => findImage(nameAndVersion)
+    }
+
+  def findImage(nameAndVersion: String): CtlIO[Option[Image]] =
+    docker("images", "-q", nameAndVersion).require {
+      case Output(0, Nil)     => None
+      case Output(0, List(h)) => Some(Image(h))
+    }
+
+  // find *running* containers
+  def findRunningContainersWithLabel(label: String): CtlIO[List[Container]] =
+    docker("ps", "-q", "--filter", s"label=$label").require {
+      case Output(0, hs) => hs.map(Container)
+    }
+
+  def allContainerNames: CtlIO[List[String]] =
+    docker("ps", "-a", "--format", "{{.Names}}").require {
+      case Output(_, ss) => ss
+    }
+
+  def getLabelValue(label: String, k: Container): CtlIO[String] =
+    getLabel(label, k.hash)
+
+  def getImageLabel(label: String, img: Image): CtlIO[String] =
+    getLabel(label, img.hash)
+
+  private def getLabel(label: String, obj: String): CtlIO[String] =
+    isRemote.flatMap { r =>
+      docker("inspect", "--format",
+        if (r) s"""'{{ index .Config.Labels "$label"}}'"""
+        else    s"""{{ index .Config.Labels "$label"}}""", obj).require {
+          case Output(0, s :: Nil) if s.nonEmpty => s
+        }
+    }
+
+  def ensureImageLabel(label: String, expected: String, img: Image): CtlIO[Unit] =
+    getLabel(label, img.hash).flatMap {
+      case `expected` => info(s"$label is $expected (as expected)")
+      case s          => error(s"$label was $s (expected $expected)") *> exit(-1)
+    }
+
+  def stopContainer(k: Container): CtlIO[Unit] =
+    docker("stop", k.hash) require {
+      case Output(0, s :: Nil) if s === k.hash => ()
+    }
+
+  def removeContainer(k: Container): CtlIO[Unit] =
+    docker("rm", k.hash) require {
+      case Output(0, s :: Nil) if s === k.hash => ()
+    }
+
+  def destroyContainer(k: Container): CtlIO[Unit] =
+    stopContainer(k) *> removeContainer(k)
+
+  def startContainer(k: Container): CtlIO[Unit] =
+    docker("start", k.hash) require {
+      case Output(0, s :: Nil) if s === k.hash => ()
+    }
+
+  def getContainerName(k: Container): CtlIO[String] =
+    isRemote.flatMap { r =>
+      docker("inspect", "--format",
+        if (r) "'{{ .Name }}'"
+        else    "{{ .Name }}", k.hash) require {
+        case Output(0, s :: Nil) if (s.startsWith("/")) => s.drop(1)
+      }
+    }
+
+}

--- a/modules/ctl/src/main/scala/low/git.scala
+++ b/modules/ctl/src/main/scala/low/git.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+package low
+
+import cats._, cats.implicits._
+import scala.util.matching.Regex
+
+import gem.ctl.free.ctl._
+import io._
+
+/** Low-level constructors for `CtlIO` operations related to git. */
+object git {
+
+  final case class Commit(hash: String)
+  object Commit {
+    implicit val OrderCommit: Order[Commit] = Order.by(_.hash)
+  }
+
+  final case class Tag(tag: String)
+
+  // Yields most recent tag matching the given pattern, if any
+  def mostRecentTag(pattern: Regex): CtlIO[Option[Tag]] =
+    shell("git", "tag").require {
+      case Output(0, ts) => ts.find(s => pattern.findFirstIn(s).isDefined).map(Tag)
+    }
+
+  // Yields the commit associated with the given revision, or fails with a nice message
+  def commitForRevision(rev: String): CtlIO[Commit] =
+    shell("git", "rev-parse", rev).require {
+      case Output(0, List(s)) => Some(Commit(s))
+      case Output(128, _)     => None
+    } .flatMap {
+      case Some(c) => c.pure[CtlIO]
+      case None    => error(s"No such revsion: $rev") *> exit[Commit](128)
+    }
+
+  val uncommittedChanges: CtlIO[Boolean] =
+    shell("git", "status", "-s").require {
+      case Output(0, deltas) => deltas.nonEmpty
+    }
+
+  // is c1 an ancestor of c2?
+  def isAncestor(c1: Commit, c2: Commit): CtlIO[Boolean] =
+    shell("git", "merge-base", "--is-ancestor", c1.hash, c2.hash).require {
+      case Output(0, Nil) => true
+      case Output(1, Nil) => false
+    }
+
+  def fileContentsAtCommit(c: Commit, path: String): CtlIO[List[String]] =
+    shell("git", "show", s"${c.hash}:$path").require {
+      case Output(0, ss) => ss
+    }
+
+  def fileContents(path: String): CtlIO[List[String]] =
+    shell("cat", path).require {
+      case Output(0, ss) => ss
+    }
+
+}

--- a/modules/ctl/src/main/scala/low/io.scala
+++ b/modules/ctl/src/main/scala/low/io.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+package low
+
+import cats.effect.IO
+
+/** Low-level constructors for `CtlIO` operations related to system I/O. */
+object io {
+
+  final case class Output(exitCode: Int, lines: List[String])
+
+  @SuppressWarnings(Array("org.wartremover.warts.MutableDataStructures"))
+  def exec(cmd: Either[String, List[String]], f: String => IO[Unit]): IO[Output] =
+    IO {
+      import scala.sys.process._
+      import collection.mutable.ListBuffer
+      val b = ListBuffer[String]()
+      val x = cmd.fold(_.cat, _.cat).run(ProcessLogger { s =>
+        f(s).unsafeRunSync // shh
+        b.append(s) // side-effect
+      }).exitValue
+      Output(x, b.toList)
+    }
+
+}

--- a/modules/ctl/src/main/scala/main.scala
+++ b/modules/ctl/src/main/scala/main.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ctl
+
+import cats.implicits._
+import cats.effect._
+
+import gem.ctl.free.interpreter.{ interpreter, InterpreterState }
+
+object main {
+
+  /** Entry point. Parse the commandline args and do what's asked, if possible. */
+  def mainʹ(args: List[String]): IO[Int] =
+    for {
+      _  <- IO(Console.println) // scalastyle:ignore
+      c  <- Parsers.parse("gemctl", args)
+      n  <- c.traverse { case (config, impl) =>
+              IORef(InterpreterState.initial)
+                .map(interpreter(config, _))
+                .flatMap(impl.foldMap(_).value)
+            }
+      _  <- IO(Console.println) // scalastyle:ignore
+    } yield n.fold(0)(_.fold(identity, _ => 0))
+
+  def main(args: Array[String]): Unit =
+    sys.exit(mainʹ(args.toList).unsafeRunSync)
+
+}

--- a/modules/db/src/main/scala/gem/Log.scala
+++ b/modules/db/src/main/scala/gem/Log.scala
@@ -1,0 +1,90 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.implicits._, cats.effect._
+import doobie._, doobie.implicits._
+import gem.dao.LogDao
+import java.util.concurrent.{ ExecutorService, Executors, TimeUnit }
+import java.util.logging._
+
+/** Logger that logs to the database and a JDK logger, on its own thread, in effect type M. */
+abstract class Log[M[_]] private (name: String, xa: Transactor[IO]) {
+  implicit val M: Sync[M]
+
+  val jdkLogger: Logger =
+    Logger.getLogger(name)
+
+  private val es: ExecutorService =
+    Executors.newSingleThreadExecutor()
+
+  private implicit class LogTaskOps(t: IO[_]) {
+    def detach: M[Unit] =
+      M.delay {
+        es.execute { () =>
+          t.unsafeRunAsync {
+            case Left(e) => jdkLogger.log(Level.SEVERE, "Database logging failed.", e)
+            case Right(_) => ()
+          }
+        }
+      }
+  }
+
+  private def now: M[Long] =
+    M.delay(System.currentTimeMillis)
+
+  private def fail[A](user: User[_], msg: => String, elapsed: Long, t: Throwable): M[A] =
+    (LogDao.insert(user, Level.SEVERE, none, msg, Some(t), Some(elapsed)).transact(xa) *>
+     IO(jdkLogger.log(Level.SEVERE, s"${user.id}: $msg ($elapsed ms)", t))).detach   *>
+    M.raiseError[A](t)
+
+  private def success[A](user: User[_], msg: => String, elapsed: Long, a: A): M[A] =
+    (LogDao.insert(user, Level.INFO, none, msg, None, Some(elapsed)).transact(xa) *>
+     IO(jdkLogger.log(Level.INFO, s"${user.id}: $msg ($elapsed ms)"))).detach.as(a)
+
+  /**
+   * Construct a new program in `M` that is equivalent to `ma` but also logs a message, elapsed
+   * time and (in case of failure) a stacktrace to the database and to a JDK logger. Logging is
+   * asynchronous so messages may not appear immediately.
+   */
+  def log[A](user: User[_], msg: => String)(ma: M[A]): M[A] =
+    for {
+      start   <- now
+      disj    <- ma.attempt
+      elapsed <- now.map(_ - start)
+      a       <- disj.fold(t => fail(user, msg, elapsed, t), a => success(user, msg, elapsed, a))
+    } yield a
+
+  /**
+   * Constructs a new program in `M` that simply writes a message without an
+   * associated timed action.  Roughly equivalent to `log(user, msg)(().pure[M])`
+   * but guaranteed to record 0 elapsed time.
+   */
+  def logMessage(user: User[_], msg: => String): M[Unit] =
+    success(user, msg, 0, ())
+
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  def shutdown(ms: Long): M[Unit] =
+    M.delay {
+      jdkLogger.info("Log shutdown requested.")
+      es.shutdown
+      es.awaitTermination(ms, TimeUnit.MILLISECONDS)
+      jdkLogger.info("Log shutdown complete.")
+    }
+
+}
+
+object Log {
+
+  /** Program in M to construct a Log, also in M. */
+  def newLog[M[_]: Sync](name: String, xa: Transactor[IO]): M[Log[M]] =
+    newLogIn[M, M](name, xa)
+
+  /** Program in F to construct a Log in M. */
+  def newLogIn[M[_]: Sync, F[_]: Sync](name: String, xa: Transactor[IO]): F[Log[M]] =
+    Sync[F].delay(new Log[M](name, xa) {
+      val M: Sync[M] = Sync[M]
+    })
+
+}

--- a/modules/db/src/main/scala/gem/dao/AsterismDao.scala
+++ b/modules/db/src/main/scala/gem/dao/AsterismDao.scala
@@ -1,0 +1,190 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+
+import gem.dao.meta._
+import gem.enum.{ AsterismType, Instrument }
+import gem.math.Index
+import gem.instances.treemap._
+import gem.syntax.treemap._
+import scala.collection.immutable.{ TreeMap }
+
+object AsterismDao {
+
+  def insert(oid: Observation.Id, a: Asterism): ConnectionIO[Unit] =
+    a match {
+      case a: Asterism.SingleTarget    => insertSingleTarget(oid, a)
+      case a: Asterism.GhostDualTarget => insertDualTarget(oid, a)
+    }
+
+  /** Select the asterism for the given observation, if any, otherwise return the Instrument, which
+    * is necessary knowledge when constructing a TargetEnvironment with an empty asterism. An
+    * exception is raised if the specified observation does not exist.
+    */
+  def select(oid: Observation.Id): ConnectionIO[Either[Asterism, Instrument]] =
+    Statements.select(oid).unique.flatMap(promote)
+
+  /** Analogous to `select` but selects all observations in the specified program, if any, yielding
+    * a map from `Index` to `Asterism`, or `Instrument` when there is no asterism.
+    */
+  def selectAll(pid: Program.Id): ConnectionIO[TreeMap[Index, Either[Asterism, Instrument]]] =
+    Statements.selectAll(pid).to[List].flatMap { pairs =>
+      TreeMap.fromList(pairs).traverse(promote)
+    }
+
+  private def insertSingleTarget(oid: Observation.Id, a: Asterism.SingleTarget): ConnectionIO[Unit] =
+    for {
+      t <- TargetDao.insert(a.target)
+      _ <- Statements.insertSingleTarget(oid, t, Instrument.forAsterism(a)).run.void
+    } yield ()
+
+  private def insertDualTarget(oid: Observation.Id, a: Asterism.GhostDualTarget): ConnectionIO[Unit] =
+    for {
+      t0 <- TargetDao.insert(a.ifu1)
+      t1 <- TargetDao.insert(a.ifu2)
+      _  <- Statements.insertGhostDualTarget(oid, t0, t1).run.void
+    } yield ()
+
+  private def toSingleTargetAsterism(t: Target, i: Instrument): Option[Asterism] =
+    i match {
+      case Instrument.Phoenix    => Some(Asterism.Phoenix(t))
+      case Instrument.Michelle   => Some(Asterism.Michelle(t))
+      case Instrument.Gnirs      => Some(Asterism.Gnirs(t))
+      case Instrument.Niri       => Some(Asterism.Niri(t))
+      case Instrument.Trecs      => Some(Asterism.Trecs(t))
+      case Instrument.Nici       => Some(Asterism.Nici(t))
+      case Instrument.Nifs       => Some(Asterism.Nifs(t))
+      case Instrument.Gpi        => Some(Asterism.Gpi(t))
+      case Instrument.Gsaoi      => Some(Asterism.Gsaoi(t))
+      case Instrument.GmosS      => Some(Asterism.GmosS(t))
+      case Instrument.AcqCam     => Some(Asterism.AcqCam(t))
+      case Instrument.GmosN      => Some(Asterism.GmosN(t))
+      case Instrument.Bhros      => Some(Asterism.Bhros(t))
+      case Instrument.Visitor    => Some(Asterism.Visitor(t))
+      case Instrument.Flamingos2 => Some(Asterism.Flamingos2(t))
+      case Instrument.Ghost      => None
+    }
+
+  private def unsafeToSingleTargetAsterism(t: Target, i: Instrument): Asterism =
+    toSingleTargetAsterism(t, i).getOrElse(sys.error(s"No single-target asterism available for $i"))
+
+  // Promote a selected row in terms of ids into one in terms of asterisms
+  private def promote(
+    row: (Instrument, Option[Either[Target.Id, (Target.Id, Target.Id)]])
+  ): ConnectionIO[Either[Asterism, Instrument]] =
+    row match {
+
+      // No asterism, return the instrument instead
+      case (i, None) =>
+        i.asRight[Asterism].pure[ConnectionIO]
+
+      // Single target, ok for any instrument other than GHOST for now (checked in unsafeToSingleTargetAsterism)
+      case (i, Some(Left(tid))) =>
+        TargetDao.selectUnique(tid).map(unsafeToSingleTargetAsterism(_, i).asLeft[Instrument])
+
+      // Dual target, ok only for GHOST
+      case (Instrument.Ghost, Some(Right((tid1, tid2)))) =>
+        (TargetDao.selectUnique(tid1), TargetDao.selectUnique(tid2)).mapN { (t1, t2) =>
+          Asterism.GhostDualTarget(t1, t2).asLeft[Instrument]
+        }
+
+      // Inconsistent
+      case x => sys.error(s"Inconsistent asterism result: $x")
+
+    }
+
+  object Statements {
+
+    import AsterismTypeMeta._
+    import EnumeratedMeta._
+    import ProgramIdMeta._
+    import IndexMeta._
+
+    def insertSingleTarget(oid: Observation.Id, t: Target.Id, i: Instrument): Update0 =
+      sql"""
+        INSERT INTO single_target_asterism (
+                      program_id,
+                      observation_index,
+                      instrument,
+                      asterism_type,
+                      target_id)
+              VALUES (
+                      ${oid.pid},
+                      ${oid.index},
+                      $i,
+                      ${AsterismType.SingleTarget: AsterismType},
+                      $t
+                    )
+      """.update
+
+    def insertGhostDualTarget(oid: Observation.Id, t0: Target.Id, t1: Target.Id): Update0 =
+      sql"""
+        INSERT INTO ghost_dual_target_asterism (
+                      program_id,
+                      observation_index,
+                      instrument,
+                      asterism_type,
+                      target1_id,
+                      target2_id)
+              VALUES (
+                      ${oid.pid},
+                      ${oid.index},
+                      ${Instrument.Ghost: Instrument},
+                      ${AsterismType.GhostDualTarget: AsterismType},
+                      $t0,
+                      $t1
+                    )
+      """.update
+
+    def select(oid: Observation.Id): Query0[(Instrument, Option[Either[Target.Id, (Target.Id, Target.Id)]])] =
+      sql"""
+         SELECT o.instrument,
+                o.asterism_type,
+                sta.target_id,
+                gdta.target1_id,
+                gdta.target2_id
+           FROM observation o
+      LEFT JOIN single_target_asterism sta
+             ON sta.program_id = o.program_id AND sta.observation_index = o.observation_index
+      LEFT JOIN ghost_dual_target_asterism gdta
+             ON gdta.program_id = o.program_id AND gdta.observation_index = o.observation_index
+          WHERE o.program_id = ${oid.pid}
+            AND o.observation_index = ${oid.index}
+      """.query[(Instrument, Option[AsterismType], Option[Target.Id], Option[Target.Id], Option[Target.Id])].map {
+        case (i, None, None, None, None)                                    => (i, None)
+        case (i, Some(AsterismType.SingleTarget), Some(t), None, None)      => (i, Some(t.asLeft))
+        case (i, Some(AsterismType.SingleTarget), None, Some(t1), Some(t2)) => (i, Some((t1, t2).asRight))
+        case x => sys.error(s"Inconsistent asterism result: $x")
+      }
+
+
+    def selectAll(pid: Program.Id): Query0[(Index, (Instrument, Option[Either[Target.Id, (Target.Id, Target.Id)]]))] =
+      sql"""
+         SELECT o.observation_index,
+                o.instrument,
+                o.asterism_type,
+                sta.target_id,
+                gdta.target1_id,
+                gdta.target2_id
+           FROM observation o
+      LEFT JOIN single_target_asterism sta
+             ON sta.program_id = o.program_id AND sta.observation_index = o.observation_index
+      LEFT JOIN ghost_dual_target_asterism gdta
+             ON gdta.program_id = o.program_id AND gdta.observation_index = o.observation_index
+          WHERE o.program_id = ${pid}
+      """.query[(Index, (Instrument, Option[AsterismType], Option[Target.Id], Option[Target.Id], Option[Target.Id]))].map {
+        case (n, (i, None, None, None, None) )                                   => (n, (i, None))
+        case (n, (i, Some(AsterismType.SingleTarget), Some(t), None, None))      => (n, (i, Some(t.asLeft)))
+        case (n, (i, Some(AsterismType.SingleTarget), None, Some(t1), Some(t2))) => (n, (i, Some((t1, t2).asRight)))
+        case x => sys.error(s"Inconsistent asterism result: $x")
+      }
+
+  }
+}

--- a/modules/db/src/main/scala/gem/dao/DatabaseConfiguration.scala
+++ b/modules/db/src/main/scala/gem/dao/DatabaseConfiguration.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.effect.Async
+import doobie._
+
+/** Configuration for a database connection. */
+final case class DatabaseConfiguration(
+  driver:     String,
+  connectUrl: String,
+  userName:   String,
+  password:   String
+) {
+
+  /** A transactor in F using the connection values provided by this configuration. */
+  def transactor[F[_]: Async]: Transactor[F] =
+    Transactor.fromDriverManager[F](driver, connectUrl, userName, password)
+
+}
+
+object DatabaseConfiguration {
+
+  /** A configuration for local testing. */
+  val forTesting: DatabaseConfiguration =
+    apply("org.postgresql.Driver", "jdbc:postgresql:gem", "postgres", "")
+
+}

--- a/modules/db/src/main/scala/gem/dao/DatasetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/DatasetDao.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.syntax.functor._
+import doobie._, doobie.implicits._
+import gem.{ Dataset, Observation }
+import gem.dao.meta._
+
+object DatasetDao {
+  import DatasetLabelMeta._
+  import ObservationIdMeta._
+
+  /**
+   * Construct a program to insert the given a `Dataset`, associating it with the given step
+   * (identified by its internal unique serial number). This program will raise a key violation
+   * if the dataset label already exists in the database.
+   */
+  def insert(stepId: Int, d: Dataset): ConnectionIO[Unit] =
+    Statements.insert(stepId, d).run.void
+
+  /** Select all datasets (if any) for the specified observation, ordered by index. */
+  def selectAll(oid: Observation.Id): ConnectionIO[List[Dataset]] =
+    Statements.selectAll(oid).to[List]
+
+  object Statements {
+
+    // StepId has a DISTINCT type due to its check constraint so we need a fine-grained mapping
+    // here to satisfy the query checker.
+    private final case class StepId(toInt: Int)
+    private object StepId {
+      implicit val StepIdMeta: Meta[StepId] =
+        Distinct.integer("id_index").xmap(StepId(_), _.toInt)
+    }
+
+    // This uses the internal unique serial number for steps, which is a code smell.
+    def insert(stepId: Int, d: Dataset): Update0 =
+      sql"""
+        INSERT INTO dataset (dataset_label,
+                             observation_id,
+                             dataset_index,
+                             step_id,
+                             filename,
+                             timestamp)
+            VALUES (${d.label},
+                    ${d.label.observationId},
+                    ${StepId(d.label.index)},
+                    ${stepId},
+                    ${d.filename},
+                    ${d.timestamp})
+      """.update
+
+    def selectAll(oid: Observation.Id): Query0[Dataset] =
+      sql"""
+        SELECT dataset_label, filename, timestamp
+          FROM dataset
+         WHERE observation_id = ${oid}
+      ORDER BY dataset_index
+      """.query[Dataset]
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EphemerisDao.scala
@@ -1,0 +1,230 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.dao.composite._
+import gem.dao.meta._
+import gem.enum.Site
+import gem.math._
+import gem.util.Timestamp
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+import fs2.{ Sink, Stream }
+
+object EphemerisDao {
+  import CoordinatesComposite._
+  import EnumeratedMeta._
+  import EphemerisKeyComposite._
+  import OffsetMeta._
+  import TimeMeta._
+
+  private def toRow(k: EphemerisKey, s: Site, i: Timestamp, c: EphemerisCoordinates): Statements.EphemerisRow =
+    (k,
+     s,
+     i,
+     c.coord,
+     RightAscension.fromStringHMS.reverseGet(c.coord.ra),
+     Declination.fromStringSignedDMS.reverseGet(c.coord.dec),
+     c.delta
+    )
+
+  def insert(k: EphemerisKey, s: Site, e: Ephemeris): ConnectionIO[Int] =
+    Statements.insert.updateMany(
+      e.toMap.toList.map { case (i, c) => toRow(k, s, i, c) }
+    )
+
+  def streamInsert(k: EphemerisKey, s: Site): Sink[ConnectionIO, Ephemeris.Element] =
+    _.map { case (i, c) => toRow(k, s, i, c) } // Stream[M, EphemerisRow]
+     .segmentN(4096)                           // Stream[M, Segment[EphemerisRow, Unit]]
+     .flatMap { rows =>
+       Stream.eval(Statements.insert.updateMany(rows.force.toVector).void)
+     }
+
+  def delete(k: EphemerisKey, s: Site): ConnectionIO[Int] =
+    Statements.delete(k, s).run
+
+  def update(k: EphemerisKey, s: Site, e: Ephemeris): ConnectionIO[Unit] =
+    (delete(k, s) *> insert(k, s, e)).void
+
+  def streamUpdate(k: EphemerisKey, s: Site): Sink[ConnectionIO, Ephemeris.Element] =
+    elems => streamInsert(k, s).apply(Stream.eval_(delete(k, s)) ++ elems)
+
+  /** Selects all ephemeris elements associated with the given key and site into
+    * an Ephemeris object.
+    */
+  def selectAll(k: EphemerisKey, s: Site): ConnectionIO[Ephemeris] =
+    runSelect(Statements.select(k, s))
+
+  /** Selects all ephemeris elements that fall between start and end (inclusive)
+    * into an Ephemeris object.
+    *
+    * @param k     ephemeris key to match
+    * @param s     site to match
+    * @param start start time (inclusive)
+    * @param end   end time (inclusive)
+    *
+    * @return Ephemeris object with just the matching elements
+    */
+  def selectRange(k: EphemerisKey, s: Site, start: Timestamp, end: Timestamp): ConnectionIO[Ephemeris] =
+    runSelect(Statements.selectRange(k, s, start, end))
+
+  private def runSelect(q: Query0[Ephemeris.Element]): ConnectionIO[Ephemeris] =
+    q.to[List].map(Ephemeris.fromFoldable[List])
+
+  def streamAll(k: EphemerisKey, s: Site): Stream[ConnectionIO, Ephemeris.Element] =
+    Statements.select(k, s).stream
+
+  def streamRange(k: EphemerisKey, s: Site, start: Timestamp, end: Timestamp): Stream[ConnectionIO, Ephemeris.Element] =
+    Statements.selectRange(k, s, start, end).stream
+
+  /** Selects the time just before (or at) start and just after (or at) end for
+    * which ephemeris elements are defined for the given key and site.
+    */
+  def bracketRange(k: EphemerisKey, s: Site, start: Timestamp, end: Timestamp): ConnectionIO[(Timestamp, Timestamp)] =
+    for {
+      startʹ <- Statements.selectTimeLE(k, s, start).unique
+      endʹ   <- Statements.selectTimeGE(k, s, end  ).unique
+    } yield (startʹ.getOrElse(start), endʹ.getOrElse(end))
+
+  /** Selects the min and max times for which an ephemeris is available, if any.
+    */
+  def selectTimes(k: EphemerisKey, s: Site): ConnectionIO[Option[(Timestamp, Timestamp)]] =
+    Statements.selectTimes(k, s).unique
+
+  /** Create the next UserSupplied ephemeris key value. */
+  val nextUserSuppliedKey: ConnectionIO[EphemerisKey.UserSupplied] =
+    Statements.selectNextUserSuppliedKey.unique
+
+  def insertMeta(k: EphemerisKey, s: Site, m: EphemerisMeta): ConnectionIO[Int] =
+    Statements.insertMeta(k, s, m).run
+
+  def updateMeta(k: EphemerisKey, s: Site, m: EphemerisMeta): ConnectionIO[Int] =
+    Statements.updateMeta(k, s, m).run
+
+  def deleteMeta(k: EphemerisKey, s: Site): ConnectionIO[Int] =
+    Statements.deleteMeta(k, s).run
+
+  def selectMeta(k: EphemerisKey, s: Site): ConnectionIO[Option[EphemerisMeta]] =
+    Statements.selectMeta(k, s).option
+
+  def selectKeys(s: Site): ConnectionIO[Set[EphemerisKey]] =
+    Statements.selectKeys(s).to[Set]
+
+  object Statements {
+
+    type EphemerisRow = (EphemerisKey, Site, Timestamp, Coordinates, String, String, Offset)
+
+    val insert: Update[EphemerisRow] =
+      Update[EphemerisRow](
+        s"""
+          INSERT INTO ephemeris (key_type,
+                                 key,
+                                 site,
+                                 timestamp,
+                                 ra,
+                                 dec,
+                                 ra_str,
+                                 dec_str,
+                                 delta_ra,
+                                 delta_dec)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """)
+
+    def delete(k: EphemerisKey, s: Site): Update0 =
+      sql"""
+        DELETE FROM ephemeris
+              WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s
+      """.update
+
+    private def selectFragment(k: EphemerisKey, s: Site): Fragment =
+      fr"""
+         SELECT timestamp,
+                ra,
+                dec,
+                delta_ra,
+                delta_dec
+           FROM ephemeris
+          WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s
+      """
+
+    def select(k: EphemerisKey, s: Site): Query0[Ephemeris.Element] =
+      selectFragment(k, s).query[Ephemeris.Element]
+
+    def selectRange(k: EphemerisKey, s: Site, start: Timestamp, end: Timestamp): Query0[Ephemeris.Element] =
+      (selectFragment(k, s) ++ fr"""AND timestamp >= $start AND timestamp <= $end""")
+        .query[Ephemeris.Element]
+
+    def selectTimeLE(k: EphemerisKey, s: Site, start: Timestamp): Query0[Option[Timestamp]] =
+      sql"""
+        SELECT max(timestamp)
+          FROM ephemeris
+         WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s AND timestamp <= $start
+      """.query[Option[Timestamp]]
+
+    def selectTimeGE(k: EphemerisKey, s: Site, end: Timestamp): Query0[Option[Timestamp]] =
+      sql"""
+        SELECT min(timestamp)
+          FROM ephemeris
+         WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s AND timestamp >= $end
+      """.query[Option[Timestamp]]
+
+    def selectTimes(k: EphemerisKey, s: Site): Query0[Option[(Timestamp, Timestamp)]] =
+      sql"""
+          SELECT min(timestamp),
+                 max(timestamp)
+            FROM ephemeris
+           WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s
+      """.query[Option[(Timestamp, Timestamp)]]
+
+    val selectNextUserSuppliedKey: Query0[EphemerisKey.UserSupplied] =
+      sql"""
+        SELECT nextval('user_ephemeris_id')
+      """.query[Long].map(id => EphemerisKey.UserSupplied(id.toInt))
+
+    def insertMeta(k: EphemerisKey, s: Site, m: EphemerisMeta): Update0 =
+      (fr"""
+        INSERT INTO ephemeris_meta (
+            key_type,
+            key,
+            site,
+            last_update,
+            last_update_check,
+            horizons_soln_ref
+        ) VALUES""" ++ values((k, s, m))).update
+
+    def updateMeta(k: EphemerisKey, s: Site, m: EphemerisMeta): Update0 =
+      (fr"""
+        UPDATE ephemeris_meta
+           SET (last_update,
+                last_update_check,
+                horizons_soln_ref
+        ) =""" ++ values(m) ++
+      fr"WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s").update
+
+    def deleteMeta(k: EphemerisKey, s: Site): Update0 =
+      sql"""
+         DELETE FROM ephemeris_meta
+               WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s
+       """.update
+
+    def selectMeta(k: EphemerisKey, s: Site): Query0[EphemerisMeta] =
+      sql"""
+        SELECT last_update,
+               last_update_check,
+               horizons_soln_ref
+          FROM ephemeris_meta
+         WHERE key_type = ${k.keyType} AND key = ${k.des} AND site = $s
+      """.query[EphemerisMeta]
+
+    def selectKeys(s: Site): Query0[EphemerisKey] =
+      sql"""
+        SELECT key_type,
+               key
+          FROM ephemeris_meta
+         WHERE site = ${s}
+      """.query[EphemerisKey]
+  }
+}

--- a/modules/db/src/main/scala/gem/dao/EventLogDao.scala
+++ b/modules/db/src/main/scala/gem/dao/EventLogDao.scala
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import doobie._, doobie.implicits._
+import gem.{Event, Observation}
+import gem.dao.meta._
+import gem.Event._
+import gem.enum.EventType
+import gem.enum.EventType.{Abort, Continue, EndIntegration, EndSequence, EndSlew, EndVisit, Pause, StartIntegration, StartSequence, StartSlew, StartVisit, Stop}
+import java.time.Instant
+
+
+object EventLogDao {
+  import EnumeratedMeta._
+  import ObservationIdMeta._
+
+  def insertAbortObserve(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(Abort, oid, None).run
+
+  def insertContinue(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(Continue, oid, None).run
+
+  def insertEndIntegration(oid: Observation.Id, step: Int): ConnectionIO[Int] =
+    Statements.insertEvent(EndIntegration, oid, Some(step)).run
+
+  def insertEndSequence(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(EndSequence, oid, None).run
+
+  def insertEndSlew(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(EndSlew, oid, None).run
+
+  def insertEndVisit(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(EndVisit, oid, None).run
+
+  def insertPauseObserve(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(Pause, oid, None).run
+
+  def insertStartIntegration(oid: Observation.Id, step: Int): ConnectionIO[Int] =
+    Statements.insertEvent(StartIntegration, oid, Some(step)).run
+
+  def insertStartSequence(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(StartSequence, oid, None).run
+
+  def insertStartSlew(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(StartSlew, oid, None).run
+
+  def insertStartVisit(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(StartVisit, oid, None).run
+
+  def insertStop(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.insertEvent(Stop, oid, None).run
+
+  def selectAll(start: Instant, end: Instant): ConnectionIO[List[Event]] =
+    Statements.selectAll(start, end).to[List]
+
+  object Statements {
+
+    def insertEvent(t: EventType, oid: Observation.Id, step: Option[Int]): Update0 =
+      sql"""
+        INSERT INTO log_observe_event (event, observation_id, step)
+             VALUES ($t :: evt_type,
+                     $oid,
+                     $step)
+      """.update
+
+    def selectAll(start: Instant, end: Instant): Query0[Event] =
+      sql"""
+        SELECT timestamp,
+               event :: evt_type,
+               observation_id,
+               step
+          FROM log_observe_event
+         WHERE timestamp BETWEEN $start AND $end
+      ORDER BY timestamp
+      """.query[(Instant, EventType, Observation.Id, Option[Int])].map {
+        case (t, Abort,            s, None   ) => abortObserve(t, s)
+        case (t, Continue,         s, None   ) => continueObserve(t, s)
+        case (t, EndIntegration,   s, Some(i)) => endIntegration(t, s, i)
+        case (t, EndSequence,      s, None   ) => endSequence(t, s)
+        case (t, EndSlew,          s, None   ) => endSlew(t, s)
+        case (t, EndVisit,         s, None   ) => endVisit(t, s)
+        case (t, Pause,            s, None   ) => pauseObserve(t, s)
+        case (t, StartIntegration, s, Some(i)) => startIntegration(t, s, i)
+        case (t, StartSequence,    s, None   ) => startSequence(t, s)
+        case (t, StartSlew,        s, None   ) => startSlew(t, s)
+        case (t, StartVisit,       s, None   ) => startVisit(t, s)
+        case (t, Stop,             s, None   ) => stopObserve(t, s)
+        case (t, e,                s, step   ) =>
+          sys.error(s"Unexpected row in log_observe_event: ($t, $e, $s, $step)")
+      }
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/GcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GcalDao.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.implicits._
+import gem.CoAdds
+import gem.config.GcalConfig
+import gem.config.GcalConfig.GcalLamp
+import doobie._, doobie.implicits._
+import gem.dao.meta._
+import gem.enum.{GcalArc, GcalContinuum, GcalDiffuser, GcalFilter, GcalShutter}
+import gem.enum.GcalArc.{ArArc, CuArArc, ThArArc, XeArc}
+import java.time.Duration
+
+/** DAO support for inserting `GcalConfig` in either step_gcal or
+  * gcal (for smart gcal lookup).
+  */
+object GcalDao {
+  import CoAddsMeta._
+  import EnumeratedMeta._
+  import TimeMeta._
+
+  def insertStepGcal(stepId: Int, gcal: GcalConfig): ConnectionIO[Int] =
+    Statements.insertStepGcal(stepId, gcal).run
+
+  def bulkInsertSmartGcal(gs: Vector[GcalConfig]): fs2.Stream[ConnectionIO, Int] =
+    Statements.bulkInsertSmartGcal.updateManyWithGeneratedKeys[Int]("gcal_id")(gs.map(Statements.GcalRow.fromGcalConfig))
+
+  def selectStepGcal(stepId: Int): ConnectionIO[Option[GcalConfig]] =
+    Statements.selectStepGcal(stepId).option.map(_.flatten)
+
+  def selectSmartGcal(gcalId: Int): ConnectionIO[Option[GcalConfig]] =
+    Statements.selectSmartGcal(gcalId).option.map(_.flatten)
+
+  object Statements {
+
+    final case class GcalRow(
+      continuum:    Option[GcalContinuum],
+      ar:           Boolean,
+      cuar:         Boolean,
+      thar:         Boolean,
+      xe:           Boolean,
+      filter:       GcalFilter,
+      diffuser:     GcalDiffuser,
+      shutter:      GcalShutter,
+      exposureTime: Duration,
+      coadds:       CoAdds)
+    {
+      def toGcalConfig: Option[GcalConfig] =
+        GcalLamp.fromConfig(continuum, ArArc -> ar, CuArArc -> cuar, ThArArc -> thar, XeArc -> xe).map { lamp =>
+          GcalConfig(lamp, filter, diffuser, shutter, exposureTime, coadds)
+        }
+    }
+
+    object GcalRow {
+      def fromGcalConfig(c: GcalConfig): GcalRow = {
+        val arcs: GcalArc => Boolean =
+          c.arcs
+
+        GcalRow(c.continuum, arcs(ArArc), arcs(CuArArc), arcs(ThArArc), arcs(XeArc), c.filter, c.diffuser, c.shutter, c.exposureTime, c.coadds)
+      }
+    }
+
+    val bulkInsertSmartGcal: Update[GcalRow] = {
+      val sql =
+        """
+          INSERT INTO gcal (continuum,
+                            ar_arc,
+                            cuar_arc,
+                            thar_arc,
+                            xe_arc,
+                            filter,
+                            diffuser,
+                            shutter,
+                            exposure_time,
+                            coadds)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+      Update[GcalRow](sql)
+    }
+
+    def insertStepGcal(stepId: Int, gcal: GcalConfig): Update0 = {
+      val arcs: GcalArc => Boolean = gcal.arcs
+      sql"""INSERT INTO step_gcal (step_gcal_id, continuum, ar_arc, cuar_arc, thar_arc, xe_arc, filter, diffuser, shutter, exposure_time, coadds)
+            VALUES ($stepId, ${gcal.continuum}, ${arcs(ArArc)}, ${arcs(CuArArc)}, ${arcs(ThArArc)}, ${arcs(XeArc)}, ${gcal.filter}, ${gcal.diffuser}, ${gcal.shutter}, ${gcal.exposureTime}, ${gcal.coadds})
+         """.update
+    }
+
+    private def selectFragment(table: String): Fragment =
+      Fragment.const(
+        s"""
+           SELECT continuum,
+                  ar_arc,
+                  cuar_arc,
+                  thar_arc,
+                  xe_arc,
+                  filter,
+                  diffuser,
+                  shutter,
+                  exposure_time,
+                  coadds
+             FROM $table
+         """
+      )
+
+    def selectStepGcal(id: Int): Query0[Option[GcalConfig]] =
+      (selectFragment("step_gcal") ++
+        fr"""WHERE step_gcal_id = $id""").query[GcalRow].map(_.toGcalConfig)
+
+    def selectSmartGcal(id: Int): Query0[Option[GcalConfig]] =
+      (selectFragment("gcal") ++
+        fr"""WHERE gcal_id = $id""").query[GcalRow].map(_.toGcalConfig)
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/LogDao.scala
+++ b/modules/db/src/main/scala/gem/dao/LogDao.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import doobie._, doobie.implicits._
+import java.util.logging.Level
+import gem.dao.meta._
+
+object LogDao {
+  import LevelMeta._
+  import ProgramIdMeta._
+
+  def insert(user: User[_], level: Level, pid: Option[Program.Id], msg: String, t: Option[Throwable], elapsed: Option[Long]): ConnectionIO[Int] =
+    Statements.insert(user, level, pid, msg, t, elapsed).run
+
+  object Statements {
+
+    def insert(user: User[_], level: Level, pid: Option[Program.Id], msg: String, t: Option[Throwable], elapsed: Option[Long]): Update0 =
+      sql"""
+        INSERT INTO log (user_id, "timestamp", level, program, message, stacktrace, elapsed)
+             VALUES (${user.id}, now(), $level :: log_level, $pid, $msg, ${t.map(stack)}, $elapsed)
+       """.update
+
+    private def stack(t: Throwable): String = {
+      val sw = new java.io.StringWriter
+      val pw = new java.io.PrintWriter(sw)
+      t.printStackTrace(pw)
+      pw.close
+      sw.close
+      sw.toString
+    }
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -1,0 +1,181 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+import gem.config.{ StaticConfig }
+import gem.dao.meta._
+import gem.enum._
+import gem.math.Index
+import gem.syntax.treemap._
+import gem.util.Location
+
+import scala.collection.immutable.TreeMap
+
+object ObservationDao {
+  import EnumeratedMeta._
+  import ObservationIdMeta._
+  import IndexMeta._
+  import ProgramIdMeta._
+
+  /**
+   * Construct a program to insert a fully-populated Observation. This program will raise a
+   * key violation if an observation with the same id already exists.
+   */
+  def insert(oid: Observation.Id, o: Observation): ConnectionIO[Unit] =
+    for {
+      _ <- Statements.insert(oid, o).run
+      _ <- StaticConfigDao.insert(oid, o.staticConfig)
+      _ <- TargetEnvironmentDao.insert(oid, o.targetEnvironment)
+      _ <- o.sequence.zipWithIndex.traverse { case (s, i) =>
+             StepDao.insert(oid, Location.unsafeMiddle((i + 1) * 100), s)
+           }.void
+    } yield ()
+
+  /** Construct a program to select the specified observation, with the
+    * instrument but not targets nor steps.
+    */
+  def selectFlat(id: Observation.Id): ConnectionIO[(String, Instrument)] =
+    Statements.selectFlat(id).unique
+
+  /** Construct a program to select the specified observation, with the
+    * targets and instrument type but not steps.
+    */
+  def selectTargets(id: Observation.Id): ConnectionIO[(String, TargetEnvironment)] =
+    for {
+      o <- selectFlat(id)
+      t <- TargetEnvironmentDao.selectObs(id)
+    } yield (o._1, t)
+
+  /** Construct a program to select the specified observation, with static
+    * config but not targets nor steps.
+    */
+  def selectStatic(id: Observation.Id): ConnectionIO[(String, StaticConfig)] =
+    for {
+      o <- selectFlat(id)
+      c <- StaticConfigDao.select(id, o._2)
+    } yield (o._1, c)
+
+  /** Construct a program to select the specified observation, with static
+    * config and steps but not targets.
+    */
+  def selectConfig(id: Observation.Id): ConnectionIO[(String, StaticConfig, TreeMap[Location.Middle, Step])] =
+    for {
+      o  <- selectStatic(id)
+      ss <- StepDao.selectAll(id)
+    } yield (o._1, o._2, ss)
+
+  /** Construct a program to select a fully specified observation, with targets,
+    * static config and steps.
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def select(id: Observation.Id): ConnectionIO[Observation] =
+    for {
+      o <- selectConfig(id)
+      t <- TargetEnvironmentDao.selectObs(id)
+    } yield Observation.unsafeAssemble(o._1, t, o._2, o._3.values.toList)
+
+  /** Construct a program to select the all obseravation ids for the specified
+    * science program.
+    */
+  def selectIds(pid: Program.Id): ConnectionIO[List[Observation.Id]] =
+    Statements.selectIds(pid).to[List]
+
+  /** Construct a program to select all observations for the specified science
+    * program, with the instrument but no targets nor steps.
+    */
+  def selectAllFlat(pid: Program.Id): ConnectionIO[TreeMap[Index, (String, Instrument)]] =
+    Statements.selectAllFlat(pid)
+      .map { case (a, b, c) => (a, (b, c)) } // :-\
+      .to[List]
+      .map(TreeMap.fromList(_))
+
+  /** Construct a program to select all observations for the specified science
+    * program, with the targets and the instrument type, but no steps.
+    */
+  def selectAllTarget(pid: Program.Id): ConnectionIO[TreeMap[Index, (String, TargetEnvironment, Instrument)]] =
+    (selectAllFlat(pid), TargetEnvironmentDao.selectProg(pid)).mapN { (rm, tm) =>
+      rm.map { case (idx, (s, i)) =>
+        idx -> ((s, tm(idx), i))
+      }
+    }
+
+  /** Construct a program to select all observations for the specified science
+    * program, with the static component but no targets nor steps.
+    */
+  def selectAllStatic(pid: Program.Id): ConnectionIO[TreeMap[Index, (String, StaticConfig)]] =
+    for {
+      ids <- selectIds(pid)
+      oss <- ids.traverse(selectStatic)
+    } yield TreeMap.fromList(ids.map(_.index).zip(oss))
+
+  /** Construct a program to select all observations for the specified science
+    * program, with static component and steps but not targets.
+    */
+  def selectAllConfig(pid: Program.Id): ConnectionIO[TreeMap[Index, (String, StaticConfig, TreeMap[Location.Middle, Step])]] =
+    for {
+      ids <- selectIds(pid)
+      oss <- ids.traverse(selectConfig)
+    } yield TreeMap.fromList(ids.map(_.index).zip(oss))
+
+  /** Construct a program to select all observations for the specified science
+    * program, with its targets, static component and steps.
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def selectAll(pid: Program.Id): ConnectionIO[TreeMap[Index, Observation]] =
+    (selectAllConfig(pid), TargetEnvironmentDao.selectProg(pid)).mapN { (rm, tm) =>
+      rm.map {  case (idx, (t, sc, seq)) =>
+        idx -> Observation.unsafeAssemble(t, tm(idx), sc, seq.values.toList)
+      }
+    }
+
+  object Statements {
+
+    import AsterismTypeMeta._
+
+    def insert(oid: Observation.Id, o: Observation): Update0 =
+      sql"""
+        INSERT INTO observation (observation_id,
+                                program_id,
+                                observation_index,
+                                asterism_type,
+                                title,
+                                instrument)
+              VALUES (${oid},
+                      ${oid.pid},
+                      ${oid.index},
+                      ${o.targetEnvironment.asterism.map(AsterismType.of)},
+                      ${o.title},
+                      ${Instrument.forObservation(o)})
+      """.update
+
+    def selectIds(pid: Program.Id): Query0[Observation.Id] =
+      sql"""
+        SELECT observation_id
+          FROM observation
+         WHERE program_id = $pid
+      """.query[Observation.Id]
+
+    def selectFlat(id: Observation.Id): Query0[(String, Instrument)] =
+      sql"""
+        SELECT title, instrument
+          FROM observation
+         WHERE observation_id = ${id}
+      """.query[(String, Instrument)]
+
+    def selectAllFlat(pid: Program.Id): Query0[(Index, String, Instrument)] =
+      sql"""
+        SELECT observation_index, title, instrument
+          FROM observation
+         WHERE program_id = ${pid}
+      ORDER BY observation_index
+      """.query[(Short, String, Instrument)]
+        .map { case (n, t, i) =>
+          (Index.fromShort.unsafeGet(n), t, i)
+        }
+
+  }
+}

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -1,0 +1,139 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.dao.meta._
+
+import cats.data.OptionT
+import cats.implicits._
+import doobie._, doobie.implicits._
+
+// import scala.collection.immutable.TreeMap
+
+object ProgramDao {
+  import EnumeratedMeta._
+  import ProgramIdMeta._
+  import IndexMeta._
+
+  /** Insert a program, disregarding its observations, if any. */
+  def insertFlat(p: Program): ConnectionIO[Program.Id] =
+    insertProgramIdSlice(p.id) *>
+    Statements.insert(p).run.as(p.id)
+
+  /** Insert a complete program. */
+  def insert(p: Program): ConnectionIO[Program.Id] =
+    insertFlat(p) <* p.observations.toList.traverse { case (i,o) =>
+      ObservationDao.insert(Observation.Id(p.id, i), o)
+    }
+
+  private def insertProgramIdSlice(pid: Program.Id): ConnectionIO[Int] =
+    pid match {
+      case id: Program.Id.Science     => insertScienceProgramIdSlice(id)
+      case id: Program.Id.Daily       => insertDailyProgramIdSlice(id)
+      case id: Program.Id.Nonstandard => insertNonstandardProgramIdSlice(id)
+    }
+
+  private def insertScienceProgramIdSlice(pid: Program.Id.Science): ConnectionIO[Int] =
+    SemesterDao.canonicalize(pid.semester) *>
+    Statements.insertScienceProgramIdSlice(pid).run
+
+  private def insertDailyProgramIdSlice(pid: Program.Id.Daily): ConnectionIO[Int] =
+    Statements.insertDailyProgramIdSlice(pid).run
+
+  private def insertNonstandardProgramIdSlice(pid: Program.Id.Nonstandard): ConnectionIO[Int] =
+    pid.semesterOption.traverse(SemesterDao.canonicalize) *>
+    Statements.insertNonstandardProgramIdSlice(pid).run
+
+  def selectBySubstring(pat: String, max: Int): ConnectionIO[List[(Program.Id, String)]] =
+    Statements.selectBySubstring(pat, max).to[List]
+
+  /** Select a program by Id, without any Observation information. */
+  def selectFlat(pid: Program.Id): ConnectionIO[Option[String]] =
+    Statements.selectFlat(pid).option
+
+  /** Select a program by id, with full Observation information. */
+  def selectFull(pid: Program.Id): ConnectionIO[Option[Program]] =
+    (for {
+      t  <- OptionT(selectFlat(pid))
+      os <- OptionT.liftF(ObservationDao.selectAll(pid))
+    } yield Program(pid, t, os)).value
+
+  object Statements {
+
+    // StepId has a DISTINCT type due to its check constraint so we need a fine-grained mapping
+    // here to satisfy the query checker.
+    private final case class Index(toInt: Int)
+    private object Index {
+      implicit val IndexMeta: Meta[Index] =
+        Distinct.integer("id_index").xmap(Index(_), _.toInt)
+    }
+
+    def selectFlat(pid: Program.Id): Query0[String] =
+      sql"""
+        SELECT title
+          FROM program
+         WHERE program_id = $pid
+      """.query[String]
+
+    def selectBySubstring(pat: String, max: Int): Query0[(Program.Id, String)] =
+      sql"""
+       SELECT program_id, title
+         FROM program
+        WHERE lower(program_id) like lower($pat) OR lower(title) like lower($pat)
+      ORDER BY program_id, title
+        LIMIT ${max.toLong}
+      """.query[(Program.Id, String)]
+
+    // N.B. assumes semester has been canonicalized
+    def insertNonstandardProgramIdSlice(pid: Program.Id.Nonstandard): Update0 =
+      sql"""
+        INSERT INTO program (program_id,
+                             site,
+                             semester_id,
+                             program_type)
+              VALUES (${pid: Program.Id},
+                      ${pid.siteOption},
+                      ${pid.semesterOption.map(_.format)},
+                      ${pid.programTypeOption})
+      """.update
+
+    def insertDailyProgramIdSlice(pid: Program.Id.Daily): Update0 =
+      sql"""
+        INSERT INTO program (program_id,
+                            site,
+                            program_type,
+                            day)
+              VALUES (${pid: Program.Id},
+                      ${pid.site},
+                      ${pid.programTypeOption},
+                      ${pid.localDate})
+      """.update
+
+    // N.B. assumes semester has been canonicalized
+    def insertScienceProgramIdSlice(pid: Program.Id.Science): Update0 =
+      sql"""
+         INSERT INTO program (program_id,
+                             site,
+                             semester_id,
+                             program_type,
+                             index)
+             VALUES (${pid: Program.Id},
+                     ${pid.site},
+                     ${pid.semester.format},
+                     ${pid.programType},
+                     ${pid.index})
+      """.update
+
+    // N.B. assumes program id slice has been inserted
+    def insert(p: Program): Update0 =
+      sql"""
+        UPDATE program
+           SET title = ${p.title}
+         WHERE program_id = ${p.id}
+      """.update
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/SemesterDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SemesterDao.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.syntax.functor._
+import doobie._, doobie.implicits._
+import gem.dao.meta._
+
+object SemesterDao {
+  import EnumeratedMeta._
+
+  def canonicalize(s: Semester): ConnectionIO[Semester] =
+    Statements.canonicalize(s).run.as(s)
+
+  object Statements {
+
+    def canonicalize(s: Semester): Update0 =
+      sql"""
+        INSERT INTO semester (semester_id, year, half)
+        VALUES (${s.format}, ${s.year.getValue.toShort}, ${s.half}::half)
+        ON CONFLICT DO NOTHING
+      """.update
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -1,0 +1,421 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+import gem._
+import gem.SmartGcal._
+import gem.config._
+import gem.dao.composite._
+import gem.dao.meta._
+import gem.enum._
+import gem.math.Wavelength
+import gem.util.Location
+import fs2.Stream
+import scala.collection.immutable.TreeMap
+
+object SmartGcalDao {
+  import EnumeratedMeta._
+  import WavelengthMeta._
+  import EitherComposite._
+
+  def select(k: SmartGcalSearchKey, t: SmartGcalType): ConnectionIO[List[GcalConfig]] =
+    for {
+      ids <- k match {
+               case f2:    SmartGcalKey.Flamingos2      => selectF2(f2, t)
+               case gn:    SmartGcalKey.GmosNorthSearch => selectGmosNorth(gn, t)
+               case gs:    SmartGcalKey.GmosSouthSearch => selectGmosSouth(gs, t)
+               case gnirs: SmartGcalKey.GnirsSearch     => selectGnirs(gnirs, t)
+             }
+      gcs <- ids.traverse { GcalDao.selectSmartGcal }.map(_.collect { case Some(a) => a })
+    } yield gcs
+
+  def selectF2(k: SmartGcalKey.Flamingos2, t: SmartGcalType): ConnectionIO[List[Int]] =
+    t.fold(Statements.selectF2ByLamp(k), Statements.selectF2ByBaseline(k)).to[List]
+
+  def selectGmosNorth(k: SmartGcalKey.GmosNorthSearch, t: SmartGcalType): ConnectionIO[List[Int]] =
+    t.fold(Statements.selectGmosNorthByLamp(k), Statements.selectGmosNorthByBaseline(k)).to[List]
+
+  def selectGmosSouth(k: SmartGcalKey.GmosSouthSearch, t: SmartGcalType): ConnectionIO[List[Int]] =
+    t.fold(Statements.selectGmosSouthByLamp(k), Statements.selectGmosSouthByBaseline(k)).to[List]
+
+  def selectGnirs(k: SmartGcalKey.GnirsSearch, t: SmartGcalType): ConnectionIO[List[Int]] =
+    t.fold(Statements.selectGnirsByLamp(k), Statements.selectGnirsByBaseline(k)).to[List]
+
+  val createIndexF2: ConnectionIO[Int] =
+    Statements.createIndexF2.run
+
+  val dropIndexF2: ConnectionIO[Int] =
+    Statements.dropIndexF2.run
+
+  val createIndexGmosNorth: ConnectionIO[Int] =
+    Statements.createIndexGmosNorth.run
+
+  val dropIndexGmosNorth: ConnectionIO[Int] =
+    Statements.dropIndexGmosNorth.run
+
+  val createIndexGmosSouth: ConnectionIO[Int] =
+    Statements.createIndexGmosSouth.run
+
+  val dropIndexGmosSouth: ConnectionIO[Int] =
+    Statements.dropIndexGmosSouth.run
+
+  val createIndexGnirs: ConnectionIO[Int] =
+    Statements.createIndexGnirs.run
+
+  val dropIndexGnirs: ConnectionIO[Int] =
+    Statements.dropIndexGnirs.run
+
+  def bulkInsertF2(entries: Vector[(GcalLampType, GcalBaselineType, SmartGcalKey.Flamingos2, GcalConfig)]): Stream[ConnectionIO, Int] =
+    bulkInsert(Statements.bulkInsertF2, entries)
+
+  def bulkInsertGmosNorth(entries: Vector[(GcalLampType, GcalBaselineType, SmartGcalKey.GmosNorthDefinition, GcalConfig)]): Stream[ConnectionIO, Int] =
+    bulkInsert[SmartGcalKey.GmosNorthDefinition](Statements.bulkInsertGmosNorth, entries)
+
+  def bulkInsertGmosSouth(entries: Vector[(GcalLampType, GcalBaselineType, SmartGcalKey.GmosSouthDefinition, GcalConfig)]): Stream[ConnectionIO, Int] =
+    bulkInsert[SmartGcalKey.GmosSouthDefinition](Statements.bulkInsertGmosSouth, entries)
+
+  def bulkInsertGnirs(entries: Vector[(GcalLampType, GcalBaselineType, SmartGcalKey.GnirsDefinition, GcalConfig)]): Stream[ConnectionIO, Int] =
+    bulkInsert[SmartGcalKey.GnirsDefinition](Statements.bulkInsertGnirs, entries)
+
+  private def bulkInsert[K](
+                update:  Update[((GcalLampType, GcalBaselineType, K), Int)],
+                entries: Vector[(GcalLampType, GcalBaselineType, K, GcalConfig)]): Stream[ConnectionIO, Int] = {
+
+    // Workaround for issue https://github.com/functional-streams-for-scala/fs2/issues/1099
+    val tups = entries.map(t => (t._1, t._2, t._3))
+    GcalDao.bulkInsertSmartGcal(entries.map(_._4))
+      .segmentN(tups.size)
+      .flatMap { rows =>
+        Stream.eval(update.updateMany(tups.zip(rows.force.toVector)))
+      }
+
+    /* https://github.com/functional-streams-for-scala/fs2/issues/1099
+      Stream.emits(entries.map(t => (t._1, t._2, t._3)))          // Stream[Pure, (Lamp, Baseline, Key)]
+        .zip(GcalDao.bulkInsertSmartGcal(entries.map(_._4)))      // Stream[ConnectionIO, ((Lamp, Baseline, Key), Id)]
+        .segmentN(4096)                                           // Stream[ConnectionIO, Segment[((Lamp, Baseline, Key), Id)]]
+        .flatMap { rows => Stream.eval(update.updateMany(rows.force.toVector)) } // Stream[ConnectionIO, Int]
+    */
+  }
+
+  type ExpansionResult[A] = EitherConnectionIO[ExpansionError, A]
+
+  private def lookupʹ(step: MaybeConnectionIO[Step], loc: Location.Middle, static: StaticConfig): ExpansionResult[ExpandedSteps] = {
+
+    // Information we need to extract from a smart gcal step in order to expand
+    // it into manual gcal steps.  The key is used to look up the gcal config
+    // from the instrument's smart table (e.g., smart_f2).  The type is used to
+    // extract the matching steps (arc vs. flat, or night vs. day baseline).
+    // The instrument config is needed to create the corresponding gcal steps.
+    type SmartContext = (SmartGcalSearchKey, SmartGcalType, DynamicConfig)
+
+    // Get the key, type, and instrument config from the step.  We'll need this
+    // information to lookup the corresponding GcalConfig.
+    val stepToContext: (Step) => ExpansionResult[SmartContext] = { step =>
+      (step.dynamicConfig, step.base) match {
+        case (d, Step.Base.SmartGcal(t)) =>
+          EitherConnectionIO.fromDisjunction {
+            (d.smartGcalKey(static).toRight(noMappingDefined)).map { k => (k, t, d) }
+          }
+        case _                    =>
+          EitherConnectionIO.pointLeft(notSmartGcal)
+      }
+    }
+
+    def expand(k: SmartGcalSearchKey, t: SmartGcalType, d: DynamicConfig): ExpansionResult[ExpandedSteps] =
+      EitherConnectionIO(select(k, t).map {
+        case Nil => Left(noMappingDefined)
+        case cs  => Right(cs.map(c => d.toStep(Step.Base.Gcal(c))))
+      })
+
+    // Find the corresponding smart gcal mapping, if any.
+    for {
+      step <- step.toRight(stepNotFound(loc))
+      ktd  <- stepToContext(step)
+      (k, t, d) = ktd
+      gcal <- expand(k, t, d)
+    } yield gcal
+  }
+
+  /** Lookup the corresponding `GcalStep`s for the smart step at `loc`, leaving
+    * the sequence unchanged.
+    *
+    * @param oid observation whose smart gcal expansion is desired for the step
+    *            at `loc`
+    * @param loc position of the smart gcal step to expand
+    *
+    * @return expansion of the smart gcal step into `GcalStep`s if `loc` is
+    *         found, refers to a smart gcal step, and a mapping is defined for
+    *         its instrument configuration
+    */
+  def lookup(oid: Observation.Id, loc: Location.Middle): ExpansionResult[ExpandedSteps] =
+    for {
+      o <- ObservationDao.selectStatic(oid).injectRight
+      s <- lookupʹ(StepDao.selectOne(oid, loc), loc, o._2)
+    } yield s
+
+  /** Expands a smart gcal step into the corresponding gcal steps so that they
+    * may be executed. Updates the sequence to replace a smart gcal step with
+    * one or more manual gcal steps.
+    *
+    * @param oid observation whose smart gcal expansion is desired for the step
+    * @param loc position of the smart gcal step to expand
+    *
+    * @return expansion of the smart gcal step into `GcalConfig` if `loc` is
+    *         found, refers to a smart gcal step, and a mapping is defined for
+    *         its instrument configuration
+    */
+  def expand(oid: Observation.Id, loc: Location.Middle): ExpansionResult[ExpandedSteps] = {
+    // Find the previous and next location for the smart gcal step that we are
+    // replacing.  This is needed to generate locations for the steps that will
+    // be inserted.
+    def bounds(steps: TreeMap[Location.Middle, Step]): (Location, Location) =
+      steps.span { case (k, _) => k < loc } match {
+        case (prev, next) => (prev.lastOption.map(_._1).widen[Location] getOrElse Location.beginning,
+                              next.headOption.map(_._1).widen[Location] getOrElse Location.end)
+      }
+
+    // Inserts manual gcal steps between `before` and `after` locations.
+    def insert(before: Location, gcal: ExpandedSteps, after: Location): ConnectionIO[Unit] =
+      Location.find(gcal.size, before, after).toList.zip(gcal).traverse { case (l, s) =>
+        StepDao.insert(oid, l, s)
+      }.void
+
+    for {
+      obs   <- ObservationDao.selectStatic(oid).injectRight
+      steps <- StepDao.selectAll(oid).injectRight
+      (locBefore, locAfter) = bounds(steps)
+      gcal  <- lookupʹ(MaybeConnectionIO.fromOption(steps.get(loc)), loc, obs._2)
+      // replaces the smart gcal step with the expanded manual gcal steps
+      _     <- StepDao.deleteAtLocation(oid, loc).injectRight
+      _     <- insert(locBefore, gcal, locAfter).injectRight
+    } yield gcal
+  }
+
+  object Statements {
+
+    private val MinWavelength = 0
+    private val MaxWavelength = Int.MaxValue
+
+    // -----------------------------------------------------------------------
+    // Flamingos2
+    // -----------------------------------------------------------------------
+
+    val createIndexF2: Update0 =
+      sql"""
+        CREATE INDEX IF NOT EXISTS smart_f2_index ON smart_f2
+          (disperser, filter, fpu)
+      """.update
+
+    val dropIndexF2: Update0 =
+      sql"""
+        DROP INDEX IF EXISTS smart_f2_index
+      """.update
+
+    def selectF2ByLamp(k: SmartGcalKey.Flamingos2)(l: GcalLampType): Query0[Int] =
+      sql"""
+          SELECT gcal_id
+            FROM smart_f2
+           WHERE lamp      = $l :: gcal_lamp_type
+             AND disperser = ${k.disperser}
+             AND filter    = ${k.filter}
+             AND fpu       = ${k.fpu}
+        """.query[Int]
+
+    def selectF2ByBaseline(k: SmartGcalKey.Flamingos2)(b: GcalBaselineType): Query0[Int] =
+      sql"""
+          SELECT gcal_id
+            FROM smart_f2
+           WHERE baseline  = $b :: gcal_baseline_type
+             AND disperser = ${k.disperser}
+             AND filter    = ${k.filter}
+             AND fpu       = ${k.fpu}
+        """.query[Int]
+
+    type F2Row = ((GcalLampType, GcalBaselineType, SmartGcalKey.Flamingos2), Int)
+
+    val bulkInsertF2: Update[F2Row] = {
+      val sql =
+        """
+          INSERT INTO smart_f2 (lamp,
+                                baseline,
+                                disperser,
+                                filter,
+                                fpu,
+                                gcal_id)
+               VALUES (? :: gcal_lamp_type, ? :: gcal_baseline_type, ?, ?, ?, ?)
+        """
+      Update[F2Row](sql)
+    }
+
+
+    // -----------------------------------------------------------------------
+    // GmosNorth
+    // -----------------------------------------------------------------------
+
+    val createIndexGmosNorth: Update0 =
+      sql"""
+        CREATE INDEX IF NOT EXISTS smart_gmos_north_index ON smart_gmos_north
+          (disperser, filter, fpu)
+      """.update
+
+    val dropIndexGmosNorth: Update0 =
+      sql"""
+        DROP INDEX IF EXISTS smart_gmos_north_index
+      """.update
+
+    val createIndexGmosSouth: Update0 =
+      sql"""
+        CREATE INDEX IF NOT EXISTS smart_gmos_south_index ON smart_gmos_south
+          (disperser, filter, fpu)
+      """.update
+
+    val dropIndexGmosSouth: Update0 =
+      sql"""
+        DROP INDEX IF EXISTS smart_gmos_south_index
+      """.update
+
+    private def selectGmos[D, F, U](table: String, searchType: Fragment, dfu: Fragment, k: SmartGcalKey.GmosCommon[D,F,U], w: Option[Wavelength]): Fragment =
+      Fragment.const(
+        s"""SELECT gcal_id
+               FROM $table
+              WHERE """) ++ searchType ++ dfu ++
+        fr"""
+                AND x_binning       = ${k.xBinning}
+                AND y_binning       = ${k.yBinning}
+                AND amp_gain        = ${k.ampGain}
+                AND min_wavelength <= ${w.map(_.toAngstroms).getOrElse(MaxWavelength)}
+                AND max_wavelength >  ${w.map(_.toAngstroms).getOrElse(MinWavelength)}
+         """
+
+    def lampFragment(l: GcalLampType): Fragment =
+      fr"""lamp = $l :: gcal_lamp_type"""
+
+    def baselineFragment(b: GcalBaselineType): Fragment =
+      fr"""baseline = $b :: gcal_baseline_type"""
+
+    def gmosNorthFragment(k: SmartGcalKey.GmosNorthCommon): Fragment =
+      fr"""
+              AND disperser       = ${k.disperser}
+              AND filter          = ${k.filter}
+              AND fpu             = ${k.fpu}
+        """
+
+    def gmosSouthFragment(k: SmartGcalKey.GmosSouthCommon): Fragment =
+      fr"""
+              AND disperser       = ${k.disperser}
+              AND filter          = ${k.filter}
+              AND fpu             = ${k.fpu}
+        """
+
+
+    def selectGmosNorthByLamp(k: SmartGcalKey.GmosNorthSearch)(l: GcalLampType): Query0[Int] =
+      selectGmos("smart_gmos_north", lampFragment(l), gmosNorthFragment(k.gmos), k.gmos, k.wavelength).query[Int]
+
+    def selectGmosSouthByLamp(k: SmartGcalKey.GmosSouthSearch)(l: GcalLampType): Query0[Int] =
+      selectGmos("smart_gmos_south", lampFragment(l), gmosSouthFragment(k.gmos), k.gmos, k.wavelength).query[Int]
+
+    def selectGmosNorthByBaseline(k: SmartGcalKey.GmosNorthSearch)(b: GcalBaselineType): Query0[Int] =
+      selectGmos("smart_gmos_north", baselineFragment(b), gmosNorthFragment(k.gmos), k.gmos, k.wavelength).query[Int]
+
+    def selectGmosSouthByBaseline(k: SmartGcalKey.GmosSouthSearch)(b: GcalBaselineType): Query0[Int] =
+      selectGmos("smart_gmos_south", baselineFragment(b), gmosSouthFragment(k.gmos), k.gmos, k.wavelength).query[Int]
+
+    def bulkInsertGmosSql(table: String): String =
+      s"""
+        INSERT INTO $table (lamp,
+                            baseline,
+                            disperser,
+                            filter,
+                            fpu,
+                            x_binning,
+                            y_binning,
+                            amp_gain,
+                            min_wavelength,
+                            max_wavelength,
+                            gcal_id)
+             VALUES (? :: gcal_lamp_type, ? :: gcal_baseline_type, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      """
+
+    type GmosNorthRow = ((GcalLampType, GcalBaselineType, SmartGcalKey.GmosNorthDefinition), Int)
+    type GmosSouthRow = ((GcalLampType, GcalBaselineType, SmartGcalKey.GmosSouthDefinition), Int)
+
+    val bulkInsertGmosNorth: Update[GmosNorthRow] =
+      Update[GmosNorthRow](bulkInsertGmosSql("smart_gmos_north"))
+
+    val bulkInsertGmosSouth: Update[GmosSouthRow] =
+      Update[GmosSouthRow](bulkInsertGmosSql("smart_gmos_south"))
+
+    // -----------------------------------------------------------------------
+    // GNIRS
+    // -----------------------------------------------------------------------
+
+    val createIndexGnirs: Update0 =
+      sql"""
+        CREATE INDEX IF NOT EXISTS smart_gnirs_index ON smart_gnirs (disperser, prism)
+      """.update
+
+    val dropIndexGnirs: Update0 =
+      sql"""
+        DROP INDEX IF EXISTS smart_gnirs_index
+      """.update
+
+    def selectGnirsByLamp(k: SmartGcalKey.GnirsSearch)(l: GcalLampType): Query0[Int] =
+      sql"""
+          SELECT gcal_id
+            FROM smart_gnirs
+           WHERE lamp       = $l :: gcal_lamp_type
+             AND acquisition_mirror = ${k.gnirs.acquisitionMirror}
+             AND pixel_scale        = ${k.gnirs.pixelScale}
+             AND disperser          = ${k.gnirs.disperser}
+             AND fpu_slit           = ${k.gnirs.fpu.right.toOption}
+             AND fpu_other          = ${k.gnirs.fpu.left.toOption}
+             AND prism              = ${k.gnirs.prism}
+             AND well_depth         = ${k.gnirs.wellDepth}
+             AND min_wavelength    <= ${k.wavelength}
+             AND max_wavelength     > ${k.wavelength}
+        """.query[Int]
+
+    def selectGnirsByBaseline(k: SmartGcalKey.GnirsSearch)(b: GcalBaselineType): Query0[Int] =
+      sql"""
+          SELECT gcal_id
+            FROM smart_gnirs
+           WHERE baseline   = $b :: gcal_baseline_type
+             AND acquisition_mirror = ${k.gnirs.acquisitionMirror}
+             AND pixel_scale        = ${k.gnirs.pixelScale}
+             AND disperser          = ${k.gnirs.disperser}
+             AND fpu_slit           = ${k.gnirs.fpu.right.toOption}
+             AND fpu_other          = ${k.gnirs.fpu.left.toOption}
+             AND prism              = ${k.gnirs.prism}
+             AND well_depth         = ${k.gnirs.wellDepth}
+             AND min_wavelength    <= ${k.wavelength}
+             AND max_wavelength     > ${k.wavelength}
+        """.query[Int]
+
+    type GnirsRow = ((GcalLampType, GcalBaselineType, SmartGcalKey.GnirsDefinition), Int)
+
+    val bulkInsertGnirs: Update[GnirsRow] = {
+      val sql =
+        """
+          INSERT INTO smart_gnirs (lamp,
+                                   baseline,
+                                   acquisition_mirror,
+                                   pixel_scale,
+                                   disperser,
+                                   fpu_other,
+                                   fpu_slit,
+                                   prism,
+                                   well_depth,
+                                   min_wavelength,
+                                   max_wavelength,
+                                   gcal_id)
+               VALUES (? :: gcal_lamp_type, ? :: gcal_baseline_type, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+      Update[GnirsRow](sql)
+    }
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
@@ -1,0 +1,298 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+import gem.enum.{ GmosDetector, Instrument, MosPreImaging }
+import gem.dao.meta._
+import gem.config._
+
+object StaticConfigDao {
+  import EnumeratedMeta._
+  import ProgramIdMeta._
+  import IndexMeta._
+  import OffsetMeta._
+
+  def insert(oid: Observation.Id, s: StaticConfig): ConnectionIO[Unit] =
+    s match {
+      case _: StaticConfig.AcqCam     => ().pure[ConnectionIO]
+      case _: StaticConfig.Bhros      => ().pure[ConnectionIO]
+      case i: StaticConfig.Flamingos2 => Statements.Flamingos2.insert(oid, i).run.void
+      case _: StaticConfig.Ghost      => ().pure[ConnectionIO]
+      case i: StaticConfig.GmosN      => Gmos.insertNorth(oid, i)
+      case i: StaticConfig.GmosS      => Gmos.insertSouth(oid, i)
+      case i: StaticConfig.Gnirs      => Statements.Gnirs.insert(oid, i).run.void
+      case _: StaticConfig.Gpi        => ().pure[ConnectionIO]
+      case _: StaticConfig.Gsaoi      => ().pure[ConnectionIO]
+      case _: StaticConfig.Michelle   => ().pure[ConnectionIO]
+      case _: StaticConfig.Nici       => ().pure[ConnectionIO]
+      case _: StaticConfig.Nifs       => ().pure[ConnectionIO]
+      case _: StaticConfig.Niri       => ().pure[ConnectionIO]
+      case _: StaticConfig.Phoenix    => ().pure[ConnectionIO]
+      case _: StaticConfig.Trecs      => ().pure[ConnectionIO]
+      case _: StaticConfig.Visitor    => ().pure[ConnectionIO]
+    }
+
+  def select(oid: Observation.Id, i: Instrument): ConnectionIO[StaticConfig] = {
+    def pure(sc: StaticConfig): ConnectionIO[StaticConfig] =
+      sc.pure[ConnectionIO]
+
+    i match {
+      case Instrument.AcqCam     => pure(StaticConfig.AcqCam())
+      case Instrument.Bhros      => pure(StaticConfig.Bhros())
+
+      case Instrument.Flamingos2 => Statements.Flamingos2.select(oid)   .unique.widen[StaticConfig]
+      case Instrument.Ghost      => pure(StaticConfig.Ghost())
+      case Instrument.GmosN      => Gmos.selectNorth(oid)              .widen[StaticConfig]
+      case Instrument.GmosS      => Gmos.selectSouth(oid)              .widen[StaticConfig]
+      case Instrument.Gnirs      => Statements.Gnirs.select(oid).unique.widen[StaticConfig]
+
+      case Instrument.Gpi        => pure(StaticConfig.Gpi())
+      case Instrument.Gsaoi      => pure(StaticConfig.Gsaoi())
+      case Instrument.Michelle   => pure(StaticConfig.Michelle())
+      case Instrument.Nici       => pure(StaticConfig.Nici())
+      case Instrument.Nifs       => pure(StaticConfig.Nifs())
+      case Instrument.Niri       => pure(StaticConfig.Niri())
+      case Instrument.Phoenix    => pure(StaticConfig.Phoenix())
+      case Instrument.Trecs      => pure(StaticConfig.Trecs())
+      case Instrument.Visitor    => pure(StaticConfig.Visitor())
+    }
+  }
+
+  /** Combines lower-level GMOS statements into higher-level inserts and
+    * selects.
+    */
+  private object Gmos {
+
+    import gem.config.GmosConfig.{ GmosCustomRoiEntry, GmosNodAndShuffle }
+    import gem.enum.Instrument.{ GmosN, GmosS }
+    import StaticConfig.{ GmosN => GmosNorth, GmosS => GmosSouth }
+
+    def insertNorth(oid: Observation.Id, gn: GmosNorth): ConnectionIO[Unit] =
+        insertNodAndShuffle(oid, GmosN, gn.common.nodAndShuffle)   *>
+          insertCustomRoiEntries(oid, GmosN, gn.common.customRois) *>
+          Statements.Gmos.insertNorth(oid, gn).run.void
+
+    def insertSouth(oid: Observation.Id, gs: GmosSouth): ConnectionIO[Unit] =
+        insertNodAndShuffle(oid, GmosS, gs.common.nodAndShuffle)   *>
+          insertCustomRoiEntries(oid, GmosS, gs.common.customRois) *>
+          Statements.Gmos.insertSouth(oid, gs).run.void
+
+    def insertCustomRoiEntries(oid: Observation.Id, i: Instrument, rois: Set[GmosCustomRoiEntry]): ConnectionIO[Unit] =
+      rois.toList.traverse(Statements.Gmos.insertCustomRoiEntry(oid, i, _).run).void
+
+    def insertNodAndShuffle(oid: Observation.Id, i: Instrument, ns: Option[GmosNodAndShuffle]): ConnectionIO[Unit] =
+      ns.fold(().pure[ConnectionIO])(ns => Statements.Gmos.insertNodAndShuffle(oid, i, ns).run.void)
+
+    def selectNorth(oid: Observation.Id): ConnectionIO[GmosNorth] =
+      for {
+        ro <- Statements.Gmos.selectCustomRoiEntry(oid, GmosN).to[List].map(_.toSet)
+        ns <- Statements.Gmos.selectNodAndShuffle(oid, GmosN).option
+        gn <- Statements.Gmos.selectNorth(oid).unique
+        gnʹ = GmosNorth.customRois.set(ro)(gn)
+      } yield GmosNorth.nodAndShuffle.set(ns)(gnʹ)
+
+    def selectSouth(oid: Observation.Id): ConnectionIO[GmosSouth] =
+      for {
+        ro <- Statements.Gmos.selectCustomRoiEntry(oid, GmosS).to[List].map(_.toSet)
+        ns <- Statements.Gmos.selectNodAndShuffle(oid, GmosS).option
+        gs <- Statements.Gmos.selectSouth(oid).unique
+        gsʹ = GmosSouth.customRois.set(ro)(gs)
+      } yield GmosSouth.nodAndShuffle.set(ns)(gsʹ)
+  }
+
+  object Statements {
+
+    /** Flamingos2 Statements. */
+    object Flamingos2 {
+
+      def select(oid: Observation.Id): Query0[StaticConfig.Flamingos2] =
+        sql"""
+          SELECT mos_preimaging
+            FROM static_f2
+           WHERE program_id        = ${oid.pid}
+             AND observation_index = ${oid.index}
+        """.query[StaticConfig.Flamingos2]
+
+      def insert(oid: Observation.Id, f2: StaticConfig.Flamingos2): Update0 =
+        sql"""
+          INSERT INTO static_f2 (program_id, observation_index, instrument, mos_preimaging)
+          VALUES (
+            ${oid.pid},
+            ${oid.index},
+            ${Instrument.Flamingos2: Instrument},
+            ${f2.mosPreImaging})
+        """.update
+    }
+
+    /** GMOS Statements. */
+    object Gmos {
+      import gem.config.GmosConfig._
+
+      // We need to define this explicitly because we're ignoring the nod and
+      // shuffle and custom ROIs.
+      implicit val GmosCommonStaticComposite: Composite[GmosCommonStaticConfig] =
+        Composite[(GmosDetector, MosPreImaging)].imap(
+          (t: (GmosDetector, MosPreImaging)) => GmosCommonStaticConfig(t._1, t._2, None, Set.empty))(
+          (s: GmosCommonStaticConfig)        => (s.detector, s.mosPreImaging)
+        )
+
+      implicit val MetaGmosShuffleOffset: Meta[GmosShuffleOffset] =
+        Meta[Int].xmap(GmosShuffleOffset.unsafeFromRowCount, _.detectorRows)
+
+      implicit val MetaGmosShuffleCycles: Meta[GmosShuffleCycles] =
+        Meta[Int].xmap(GmosShuffleCycles.unsafeFromCycleCount, _.toInt)
+
+      implicit val GmosCustomRoiEntryComposite: Composite[GmosCustomRoiEntry] =
+        Composite[(Short, Short, Short, Short)].imap(
+          (t: (Short, Short, Short, Short)) => GmosCustomRoiEntry.unsafeFromDescription(t._1, t._2, t._3, t._4))(
+          (r: GmosCustomRoiEntry)           => (r.xMin, r.yMin, r.xRange, r.yRange)
+        )
+
+      def selectCustomRoiEntry(oid: Observation.Id, i: Instrument): Query0[GmosCustomRoiEntry] =
+        sql"""
+          SELECT x_min,
+                 y_min,
+                 x_range,
+                 y_range
+            FROM gmos_custom_roi
+           WHERE program_id        = ${oid.pid}   AND
+                 observation_index = ${oid.index} AND
+                 instrument        = $i
+         """.query[GmosCustomRoiEntry]
+
+      def selectNodAndShuffle(oid: Observation.Id, i: Instrument): Query0[GmosNodAndShuffle] =
+        sql"""
+          SELECT a_offset_p,
+                 a_offset_q,
+                 b_offset_p,
+                 b_offset_q,
+                 e_offset,
+                 offset_rows,
+                 cycles
+            FROM gmos_nod_and_shuffle
+           WHERE program_id        = ${oid.pid}
+             AND observation_index = ${oid.index}
+             AND instrument        = $i
+        """.query[GmosNodAndShuffle]
+
+      def selectNorth(oid: Observation.Id): Query0[StaticConfig.GmosN] =
+        sql"""
+          SELECT detector,
+                 mos_preimaging,
+                 stage_mode
+            FROM static_gmos_north
+           WHERE program_id        = ${oid.pid}
+             AND observation_index = ${oid.index}
+        """.query[StaticConfig.GmosN]
+
+      def selectSouth(oid: Observation.Id): Query0[StaticConfig.GmosS] =
+        sql"""
+          SELECT detector,
+                 mos_preimaging,
+                 stage_mode
+            FROM static_gmos_south
+           WHERE program_id        = ${oid.pid}
+             AND observation_index = ${oid.index}
+        """.query[StaticConfig.GmosS]
+
+      def insertCustomRoiEntry(oid: Observation.Id, inst: Instrument, roi: GmosCustomRoiEntry): Update0 =
+        sql"""
+          INSERT INTO gmos_custom_roi (
+                        program_id,
+                        observation_index,
+                        instrument,
+                        x_min,
+                        y_min,
+                        x_range,
+                        y_range)
+               VALUES (
+                      ${oid.pid},
+                      ${oid.index},
+                      $inst,
+                      ${roi.xMin},
+                      ${roi.yMin},
+                      ${roi.xRange},
+                      ${roi.yRange})
+        """.update
+
+      def insertNodAndShuffle(oid: Observation.Id, inst: Instrument, ns: GmosNodAndShuffle): Update0 =
+        sql"""
+          INSERT INTO gmos_nod_and_shuffle (
+                program_id,
+                observation_index,
+                instrument,
+                a_offset_p,
+                a_offset_q,
+                b_offset_p,
+                b_offset_q,
+                e_offset,
+                offset_rows,
+                cycles)
+         VALUES (
+              ${oid.pid},
+              ${oid.index},
+              $inst,
+              ${ns.posA.p},
+              ${ns.posA.q},
+              ${ns.posB.p},
+              ${ns.posB.q},
+              ${ns.eOffset},
+              ${ns.shuffle},
+              ${ns.cycles})
+        """.update
+
+      def insertNorth(oid: Observation.Id, g: StaticConfig.GmosN): Update0 =
+        sql"""
+          INSERT INTO static_gmos_north (program_id, observation_index, instrument, detector, mos_preimaging, stage_mode)
+          VALUES (
+            ${oid.pid},
+            ${oid.index},
+            ${Instrument.GmosN: Instrument},
+            ${g.common.detector},
+            ${g.common.mosPreImaging},
+            ${g.stageMode})
+        """.update
+
+      def insertSouth(oid: Observation.Id, g: StaticConfig.GmosS): Update0 =
+        sql"""
+          INSERT INTO static_gmos_south (program_id, observation_index, instrument, detector, mos_preimaging, stage_mode)
+          VALUES (
+            ${oid.pid},
+            ${oid.index},
+            ${Instrument.GmosS: Instrument},
+            ${g.common.detector},
+            ${g.common.mosPreImaging},
+            ${g.stageMode})
+        """.update
+
+    }
+
+    /** GNIRS Statements. */
+    object Gnirs {
+
+      def select(oid: Observation.Id): Query0[StaticConfig.Gnirs] =
+        sql"""
+          SELECT well_depth
+            FROM static_gnirs
+           WHERE program_id        = ${oid.pid}
+             AND observation_index = ${oid.index}
+        """.query[StaticConfig.Gnirs]
+
+      def insert(oid: Observation.Id, gnirs: StaticConfig.Gnirs): Update0 =
+        sql"""
+          INSERT INTO static_gnirs (program_id, observation_index, instrument, well_depth)
+          VALUES (
+            ${oid.pid},
+            ${oid.index},
+            ${Instrument.Gnirs: Instrument},
+            ${gnirs.wellDepth})
+        """.update
+    }
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/StepDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StepDao.scala
@@ -1,0 +1,622 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+import gem.util.Location
+import gem.CoAdds
+import gem.config._
+import gem.config.GcalConfig.GcalLamp
+import gem.dao.composite._
+import gem.dao.meta._
+import gem.enum._
+import gem.math.Offset
+import gem.syntax.treemap._
+import java.time.Duration
+import scala.collection.immutable.TreeMap
+
+object StepDao {
+  import CoAddsMeta._
+  import EnumeratedMeta._
+  import LocationMeta._
+  import ProgramIdMeta._
+  import IndexMeta._
+  import OffsetMeta._
+  import TimeMeta._
+  import WavelengthMeta._
+
+  type Loc = Location.Middle
+
+  private implicit class ToMap[A](q: Query0[(Loc, A)]) {
+    def toMap[B >: A]: ConnectionIO[TreeMap[Loc, B]] =
+      q.to[List].map(ps => TreeMap.fromList(ps.widen[(Loc, B)]))
+  }
+
+  import Statements._
+
+
+  def insert(oid: Observation.Id, loc: Loc, s: Step): ConnectionIO[Int] =
+    for {
+      id <- Statements.insertBaseSlice(oid, loc, Instrument.forStep(s), StepType.forStep(s)).withUniqueGeneratedKeys[Int]("step_id")
+      _  <- s.base match {
+              case Step.Base.Bias         => Statements.insertBiasSlice(id).run
+              case Step.Base.Dark         => Statements.insertDarkSlice(id).run
+              case Step.Base.Science(t)   => Statements.insertScienceSlice(id, t).run
+              case Step.Base.SmartGcal(t) => Statements.insertSmartGcalSlice(id, t).run
+              case Step.Base.Gcal(g)      => GcalDao.insertStepGcal(id, g)
+            }
+      _  <- insertConfigSlice(id, s.dynamicConfig)
+    } yield id
+
+  /** Selects a `Step` with an `Instrument` element at the given location in the
+    * sequence but without any instrument configuration information.
+    *
+    * @param oid observation whose step should be selected
+    * @param loc position of the step to select
+    */
+  def selectOneInstrumentAndBase(oid: Observation.Id, loc: Loc): MaybeConnectionIO[(Instrument, Step.Base)] =
+    Statements.selectOneInstrumentAndBase(oid, loc).maybe
+
+  /** Selects `Step`s with an `Instrument` element but without any instrument
+    * configuration information.
+    *
+    * @param oid observation whose steps should be selected
+    */
+  def selectAllInstrumentAndBase(oid: Observation.Id): ConnectionIO[TreeMap[Loc, (Instrument, Step.Base)]] =
+    Statements.selectAllInstrumentAndBase(oid).to[List].map(ps => TreeMap.fromList(ps))
+
+  /** Selects the step at the indicated location in the sequence associated with
+    * the indicated observation.
+    *
+    * @param oid observation whose step configuration is sought
+    * @param loc location within the sequence to find
+    */
+  def selectOne(oid: Observation.Id, loc: Loc): MaybeConnectionIO[Step] =
+    selectOneInstrumentAndBase(oid, loc).flatMap {
+      case (Instrument.AcqCam, b)     => MaybeConnectionIO.some(DynamicConfig.AcqCam().toStep(b))
+      case (Instrument.Bhros, b)      => MaybeConnectionIO.some(DynamicConfig.Bhros().toStep(b))
+      case (Instrument.Flamingos2, b) => Flamingos2.selectOne(oid, loc).map(_.toStep(b): Step).maybe
+      case (Instrument.Ghost, b)      => MaybeConnectionIO.some(DynamicConfig.Ghost().toStep(b))
+      case (Instrument.GmosN, b)      => Gmos.selectOneNorth(oid, loc).map(_.toStep(b): Step).maybe
+      case (Instrument.GmosS, b)      => Gmos.selectOneSouth(oid, loc).map(_.toStep(b): Step).maybe
+      case (Instrument.Gnirs, b)      => Gnirs.selectOne(oid, loc)    .map(_.toStep(b): Step).maybe
+      case (Instrument.Gpi, b)        => MaybeConnectionIO.some(DynamicConfig.Gpi().toStep(b))
+      case (Instrument.Gsaoi, b)      => MaybeConnectionIO.some(DynamicConfig.Gsaoi().toStep(b))
+      case (Instrument.Michelle, b)   => MaybeConnectionIO.some(DynamicConfig.Michelle().toStep(b))
+      case (Instrument.Nici, b)       => MaybeConnectionIO.some(DynamicConfig.Nici().toStep(b))
+      case (Instrument.Nifs, b)       => MaybeConnectionIO.some(DynamicConfig.Nifs().toStep(b))
+      case (Instrument.Niri, b)       => MaybeConnectionIO.some(DynamicConfig.Niri().toStep(b))
+      case (Instrument.Phoenix, b)    => MaybeConnectionIO.some(DynamicConfig.Phoenix().toStep(b))
+      case (Instrument.Trecs, b)      => MaybeConnectionIO.some(DynamicConfig.Trecs().toStep(b))
+      case (Instrument.Visitor, b)    => MaybeConnectionIO.some(DynamicConfig.Visitor().toStep(b))
+    }
+
+  /** Selects all steps with their instrument configuration data.
+    *
+    * @param oid observation whose step configurations are sought
+    */
+  def selectAll(oid: Observation.Id): ConnectionIO[TreeMap[Loc, Step]] = {
+
+    def pure(dc: DynamicConfig): ConnectionIO[TreeMap[Loc, DynamicConfig]] =
+      TreeMap(Location.unsafeMiddle(0) -> dc).pure[ConnectionIO]
+
+    def instrumentConfig(ss: TreeMap[Loc, (Instrument, Step.Base)]): ConnectionIO[TreeMap[Loc, DynamicConfig]] =
+      ss.headOption.map(_._2).fold(TreeMap.empty[Loc, DynamicConfig].pure[ConnectionIO]) {
+        case (Instrument.AcqCam, _)     => pure(DynamicConfig.AcqCam())
+        case (Instrument.Bhros, _)      => pure(DynamicConfig.Bhros())
+        case (Instrument.Flamingos2, _) => Flamingos2.selectAll(oid)       .toMap[DynamicConfig] //.map(a => a: TreeMap[Loc, DynamicConfig])
+        case (Instrument.Ghost, _)      => pure(DynamicConfig.Ghost())
+        case (Instrument.GmosN, _)      => Gmos.selectAllNorth(oid).toMap[DynamicConfig] //.map(a => a: TreeMap[Loc, DynamicConfig])
+        case (Instrument.GmosS, _)      => Gmos.selectAllSouth(oid).toMap[DynamicConfig] //.map(a => a: TreeMap[Loc, DynamicConfig])
+        case (Instrument.Gnirs, _)      => Gnirs.selectAll(oid)    .toMap[DynamicConfig] //.map(a => a: TreeMap[Loc, DynamicConfig])
+        case (Instrument.Gpi, _)        => pure(DynamicConfig.Gpi())
+        case (Instrument.Gsaoi, _)      => pure(DynamicConfig.Gsaoi())
+        case (Instrument.Michelle, _)   => pure(DynamicConfig.Michelle())
+        case (Instrument.Nici, _)       => pure(DynamicConfig.Nici())
+        case (Instrument.Nifs, _)       => pure(DynamicConfig.Nifs())
+        case (Instrument.Niri, _)       => pure(DynamicConfig.Niri())
+        case (Instrument.Phoenix, _)    => pure(DynamicConfig.Phoenix())
+        case (Instrument.Trecs, _)      => pure(DynamicConfig.Trecs())
+        case (Instrument.Visitor, _)    => pure(DynamicConfig.Visitor())
+      }
+
+    // n log n
+    def intersect[K: Ordering, A, B, C](ma: TreeMap[K, A], mb: TreeMap[K, B])(f: (A, B) => C): TreeMap[K, C] =
+      ma.toList.foldLeft(TreeMap.empty[K, C]) { case (kc, (k, a)) =>
+        mb.get(k).fold(kc)(b => kc + (k -> f(a, b)))
+      }
+
+    for {
+      ss <- selectAllInstrumentAndBase(oid)
+      is <- instrumentConfig(ss)
+    } yield intersect(ss, is) { case ((_, b), dc) => dc.toStep(b) }
+
+  }
+
+  /** Deletes the step at the indicated location, if any.
+    *
+    * @param oid observation whose step should be deleted
+    * @param loc location of the step to delete
+    */
+  def deleteAtLocation(oid: Observation.Id, loc: Loc): ConnectionIO[Int] =
+    Statements.deleteAtLocation(oid, loc).run
+
+  /** Deletes all steps for the given observation, if any.
+    *
+    * @param oid observation whose steps should be deleted
+    */
+  def delete(oid: Observation.Id): ConnectionIO[Int] =
+    Statements.delete(oid).run
+
+  // HELPERS
+
+  private def insertConfigSlice(id: Int, d: DynamicConfig): ConnectionIO[Unit] =
+    d match {
+      case _: DynamicConfig.AcqCam     => FC.unit
+      case _: DynamicConfig.Bhros      => FC.unit
+      case i: DynamicConfig.Flamingos2 => Flamingos2.insert(id, i).run.void
+      case _: DynamicConfig.Ghost      => FC.unit
+      case i: DynamicConfig.GmosN      => Gmos.insertCommon(id, i.common).run *> Gmos.insertNorth(id, i).run.void
+      case i: DynamicConfig.GmosS      => Gmos.insertCommon(id, i.common).run *> Gmos.insertSouth(id, i).run.void
+      case g: DynamicConfig.Gnirs      => Gnirs.insert(id, g).run.void
+      case _: DynamicConfig.Gpi        => FC.unit
+      case _: DynamicConfig.Gsaoi      => FC.unit
+      case _: DynamicConfig.Michelle   => FC.unit
+      case _: DynamicConfig.Nici       => FC.unit
+      case _: DynamicConfig.Nifs       => FC.unit
+      case _: DynamicConfig.Niri       => FC.unit
+      case _: DynamicConfig.Phoenix    => FC.unit
+      case _: DynamicConfig.Trecs      => FC.unit
+      case _: DynamicConfig.Visitor    => FC.unit
+    }
+
+  // The type we get when we select the fully joined step
+  private final case class StepKernel(
+    i: Instrument,
+    stepType: StepType, // todo: make an enum
+    gcal: (Option[GcalContinuum], Option[Boolean], Option[Boolean], Option[Boolean], Option[Boolean], Option[GcalFilter], Option[GcalDiffuser], Option[GcalShutter], Option[Duration], Option[Short]),
+    telescope: (Option[Offset.P],  Option[Offset.Q]),
+    smartGcalType: Option[SmartGcalType])
+  {
+    def toInstrumentAndBase: (Instrument, Step.Base) =
+      stepType match {
+
+        case StepType.Bias => (i, Step.Base.Bias)
+        case StepType.Dark => (i, Step.Base.Dark)
+
+        case StepType.Gcal =>
+          import GcalArc._
+          val (continuumOpt, arOpt, cuarOpt, tharOpt, xeOpt, filterOpt, diffuserOpt, shutterOpt, exposureOpt, coaddsOpt) = gcal
+          (for {
+            ar   <- arOpt
+            cuar <- cuarOpt
+            thar <- tharOpt
+            xe   <- xeOpt
+            l    <- GcalLamp.fromConfig(continuumOpt, ArArc -> ar, CuArArc -> cuar, ThArArc -> thar, XeArc -> xe)
+            f    <- filterOpt
+            d    <- diffuserOpt
+            s    <- shutterOpt
+            e    <- exposureOpt
+            c    <- coaddsOpt.flatMap(CoAdds.fromShort.getOption)
+          } yield (i, Step.Base.Gcal(GcalConfig(l, f, d, s, e, c)))).getOrElse(sys.error(s"missing gcal information: $gcal"))
+
+        case StepType.SmartGcal =>
+          smartGcalType.map(t => (i, Step.Base.SmartGcal(t))).getOrElse(sys.error("missing smart gcal type"))
+
+        case StepType.Science =>
+          telescope.mapN(TelescopeConfig(_, _))
+            .map(c => (i, Step.Base.Science(c)))
+            .getOrElse(sys.error(s"missing telescope information: $telescope"))
+
+      }
+  }
+
+  object Statements {
+
+    def deleteAtLocation(oid: Observation.Id, loc: Loc): Update0 =
+      sql"""
+        DELETE FROM step
+              WHERE program_id        = ${oid.pid}
+                AND observation_index = ${oid.index}
+                AND location          = $loc
+      """.update
+
+    def delete(oid: Observation.Id): Update0 =
+      sql"""
+        DELETE FROM step
+              WHERE program_id        = ${oid.pid}
+                AND observation_index = ${oid.index}
+      """.update
+
+    def selectAllInstrumentAndBase(oid: Observation.Id): Query0[(Loc, (Instrument, Step.Base))] =
+      sql"""
+        SELECT s.location,
+               s.instrument,
+               s.step_type,
+               gc.continuum,
+               gc.ar_arc,
+               gc.cuar_arc,
+               gc.thar_arc,
+               gc.xe_arc,
+               gc.filter,
+               gc.diffuser,
+               gc.shutter,
+               gc.exposure_time,
+               gc.coadds,
+               sc.offset_p,
+               sc.offset_q,
+               ss.type
+          FROM step s
+               LEFT OUTER JOIN step_gcal gc
+                  ON gc.step_gcal_id       = s.step_id
+               LEFT OUTER JOIN step_science sc
+                  ON sc.step_science_id    = s.step_id
+               LEFT OUTER JOIN step_smart_gcal ss
+                  ON ss.step_smart_gcal_id = s.step_id
+         WHERE s.program_id        = ${oid.pid}
+           AND s.observation_index = ${oid.index}
+      """.query[(Loc, StepKernel)].map(_.map(_.toInstrumentAndBase))
+
+    def selectOneInstrumentAndBase(oid: Observation.Id, loc: Loc): Query0[(Instrument, Step.Base)] =
+      sql"""
+        SELECT s.instrument,
+               s.step_type,
+               gc.continuum,
+               gc.ar_arc,
+               gc.cuar_arc,
+               gc.thar_arc,
+               gc.xe_arc,
+               gc.filter,
+               gc.diffuser,
+               gc.shutter,
+               gc.exposure_time,
+               gc.coadds,
+               sc.offset_p,
+               sc.offset_q,
+               ss.type
+          FROM step s
+               LEFT OUTER JOIN step_gcal gc
+                  ON gc.step_gcal_id       = s.step_id
+               LEFT OUTER JOIN step_science sc
+                  ON sc.step_science_id    = s.step_id
+               LEFT OUTER JOIN step_smart_gcal ss
+                  ON ss.step_smart_gcal_id = s.step_id
+         WHERE s.program_id        = ${oid.pid}
+           AND s.observation_index = ${oid.index}
+           AND s.location          = $loc
+      """.query[StepKernel].map(_.toInstrumentAndBase)
+
+    def insertScienceSlice(id: Int, t: TelescopeConfig): Update0 =
+      sql"""
+        INSERT INTO step_science (step_science_id, offset_p, offset_q)
+        VALUES ($id, ${t.p}, ${t.q})
+      """.update
+
+    def insertSmartGcalSlice(id: Int, t: SmartGcalType): Update0 =
+      sql"""
+        INSERT INTO step_smart_gcal (step_smart_gcal_id, type)
+        VALUES ($id, $t :: smart_gcal_type)
+      """.update
+
+    def insertDarkSlice(id: Int): Update0 =
+      sql"""
+        INSERT INTO step_dark (step_dark_id)
+        VALUES ($id)
+      """.update
+
+    def insertBiasSlice(id: Int): Update0 =
+      sql"""
+        INSERT INTO step_bias (step_bias_id)
+        VALUES ($id)
+      """.update
+
+    def insertBaseSlice(oid: Observation.Id, loc: Loc, i: Instrument, t: StepType): Update0 =
+      sql"""
+        INSERT INTO step (program_id, observation_index, location, instrument, step_type)
+        VALUES (${oid.pid}, ${oid.index}, $loc, ${i: Instrument}, ${t} :: step_type)
+      """.update
+
+    object Flamingos2 {
+      import F2Config.F2FpuChoice
+      import F2Config.F2FpuChoice._
+
+      final case class F2FpuBuilder(fpu: Option[F2Fpu], customMask: Boolean) {
+        def toFpuChoice: Option[F2FpuChoice] =
+          if (customMask) Some(Custom) else fpu.map(Builtin(_))
+      }
+
+      final case class F2Builder(
+        disperser:     Option[F2Disperser],
+        exposureTime:  Duration,
+        filter:        F2Filter,
+        fpuBuilder:    F2FpuBuilder,
+        lyotWheel:     F2LyotWheel,
+        readMode:      F2ReadMode,
+        windowCover:   F2WindowCover
+      ) {
+        def toF2: DynamicConfig.Flamingos2 =
+          DynamicConfig.Flamingos2(disperser, exposureTime, filter, fpuBuilder.toFpuChoice, lyotWheel, readMode, windowCover)
+      }
+
+      def selectAll(oid: Observation.Id): Query0[(Loc, DynamicConfig.Flamingos2)] =
+        sql"""
+          SELECT s.location,
+                 i.disperser,
+                 i.exposure_time,
+                 i.filter,
+                 i.fpu,
+                 i.custom_mask,
+                 i.lyot_wheel,
+                 i.read_mode,
+                 i.window_cover
+            FROM step s
+                 LEFT OUTER JOIN step_f2 i
+                   ON i.step_f2_id = s.step_id
+           WHERE s.program_id        = ${oid.pid}
+             AND s.observation_index = ${oid.index}
+        """.query[(Loc, F2Builder)].map(_.map(_.toF2))
+
+      def selectOne(oid: Observation.Id, loc: Loc): Query0[DynamicConfig.Flamingos2] =
+        sql"""
+          SELECT i.disperser,
+                 i.exposure_time,
+                 i.filter,
+                 i.fpu,
+                 i.custom_mask,
+                 i.lyot_wheel,
+                 i.read_mode,
+                 i.window_cover
+            FROM step s
+                 LEFT OUTER JOIN step_f2 i
+                   ON i.step_f2_id = s.step_id
+           WHERE s.program_id        = ${oid.pid}
+             AND s.observation_index = ${oid.index}
+             AND s.location          = $loc
+        """.query[F2Builder].map(_.toF2)
+
+      def insert(id: Int, f2: DynamicConfig.Flamingos2): Update0 =
+        sql"""
+          INSERT INTO step_f2 (
+            step_f2_id,
+            disperser, exposure_time, filter, fpu, custom_mask, lyot_wheel, read_mode, window_cover
+          )
+          VALUES (
+            $id,
+            ${f2.disperser},
+            ${f2.exposureTime},
+            ${f2.filter},
+            ${f2.fpu.flatMap(_.toBuiltin)},
+            ${f2.fpu.contains(Custom)},
+            ${f2.lyotWheel},
+            ${f2.readMode},
+            ${f2.windowCover})
+        """.update
+    }
+
+    object Gmos {
+
+      import gem.config.GmosConfig.{ GmosCommonDynamicConfig, GmosCustomMask, GmosGrating }
+      import DynamicConfig.{ GmosN, GmosS }
+
+      final case class GmosFpuBuilder[U](
+                         mdfFileName: Option[String],
+                         customSlitWidth: Option[GmosCustomSlitWidth],
+                         builtin: Option[U]) {
+
+        val toFpu: Option[Either[GmosCustomMask, U]] = {
+          val customMask: Option[GmosCustomMask] =
+            for {
+              m <- mdfFileName
+              w <- customSlitWidth
+            } yield GmosCustomMask(m, w)
+
+          customMask.map(Left(_)) orElse
+            builtin.map(Right(_))
+        }
+      }
+
+      final case class GmosNorthBuilder(
+                         c: GmosCommonDynamicConfig,
+                         g: Option[GmosGrating[GmosNorthDisperser]],
+                         f: Option[GmosNorthFilter],
+                         u: GmosFpuBuilder[GmosNorthFpu]) {
+
+        val toDynamicConfig: GmosN =
+          GmosN(c, g, f, u.toFpu)
+      }
+
+      final case class GmosSouthBuilder(
+                         c: GmosCommonDynamicConfig,
+                         g: Option[GmosGrating[GmosSouthDisperser]],
+                         f: Option[GmosSouthFilter],
+                         u: GmosFpuBuilder[GmosSouthFpu]) {
+
+        val toDynamicConfig: GmosS =
+          GmosS(c, g, f, u.toFpu)
+      }
+
+      private def selectFragment(withLocation: Boolean, table: String, oid: Observation.Id): Fragment =
+        Fragment.const(
+          s"""SELECT ${if (withLocation) "s.location," else ""}
+                     c.x_binning,
+                     c.y_binning,
+                     c.amp_count,
+                     c.amp_gain,
+                     c.amp_read_mode,
+                     c.dtax,
+                     c.exposure_time,
+                     c.roi,
+                     i.disperser,
+                     i.disperser_order,
+                     i.wavelength,
+                     i.filter,
+                     i.mdf_file_name,
+                     i.custom_slit_width,
+                     i.fpu
+                FROM step s
+                     LEFT OUTER JOIN step_gmos_common c
+                       ON c.step_id = s.step_id
+                     LEFT OUTER JOIN $table i
+                       ON i.step_id = s.step_id
+            """) ++
+          fr"""WHERE s.program_id = ${oid.pid} AND s.observation_index = ${oid.index}"""
+
+      def selectAllNorth(oid: Observation.Id): Query0[(Loc, GmosN)] =
+        selectFragment(withLocation = true, "step_gmos_north", oid)
+          .query[(Loc, GmosNorthBuilder)].map(_.map(_.toDynamicConfig))
+
+      def selectOneNorth(oid: Observation.Id, loc: Loc): Query0[GmosN] =
+        (selectFragment(withLocation = false, "step_gmos_north", oid) ++
+          fr"""AND s.location = $loc"""
+          ).query[GmosNorthBuilder].map(_.toDynamicConfig)
+
+      def selectAllSouth(oid: Observation.Id): Query0[(Loc, GmosS)] =
+        selectFragment(withLocation = true, "step_gmos_south", oid)
+          .query[(Loc, GmosSouthBuilder)].map(_.map(_.toDynamicConfig))
+
+      def selectOneSouth(oid: Observation.Id, loc: Loc): Query0[GmosS] =
+        (selectFragment(withLocation = false, "step_gmos_south", oid) ++
+          fr"""AND s.location = $loc"""
+          ).query[GmosSouthBuilder].map(_.toDynamicConfig)
+
+
+      def insertCommon(id: Int, g: GmosCommonDynamicConfig): Update0 =
+        sql"""
+          INSERT INTO step_gmos_common (
+            step_id,
+            x_binning, y_binning, amp_count, amp_gain, amp_read_mode, dtax, exposure_time, roi
+          )
+          VALUES (
+            $id,
+            ${g.ccdReadout.xBinning},
+            ${g.ccdReadout.yBinning},
+            ${g.ccdReadout.ampCount},
+            ${g.ccdReadout.ampGain},
+            ${g.ccdReadout.ampReadMode},
+            ${g.dtaxOffset},
+            ${g.exposureTime},
+            ${g.roi})
+        """.update
+
+      def insertNorth(id: Int, g: GmosN): Update0 =
+        sql"""
+          INSERT INTO step_gmos_north (
+            step_id,
+            disperser, disperser_order, wavelength, filter, mdf_file_name, custom_slit_width, fpu
+          )
+          VALUES (
+            $id,
+            ${g.grating.map(_.disperser)},
+            ${g.grating.map(_.order)},
+            ${g.grating.map(_.wavelength.toAngstroms)},
+            ${g.filter},
+            ${g.fpu.flatMap(_.swap.toOption.map(_.maskDefinitionFilename))},
+            ${g.fpu.flatMap(_.swap.toOption.map(_.slitWidth))},
+            ${g.fpu.flatMap(_.toOption)})
+        """.update
+
+      def insertSouth(id: Int, g: GmosS): Update0 =
+        sql"""
+          INSERT INTO step_gmos_south (
+            step_id,
+            disperser, disperser_order, wavelength, filter, mdf_file_name, custom_slit_width, fpu
+          )
+          VALUES (
+            $id,
+            ${g.grating.map(_.disperser)},
+            ${g.grating.map(_.order)},
+            ${g.grating.map(_.wavelength.toAngstroms)},
+            ${g.filter},
+            ${g.fpu.flatMap(_.swap.toOption.map(_.maskDefinitionFilename))},
+            ${g.fpu.flatMap(_.swap.toOption.map(_.slitWidth))},
+            ${g.fpu.flatMap(_.toOption)})
+        """.update
+    }
+
+    object Gnirs {
+
+      import EitherComposite._
+
+      def selectAll(oid: Observation.Id): Query0[(Loc, DynamicConfig.Gnirs)] =
+        sql"""
+          SELECT s.location,
+                 i.acquisition_mirror,
+                 i.camera,
+                 i.coadds,
+                 i.decker,
+                 i.disperser,
+                 i.exposure_time,
+                 i.filter,
+                 i.fpu_slit,
+                 i.fpu_other,
+                 i.prism,
+                 i.read_mode,
+                 i.wavelength
+            FROM step s
+                 LEFT OUTER JOIN step_gnirs i
+                   ON i.step_gnirs_id = s.step_id
+           WHERE s.program_id        = ${oid.pid}
+             AND s.observation_index = ${oid.index}
+        """.query
+
+      def selectOne(oid: Observation.Id, loc: Loc): Query0[DynamicConfig.Gnirs] =
+        sql"""
+          SELECT i.acquisition_mirror,
+                 i.camera,
+                 i.coadds,
+                 i.decker,
+                 i.disperser,
+                 i.exposure_time,
+                 i.filter,
+                 i.fpu_slit,
+                 i.fpu_other,
+                 i.prism,
+                 i.read_mode,
+                 i.wavelength
+            FROM step s
+                 LEFT OUTER JOIN step_gnirs i
+                   ON i.step_gnirs_id = s.step_id
+           WHERE s.program_id        = ${oid.pid}
+             AND s.observation_index = ${oid.index}
+             AND s.location          = $loc
+        """.query
+
+      def insert(id: Int, gnirs: DynamicConfig.Gnirs): Update0 =
+        sql"""
+          INSERT INTO step_gnirs (
+            step_gnirs_id,
+            acquisition_mirror,
+            camera,
+            coadds,
+            decker,
+            disperser,
+            exposure_time,
+            filter,
+            fpu_slit,
+            fpu_other,
+            prism,
+            read_mode,
+            wavelength
+          )
+          VALUES (
+            $id,
+            ${gnirs.acquisitionMirror},
+            ${gnirs.camera},
+            ${gnirs.coadds},
+            ${gnirs.decker},
+            ${gnirs.disperser},
+            ${gnirs.exposureTime},
+            ${gnirs.filter},
+            ${gnirs.fpu.toOption},
+            ${gnirs.fpu.swap.toOption},
+            ${gnirs.prism},
+            ${gnirs.readMode},
+            ${gnirs.wavelength})
+        """.update
+    }
+
+  }
+}

--- a/modules/db/src/main/scala/gem/dao/TargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetDao.scala
@@ -1,0 +1,115 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import doobie._
+import doobie.implicits._
+import gem.dao.meta._
+import gem.dao.composite._
+import gem.enum.TrackType
+import gem.math.{ Declination, ProperMotion, RightAscension }
+
+object TargetDao extends EnumeratedMeta /* extend EnumeratedMeta to lower the priority - see MetaTrackType below and issue #170 */ {
+
+  import EphemerisKeyComposite._
+  import ProperMotionComposite._
+
+  // MetaTrackType is a workaround until issue #170 is implemented.
+  import doobie.postgres.implicits._
+  implicit val MetaTrackType: Meta[TrackType] =
+    pgEnumString("e_track_type", TrackType.unsafeFromTag, _.tag)
+
+  def select(id: Target.Id): ConnectionIO[Option[Target]] =
+    Statements.select(id).option
+
+  def selectUnique(id: Target.Id): ConnectionIO[Target] =
+    Statements.select(id).unique
+
+  def insert(target: Target): ConnectionIO[Target.Id] =
+    Statements.insert(target)
+              .withUniqueGeneratedKeys[Int]("id")
+              .map(Target.Id(_))
+
+  def update(id: Target.Id, target: Target): ConnectionIO[Int] =
+    Statements.update(id, target).run
+
+  def delete(id: Target.Id): ConnectionIO[Int] =
+    Statements.delete(id).run
+
+  object Statements {
+
+    private final case class TargetKernel(
+      name: String,
+      trackType: TrackType,
+      ephemerisKey: Option[EphemerisKey],
+      properMotion: Option[ProperMotion]
+    ) {
+
+      def toTarget: Target =
+        trackType match {
+          case TrackType.Nonsidereal =>
+            Target(name, ephemerisKey.toLeft(sys.error("missing ephemeris key")))
+          case TrackType.Sidereal    =>
+            Target(name, properMotion.toRight(sys.error("missing proper motion")))
+        }
+
+    }
+
+    private def trackType(t: Target): TrackType =
+      t.track.fold(_ => TrackType.Nonsidereal, _ => TrackType.Sidereal)
+
+    // base coordinates formatted as readable strings, if target is sidereal
+    private def stringyCoordinates(t: Target): Option[(String, String)] =
+      t.track.toOption.map { pm =>
+        val cs = pm.baseCoordinates
+        (RightAscension.fromStringHMS.reverseGet(cs.ra),
+         Declination.fromStringSignedDMS.reverseGet(cs.dec))
+      }
+
+    def select(id: Target.Id): Query0[Target] =
+      sql"""
+        SELECT name, track_type,
+               e_key_type, e_key,                     -- ephemeris key
+               ra, dec, epoch, pv_ra, pv_dec, rv, px  -- proper motion
+          FROM target
+         WHERE id = $id
+      """.query[TargetKernel].map(_.toTarget)
+
+    def insert(target: Target): Update0 =
+      (fr"""INSERT INTO target (
+              name, track_type,
+              e_key_type, e_key,                     -- ephemeris key
+              ra, dec, epoch, pv_ra, pv_dec, rv, px, -- proper motion
+              ra_str, dec_str                        -- stringy coordinates
+           ) VALUES""" ++ values(
+             (target.name, trackType(target),
+              target.track.left.toOption,
+              target.track.right.toOption,
+              stringyCoordinates(target)
+             )
+           )
+      ).update
+
+    def update(id: Target.Id, target: Target): Update0 =
+      (fr"""UPDATE target
+            SET (name, track_type,
+                 e_key_type, e_key,                     -- ephemeris key
+                 ra, dec, epoch, pv_ra, pv_dec, rv, px, -- proper motion
+                 ra_str, dec_str                        -- stringy coordinates
+            ) =""" ++ values(
+            (target.name, trackType(target),
+             target.track.left.toOption,
+             target.track.right.toOption,
+             stringyCoordinates(target)
+            )
+      ) ++
+       fr"WHERE id = $id").update
+
+    def delete(id: Target.Id): Update0 =
+      sql"DELETE FROM target WHERE id=$id".update
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats._
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import gem.instances.treeset._
+import gem.math.Index
+
+object TargetEnvironmentDao {
+
+  private implicit def m: Monoid[ConnectionIO[Unit]] =
+    Applicative.monoid
+
+  def insert(oid: Observation.Id, e: TargetEnvironment): ConnectionIO[Unit] =
+    e.asterism.foldMap(AsterismDao.insert(oid, _)) *>
+    e.userTargets.toList.traverse(UserTargetDao.insert(oid, _)).void
+
+  def selectObs(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
+    (AsterismDao.select(oid), UserTargetDao.selectObs(oid)).mapN {
+      case (Left(a), uts)  => TargetEnvironment.fromAsterism(a, uts)
+      case (Right(i), uts) => TargetEnvironment.fromInstrument(i, uts)
+    }
+
+  def selectProg(pid: Program.Id): ConnectionIO[Map[Index, TargetEnvironment]] =
+    (AsterismDao.selectAll(pid), UserTargetDao.selectProg(pid)).mapN { (am, um) =>
+      am.map { case (idx, e) =>
+        val uts = um.get(idx).orEmpty
+        e match {
+          case Left(a)  => idx -> TargetEnvironment.fromAsterism(a, uts)
+          case Right(i) => idx -> TargetEnvironment.fromInstrument(i, uts)
+        }
+      }
+    }
+
+}

--- a/modules/db/src/main/scala/gem/dao/TrackDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TrackDao.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+
+import gem.enum.Site
+import gem.math.ProperMotion
+import gem.util.Timestamp
+
+
+object TrackDao {
+
+  /** Obtains, loading from the database if necessary, target tracking data.
+    * Enables coordinate queries for a target for the given site and time range.
+    */
+  def select(t: Target, s: Site, start: Timestamp, end: Timestamp): ConnectionIO[Track] =
+    t.track.fold(nonsidereal(_, s, start, end), sidereal)
+
+  private def sidereal(p: ProperMotion): ConnectionIO[Track] =
+    Track.Sidereal(p).pure[ConnectionIO].widen[Track]
+
+  private def nonsidereal(k: EphemerisKey, s: Site, start: Timestamp, end: Timestamp): ConnectionIO[Track] =
+    for {
+      range <- EphemerisDao.bracketRange(k, s, start, end)
+      eph   <- EphemerisDao.selectRange(k, s, range._1, range._2)
+    } yield Track.Nonsidereal(Map(s -> eph))
+
+}

--- a/modules/db/src/main/scala/gem/dao/UserDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserDao.scala
@@ -1,0 +1,153 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.dao.meta._
+import gem.enum.ProgramRole
+import cats.data._, cats.implicits._
+
+import doobie._, doobie.implicits._
+
+object UserDao {
+  import EnumeratedMeta._
+  import ProgramIdMeta._
+
+  /**
+   * Select the root user, for system processes. Always succceds if the system is consistent;
+   * raises an exception if the root user is missing.
+   * @group Queries
+   */
+  val selectRootUser: ConnectionIO[User[ProgramRole]] =
+    OptionT(selectUser(User.Id.Root)).getOrElse(sys.error("No root user. Cannot continue."))
+
+  // Helper method to add roles to a selected user, if any.
+  private def selectUserImpl(q: Query0[User[Nothing]]): ConnectionIO[Option[User[ProgramRole]]] = {
+    for {
+      u <- OptionT(q.option)
+      r <- OptionT(selectRoles(u.id).map(Option(_)))
+    } yield u.copy(roles = r)
+  } .value
+
+  /**
+   * Select the given user, if any, with roles.
+   * @group Queries
+   */
+  def selectUser(uid: User.Id): ConnectionIO[Option[User[ProgramRole]]] =
+    selectUserImpl(Statements.selectUser(uid))
+
+  /**
+   * Select the given user, if any, with roles, if the id and password match a known user.
+   * @group Queries
+   */
+  def selectUserʹ(uid: User.Id, password: String): ConnectionIO[Option[User[ProgramRole]]] =
+    selectUserImpl(Statements.selectUserʹ(uid, password))
+
+  /**
+   * Select the map of roles associated with the given user.
+   * @group Queries
+   */
+  def selectRoles(id: User.Id): ConnectionIO[Map[Program.Id, Set[ProgramRole]]] =
+    Statements.selectRoles(id).to[List].map(_.foldMap { case (k, v) => Map((k -> Set(v))) })
+
+  /**
+   * Insert or update a program role.
+   * @group Updates
+   */
+  def setRole(id: User.Id, pid: Program.Id, role: ProgramRole): ConnectionIO[Unit] =
+    Statements.setRole(id, pid, role).run.void
+
+  /**
+   * Drop a program role, if it exists, returning true if a role was dropped.
+   * @group Updates
+   */
+  def unsetRole(id: User.Id, pid: Program.Id, role: ProgramRole): ConnectionIO[Boolean] =
+    Statements.unsetRole(id, pid, role).run.map(_ > 0)
+
+  /**
+   * Insert a user.
+   * @group Updates
+   */
+  def insertUser(user: User[ProgramRole], password: String): ConnectionIO[Unit] =
+    Statements.insertUserFlat(user, password).run *>
+    user.roles.toList.traverse { case (p, rs) =>
+      rs.toList.traverse { r =>
+        Statements.setRole(user.id, p, r).run
+      }
+    } .void
+
+  /**
+   * Attempts to change the specified user's password, yielding success. A cause of failure (user
+   * not found, old password incorrect) is not given.
+   * @group Updates
+   */
+  def changePassword(uid: User.Id, oldPassword: String, newPassword: String): ConnectionIO[Boolean] =
+    Statements.changePassword(uid, oldPassword, newPassword).run.map(_ === 1)
+
+  object Statements {
+
+    private def andHash(password: String): Fragment =
+      fr"AND hash = crypt($password, hash)"
+
+    private def selectUserImpl(id: String, and: Fragment): Query0[User[Nothing]] =
+      (fr"""
+        SELECT id, first, last, email, staff
+        FROM gem_user
+        WHERE id = $id
+       """ ++ and).query[(String, String, String, String, Boolean)].map {
+        case (i, f, l, e, s) => User(i, f, l, e, s, Map.empty)
+      }
+
+    def selectUser(id: String): Query0[User[Nothing]] =
+      selectUserImpl(id, Fragment.empty)
+
+    def selectUserʹ(id: String, password: String): Query0[User[Nothing]] =
+      selectUserImpl(id, andHash(password))
+
+    def selectRoles(id: User.Id): Query0[(Program.Id, ProgramRole)] =
+      sql"""
+        SELECT program_id, program_role
+        FROM gem_user_program
+        WHERE user_id = $id
+      """.query
+
+    def changePassword(uid: User.Id, oldPassword: String, newPassword: String): Update0 =
+      (fr"""
+        UPDATE gem_user
+        SET    hash = crypt($newPassword, gen_salt('bf', 10))
+        WHERE  id   = ${uid}
+      """ ++ andHash(oldPassword)).update
+
+    def setRole(uid: User.Id, pid: Program.Id, role: ProgramRole): Update0 =
+      sql"""
+        INSERT INTO gem_user_program (user_id, program_id, program_role)
+        VALUES ($uid, $pid, $role)
+        ON CONFLICT (user_id, program_id, program_role) DO UPDATE
+          SET program_role = $role
+      """.update
+
+    def unsetRole(uid: User.Id, pid: Program.Id, role: ProgramRole): Update0 =
+      sql"""
+        DELETE FROM gem_user_program
+        WHERE  user_id      = $uid
+          AND  program_id   = $pid
+          AND  program_role = $role
+      """.update
+
+    def insertUserFlat(u: User[_], password: String): Update0 =
+      sql"""
+        INSERT INTO gem_user (id, first, last, hash, email, staff)
+        VALUES (
+          ${u.id},
+          ${u.firstName},
+          ${u.lastName},
+          crypt($password, gen_salt('bf', 10)),
+          ${u.email},
+          ${u.isStaff}
+        )
+      """.update
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -1,0 +1,135 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.dao.meta._
+import gem.enum.UserTargetType
+import gem.math.Index
+import gem.syntax.treesetcompanion._
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+
+import scala.collection.immutable.TreeSet
+
+object UserTargetDao {
+
+  // A target ID and the corresponding user target type.  We use the id to
+  // get the actual target.
+  final case class ProtoUserTarget(targetId: Target.Id, targetType: UserTargetType, oi: Index) {
+
+    val toUserTarget: ConnectionIO[Option[UserTarget]] =
+      TargetDao.select(targetId).map { _.map(UserTarget(_, targetType)) }
+  }
+
+  import EnumeratedMeta._
+  import ObservationIdMeta._
+
+  def insert(oid: Observation.Id, userTarget: UserTarget): ConnectionIO[UserTarget.Id] =
+    for {
+      tid <- TargetDao.insert(userTarget.target)
+      uid <- Statements.insert(tid, userTarget.targetType, oid)
+                       .withUniqueGeneratedKeys[Int]("id")
+                       .map(UserTarget.Id(_))
+    } yield uid
+
+  /** Selects the single `UserTarget` associated with the given id, if any. */
+  def select(id: UserTarget.Id): ConnectionIO[Option[UserTarget]] =
+    for {
+      oput <- Statements.select(id).option
+      out  <- oput.fold(Option.empty[UserTarget].pure[ConnectionIO]) { _.toUserTarget }
+    } yield out
+
+  private def selectAll(
+    targetsQuery: Query0[(UserTarget.Id, ProtoUserTarget)]
+  ): ConnectionIO[List[(Index, (UserTarget.Id, UserTarget))]] =
+    for {
+      puts <- targetsQuery.to[List]                              // List[(UserTarget.Id, ProtoUserTarget)]
+      ots  <- puts.map(_._2.targetId).traverse(TargetDao.select) // List[Option[Target]]
+    } yield puts.zip(ots).flatMap { case ((id, put), ot) =>
+      ot.map(t => (put.oi, (id, UserTarget(t, put.targetType)))).toList
+    }
+
+  private def toUserTargetSet(lst: List[(UserTarget.Id, UserTarget)]): TreeSet[UserTarget] =
+    TreeSet.fromList(lst.unzip._2)
+
+  /** Selects all `UserTarget`s for an observation.
+    */
+  def selectObs(oid: Observation.Id): ConnectionIO[TreeSet[UserTarget]] =
+    selectObsWithId(oid).map(toUserTargetSet)
+
+  /** Selects all `UserTarget`s for an observation paired with the `UserTarget`
+    * id itself.
+    */
+  def selectObsWithId(oid: Observation.Id): ConnectionIO[List[(UserTarget.Id, UserTarget)]] =
+    selectAll(Statements.selectObs(oid)).map(_.unzip._2)
+
+  /** Selects all `UserTarget`s for a program.
+    */
+  def selectProg(pid: Program.Id): ConnectionIO[Map[Index, TreeSet[UserTarget]]] =
+    selectProgWithId(pid).map(_.mapValues(toUserTargetSet))
+
+  /** Selects all `UserTarget`s for a program paired with the `UserTarget` id
+    * itself.
+    */
+  def selectProgWithId(pid: Program.Id): ConnectionIO[Map[Index, List[(UserTarget.Id, UserTarget)]]] =
+    selectAll(Statements.selectProg(pid)).map {
+      _.groupBy(_._1).mapValues(_.unzip._2)
+    }
+
+
+  object Statements {
+
+    import gem.dao.meta.ProgramIdMeta._
+    import gem.dao.meta.IndexMeta._
+
+    def insert(targetId: Target.Id, targetType: UserTargetType, oid: Observation.Id): Update0 =
+      sql"""
+        INSERT INTO user_target (
+          target_id,
+          user_target_type,
+          program_id,
+          observation_index,
+          observation_id
+        ) VALUES (
+          $targetId,
+          $targetType,
+          ${oid.pid},
+          ${oid.index},
+          $oid
+        )
+      """.update
+
+    def select(id: UserTarget.Id): Query0[ProtoUserTarget] =
+      sql"""
+        SELECT target_id,
+               user_target_type,
+               observation_index
+          FROM user_target
+         WHERE id = $id
+      """.query[ProtoUserTarget]
+
+    def selectObs(oid: Observation.Id): Query0[(UserTarget.Id, ProtoUserTarget)] =
+      sql"""
+        SELECT id,
+               target_id,
+               user_target_type,
+               observation_index
+          FROM user_target
+         WHERE program_id = ${oid.pid} AND observation_index = ${oid.index}
+      """.query[(UserTarget.Id, ProtoUserTarget)]
+
+    def selectProg(pid: Program.Id): Query0[(UserTarget.Id, ProtoUserTarget)] =
+      sql"""
+        SELECT id,
+               target_id,
+               user_target_type,
+               observation_index
+          FROM user_target
+         WHERE program_id = $pid
+      """.query[(UserTarget.Id, ProtoUserTarget)]
+
+  }
+}

--- a/modules/db/src/main/scala/gem/dao/composite/Coordinates.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/Coordinates.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.composite
+
+import doobie._
+import gem.dao.meta._
+
+import gem.math._
+
+trait CoordinatesComposite {
+
+  /** Coordinates composite, laid out in natural order, in microarcseconds. */
+  implicit val CoordinatesComposite: Composite[Coordinates] =
+    CoordinatesCompositeLemmas.CoordinatesComposite
+
+  implicit val CoordinatesOptionComposite: Composite[Option[Coordinates]] =
+    CoordinatesCompositeLemmas.CoordinatesOptionComposite
+
+}
+object CoordinatesComposite extends CoordinatesComposite
+
+/** Derivation of Composite instances for Coordinates. */
+private object CoordinatesCompositeLemmas {
+  import DeclinationMeta._
+  import RightAscensionMeta._
+
+  val CoordinatesComposite: Composite[Coordinates] = implicitly
+  val CoordinatesOptionComposite: Composite[Option[Coordinates]] = implicitly
+
+}

--- a/modules/db/src/main/scala/gem/dao/composite/EitherComposite.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/EitherComposite.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.composite
+
+import doobie._
+
+trait EitherComposite {
+
+  /** Two-column mapping for Either. */
+  implicit def eitherComposite[A: Meta, B: Meta]: Composite[Either[A, B]] =
+    Composite[(Option[A], Option[B])].imap {
+      case (Some(a), None) => Left(a)
+      case (None, Some(b)) => Right(b)
+      case (a, b) => sys.error(s"Invariant violated: can't map ($a, $b) to Either!")
+    } {
+      case Left(a) => (Some(a), None)
+      case Right(b) => (None, Some(b))
+    }
+
+}
+object EitherComposite extends EitherComposite

--- a/modules/db/src/main/scala/gem/dao/composite/EphemerisKey.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/EphemerisKey.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.composite
+
+import doobie._
+import gem.EphemerisKey
+import gem.dao.meta._
+
+trait EphemerisKeyComposite {
+  import EnumeratedMeta._
+  import FormatComposite._
+
+  /** Map an EphemerisKey as an (EphemerisKeyType, String) pair. */
+  implicit val CompositeEphemerisKey: Composite[EphemerisKey] =
+    EphemerisKey.fromTypeAndDes.toComposite
+
+  /** Map an Option[EphemerisKey] as a nullable (EphemerisKeyType, String) pair. */
+  implicit lazy val CompositeOptionEphemerisKey: Composite[Option[EphemerisKey]] =
+    EphemerisKey.fromTypeAndDes.toOptionComposite
+
+}
+object EphemerisKeyComposite extends EphemerisKeyComposite

--- a/modules/db/src/main/scala/gem/dao/composite/FormatComposite.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/FormatComposite.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.composite
+
+import doobie._
+import gem.optics.Format
+
+/**
+ * Given an Format[A, B] and a Composite[A] for the external type, we can create a Composite[B] that
+ * will raise an exception if validation fails on read.
+ */
+class FormatOps[A, B](f: Format[A, B]) {
+
+  def toComposite(implicit mb: Composite[A]): Composite[B] =
+    mb.imap(f.unsafeGet(_))(f.reverseGet)
+
+  def toOptionComposite(implicit mb: Composite[Option[A]]): Composite[Option[B]] =
+    mb.imap(_.map(a => f.unsafeGet(a)))(_.map(f.reverseGet))
+
+}
+
+trait FormatComposite {
+  implicit def toFormatOps[A, B](f: Format[A, B]): FormatOps[A, B] =
+    new FormatOps(f)
+}
+
+object FormatComposite extends FormatComposite

--- a/modules/db/src/main/scala/gem/dao/composite/ProperMotion.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/ProperMotion.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.composite
+
+import doobie._
+import gem.dao.meta._
+
+import gem.math._
+
+trait ProperMotionComposite {
+
+  /** ProperMotion composite, laid out in natural order. */
+  implicit val ProperMotionComposite: Composite[ProperMotion] =
+    ProperMotionCompositeLemmas.ProperMotionComposite
+
+  implicit val ProperMotionOptionComposite: Composite[Option[ProperMotion]] =
+    ProperMotionCompositeLemmas.ProperMotionOptionComposite
+
+}
+object ProperMotionComposite extends ProperMotionComposite
+
+/** Derivation of Composite instances for ProperMotion. */
+private object ProperMotionCompositeLemmas {
+  import CoordinatesComposite._
+  import EnumeratedMeta._
+  import EpochMeta._
+  import RadialVelocityMeta._
+
+  // The parallax member is an angle, which we will store as signed milliarcseconds
+  // N.B. if this is marked private we get a spurious "unused" warning
+  implicit lazy val AngleMasMeta: Meta[Angle] =
+    AngleMeta.AngleMetaAsSignedMilliarcseconds
+
+  val ProperMotionComposite: Composite[ProperMotion] = implicitly
+  val ProperMotionOptionComposite: Composite[Option[ProperMotion]] = implicitly
+
+}

--- a/modules/db/src/main/scala/gem/dao/composite/TaggedCoproduct.scala
+++ b/modules/db/src/main/scala/gem/dao/composite/TaggedCoproduct.scala
@@ -1,0 +1,135 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.composite
+
+import cats._
+import cats.implicits._
+import doobie._
+import shapeless._
+import shapeless.ops.coproduct.{ Inject, Unifier }
+
+object TaggedCoproduct {
+
+  /**
+   * Typeclass witnessing that a coproduct A :+: B :+: ... :+: CNil can be encoded as a pair of
+   * tag and product of options  (T, Option[A] :: Option[B] :: ... :: HNil) and can be decoded in
+   * cases where the encoding is valid. If the latter type has a Composite instance then the former
+   * does as well. This allows us to encode a coproduct as a column vector. The tag is normally
+   * redundant but is necessary in when a coproduct element has all Option fields and is thus never
+   * read as None.
+   */
+  sealed trait TaggedCoproductEncoder[T, C <: Coproduct] { outer =>
+
+    /**
+     * The product encoding of C, an HList of options, uniquely determined by C. For example
+     * A :+: B :+: CNil is encoded as Option[A] :: Option[B] :: HNil.
+     */
+    type Out <: HList
+
+    /**
+     * A value of type Out in which every element is None. So if Out is Option[A] :: Option[B] ::
+     * HNil then empty will be None :: None :: HNil.
+     */
+    def empty: Out
+
+    /** Encode a coproduct C as a tuple of a tag T and hlist of options Out. */
+    def encode(c: C): (T, Out)
+
+    /** Inject a value A into C. Users will need to do this if they're mapping an ADT into C. */
+    def inj[A: Inject[C, ?]](a: A): C =
+      Coproduct(a)
+
+    /** Inject a value A into C and encode. */
+    def apply[A: Inject[C, ?]](a: A): (T, Out) =
+      encode(inj(a))
+
+    /** Decode a tag T and hlist Out into a C if possible. */
+    def decode(t: T, o: Out)(implicit ev: Eq[T]): Option[C]
+
+    /** Decode optimistically, raising an exception on failure. */
+    def unsafeDecode(t: T, o: Out)(implicit ev: Eq[T]): C =
+      decode(t, o).getOrElse(sys.error(s"invalid tagged coproduct encoding ($t, $o)"))
+
+    /**
+     * Extend this encoder by consing a new type/tag onto the front via the little DSL. We can
+     * widen the type of T in the process, which proves useful if T is an ADT.
+     */
+    def :+:[TT >: T, A](t: Tag.Tag[TT, A]): TaggedCoproductEncoder.Aux[TT, A :+: C, Option[A] :: Out] =
+      TaggedCoproductEncoder.cons(t.tag, this.widen[TT])
+
+    /**
+     * Given Composite[(T, Out)] and Eq[T] we can get Composite[C]. Ultimately this is the purpose
+     * of this typeclass.
+     */
+    def composite(implicit ev: Composite[(T, Out)], eq: Eq[T]): Composite[C] =
+      ev.imap((unsafeDecode _).tupled)(encode)
+
+    /**
+     * Convenience method, equivalent to `composite.imap[A](_.unify)(inj)`. Requires that A be a
+     * unifier of C; i.e., some supertype of its element types.
+     */
+    def unifiedComposite[A](inj: A => C)(
+      implicit ev: Composite[(T, Out)],
+               eq: Eq[T],
+               un: Unifier.Aux[C, A]
+             ): Composite[A] =
+      composite.imap(_.unify)(inj)
+
+    /**
+     * Widen the tag type. This is a no-op but Scala needs some convincing. Observe that you can
+     * widen nil and cons trivially by constructing an identical instance with different type
+     * arguments, which means the runtime representations must be identical, which means we can just
+     * do it as a cast and avoid allocating anything at all.
+     */
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    def widen[TT >: T]: TaggedCoproductEncoder.Aux[TT, C, Out] =
+      this.asInstanceOf[TaggedCoproductEncoder.Aux[TT, C, Out]]
+
+  }
+  object TaggedCoproductEncoder {
+
+    /** Universal representation that lets us talk about the Out type member. */
+    type Aux[T, C <: Coproduct, O] = TaggedCoproductEncoder[T, C] { type Out = O }
+
+    /**
+     * Base case: encoder for an empty coproduct. This is trivial because encode can never be
+     * called (CNil is uninhabited) and decode always fails.
+     */
+    def nil[T]: Aux[T, CNil, HNil] =
+      new TaggedCoproductEncoder[T, CNil] {
+        type Out = HNil
+        override def empty = HNil
+        override def encode(c: CNil) = sys.error("unpossible: empty coproduct")
+        override def decode(t: T, o: Out)(implicit ev: Eq[T]) = None
+      }
+
+    /** Inductive case: extend an encoder by consing a new type/tag onto the front. */
+    def cons[T, A, B <: Coproduct](tag: T, te: TaggedCoproductEncoder[T, B]): Aux[T, A :+: B, Option[A] :: te.Out] =
+      new TaggedCoproductEncoder[T, A :+: B] {
+        type Out = Option[A] :: te.Out
+        override def empty = None :: te.empty
+        override def encode(c: A :+: B) =
+          c match {
+            case Inl(a) => (tag, Some(a) :: te.empty)
+            case Inr(b) => te.encode(b).map(None :: _)
+          }
+        override def decode(t: T, o: Out)(implicit ev: Eq[T]) =
+          if (t === tag)    o.head .map(Inl(_))
+          else te.decode(t, o.tail).map(Inr(_))
+      }
+
+  }
+
+  // a little dsl for constructing instances: Tag[Int]("foo") :+: Tag[String]("bar") :+: TNil
+  object Tag {
+    final case class Tag[+T, A](tag: T)
+    def apply[A]: TaggedPartial[A] = new TaggedPartial[A]
+    final class TaggedPartial[A] {
+      def apply[T](t: T): Tag[T, A] = Tag[T, A](t)
+    }
+  }
+  val TNil: TaggedCoproductEncoder.Aux[Nothing, CNil, HNil] =
+    TaggedCoproductEncoder.nil[Nothing]
+
+}

--- a/modules/db/src/main/scala/gem/dao/meta/Angle.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Angle.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math.{ Angle, HourAngle }
+
+trait AngleMeta {
+
+  private def signedBigDecimal(d: Int): Meta[Angle] =
+    Meta[java.math.BigDecimal]
+      .xmap[Angle](
+        b => Angle.fromMicroarcseconds(b.movePointRight(d).longValue),
+        a => new java.math.BigDecimal(Angle.signedMicroarcseconds.get(a)).movePointLeft(d)
+      )
+
+  // Angle mapping to signed arcseconds via NUMERIC. NOT implicit. We're mapping a type that
+  // is six orders of magnitude more precise than the database column, so we will shift
+  // the decimal pure back and forth.
+  val AngleMetaAsSignedArcseconds: Meta[Angle] =
+    signedBigDecimal(6)
+
+  val AngleMetaAsSignedMilliarcseconds: Meta[Angle] =
+    signedBigDecimal(3)
+
+  val AngleMetaAsMicroarcseconds: Meta[Angle] =
+    Meta[Long].xmap[Angle](Angle.fromMicroarcseconds, _.toMicroarcseconds)
+
+  val HourAngleMetaAsMicroseconds: Meta[HourAngle] =
+    Meta[Long].xmap[HourAngle](HourAngle.fromMicroseconds, _.toMicroseconds)
+
+}
+object AngleMeta extends AngleMeta

--- a/modules/db/src/main/scala/gem/dao/meta/AsterismType.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/AsterismType.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie.Meta
+import doobie.postgres.implicits._
+import gem.enum.AsterismType
+
+trait AsterismTypeMeta {
+
+  // Workaround until issue #170 is implemented.
+  implicit val MetaAsterismType: Meta[AsterismType] =
+    pgEnumString("asterism_type", AsterismType.unsafeFromTag, _.tag)
+
+}
+
+object AsterismTypeMeta extends AsterismTypeMeta

--- a/modules/db/src/main/scala/gem/dao/meta/CoAdds.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/CoAdds.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.CoAdds
+import gem.syntax.prism._
+
+trait CoAddsMeta {
+
+  implicit val CoAddsMetaShort: Meta[CoAdds] =
+    Distinct.short("coadds").xmap(CoAdds.fromShort.unsafeGet(_), _.toShort)
+
+}
+
+object CoAddsMeta extends CoAddsMeta

--- a/modules/db/src/main/scala/gem/dao/meta/DatasetLabel.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/DatasetLabel.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.Dataset
+
+trait DatasetLabelMeta {
+  import FormatMeta._
+
+  // Dataset.Label as string
+  implicit val DatasetLabelMeta: Meta[Dataset.Label] =
+    Dataset.Label.fromString.asMeta
+
+}
+object DatasetLabelMeta extends DatasetLabelMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Declination.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Declination.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math._
+import gem.syntax.prism._
+
+trait DeclinationMeta {
+  import AngleMeta._
+
+  implicit val DeclinationMeta: Meta[Declination] =
+    AngleMetaAsMicroarcseconds.xmap(Declination.fromAngle.unsafeGet(_), _.toAngle)
+
+}
+object DeclinationMeta extends DeclinationMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Distinct.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Distinct.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import cats.data.NonEmptyList
+import doobie._
+import doobie.enum.JdbcType.{ Distinct => JdbcDistinct, _ }
+
+/**
+ * Constructor for a Meta instances with an underlying types that are reported by JDBC as
+ * type Distinct, as happens when a column has a check constraint. By using a data type with
+ * a Distinct Meta instance we can satisfy the query checker.
+ */
+object Distinct {
+
+  def integer(name: String): Meta[Int] =
+    Meta.advanced(
+      NonEmptyList.of(JdbcDistinct, Integer),
+      NonEmptyList.of(name),
+      _ getInt _,
+      _.setInt(_, _),
+      _.updateInt(_, _)
+    )
+
+  def long(name: String): Meta[Long] =
+    Meta.advanced(
+      NonEmptyList.of(JdbcDistinct, BigInt),
+      NonEmptyList.of(name),
+      _ getLong _,
+      _.setLong(_, _),
+      _.updateLong(_, _)
+    )
+
+  def short(name: String): Meta[Short] =
+    Meta.advanced(
+      NonEmptyList.of(JdbcDistinct, SmallInt),
+      NonEmptyList.of(name),
+      _ getShort _,
+      _.setShort(_, _),
+      _.updateShort(_, _)
+    )
+
+  def string(name: String): Meta[String] =
+    Meta.advanced(
+      NonEmptyList.of(JdbcDistinct, VarChar),
+      NonEmptyList.of(name),
+      _ getString _,
+      _.setString(_, _),
+      _.updateString(_, _)
+    )
+
+}

--- a/modules/db/src/main/scala/gem/dao/meta/Enumerated.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Enumerated.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.util.Enumerated
+import scala.reflect.runtime.universe.TypeTag
+
+trait EnumeratedMeta {
+
+  // Enumerated by tag as DISTINCT (identifier)
+  implicit def enumeratedMeta[A >: Null : TypeTag](implicit ev: Enumerated[A]): Meta[A] =
+    Distinct.string("identifier").xmap[A](ev.unsafeFromTag(_), ev.tag(_))
+
+}
+object EnumeratedMeta extends EnumeratedMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Epoch.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Epoch.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math._
+
+trait EpochMeta {
+  import FormatMeta._
+
+  /** Epoch as a string, like J2012.123 */
+  implicit lazy val EpochMeta: Meta[Epoch] =
+    Epoch.fromString.asMeta
+
+}
+object EpochMeta extends EpochMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Format.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Format.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.optics.Format
+import scala.reflect.runtime.universe.TypeTag
+
+/**
+ * Given an Format[A, B] and a Meta[A] for the external format, we can create a Meta[B] that will
+ * raise an exception if validation fails on read.
+ */
+class FormatOps[A, B](f: Format[A, B]) {
+  def asMeta(
+    implicit mb: Meta[A],
+             ta: TypeTag[B]
+  ): Meta[B] =
+    mb.xmap(f.getOption(_).getOrElse(sys.error("Validation failed.")), f.reverseGet)
+}
+
+trait FormatMeta {
+  implicit def toFormatOps[A, B](f: Format[A, B]): FormatOps[A, B] =
+    new FormatOps(f)
+}
+
+object FormatMeta extends FormatMeta

--- a/modules/db/src/main/scala/gem/dao/meta/IndexMeta.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/IndexMeta.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math.Index
+import gem.syntax.prism._
+
+trait IndexMeta {
+
+  // Index has a DISTINCT type due to its check constraint so we
+  // need a fine-grained mapping here to satisfy the query checker.
+  implicit val IndexMeta: Meta[Index] =
+    Distinct.short("id_index").xmap(Index.fromShort.unsafeGet, _.toShort)
+
+}
+object IndexMeta extends IndexMeta
+

--- a/modules/db/src/main/scala/gem/dao/meta/Level.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Level.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import java.util.logging.Level
+
+trait LevelMeta {
+
+  // Java Log Levels (not nullable)
+  implicit val levelMeta: Meta[Level] =
+    Meta[String].xmap(Level.parse, _.getName)
+
+}
+object LevelMeta extends LevelMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Location.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Location.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import cats.implicits._
+import doobie._
+import doobie.postgres.implicits._
+import gem.util.Location
+
+trait LocationMeta {
+
+  implicit val LocationMeta: Meta[Location.Middle] =
+    Meta[List[Int]].xmap(Location.unsafeMiddleFromFoldable(_), _.toList)
+
+}
+object LocationMeta extends LocationMeta

--- a/modules/db/src/main/scala/gem/dao/meta/ObservationId.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/ObservationId.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.Observation
+
+trait ObservationIdMeta {
+
+  // Observation.Id as string
+  implicit val ObservationIdMeta: Meta[Observation.Id] =
+    Meta[String].xmap(Observation.Id.unsafeFromString, _.format)
+
+}
+object ObservationIdMeta extends ObservationIdMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Offset.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Offset.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math.Offset
+
+trait OffsetMeta {
+  import AngleMeta._
+
+  // OffsetP maps to a signed angle in arcseconds
+  implicit val OffsetPMeta: Meta[Offset.P] =
+    AngleMetaAsSignedArcseconds.xmap(Offset.P(_), _.toAngle)
+
+  // OffsetQ maps to a signed angle in arcseconds
+  implicit val OffsetQMeta: Meta[Offset.Q] =
+    AngleMetaAsSignedArcseconds.xmap(Offset.Q(_), _.toAngle)
+
+}
+object OffsetMeta extends OffsetMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Prism.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Prism.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.syntax.prism._
+import monocle.Prism
+import scala.reflect.runtime.universe.TypeTag
+
+/**
+ * Given an Prism[A, B] and a Meta[A] for the external Prism, we can create a Meta[B] that will
+ * raise an exception if validation fails on read.
+ */
+class PrismOps[A, B](f: Prism[A, B]) {
+  def asMeta(
+    implicit mb: Meta[A],
+             ta: TypeTag[B]
+  ): Meta[B] =
+    mb.xmap(f.unsafeGet(_), f.reverseGet)
+}
+
+trait PrismMeta {
+  implicit def toPrismOps[A, B](f: Prism[A, B]): PrismOps[A, B] =
+    new PrismOps(f)
+}
+
+object PrismMeta extends PrismMeta

--- a/modules/db/src/main/scala/gem/dao/meta/ProgramId.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/ProgramId.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.Program
+
+trait ProgramIdMeta {
+  import PrismMeta._
+
+  // Program.Id as string
+  implicit val ProgramIdMeta: Meta[Program.Id] =
+    Program.Id.fromString.asMeta
+
+}
+object ProgramIdMeta extends ProgramIdMeta

--- a/modules/db/src/main/scala/gem/dao/meta/RadialVelocity.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/RadialVelocity.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math._
+
+trait RadialVelocityMeta {
+
+  /** Radial velocity in meters per second. */
+  implicit lazy val RadialVelocityMeta: Meta[RadialVelocity] =
+    Meta[Int].xmap(RadialVelocity.apply, _.toMetersPerSecond)
+
+}
+object RadialVelocityMeta extends RadialVelocityMeta

--- a/modules/db/src/main/scala/gem/dao/meta/RightAscension.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/RightAscension.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math._
+
+trait RightAscensionMeta {
+  import AngleMeta._
+
+  implicit val RightAscensionMeta: Meta[RightAscension] =
+    HourAngleMetaAsMicroseconds.xmap(RightAscension(_), _.toHourAngle)
+
+}
+object RightAscensionMeta extends RightAscensionMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Time.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Time.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.util.Timestamp
+import java.time.{ Instant, Duration }
+
+trait TimeMeta {
+
+  implicit val TimestampMeta: Meta[Timestamp] =
+    Meta[Instant].xmap(Timestamp.unsafeFromInstant, _.toInstant)
+
+  implicit val DurationMeta: Meta[Duration] =
+    Distinct.long("milliseconds").xmap(Duration.ofMillis, _.toMillis)
+
+}
+object TimeMeta extends TimeMeta

--- a/modules/db/src/main/scala/gem/dao/meta/Wavelength.scala
+++ b/modules/db/src/main/scala/gem/dao/meta/Wavelength.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao.meta
+
+import doobie._
+import gem.math.Wavelength
+
+trait WavelengthMeta {
+  import PrismMeta._
+
+  // Wavelength maps to an integer in angstroms
+  implicit val WavelengthMeta: Meta[Wavelength] =
+    Wavelength.fromAngstroms.asMeta
+
+}
+object WavelengthMeta extends WavelengthMeta

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -1,0 +1,71 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.data._, cats.implicits._
+import doobie._, doobie.implicits._
+
+package object dao {
+
+  // Uncomment to turn on statement logging
+  // implicit val han = LogHandler.jdkLogHandler
+
+  type MaybeConnectionIO[A] = OptionT[ConnectionIO, A]
+
+  object MaybeConnectionIO {
+    def apply[A](coa: ConnectionIO[Option[A]]): MaybeConnectionIO[A] =
+      OptionT(coa)
+
+    def fromOption[A](oa: Option[A]): MaybeConnectionIO[A] =
+      oa.fold(OptionT.none[ConnectionIO, A]) { a =>
+        OptionT.some[ConnectionIO](a)
+      }
+
+    def none[A]: MaybeConnectionIO[A] =
+      OptionT.none[ConnectionIO, A]
+
+    def some[A](a: => A): MaybeConnectionIO[A] =
+      OptionT.some[ConnectionIO](a)
+  }
+
+  implicit class Query0Ops[A](a: Query0[A]) {
+    def maybe: MaybeConnectionIO[A] =
+      MaybeConnectionIO(a.option)
+  }
+
+  type EitherConnectionIO[A, B] = EitherT[ConnectionIO, A, B]
+
+  object EitherConnectionIO {
+    def apply[A, B](ceab: ConnectionIO[Either[A, B]]): EitherConnectionIO[A, B] =
+      EitherT(ceab)
+
+    def left[A, B](a: ConnectionIO[A]): EitherConnectionIO[A, B] =
+      EitherT.left(a)
+
+    def pointLeft[A, B](a: A): EitherConnectionIO[A, B] =
+      left(a.pure[ConnectionIO])
+
+    def right[A, B](b: ConnectionIO[B]): EitherConnectionIO[A, B] =
+      EitherT.right(b)
+
+    def pointRight[A, B](b: B): EitherConnectionIO[A, B] =
+      right(b.pure[ConnectionIO])
+
+    def fromDisjunction[A, B](eab: Either[A, B]): EitherConnectionIO[A, B] =
+      EitherT.fromEither(eab)
+  }
+
+  implicit class ConnectionIOOps[T](c: ConnectionIO[T]) {
+    def injectLeft[B]: EitherConnectionIO[T, B] =
+      EitherConnectionIO.left[T, B](c)
+
+    def injectRight[A]: EitherConnectionIO[A, T] =
+      EitherConnectionIO.right[A, T](c)
+  }
+
+  /** Flattened `a` as a VALUES argument (...). */
+  def values[A](a: A)(implicit ev: Composite[A]): Fragment =
+    Fragment(List.fill(ev.length)("?").mkString("(", ", ", ")"), a)
+
+}

--- a/modules/db/src/test/scala/gem/dao/DaoTest.scala
+++ b/modules/db/src/test/scala/gem/dao/DaoTest.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.effect.IO
+import doobie._, doobie.implicits._
+import gem.Program
+import gem.syntax.prism._
+
+import scala.collection.immutable.TreeMap
+
+/** Base trait for DAO test cases.
+  */
+trait DaoTest extends gem.Arbitraries {
+  val pid = Program.Id.fromString.unsafeGet("GS-1234A-Q-1")
+
+  protected val xa: Transactor[IO] =
+    Transactor.after.set(DatabaseConfiguration.forTesting.transactor[IO], HC.rollback)
+
+  def withProgram[A](test: ConnectionIO[A]): A =
+    (for {
+      _ <- ProgramDao.insertFlat(Program(pid, "Test Prog", TreeMap.empty))
+      a <- test
+    } yield a).transact(xa).unsafeRunSync()
+
+}

--- a/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/EphemerisDaoSpec.scala
@@ -1,0 +1,354 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.arb.ArbEnumerated._
+import gem.arb.ArbEphemeris._
+import gem.arb.ArbEphemerisKey._
+import gem.arb.ArbEphemerisMeta._
+import gem.arb.ArbTime._
+import gem.enum.Site
+import gem.math.Ephemeris
+import gem.util.Timestamp
+
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+
+import fs2.Stream
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalatest._
+import org.scalatest.prop._
+import org.scalatest.Matchers._
+
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
+class EphemerisDaoSpec extends PropSpec with PropertyChecks with DaoTest {
+
+  import EphemerisDaoSpec._
+
+  //
+  // Inserts all the ephemeris data and executes the given command.
+  //
+  private def execTest[A](m: EphemerisMap, ca: ConnectionIO[A]): A =
+    ((m.toList.traverse { case (ks, e) => EphemerisDao.insert(ks.key, ks.site, e) }) *> ca)
+      .transact(xa)
+      .unsafeRunSync
+
+  property("EphemerisDao should return empty ephmeris if the key is not found") {
+    forAll { (ks: KS, m: EphemerisMap) =>
+      val e = execTest(m - ks, EphemerisDao.selectAll(ks.key, ks.site))
+      e shouldEqual Ephemeris.empty
+    }
+  }
+
+  property("EphemerisDao should selectAll") {
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
+      val eʹ = execTest(m + (ks -> e), EphemerisDao.selectAll(ks.key, ks.site))
+      e shouldEqual eʹ
+    }
+  }
+
+  property("EphemerisDao should selectRange") {
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap, i0: Timestamp, i1: Timestamp) =>
+      val List(start, end) = List(i0, i1).sorted
+      val eʹ = execTest(m + (ks -> e), EphemerisDao.selectRange(ks.key, ks.site, start, end))
+      e.toMap.range(start, end) shouldEqual eʹ.toMap
+    }
+  }
+
+  property("EphemerisDao should delete by key") {
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
+      val eʹ = execTest(m + (ks -> e), EphemerisDao.delete(ks.key, ks.site) *> EphemerisDao.selectAll(ks.key, ks.site))
+      eʹ shouldEqual Ephemeris.empty
+    }
+  }
+
+  property("EphemerisDao should not delete others") {
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
+      val p  = EphemerisDao.delete(ks.key, ks.site) *>
+                 (m - ks).keys.toList.traverse(ksʹ => EphemerisDao.selectAll(ksʹ.key, ksʹ.site).tupleLeft(ksʹ)).map(_.toMap)
+
+      (m - ks) shouldEqual execTest(m + (ks -> e), p)
+    }
+  }
+
+  property("EphemerisDao update should replace existing") {
+    forAll { (ks: KS, e0: Ephemeris, e1: Ephemeris, m: EphemerisMap) =>
+      val p = EphemerisDao.update(ks.key, ks.site, e1) *>
+                EphemerisDao.selectAll(ks.key, ks.site)
+
+      e1 shouldEqual execTest(m + (ks -> e0), p)
+    }
+  }
+
+  property("EphemerisDao should generate UserSupplied ephemeris keys") {
+
+    // Select a handful of ids and make sure they are unique.
+    //
+    // NOTE: even though we abort the transaction and rollback, this doesn't
+    // reset the sequence id counter because SEQUENCE is "non-transactional".
+    // A flywayClean followed by flywayMigrate will reset the sequence of
+    // course, or an explicit SELECT setval('user_ephemeris_id', 0, false).
+
+    val ids: List[EphemerisKey.UserSupplied] =
+      (1 to 10)
+        .toList
+        .traverse(_ => EphemerisDao.nextUserSuppliedKey)
+        .transact(xa)
+        .unsafeRunSync
+
+    ids.distinct shouldEqual ids
+  }
+
+  property("EphemerisDao meta select should return None if unknown key") {
+    forAll { (ks: KS) =>
+      val meta = EphemerisDao.selectMeta(ks.key, ks.site)
+        .transact(xa)
+        .unsafeRunSync
+
+      meta shouldEqual None
+    }
+  }
+
+  property("EphemerisDao meta should roundtrip") {
+    forAll { (ks: KS, m: EphemerisMeta) =>
+      val p = EphemerisDao.insertMeta(ks.key, ks.site, m) *>
+                EphemerisDao.selectMeta(ks.key, ks.site)
+
+      p.transact(xa).unsafeRunSync shouldEqual Some(m)
+    }
+  }
+
+  property("EphemerisDao meta should select by key and site") {
+    forAll { (head: (KS, EphemerisMeta), tail: List[(KS, EphemerisMeta)], i: Int) =>
+
+      val env = EphemerisMetaTestEnv(head, tail, i)
+
+      // Select from the DB the one that we picked
+      val selectOne = EphemerisDao.selectMeta(env.key, env.site)
+
+      // Run the test
+      val res = (env.insertAll *> selectOne).transact(xa).unsafeRunSync
+
+      res shouldEqual Some(env.meta)
+    }
+  }
+
+  property("EphemerisDao meta should update") {
+    forAll { (head: (KS, EphemerisMeta), tail: List[(KS, EphemerisMeta)], i: Int, meta: EphemerisMeta) =>
+
+      val env = EphemerisMetaTestEnv(head, tail, i)
+
+      // Update the one that we picked
+      val updateOne = EphemerisDao.updateMeta(env.key, env.site, meta)
+
+      // Try to select the updated one
+      val selectOne = EphemerisDao.selectMeta(env.key, env.site)
+
+      // Run the test
+      val res = (env.insertAll *> updateOne *> selectOne).transact(xa).unsafeRunSync
+
+      res shouldEqual Some(meta)
+    }
+  }
+
+  property("EphemerisDao meta should delete") {
+    forAll { (head: (KS, EphemerisMeta), tail: List[(KS, EphemerisMeta)], i: Int) =>
+
+      val env = EphemerisMetaTestEnv(head, tail, i)
+
+      // Delete the one that we picked
+      val deleteOne = EphemerisDao.deleteMeta(env.key, env.site)
+
+      // Try to select the deleted one
+      val selectOne = EphemerisDao.selectMeta(env.key, env.site)
+
+      // Run the test
+      val res = (env.insertAll *> deleteOne *> selectOne).transact(xa).unsafeRunSync
+
+      res shouldEqual None
+    }
+  }
+
+  property("EphemerisDao should stream insert") {
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
+
+      val mʹ = m + (ks -> e)
+      val p  = (mʹ.toList.traverse { case (ks, e) =>
+        Stream.emits(e.toMap.toList).covary[ConnectionIO]
+          .to(EphemerisDao.streamInsert(ks.key, ks.site))
+          .compile
+          .drain
+      }) *> EphemerisDao.selectAll(ks.key, ks.site)
+
+      e shouldEqual p.transact(xa).unsafeRunSync
+    }
+  }
+
+  property("EphemerisDao should stream update") {
+    forAll { (ks: KS, e0: Ephemeris, e1: Ephemeris, m: EphemerisMap) =>
+
+      val mʹ = m + (ks -> e0)
+
+      // Setup a program that will insert all the ephemeris maps.
+      val p  = mʹ.toList.traverse { case (ks, e) =>
+        Stream.emits(e.toMap.toList).covary[ConnectionIO]
+          .to(EphemerisDao.streamInsert(ks.key, ks.site))
+          .compile
+          .drain
+      }
+
+      // Now stream update the ephemeris elements in e0 to those in e1
+      val pʹ = p *> Stream.emits(e1.toMap.toList).covary[ConnectionIO]
+                      .to(EphemerisDao.streamUpdate(ks.key, ks.site))
+                      .compile
+                      .drain
+
+      // Select the values with the matching key and site, which should now be
+      // updated
+      val pʹʹ = pʹ *> EphemerisDao.selectAll(ks.key, ks.site)
+
+      e1 shouldEqual pʹʹ.transact(xa).unsafeRunSync
+    }
+  }
+
+  property("EphemerisDao should select times") {
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
+
+      val p  = EphemerisDao.selectTimes(ks.key, ks.site)
+      val em = e.toMap
+
+      val expected =
+        if (em.isEmpty) Option.empty[(Timestamp, Timestamp)]
+        else Some((em.firstKey, em.lastKey))
+
+      expected shouldEqual execTest(m + (ks -> e), p)
+    }
+  }
+
+  property("EphemerisDao bracketRange") {
+    import Timestamp.{ Max, Min }
+
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
+      val em = e.toMap
+
+      val (eMin, qMin) = (for {
+        e <- em.headOption.map(_._1)
+        q <- e.plusMicros(1L)
+      } yield (e, q)).getOrElse((Min, Min))
+
+      val (eMax, qMax) = (for {
+        e <- em.lastOption.map(_._1)
+        q <- e.plusMicros(-1L)
+      } yield (e, q)).getOrElse((Max, Max))
+
+      val p = EphemerisDao.bracketRange(ks.key, ks.site, qMin, qMax)
+
+      (eMin, eMax) shouldEqual execTest(m + (ks -> e), p)
+    }
+  }
+
+  property("EphemerisDao bracketRange exact") {
+    import Timestamp.{ Max, Min }
+
+    forAll { (ks: KS, e: Ephemeris, m: EphemerisMap) =>
+      val em = e.toMap
+
+      val (min, max) = if (em.isEmpty) (Min, Max) else (em.firstKey, em.lastKey)
+
+      val p = EphemerisDao.bracketRange(ks.key, ks.site, min, max)
+
+      (min, max) shouldEqual execTest(m + (ks -> e), p)
+    }
+  }
+
+  property("EphemerisDao should select None times if no matching ephemeris") {
+    forAll { (ks: KS, m: EphemerisMap) =>
+
+      val p  = EphemerisDao.selectTimes(ks.key, ks.site)
+
+      None shouldEqual execTest(m - ks, p)
+    }
+
+  }
+
+  property("EphemerisDao should select all keys") {
+    forAll { (head: (KS, EphemerisMeta), tail: List[(KS, EphemerisMeta)], i: Int) =>
+
+      val env = EphemerisMetaTestEnv(head, tail, i)
+
+      // The keys we expect to select from the database.
+      val expectedKeys = (head :: tail).collect {
+        case (KS(k, s), _) if s == env.site => k
+      }.toSet
+
+      val selectKeys = EphemerisDao.selectKeys(env.site)
+
+      // Run the test
+      val res = (env.insertAll *> selectKeys).transact(xa).unsafeRunSync
+
+      res shouldEqual expectedKeys
+    }
+  }
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals"))
+object EphemerisDaoSpec {
+  final case class KS(key: EphemerisKey, site: Site)
+
+  implicit val arbitraryKS: Arbitrary[KS] =
+    Arbitrary {
+      for {
+        k <- arbitrary[EphemerisKey]
+        s <- arbitrary[Site]
+      } yield KS(k, s)
+    }
+
+  type EphemerisMap = Map[KS, Ephemeris]
+
+  /** Environment for running EphemerisMeta tests.  It is a program for
+    * inserting a collection of ephemeris meta for testing and the key, site,
+    * and EphemerisMeta corresponding to one of the members of the collection
+    * at random.
+    *
+    * @param insertAll action that inserts an initial collection of ephemeris
+    *                  meta values
+    * @param key       a random key referring to one of the values that will be
+    *                  inserted
+    * @param site      a random site referring to one of the values that will be
+    *                  inserted
+    * @param meta      ephemeris meta value corresponding to (key, site)
+    */
+  final class EphemerisMetaTestEnv(
+    val insertAll: ConnectionIO[Unit],
+    val key:       EphemerisKey,
+    val site:      Site,
+    val meta:      EphemerisMeta)
+
+  object EphemerisMetaTestEnv {
+    def apply(head: (KS, EphemerisMeta),
+              tail: List[(KS, EphemerisMeta)],
+              i:    Int): EphemerisMetaTestEnv = {
+
+      // Eliminate duplicate keys
+      val all = (head :: tail).toMap.toList
+
+      // Pick an element at random
+      val index = if (i == Int.MinValue) i + 1 else i
+      val (ks, em) = all(index.abs % all.size)
+
+      // Insert all the ephemeris meta data
+      val insertAll = all.traverse { case (ksʹ, emʹ) =>
+        EphemerisDao.insertMeta(ksʹ.key, ksʹ.site, emʹ)
+      }.void
+
+      new EphemerisMetaTestEnv(insertAll, ks.key, ks.site, em)
+    }
+  }
+}

--- a/modules/db/src/test/scala/gem/dao/EventLogDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/EventLogDaoSample.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.effect.IO
+import doobie._, doobie.implicits._
+import gem._
+import java.time.Instant
+
+object EventLogDaoSample {
+  import EventLogDao._
+
+  val xa: Transactor[IO] =
+    Transactor.fromDriverManager[IO](
+      "org.postgresql.Driver",
+      "jdbc:postgresql:gem",
+      "postgres",
+      ""
+    )
+
+  val oid: Observation.Id = Observation.Id.unsafeFromString("GS-2017A-Q-1-2")
+
+  def insertEvents: ConnectionIO[List[Event]] =
+    for {
+      _ <- insertStartSlew(oid)
+      _ <- insertStartVisit(oid)
+      _ <- insertStartIntegration(oid, 1)
+      _ <- insertEndIntegration(oid, 1)
+      _ <- insertPauseObserve(oid)
+      _ <- insertAbortObserve(oid)
+      _ <- insertEndVisit(oid)
+      _ <- insertEndSlew(oid)
+      l <- selectAll(Instant.now().minusSeconds(10), Instant.now().plusSeconds(10))
+    } yield l
+
+  val run: IO[Unit] =
+    for {
+      l <- insertEvents.transact(xa)
+      _ <- IO(Console.println(l.mkString(",\n")))
+      _ <- IO(Console.println("Done."))
+    } yield ()
+
+  def main(args: Array[String]): Unit =
+    run.unsafeRunSync
+
+}

--- a/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/ObservationDaoSpec.scala
@@ -1,0 +1,114 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.implicits._
+import doobie.implicits._
+import gem.Observation
+import gem.enum._
+import gem.math.Index
+import org.scalatest._
+import org.scalatest.prop._
+import org.scalatest.Matchers._
+
+class ObservationDaoSpec extends PropSpec with PropertyChecks with DaoTest {
+
+  property("ObservationDao should select all observation ids for a program") {
+    forAll(genObservationMap(limit = 50)) { obsMap =>
+      val oids = withProgram {
+        for {
+          _ <- obsMap.toList.traverse { case (i,o) => ObservationDao.insert(Observation.Id(pid, i), o) }
+          o <- ObservationDao.selectIds(pid)
+        } yield o
+      }
+
+      oids.toSet shouldEqual obsMap.keys.map(idx => Observation.Id(pid, idx)).toSet
+    }
+  }
+
+  property("ObservationDao should select flat observations") {
+    val oid = Observation.Id(pid, Index.One)
+
+    forAll { (obsIn: Observation) =>
+      val obsOut = withProgram {
+        for {
+          _ <- ObservationDao.insert(oid, obsIn)
+          o <- ObservationDao.selectFlat(oid)
+        } yield o
+      }
+
+      // Take the generated observation, remove the targets and steps, and map
+      // the the static config to the instrument.
+      val expected = (obsIn.title, Instrument.forObservation(obsIn))
+
+      obsOut shouldEqual expected
+    }
+  }
+
+  property("ObservationDao should select static-only observations") {
+    val oid = Observation.Id(pid, Index.One)
+
+    forAll { (obsIn: Observation) =>
+      val obsOut = withProgram {
+        for {
+          _ <- ObservationDao.insert(oid, obsIn)
+          o <- ObservationDao.selectStatic(oid)
+        } yield o
+      }
+
+      // Take the generated observation and remove the targets and steps
+      val expected = (obsIn.title, obsIn.staticConfig)
+
+      obsOut shouldEqual expected
+    }
+  }
+
+  property("ObservationDao should select target-only observations") {
+    val oid = Observation.Id(pid, Index.One)
+
+    forAll { (obsIn: Observation) =>
+      val obsOut = withProgram {
+        for {
+          _ <- ObservationDao.insert(oid, obsIn)
+          o <- ObservationDao.selectTargets(oid)
+        } yield o
+      }
+
+      // Take the generated observation, replace the static config with the
+      // instrument type and remove the steps.
+      val expected = (obsIn.title, obsIn.targetEnvironment)
+
+      obsOut shouldEqual expected
+    }
+  }
+
+  property("ObservationDao should roundtrip complete observations") {
+    val oid = Observation.Id(pid, Index.One)
+
+    forAll { (obsIn: Observation) =>
+      val obsOut = withProgram {
+        for {
+          _ <- ObservationDao.insert(oid, obsIn)
+          o <- ObservationDao.select(oid)
+        } yield o
+      }
+
+      obsOut shouldEqual obsIn
+    }
+  }
+
+  property("ObservationDao should roundtrip complete observation lists") {
+    forAll(genObservationMap(limit = 50)) { obsMapIn =>
+      val obsMapOut = withProgram {
+        for {
+          _ <- obsMapIn.toList.traverse { case (i,o) => ObservationDao.insert(Observation.Id(pid, i), o) }
+          o <- ObservationDao.selectAll(pid)
+        } yield o
+      }
+
+      obsMapOut shouldEqual obsMapIn
+    }
+  }
+
+}

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSample.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+import gem.arb.ArbEnumerated._
+import gem.config._
+import gem.enum.{ Instrument, SmartGcalType }
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary.arbitrary
+
+// Sample code that exercises SmartGcalDao.select.
+object SmartGcalSample extends TimedSample with gem.config.Arbitraries {
+
+  type Result = List[(SmartGcalSearchKey, SmartGcalType, List[GcalConfig])]
+
+  private def nextType(): Option[SmartGcalType] =
+    arbitrary[SmartGcalType].sample
+
+  private def nextKey(): Option[SmartGcalSearchKey] =
+    (for {
+      i <- Gen.oneOf(Instrument.Flamingos2, Instrument.GmosN, Instrument.GmosS, Instrument.Gnirs)
+      s <- genStaticConfigOf(i)
+      d <- genDynamicConfigOf(i)
+    } yield d.smartGcalKey(s)).sample.flatten
+
+  private def nextTest(): Option[(SmartGcalSearchKey, SmartGcalType)] =
+    for {
+      k <- nextKey()
+      t <- nextType()
+    } yield (k, t)
+
+  override def runl(args: List[String]): ConnectionIO[Result] =
+    ((1 to 1000).toList.flatMap(_ => nextTest().toList)).traverse { case (k, t) =>
+      SmartGcalDao.select(k, t).map { g => (k, t, g) }
+    }
+
+  override def format(r: Result): String =
+    r.mkString(", \n")
+}

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -1,0 +1,163 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+import gem._
+import gem.SmartGcal._
+import gem.config._
+import gem.config.F2Config.F2FpuChoice.Builtin
+import gem.config.GcalConfig.GcalLamp
+import gem.enum._
+import gem.math.Index
+import gem.util.Location
+import org.scalatest.{Assertion, FlatSpec, Matchers}
+import java.time.Duration
+import scala.collection.immutable.{ TreeMap, TreeSet }
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.NonUnitStatements"))
+class SmartGcalSpec extends FlatSpec with Matchers with DaoTest {
+  import GcalLampType.{ Arc, Flat }
+  import GcalBaselineType.Night
+  import SmartGcalSpec._
+
+  "SmartGcalDao" should "expand smart gcal arc steps" in {
+    runF2Expansionʹ(SmartGcalType.Arc) { (_, steps) =>
+      verifySteps(Left(Arc), steps)
+    }
+  }
+
+  it should "expand smart gcal flat steps" in {
+    runF2Expansionʹ(SmartGcalType.Flat) { (_, steps) =>
+      verifySteps(Left(Flat), steps)
+    }
+  }
+
+  it should "expand smart gcal baseline steps" in {
+    runF2Expansionʹ(SmartGcalType.NightBaseline) { (_, steps) =>
+      verifySteps(Right(Night), steps)
+    }
+  }
+
+  it should "fail when there is no corresponding mapping" in {
+    runF2Expansionʹ(SmartGcalType.DayBaseline) { (expansion, steps) =>
+      expansion    shouldEqual Left(noMappingDefined)
+      steps.values.toList shouldEqual List(f2.toStep(Step.Base.SmartGcal(SmartGcalType.DayBaseline)))
+    }
+  }
+
+  it should "fail when the location is not found" in {
+    runF2Expansion(SmartGcalType.Arc, loc1, loc2) { (expansion, steps) =>
+      expansion shouldEqual Left(stepNotFound(loc2))
+      steps.values.toList shouldEqual List(f2.toStep(Step.Base.SmartGcal(SmartGcalType.Arc)))
+    }
+  }
+
+  it should "fail when the location is not a smart gcal step" in {
+    val expansion = doTest {
+      for {
+        _  <- StepDao.insert(oid, loc1, f2.toStep(Step.Base.Bias))
+        ex <- SmartGcalDao.expand(oid, loc1).value
+        ss <- StepDao.selectAll(oid)
+        _  <- ss.keys.toList.traverse { StepDao.deleteAtLocation(oid, _) }
+      } yield ex
+    }
+
+    expansion shouldEqual Left(notSmartGcal)
+  }
+
+  it should "expand intermediate smart gcal steps" in {
+    val steps = doTest {
+      for {
+        _  <- StepDao.insert(oid, loc1, f2.toStep(Step.Base.Bias))
+        _  <- StepDao.insert(oid, loc2, f2.toStep(Step.Base.SmartGcal(SmartGcalType.NightBaseline)))
+        _  <- StepDao.insert(oid, loc9, f2.toStep(Step.Base.Dark))
+        _  <- SmartGcalDao.expand(oid, loc2).value
+        ss <- StepDao.selectAll(oid)
+        _  <- ss.keys.toList.traverse { StepDao.deleteAtLocation(oid, _) }
+      } yield ss
+    }
+
+    val exp = gcals.filter(_._2 == GcalBaselineType.Night).map { case (_, _, config) => f2.toStep(Step.Base.Gcal(config)) }
+    steps.values.toList shouldEqual (f2.toStep(Step.Base.Bias) :: exp) :+ f2.toStep(Step.Base.Dark)
+  }
+
+  private def verifySteps(m: Either[GcalLampType, GcalBaselineType], ss: TreeMap[Location.Middle, Step]): Assertion = {
+    def lookup(m: Either[GcalLampType, GcalBaselineType]): List[GcalConfig] =
+      gcals.filter(t => m.fold(_ == t._1, _ == t._2)).map(_._3)
+
+    ss.values.toList shouldEqual lookup(m).map(a => f2.toStep(Step.Base.Gcal(a)))
+  }
+
+  private val oid = Observation.Id(pid, Index.One)
+
+  private def doTest[A](test: ConnectionIO[A]): A =
+    withProgram {
+      for {
+        _ <- ObservationDao.insert(oid, Observation.Flamingos2("SmartGcalSpec Obs", TargetEnvironment.Flamingos2(None, TreeSet.empty), StaticConfig.Flamingos2.Default, Nil))
+        a <- test
+      } yield a
+    }
+
+  private def runF2Expansionʹ(t: SmartGcalType)(
+    verify: (Either[ExpansionError, ExpandedSteps], TreeMap[Location.Middle, Step]) => Assertion
+  ): Assertion =
+    runF2Expansion(t, loc1, loc1)(verify)
+
+  private def runF2Expansion(t: SmartGcalType, insertionLoc: Location.Middle, searchLoc: Location.Middle)(
+    verify: (Either[ExpansionError, ExpandedSteps], TreeMap[Location.Middle, Step]) => Assertion
+  ): Assertion = {
+    val (expansion, steps) = doTest {
+      for {
+        _  <- StepDao.insert(oid, insertionLoc, f2.toStep(Step.Base.SmartGcal(t)))
+        ex <- SmartGcalDao.expand(oid, searchLoc).value
+        ss <- StepDao.selectAll(oid)
+        _  <- ss.keys.toList.traverse { StepDao.deleteAtLocation(oid, _) }
+      } yield (ex, ss)
+    }
+
+    verify(expansion, steps)
+  }
+}
+
+object SmartGcalSpec {
+  import GcalLampType.{ Arc, Flat }
+  import GcalBaselineType.Night
+
+  private val loc1: Location.Middle = Location.unsafeMiddle(1)
+  private val loc2: Location.Middle = Location.unsafeMiddle(2)
+  private val loc9: Location.Middle = Location.unsafeMiddle(9)
+
+  private val f2: DynamicConfig.Flamingos2 =
+    DynamicConfig.Flamingos2(
+      /* Disperser             */ Some(F2Disperser.R1200JH),
+      Duration.ofMillis(1000),
+      /* Filter                */ F2Filter.JH,
+      /* FPU                   */ Some(Builtin(F2Fpu.LongSlit1)),
+      F2LyotWheel.F16,
+      F2ReadMode.Bright,
+      F2WindowCover.Open)
+
+
+  private val gcals: List[(GcalLampType, GcalBaselineType, GcalConfig)] =
+    List(
+      (Arc, Night, GcalConfig(
+        GcalLamp.fromArcs(GcalArc.ArArc),
+        GcalFilter.Nir,
+        GcalDiffuser.Ir,
+        GcalShutter.Closed,
+        Duration.ofMillis(30000),
+        CoAdds.One
+      )),
+      (Flat, Night, GcalConfig(
+        GcalLamp.fromContinuum(GcalContinuum.IrGreyBodyHigh),
+        GcalFilter.Nd20,
+        GcalDiffuser.Ir,
+        GcalShutter.Open,
+        Duration.ofMillis(20000),
+        CoAdds.One
+      ))
+    )
+}

--- a/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSample.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import doobie._
+import gem.{ Observation, Step }
+import gem.util.Location
+import scala.collection.immutable.TreeMap
+
+object StepDaoSample extends TimedSample {
+  type Result = TreeMap[Location.Middle, Step]
+
+  val oid: Observation.Id = Observation.Id.unsafeFromString("GS-2016A-Q-102-108")
+
+  override def runl(args: List[String]): ConnectionIO[Result] =
+    StepDao.selectAll(oid)
+
+  override def format(r: Result): String =
+    r.toList.map { case (l, s) => f"$l%10s -> $s" }.mkString(", \n")
+}

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import doobie.implicits._
+import gem._
+import gem.config._
+import gem.config.F2Config.F2FpuChoice.Builtin
+import gem.enum._
+import gem.math._
+import java.time.Duration
+import org.scalatest._
+import scala.collection.immutable.{ TreeMap, TreeSet }
+
+
+class StepDaoSpec extends FlatSpec with Matchers with DaoTest {
+
+  "StepDao" should "serialize telescope configurations properly" in {
+
+    val idx  = Index.One
+
+    // We specifically want to test round-tripping of telescope offsets.
+    val pid  = Program.Id.fromString.unsafeGet("GS-1234A-Q-1")
+    val orig = Program(
+      pid,
+      "Untitled Prog",
+      TreeMap(idx ->
+        Observation.Flamingos2(
+          "Untitled Obs",
+          TargetEnvironment.Flamingos2(None, TreeSet.empty),
+          StaticConfig.Flamingos2(MosPreImaging.IsNotMosPreImaging),
+          List(
+            Step.Flamingos2(
+              DynamicConfig.Flamingos2(
+                None,
+                Duration.ZERO,
+                F2Filter.Dark,
+                Some(Builtin(F2Fpu.LongSlit1)),
+                F2LyotWheel.F16,
+                F2ReadMode.Bright,
+                F2WindowCover.Close
+              ),
+              Step.Base.Science(
+                TelescopeConfig(
+                  Offset.P(Angle.milliarcseconds.reverseGet( 1250)), // 1.25 arcseconds
+                  Offset.Q(Angle.milliarcseconds.reverseGet(-2750))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+
+    // We should be able to round-trip the program.
+    import ProgramDao._
+    val rted = (insert(orig) flatMap selectFull).transact(xa).unsafeRunSync
+    rted shouldEqual Some(orig)
+
+  }
+
+}

--- a/modules/db/src/test/scala/gem/dao/TimedSample.scala
+++ b/modules/db/src/test/scala/gem/dao/TimedSample.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.effect.IO
+import doobie._, doobie.implicits._
+import java.time.{Duration, Instant}
+
+
+trait TimedSample {
+  type Result
+
+  val xa = Transactor.fromDriverManager[IO](
+    "org.postgresql.Driver",
+    "jdbc:postgresql:gem",
+    "postgres",
+    ""
+  )
+
+  def runl(args: List[String]): ConnectionIO[Result]
+
+  def format(r: Result): String
+
+  def main(args: Array[String]): Unit = {
+    val p     = runl(args.toList)
+    val start = Instant.now()
+    val a     = p.transact(xa).unsafeRunSync()
+    val end   = Instant.now()
+
+    println(format(a))
+    println(Duration.ofMillis(end.toEpochMilli - start.toEpochMilli))
+  }
+}

--- a/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
@@ -1,0 +1,114 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+import doobie.postgres.implicits._
+import gem._
+import gem.enum.ProgramRole
+import gem.syntax.prism._
+import org.scalatest._
+
+import scala.collection.immutable.TreeMap
+
+
+class UserDaoSpec extends FlatSpec with Matchers with DaoTest {
+
+  private val pid1 = Program.Id.fromString.unsafeGet("GS-1234A-Q-1")
+  private val pid2 = Program.Id.fromString.unsafeGet("GS-1234A-Q-3")
+
+  private val prog1 = Program(pid1, "prog1", TreeMap.empty)
+  private val prog2 = Program(pid2, "prog2", TreeMap.empty)
+
+  private val user1 =
+    User[ProgramRole]("bob", "Bob", "Dobbs", "bob@dobbs.com", false,
+      Map(
+        pid1 -> Set(ProgramRole.PI, ProgramRole.GEM),
+        pid2 -> Set(ProgramRole.PI)
+      )
+    )
+
+  private val user2 =
+    User[ProgramRole]("homer", "Homer", "Simpson", "chunkylover53@aol.com", false, Map.empty)
+
+  "UserDao" should "select the root user" in {
+    val r = UserDao.selectRootUser.transact(xa).unsafeRunSync
+    r.id shouldEqual User.Id.Root
+  }
+
+  it should "round-trip a user with roles" in {
+    val prog: ConnectionIO[Option[User[ProgramRole]]] =
+      for {
+        _ <- ProgramDao.insert(prog1)
+        _ <- ProgramDao.insert(prog2)
+        _ <- UserDao.insertUser(user1, "pass")
+        u <- UserDao.selectUserʹ(user1.id, "pass")
+      } yield u
+    prog.transact(xa).unsafeRunSync shouldEqual Some(user1)
+  }
+
+  it should "set roles" in {
+    val prog: ConnectionIO[Option[User[ProgramRole]]] =
+      for {
+        _ <- ProgramDao.insert(prog1)
+        _ <- UserDao.insertUser(user2, "pass")
+        _ <- UserDao.setRole(user2.id, prog1.id, ProgramRole.PI)
+        _ <- UserDao.setRole(user2.id, prog1.id, ProgramRole.GEM)
+        u <- UserDao.selectUserʹ(user2.id, "pass")
+      } yield u
+    prog.transact(xa).unsafeRunSync.flatMap(_.roles.get(prog1.id))
+      .shouldEqual(Some(Set(ProgramRole.PI, ProgramRole.GEM)))
+  }
+
+  it should "unset roles" in {
+    val prog: ConnectionIO[Option[User[ProgramRole]]] =
+      for {
+        _ <- ProgramDao.insert(prog1)
+        _ <- ProgramDao.insert(prog2)
+        _ <- UserDao.insertUser(user1, "pass")
+        _ <- UserDao.unsetRole(user1.id, prog1.id, ProgramRole.GEM)
+        u <- UserDao.selectUserʹ(user1.id, "pass")
+      } yield u
+    prog.transact(xa).unsafeRunSync.flatMap(_.roles.get(prog1.id))
+      .shouldEqual(Some(Set(ProgramRole.PI)))
+  }
+
+  it should "fail to select a user with an incorrect password" in {
+    val prog: ConnectionIO[Option[User[ProgramRole]]] =
+      for {
+        _ <- UserDao.insertUser(user2, "pass")
+        u <- UserDao.selectUserʹ(user2.id, "banana")
+      } yield u
+    prog.transact(xa).unsafeRunSync shouldEqual None
+  }
+
+  it should "change password if correct original password is specified" in {
+    val prog: ConnectionIO[Boolean] =
+      for {
+        _ <- UserDao.insertUser(user2, "pass")
+        b <- UserDao.changePassword(user2.id, "pass", "eskimo")
+      } yield b
+    prog.transact(xa).unsafeRunSync shouldEqual true
+  }
+
+  it should "fail to change password if incorrect original password is specified" in {
+    val prog: ConnectionIO[Boolean] =
+      for {
+        _ <- UserDao.insertUser(user2, "pass")
+        b <- UserDao.changePassword(user2.id, "banana", "eskimo")
+      } yield b
+    prog.transact(xa).unsafeRunSync shouldEqual false
+  }
+
+  it should "raise a key violation on duplicate id" in {
+    val prog: ConnectionIO[Boolean] =
+      for {
+        _ <- UserDao.insertUser(user2, "pass1")
+        _ <- UserDao.insertUser(user2, "pass2")
+      } yield true
+    prog.onUniqueViolation(false.pure[ConnectionIO]).transact(xa).unsafeRunSync shouldEqual false
+  }
+
+}

--- a/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserTargetDaoSpec.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import cats.implicits._
+import doobie.implicits._
+import gem.math.Index
+import org.scalatest._
+import org.scalatest.prop._
+import org.scalatest.Matchers._
+
+
+class UserTargetDaoSpec extends PropSpec with PropertyChecks with DaoTest {
+  import gem.arb.ArbUserTarget._
+
+  property("UserTargetDao should roundtrip") {
+    forAll { (obs: Observation, ut: UserTarget) =>
+      val oid = Observation.Id(pid, Index.One)
+
+      val utʹ = withProgram {
+        for {
+          _  <- ObservationDao.insert(oid, obs)
+          id <- UserTargetDao.insert(oid, ut)
+          uʹ <- UserTargetDao.select(id)
+        } yield uʹ
+      }
+
+      Some(ut) shouldEqual utʹ
+    }
+  }
+
+  property("UserTargetDao should bulk select observation") {
+    forAll { (obs: Observation) =>
+      val oid = Observation.Id(pid, Index.One)
+
+      val actual = withProgram {
+        for {
+          _   <- ObservationDao.insert(oid, obs)
+          uts <- UserTargetDao.selectObs(oid)
+        } yield uts
+      }
+
+      obs.targetEnvironment.userTargets shouldEqual actual
+    }
+  }
+
+  property("UserTargetDao should bulk select program") {
+    forAll(genObservationMap(10)) { m =>
+
+      val obsList = m.toList
+
+      val expected = obsList.map { case (oi, obs) =>
+        oi -> obs.targetEnvironment.userTargets
+      }.filter(_._2.nonEmpty).toMap
+
+      val actual = withProgram {
+        for {
+          _   <- obsList.traverse_ { case (oi, obs) => ObservationDao.insert(Observation.Id(pid, oi), obs) }
+          uts <- UserTargetDao.selectProg(pid)
+        } yield uts
+      }
+
+      expected shouldEqual actual
+    }
+  }
+}

--- a/modules/db/src/test/scala/gem/dao/check/AsterismCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/AsterismCheck.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import gem.Target
+import gem.enum.Instrument
+
+class AsterismCheck extends Check {
+
+  import AsterismDao.Statements._
+
+  "AsterismDao.Statements" should
+            "SingleTarget.insert"    in check(insertSingleTarget(Dummy.observationId, Target.Id(0), Instrument.GmosS))
+  it should "GhostDualTarget.insert" in check(insertGhostDualTarget(Dummy.observationId, Target.Id(0), Target.Id(0)))
+  it should "select"                 in check(select(Dummy.observationId))
+  it should "selectAll"              in check(selectAll(Dummy.programId))
+}

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -1,0 +1,98 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import cats.effect.IO
+import doobie.Transactor
+import doobie.scalatest.imports._
+import gem._
+import gem.enum._
+import gem.config._
+import gem.util.{ Timestamp, Location }
+import gem.math._
+import java.time.LocalDate
+import org.scalatest._
+import scala.collection.immutable.{ TreeMap, TreeSet }
+
+/** Trait for tests that check statement syntax and mappings. */
+trait Check extends FlatSpec with Matchers with IOChecker {
+
+  val transactor: Transactor[IO] =
+    DatabaseConfiguration.forTesting.transactor[IO]
+
+  /**
+   * Some dummy values to pass to statement constructors. The actual values don't matter because
+   * the statements are never executed, but they are dereferenced and cannot be null.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object Dummy {
+    val instant          = java.time.Instant.EPOCH
+    val duration         = java.time.Duration.ZERO
+    val programId        = Program.Id.fromString.unsafeGet("GS-foobar") match { case n: Program.Id.Nonstandard => n ; case _ => sys.error("unpossbile") }
+    val semester         = Semester.unsafeFromString("2015B")
+    val site             = Site.GN
+    val programType      = ProgramType.C
+    val dailyProgramId   = Program.Id.Daily(site, DailyProgramType.ENG, LocalDate.now())
+    val scienceProgramId = Program.Id.Science(site, semester, programType, Index.One)
+    val observationId    = Observation.Id(programId, Index.One)
+    val datasetLabel     = Dataset.Label(observationId, 0)
+    val dataset          = Dataset(datasetLabel, "", instant)
+    val eventType        = EventType.Abort
+    val gcalLamp         = Left(GcalContinuum.IrGreyBodyLow)
+    val gcalFilter       = GcalFilter.None
+    val gcalDiffuser     = GcalDiffuser.Ir
+    val gcalShutter      = GcalShutter.Open
+    val gcalConfig       = GcalConfig(gcalLamp, gcalFilter, gcalDiffuser, gcalShutter, duration, CoAdds.One)
+    val user             = User[Nothing]("", "", "", "", false, Map.empty)
+    val observation      = Observation.Flamingos2("", TargetEnvironment.Flamingos2(None, TreeSet.empty), StaticConfig.Flamingos2.Default, Nil)
+    val program          = Program(programId, "", TreeMap.empty)
+    val f2SmartGcalKey   = DynamicConfig.Flamingos2.Default.key
+    val gcalLampType     = GcalLampType.Arc
+    val gcalBaselineType = GcalBaselineType.Day
+    val locationMiddle   = Location.unsafeMiddle(1)
+    val f2Config         = DynamicConfig.Flamingos2.Default
+    val telescopeConfig  = TelescopeConfig(Offset.P.Zero, Offset.Q.Zero)
+    val smartGcalType    = SmartGcalType.Arc
+    val instrumentConfig = f2Config
+    val stepType         = StepType.Science
+    val ephemerisKey     = EphemerisKey.Comet("Lanrezac")
+    val horizonsSolnRef  = HorizonsSolutionRef("JPL#K162/5")
+    val ephemerisMeta    = EphemerisMeta(Timestamp.Min, Timestamp.Min, Some(horizonsSolnRef))
+
+    val gmosCustomRoiEntry =
+      gem.config.GmosConfig.GmosCustomRoiEntry.unsafeFromDescription(1, 1, 1, 1)
+
+    val gmosNorthSmartGcalSearchKey     =
+      DynamicConfig.GmosN.Default.key
+
+    val gmosSouthSmartGcalSearchKey     =
+      DynamicConfig.GmosS.Default.key
+
+    val gmosNorthSmartGcalDefinitionKey = {
+      val sk = DynamicConfig.GmosN.Default.key
+      SmartGcalKey.GmosDefinition(
+        sk.gmos,
+        (Wavelength.Min, Wavelength.Min)
+      )
+    }
+
+    val gmosSouthSmartGcalDefinitionKey = {
+      val sk = DynamicConfig.GmosS.Default.key
+      SmartGcalKey.GmosDefinition(
+        sk.gmos,
+        (Wavelength.Min, Wavelength.Min)
+      )
+    }
+
+    val target: Target =
+      Target("untitled", Right(ProperMotion.const(Coordinates.Zero)))
+
+    val gnirsConfig = DynamicConfig.Gnirs.Default
+
+    val gnirsSmartGcalKey = DynamicConfig.Gnirs.Default.key(StaticConfig.Gnirs.Default)
+
+  }
+
+}

--- a/modules/db/src/test/scala/gem/dao/check/DatasetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/DatasetCheck.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+class DatasetCheck extends Check {
+  import DatasetDao.Statements._
+  "DatasetDao.Statements" should
+            "selectAll" in check(selectAll(Dummy.observationId))
+  it should "insert"    in check(insert(0, Dummy.dataset))
+}

--- a/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EphemerisCheck.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import gem.util.Timestamp
+
+class EphemerisCheck extends Check {
+  import EphemerisDao.Statements._
+  "EphemerisDao.Statements" should
+            "insert"      in check(insert)
+  it should "delete"      in check(delete(Dummy.ephemerisKey, Dummy.site))
+  it should "select"      in check(select(Dummy.ephemerisKey, Dummy.site))
+  it should "selectRange" in check(selectRange(Dummy.ephemerisKey, Dummy.site, Timestamp.Min, Timestamp.Max))
+
+  it should "selectNextUserSuppliedKey" in check(selectNextUserSuppliedKey)
+
+  it should "insertMeta"  in check(insertMeta(Dummy.ephemerisKey, Dummy.site, Dummy.ephemerisMeta))
+  it should "updateMeta"  in check(updateMeta(Dummy.ephemerisKey, Dummy.site, Dummy.ephemerisMeta))
+  it should "deleteMeta"  in check(deleteMeta(Dummy.ephemerisKey, Dummy.site))
+  it should "selectMeta"  in check(selectMeta(Dummy.ephemerisKey, Dummy.site))
+
+  it should "selectTimes"  in check(selectTimes(Dummy.ephemerisKey, Dummy.site))
+  it should "selectTimeLE" in check(selectTimeLE(Dummy.ephemerisKey, Dummy.site, Timestamp.Max))
+  it should "selectTimeGE" in check(selectTimeGE(Dummy.ephemerisKey, Dummy.site, Timestamp.Min))
+
+  it should "selectKeys"  in check(selectKeys(Dummy.site))
+}

--- a/modules/db/src/test/scala/gem/dao/check/EventLogCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/EventLogCheck.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+class EventLogCheck extends Check {
+  import EventLogDao.Statements._
+  "EventLogDao.Statements" should
+            "insertEvent" in check(insertEvent(Dummy.eventType, Dummy.observationId, None))
+  it should "selectAll"   in check(selectAll(Dummy.instant, Dummy.instant))
+}

--- a/modules/db/src/test/scala/gem/dao/check/GcalCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/GcalCheck.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+class GcalCheck extends Check {
+  import GcalDao.Statements._
+  "GcalDao.Statements" should
+            "insertStepGcal"      in check(insertStepGcal(0, Dummy.gcalConfig))
+  it should "selectStepGcal"      in check(selectStepGcal(0))
+  it should "selectSmartGcal"     in check(selectSmartGcal(0))
+  it should "bulkInsertSmartGcal" in check(bulkInsertSmartGcal)
+}

--- a/modules/db/src/test/scala/gem/dao/check/LogCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/LogCheck.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import java.util.logging.Level
+
+class LogCheck extends Check {
+  import LogDao.Statements._
+  "LogDao.Statements" should
+            "insert" in check(insert(Dummy.user, Level.INFO, None, "", None, None))
+}

--- a/modules/db/src/test/scala/gem/dao/check/ObservationCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/ObservationCheck.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+class ObservationCheck extends Check {
+  import ObservationDao.Statements._
+  "ObservationDao.Statements" should
+            "insert"         in check(insert(Dummy.observationId, Dummy.observation))
+  it should "selectIds"      in check(selectIds(Dummy.programId))
+  it should "selectFlat"     in check(selectFlat(Dummy.observationId))
+  it should "selectAllFlat"  in check(selectAllFlat(Dummy.programId))
+}

--- a/modules/db/src/test/scala/gem/dao/check/ProgramCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/ProgramCheck.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+class ProgramCheck extends Check {
+  import ProgramDao.Statements._
+  "ProgramDao.Statements" should
+            "selectFlat"                    in check(selectFlat(Dummy.programId))
+  it should "selectBySubstring"             in check(selectBySubstring("", 0))
+  it should "insertArbitraryProgramIdSlice" in check(insertNonstandardProgramIdSlice(Dummy.programId))
+  it should "insertDailyProgramIdSlice"     in check(insertDailyProgramIdSlice(Dummy.dailyProgramId))
+  it should "insert"                        in check(insert(Dummy.program))
+}

--- a/modules/db/src/test/scala/gem/dao/check/SemesterCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/SemesterCheck.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+class SemesterCheck extends Check {
+  import SemesterDao.Statements._
+  "SemesterDao.Statements" should
+            "canonicalize" in check(canonicalize(Dummy.semester))
+}

--- a/modules/db/src/test/scala/gem/dao/check/SmartGcalCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/SmartGcalCheck.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+class SmartGcalCheck extends Check {
+  import SmartGcalDao.Statements._
+  "SmartGcalDao.Statements" should
+            "selectF2byLamp"            in check(selectF2ByLamp(Dummy.f2SmartGcalKey)(Dummy.gcalLampType))
+  it should "selectF2byBaseline"        in check(selectF2ByBaseline(Dummy.f2SmartGcalKey)(Dummy.gcalBaselineType))
+  it should "createIndexF2"             in check(createIndexF2)
+  it should "dropIndexF2"               in check(dropIndexF2)
+  it should "selectGmosNorthByLamp"     in check(selectGmosNorthByLamp(Dummy.gmosNorthSmartGcalSearchKey)(Dummy.gcalLampType))
+  it should "selectGmosNorthByBaseline" in check(selectGmosNorthByBaseline(Dummy.gmosNorthSmartGcalSearchKey)(Dummy.gcalBaselineType))
+  it should "selectGmosSouthByLamp"     in check(selectGmosSouthByLamp(Dummy.gmosSouthSmartGcalSearchKey)(Dummy.gcalLampType))
+  it should "selectGmosSouthByBaseline" in check(selectGmosSouthByBaseline(Dummy.gmosSouthSmartGcalSearchKey)(Dummy.gcalBaselineType))
+  it should "bulkInsertGmosNorth"       in check(bulkInsertGmosNorth)
+  it should "bulkInsertGmosSouth"       in check(bulkInsertGmosSouth)
+  it should "createIndexGmosNorth"      in check(createIndexGmosNorth)
+  it should "dropIndexGmosNorth"        in check(dropIndexGmosNorth)
+  it should "createIndexGmosSouth"      in check(createIndexGmosSouth)
+  it should "dropIndexGmosSouth"        in check(dropIndexGmosSouth)
+  it should "selectGnirsByLamp"         in check(selectGnirsByLamp(Dummy.gnirsSmartGcalKey)(Dummy.gcalLampType))
+  it should "selectGnirsbyBaseline"     in check(selectGnirsByBaseline(Dummy.gnirsSmartGcalKey)(Dummy.gcalBaselineType))
+  it should "createIndexGnirs"          in check(createIndexGnirs)
+  it should "dropIndexGnirs"            in check(dropIndexGnirs)
+}

--- a/modules/db/src/test/scala/gem/dao/check/StaticCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/StaticCheck.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import gem.enum.Instrument.GmosN
+import gem.config.StaticConfig
+import gem.config.GmosConfig.GmosNodAndShuffle
+
+class StaticCheck extends Check {
+  import StaticConfigDao.Statements._
+
+  "StaticDao.Statements" should
+            "Flamingos2.insert"         in check(Flamingos2.insert(Dummy.observationId, StaticConfig.Flamingos2.Default))
+  it should "Flamingos2.select"         in check(Flamingos2.select(Dummy.observationId))
+  it should "Gmos.insertNorth"          in check(Gmos.insertNorth(Dummy.observationId, StaticConfig.GmosN.Default))
+  it should "Gmos.insertSouth"          in check(Gmos.insertSouth(Dummy.observationId, StaticConfig.GmosS.Default))
+  it should "Gmos.insertCustomRoiEntry" in check(Gmos.insertCustomRoiEntry(Dummy.observationId, GmosN, Dummy.gmosCustomRoiEntry))
+  it should "Gmos.insertNodAndShuffle"  in check(Gmos.insertNodAndShuffle(Dummy.observationId, GmosN, GmosNodAndShuffle.Default))
+  it should "Gmos.selectNorth"          in check(Gmos.selectNorth(Dummy.observationId))
+  it should "Gmos.selectSouth"          in check(Gmos.selectSouth(Dummy.observationId))
+  it should "Gmos.selectCustomRoiEntry" in check(Gmos.selectCustomRoiEntry(Dummy.observationId, GmosN))
+  it should "Gmos.selectNodAndShuffle"  in check(Gmos.selectNodAndShuffle(Dummy.observationId, GmosN))
+}

--- a/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/StepCheck.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import gem.enum.Instrument
+
+class StepCheck extends Check {
+  import StepDao.Statements._
+  "StepDao.Statements" should
+            "deleteAtLocation"      in check(deleteAtLocation(Dummy.observationId, Dummy.locationMiddle))
+  it should "delete"                in check(delete(Dummy.observationId))
+  it should "selectAllInstrumentAndBase" in check(selectAllInstrumentAndBase(Dummy.observationId))
+  it should "selectOneInstrumentAndBase" in check(selectOneInstrumentAndBase(Dummy.observationId, Dummy.locationMiddle))
+  it should "insertScienceSlice"    in check(insertScienceSlice(0, Dummy.telescopeConfig))
+  it should "insertSmartGcalSlice"  in check(insertSmartGcalSlice(0, Dummy.smartGcalType))
+  it should "insertDarkSlice"       in check(insertDarkSlice(0))
+  it should "insertBiasSlice"       in check(insertBiasSlice(0))
+  it should "insertBaseSlice"       in check(insertBaseSlice(Dummy.observationId, Dummy.locationMiddle, Instrument.Flamingos2, Dummy.stepType))
+
+  it should "Flamingos2.insert"     in check(Flamingos2.insert(0, Dummy.f2Config))
+  it should "Flamingos2.selectAll"  in check(Flamingos2.selectAll(Dummy.observationId))
+  it should "Flamingos2.selectOne"  in check(Flamingos2.selectOne(Dummy.observationId, Dummy.locationMiddle))
+
+  it should "Gmos.insertNorth"      in check(Gmos.insertNorth(0, gem.config.DynamicConfig.GmosN.Default))
+  it should "Gmos.insertSouth"      in check(Gmos.insertSouth(0, gem.config.DynamicConfig.GmosS.Default))
+  it should "Gmos.selectAllNorth"   in check(Gmos.selectAllNorth(Dummy.observationId))
+  it should "Gmos.selectOneNorth"   in check(Gmos.selectOneNorth(Dummy.observationId, Dummy.locationMiddle))
+  it should "Gmos.selectAllSouth"   in check(Gmos.selectAllSouth(Dummy.observationId))
+  it should "Gmos.selectOneSouth"   in check(Gmos.selectOneSouth(Dummy.observationId, Dummy.locationMiddle))
+  it should "Gnirs.insert"          in check(Gnirs.insert(0, Dummy.gnirsConfig))
+  it should "Gnirs.selectAll"       in check(Gnirs.selectAll(Dummy.observationId))
+  it should "Gnirs.selectOne"       in check(Gnirs.selectOne(Dummy.observationId, Dummy.locationMiddle))
+}

--- a/modules/db/src/test/scala/gem/dao/check/TargetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/TargetCheck.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import gem.Target
+
+class TargetCheck extends Check {
+  import TargetDao.Statements._
+  "TargetDao.Statements" should
+            "select" in check(select(Target.Id(0)))
+  it should "insert" in check(insert(Dummy.target))
+  it should "update" in check(update(Target.Id(0), Dummy.target))
+  it should "delete" in check(delete(Target.Id(0)))
+}

--- a/modules/db/src/test/scala/gem/dao/check/UserCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserCheck.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import gem.enum.ProgramRole
+
+class UserCheck extends Check {
+  import UserDao.Statements._
+  "UserDao.Statements" should
+            "selectUser"      in check(selectUser(""))
+  it should "selectUserʹ"     in check(selectUserʹ("", ""))
+  it should "selectRoles"     in check(selectRoles(""))
+  it should "changePassword"  in check(changePassword("", "", ""))
+  it should "setRole"         in check(setRole("", Dummy.programId, ProgramRole.PI))
+  it should "unsetRole"       in check(unsetRole("", Dummy.programId, ProgramRole.PI))
+  it should "insertUserFlat"  in check(insertUserFlat(Dummy.user, ""))
+}

--- a/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/UserTargetCheck.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.dao
+package check
+
+import gem.{ Target, UserTarget }
+import gem.enum.UserTargetType.Other
+
+class UserTargetCheck extends Check {
+  import UserTargetDao.Statements._
+
+  "UserTargetDao.Statements" should
+            "insert"           in check(insert(Target.Id(0), Other, Dummy.observationId))
+  it should "select"           in check(select(UserTarget.Id(0)))
+  it should "selectAllForObs"  in check(selectObs(Dummy.observationId))
+  it should "selectAllForProg" in check(selectProg(Dummy.programId))
+
+}

--- a/modules/describe/src/main/scala/gem/StepLens.scala
+++ b/modules/describe/src/main/scala/gem/StepLens.scala
@@ -1,0 +1,69 @@
+package gem
+
+import gem.describe._
+
+import scalaz.Scalaz._
+import scalaz._
+
+/** Support for getting and setting property values across multiple steps. */
+final case class StepLens[A: Describe, I: Describe](prop: Prop[A], aLens: Step[I] @?> A) {
+  val lens: Step[I] @?> prop.B = aLens >=> prop.lens.partial
+
+  // private def collectSteps[B](seq: Sequence[I], selected: Set[Int])(f: (Step[I], Int) => B): List[B] =
+  //   seq.toSteps.to[List].zipWithIndex.collect { case (step, i) if selected(i) => f(step, i) }
+
+  // private def selectedSteps(seq: Sequence[I], selected: Set[Int]): List[Step[I]] =
+  //   collectSteps(seq, selected)((step, _) => step)
+
+  /** Gets all values, one per provided step. If the step type doesn't support
+    * the property, the corresponding list element will be None. */
+  def getAll(ss: List[Step[I]]): List[Option[prop.B]] =
+    ss.map(lens.get)
+
+  // def getAll(seq: Sequence[I]): List[Option[prop.B]]  =
+  //   getAll(seq.toSteps.to[List])
+
+  // def getAll(seq: Sequence[I], selected: Set[Int]): List[(Option[prop.B], Int)] =
+  //   collectSteps(seq, selected) { (step, i) => (lens.get(step), i) }
+
+  /** The common value if it is the same across all steps that support the
+    * property. If two or more property supporting steps have different values
+    * then None. */
+  def getCommon(ss: List[Step[I]]): Option[prop.B] =
+    getAll(ss).flatten.toSet.toList match {
+      case pb :: Nil => Some(pb)
+      case _         => None
+    }
+
+  // def getCommon(seq: Sequence[I]): Option[prop.B] =
+  //   getCommon(seq.toSteps.to[List])
+
+  // def getCommon(seq: Sequence[I], selected: Set[Int]): Option[prop.B] =
+  //   getCommon(selectedSteps(seq, selected))
+
+  def hasCommon(ss: List[Step[I]]): Boolean = {
+    val lst = getAll(ss).dropWhile(_.isEmpty)
+    lst.headOption.flatten.exists(v => lst.forall(_.forall(_ == v)))
+  }
+
+  // def hasCommon(seq: Sequence[I]): Boolean =
+  //   hasCommon(seq.toSteps.to[List])
+
+  // def hasCommon(seq: Sequence[I], selected: Set[Int]): Boolean =
+  //   hasCommon(selectedSteps(seq, selected))
+
+  /** Sets the property value for all step types that support the property,
+    * leaving those that do not unchanged. */
+  def setAll(ss: List[Step[I]], pb: prop.B): List[Step[I]] =
+    ss.map(s => lens.set(s, pb).getOrElse(s))
+
+  // def setAll(seq: Sequence[I], pb: prop.B): Sequence[I] =
+  //   Sequence.fromSteps(setAll(seq.toSteps.to[List], pb).toNel.get)
+
+  // def setAll(seq: Sequence[I], selected: Set[Int], pb: prop.B): Sequence[I] = {
+  //   val newSteps = seq.toSteps.to[List].zipWithIndex.map { case (step, i) =>
+  //     if (selected(i)) lens.set(step, pb).getOrElse(step) else step
+  //   }
+  //   Sequence.fromSteps(newSteps.toNel.get)
+  // }
+}

--- a/modules/describe/src/main/scala/gem/describe/Describe.scala
+++ b/modules/describe/src/main/scala/gem/describe/Describe.scala
@@ -1,0 +1,94 @@
+package gem
+package describe
+
+import scala.language.implicitConversions
+import scalaz._
+import Scalaz._
+
+/** A typeclass for things that can be described by a list of `Prop`. */
+trait Describe[A] { self =>
+
+  /** All properties of A. */
+  def props: List[Prop[A]]
+
+  /** Default value for A. */
+  def default: A
+
+  /** Compares two values for equality based upon their values of the
+    * properties. */
+  def equal(a0: A, a1: A): Boolean =
+    props.forall(_.propEqual(a0, a1))
+
+  /** Returns a function that transforms `a0` into `a1`. */
+  def diff(a0: A, a1: A): A => A =
+    props.foldLeft[A => A](identity) { (f, p) =>
+      if (p.propEqual(a0, a1)) f else f.andThen(p.lens.set(_, p.lens.get(a1)))
+    }
+
+  /** Invariant map. */
+  def xmap[B](f: A => B, g: B => A): Describe[B] =
+    new Describe[B] {
+      val default: B = f(self.default)
+
+      val props = self.props.map(_.xmap(f, g))
+
+      override def equal(b0: B, b1: B): Boolean =
+        self.equal(g(b0), g(b1))
+
+      override def diff(b0: B, b1: B): B => B =
+        self.diff(g(b0), g(b1)).map(f).compose(g)
+    }
+}
+
+object Describe {
+  /** Summons an instance if in scope. */
+  implicit def apply[A](implicit ev: Describe[A]): Describe[A] = ev
+
+  /** Construct an instance from its properties. */
+  def forProps[A](defaultValue: A, ps: Prop[A]*): Describe[A] =
+    new Describe[A] {
+      val default = defaultValue
+      val props   = ps.toList
+    }
+
+  implicit def describe2[A, B](implicit da: Describe[A], db: Describe[B]): Describe[(A, B)] =
+    new Describe[(A, B)] {
+      val default: (A, B) =
+        (da.default, db.default)
+
+      val props: List[Prop[(A, B)]] =
+        da.props.map(_ compose LensFamily.firstLens[A, B]) ++
+        db.props.map(_ compose LensFamily.secondLens[A, B])
+    }
+
+  implicit def describe3[A: Describe, B: Describe, C: Describe]: Describe[(A, B, C)] =
+    describe2[A, (B, C)].xmap[(A, B, C)](
+      t => (t._1, t._2._1, t._2._2),  // case (a, (b, c)) => (a, b, c)
+      t => (t._1, (t._2, t._3))       // case (a, b, c)   => (a, (b, c))
+    )
+
+  implicit def describe4[A: Describe, B: Describe, C: Describe, D: Describe]: Describe[(A, B, C, D)] =
+    describe2[A, (B, C, D)].xmap[(A, B, C, D)](
+      t => (t._1, t._2._1, t._2._2, t._2._3),  // case (a, (b, c, d)) => (a, b, c, d)
+      t => (t._1, (t._2, t._3, t._4))          // case (a, b, c, d)   => (a, (b, c, d))
+    )
+
+  import shapeless._
+
+  def hlistHeadLens[A, B <: HList]: (A :: B) @> A = Lens.lensu((a, b) => b :: a.tail, _.head)
+  def hlistTailLens[A, B <: HList]: (A :: B) @> B = Lens.lensu((a, b) => a.head :: b, _.tail)
+
+  implicit val HNilDescribe: Describe[HNil] =
+    Describe.forProps(HNil)
+
+  implicit def HConsDescribe[A, B <: HList](implicit da: Describe[A], db: Describe[B]): Describe[A :: B] =
+    new Describe[A :: B] {
+      val default = da.default :: db.default
+      val props =
+        da.props.map(_ compose hlistHeadLens[A, B]) ++
+        db.props.map(_ compose hlistTailLens[A, B])
+    }
+
+}
+
+

--- a/modules/describe/src/main/scala/gem/describe/F2Describe.scala
+++ b/modules/describe/src/main/scala/gem/describe/F2Describe.scala
@@ -1,0 +1,76 @@
+trait F2Describe {
+
+  val Lab = Label("F2")
+
+  private def lab(name: String): Label = Label(Lab, name)
+
+  import BooleanMetadata.forBoolean
+  import EnumMetadata.forEnumerated
+
+  object FocalPlaneUnitProp extends Prop[F2Config] {
+    type B = F2FpUnit
+    val eq: Equal[F2FpUnit]  = implicitly
+    val lens: F2Config @> F2FpUnit = Lens.lensu((a,b) => a.copy(fpu = b), _.fpu)
+    val meta = forEnumerated[F2FpUnit](Attrs(lab("Focal Plane Unit"), Science, SingleStep))
+  }
+
+  object MosPreimagingProp extends Prop[F2Config] {
+    type B = Boolean
+    val eq: Equal[Boolean]  = implicitly
+    val lens: F2Config @> Boolean = Lens.lensu((a,b) => a.copy(mosPreimaging = b), _.mosPreimaging)
+    val meta = forBoolean(Attrs(lab("MOS pre-imaging"), Science, Global))
+  }
+
+  object ExposureTimeProp extends Prop[F2Config] {
+    type B = Duration
+    val eq: Equal[Duration]  = Equal.equalA
+    val lens: F2Config @> Duration = Lens.lensu((a,b) => a.copy(exposureTime = b), _.exposureTime)
+
+    val meta = TextMetadata[Duration](
+      Attrs(lab("Exposure Time"), Science, SingleStep),
+      Some("sec"),
+      et => f"${et.toMillis/1000.0}%3.01f",
+      doubleParser("Exposure Time", _)(d => Duration.ofMillis(math.round(d * 1000)))
+    )
+  }
+
+  object FilterProp extends Prop[F2Config] {
+    type B = F2Filter
+    val eq: Equal[F2Filter]  = implicitly
+    val lens: F2Config @> F2Filter = Lens.lensu((a,b) => a.copy(F2filter = b), _.F2filter)
+    val meta = forEnumerated[F2Filter](Attrs(lab("F2Filter"), Science, SingleStep))
+  }
+
+  object LyotWheelProp extends Prop[F2Config] {
+    type B = F2LyotWheel
+    val eq: Equal[F2LyotWheel]  = implicitly
+    val lens: F2Config @> F2LyotWheel = Lens.lensu((a,b) => a.copy(lyotWheel = b), _.lyotWheel)
+    val meta = forEnumerated[F2LyotWheel](Attrs(lab("Lyot Wheel"), Science, SingleStep))
+  }
+
+  object DisperserProp extends Prop[F2Config] {
+    type B = F2Disperser
+    val eq: Equal[F2Disperser]  = implicitly
+    val lens: F2Config @> F2Disperser = Lens.lensu((a,b) => a.copy(disperser = b), _.disperser)
+    val meta = forEnumerated[F2Disperser](Attrs(lab("Disperser"), Science, SingleStep))
+  }
+
+  implicit val DescribeF2: Describe[F2Config] =
+    Describe.forProps(
+      F2Config(
+        F2FpUnit.None,
+        mosPreimaging = false,
+        Duration.ofMillis(85000),
+        F2Filter.Open,
+        F2LyotWheel.F16,
+        F2Disperser.NoDisperser
+      ),
+      FocalPlaneUnitProp,
+      MosPreimagingProp,
+      ExposureTimeProp,
+      FilterProp,
+      LyotWheelProp,
+      DisperserProp
+    )
+
+}

--- a/modules/describe/src/main/scala/gem/describe/GcalDescribe.scala
+++ b/modules/describe/src/main/scala/gem/describe/GcalDescribe.scala
@@ -1,0 +1,30 @@
+trait GcalDescribe {
+  import EnumMetadata.forEnumerated
+
+  val Lab = Label("Gcal Unit")
+
+  def lab(name: String): Label = Label(Lab, name)
+
+  object LampProp extends Prop[GcalConfig] {
+    type B = GcalLamp
+    val eq: Equal[GcalLamp]    = Equal.equalA
+    val lens: GcalConfig @> GcalLamp = Lens.lensu((a,b) => a.copy(lamp = b), _.lamp)
+
+    val meta = forEnumerated[GcalLamp](Attrs(lab("Lamp"), Science, SingleStep))
+  }
+
+
+  object ShutterProp extends Prop[GcalConfig] {
+    type B = GcalShutter
+    val eq: Equal[GcalShutter]    = Equal.equalA
+    val lens: GcalConfig @> GcalShutter = Lens.lensu((a,b) => a.copy(shutter = b), _.shutter)
+
+    val meta = forEnumerated[GcalShutter](Attrs(lab("Shutter"), Science, SingleStep))
+  }
+
+  implicit val DescribeGcal: Describe[GcalConfig] =
+    Describe.forProps(
+      GcalConfig(GcalLamp.IrGreyBodyHigh, GcalShutter.Open),
+      LampProp, ShutterProp
+    )
+}

--- a/modules/describe/src/main/scala/gem/describe/Metadata.scala
+++ b/modules/describe/src/main/scala/gem/describe/Metadata.scala
@@ -1,0 +1,103 @@
+package gem
+package describe
+
+import scalaz._
+import Scalaz._
+
+/** Metadata describing the values of a property. */
+sealed trait Metadata[A] {
+  def attrs: Metadata.Attrs
+  def show: A => String
+  def read: String => String \/ A
+}
+
+object Metadata {
+  case class Label(parent: Option[Label], name: String)
+
+  object Label {
+    def apply(name: String): Label = Label(none, name)
+
+    def apply(parent: Label, name: String): Label = Label(some(parent), name)
+
+    implicit val ShowLabel: Show[Label] = Show.shows { l =>
+      l.parent.fold(l.name)(p => s"${p.shows} / ${l.name}")
+    }
+
+    implicit val OrderLabel: Order[Label] = Order[String].contramap(_.shows)
+
+    implicit val OrderingLabel: scala.Ordering[Label] = OrderLabel.toScalaOrdering
+  }
+
+
+  sealed trait Access
+  object Access {
+    case object Engineering extends Access
+    case object Science     extends Access
+  }
+
+  sealed trait Scope
+  object Scope {
+    case object Global     extends Scope
+    case object SingleStep extends Scope
+  }
+
+  case class Attrs(label: Label, access: Access, scope: Scope)
+}
+
+/** Metadata for properties with a list of possible values.  The idea is that
+  * these will be edited with a combo box widget. */
+final case class EnumMetadata[A](attrs: Metadata.Attrs, values: NonEmptyList[A]) extends Metadata[A] {
+  override val show: A => String = {
+    // case l: LoggableSpType => l.logValue
+    case a                 => a.toString
+  }
+
+  override val read: String => String \/ A = (s: String) =>
+    values.to[List].find(v => show(v) === s) \/> s"${attrs.label} `$s` not recognized"
+}
+
+object EnumMetadata {
+  // /** Support for creating an EnumMetadata from a Java enum. */
+  // def fromJava[A <: java.lang.Enum[A]](attrs: Metadata.Attrs, c: Class[A]): Metadata[A] = {
+  //   val values = c.getEnumConstants
+  //   EnumMetadata[A](attrs, NonEmptyList.nel(values.head, IList.fromList(values.tail.toList)))
+  // }
+
+  def forEnumerated[A](attrs: Metadata.Attrs)(implicit ev: Enumerated[A]): Metadata[A] =
+    EnumMetadata(attrs, ev.all.toNel.get)
+
+}
+
+
+
+
+/** Metadata for properties with two values, one that can be interpreted as
+  * true and the other false.  These can be edited with check boxes. Note,
+  * there is no requirement that "boolean" properties actually have underlying
+  * type Boolean. */
+final case class BooleanMetadata[A](
+    attrs: Metadata.Attrs,
+    t: A,
+    f: A,
+    show: A => String,
+    read: String => String \/ A) extends Metadata[A]
+
+object BooleanMetadata {
+  /** Support for creating BooleanMetadata for properties with underlying type
+    * Boolean. */
+  def forBoolean(attrs: Metadata.Attrs): Metadata[Boolean] = {
+    BooleanMetadata[Boolean](attrs, true, false, _.toString, {
+      case "true"  => true.right
+      case "false" => false.right
+      case s       => s"${attrs.label.name} value must be `true` or `false`, not `$s".left
+    })
+  }
+}
+
+/** Metadata for properties of arbitrary type that can be represented with a
+  * String value.  These properties can be edited with a text field. */
+final case class TextMetadata[A](
+  attrs: Metadata.Attrs,
+  units: Option[String],
+  show: A => String,
+  read: String => String \/ A) extends Metadata[A]

--- a/modules/describe/src/main/scala/gem/describe/Prop.scala
+++ b/modules/describe/src/main/scala/gem/describe/Prop.scala
@@ -1,0 +1,45 @@
+package gem
+package describe
+
+import scalaz._
+import Scalaz._
+
+/** A property of a larger containing type A.  The property itself is
+  * an existential type.  Provides a lens into that property and an equality
+  * definition. */
+trait Prop[A] { self =>
+  type B
+
+  def eq: Equal[B]
+  def lens: A @> B
+
+  def meta: Metadata[B]
+
+  /** Determines whether the property value is the same across two instances. */
+  def propEqual(a0: A, a1: A): Boolean = eq.equal(lens.get(a0), lens.get(a1))
+
+  /** Invariant map. */
+  def xmap[T](f: A => T, g: T => A): Prop[T] { type B = self.B } =
+    new Prop[T] {
+      type B = self.B
+
+      val eq   = self.eq
+      val lens = self.lens.xmapA(f)(g)
+
+      val meta = self.meta
+    }
+
+  def compose[T](ta: T @> A): Prop[T] { type B = self.B } =
+    new Prop[T] {
+      type B = self.B
+
+      val eq   = self.eq
+      val lens = self.lens compose ta
+
+      val meta = self.meta
+    }
+}
+
+object Prop {
+  type Aux[A, B0] = Prop[A] { type B = B0 }
+}

--- a/modules/describe/src/main/scala/gem/describe/PropGroup.scala
+++ b/modules/describe/src/main/scala/gem/describe/PropGroup.scala
@@ -1,0 +1,42 @@
+// package gem
+// package describe
+
+// import gem.config._
+// import gem.Step.{Gcal, Science, Smart}
+
+// import cats._, cats.data._, cats.implicits._
+
+// /** Groups a collection of properties for some Describe-able type A.  Provides
+//   * access to `StepLens`es for getting and setting property values across a
+//   * sequence or list of steps. */
+// case class PropGroup[A: Describe, I: Describe](aLens: Step[I] @?> A) {
+//   val props: List[Prop[A]] =
+//     implicitly[Describe[A]].props.sortBy(_.meta.attrs.label)
+
+//   val stepLenses: List[StepLens[A, I]] =
+//     props.map(StepLens(_, aLens))
+
+//   val label: Option[Metadata.Label] =
+//     props.headOption.flatMap(_.meta.attrs.label.parent)
+// }
+
+// object PropGroup {
+//   // def groups[I: Describe](seq: Sequence[I]): List[PropGroup[_, I]] =
+//   //   groups(seq.toSteps.toList)
+
+//   def groups[I: Describe](ss: List[Step[I]]): List[PropGroup[_, I]] = {
+//     val types = (Set.empty[Step.Type]/:ss) { _ + _.stepType }
+
+//     val groups = (List.empty[PropGroup[_, I]]/:types) { (groups, t) =>
+//       t match {
+//         // case Gcal    => new PropGroup[GcalUnit, I](Step.gcal)       :: groups
+//         case Science => new PropGroup[TelescopeConfig, I](Step.telescope) :: groups
+//         case Smart   => new PropGroup[SmartCalConfig, I](Step.smartCal)   :: groups
+//         case _       => groups
+//       }
+//     }
+
+//     if (types.isEmpty) Nil
+//     else new PropGroup[I, I](Step.instrument) :: groups
+//   }
+// }

--- a/modules/describe/src/main/scala/gem/describe/SmartCalDescribe.scala
+++ b/modules/describe/src/main/scala/gem/describe/SmartCalDescribe.scala
@@ -1,0 +1,18 @@
+trait SmartCalDescribe {
+  val Lab = Label("Smart")
+
+  object TypeProp extends Prop[SmartCalConfig] {
+    type B = Type
+    val eq: Equal[Type] = Equal.equalA
+
+    def lens: SmartCalConfig @> Type = Lens.lensu((a, b) => a.copy(smartCalType = b), _.smartCalType)
+
+    val meta = EnumMetadata[Type](Attrs(Label(Lab, "Cal Type"), Science, SingleStep), Type.All)
+  }
+
+  implicit val DescribeSmartCal: Describe[SmartCalConfig] =
+    Describe.forProps(
+      SmartCalConfig(SmartCalConfig.Type.Default),
+      TypeProp
+    )
+}

--- a/modules/describe/src/main/scala/gem/describe/StepDescribe.scala
+++ b/modules/describe/src/main/scala/gem/describe/StepDescribe.scala
@@ -1,0 +1,110 @@
+trait StepDescribe {
+
+  implicit def showStep[I : Describe]: Show[Step[I]] = {
+    def showVals[A : Describe](name: String, a: A): String = {
+      val props  = implicitly[Describe[A]].props
+      val values = props.map { p =>
+        val b = p.lens.get(a)
+        s"${p.meta.attrs.label.name} = ${p.meta.show(b)}"
+      }
+
+      values.mkString(name + " {", ", ", "}")
+    }
+
+    Show.shows[Step[I]] {
+      case BiasStep(i)       => "Bias: "      + showVals("inst", i)
+      case DarkStep(i)       => "Dark: "      + showVals("inst", i)
+      case GcalStep(i, g)    => "Gcal: "      + showVals("inst", i) + " " + showVals("gcal", g)
+      case ScienceStep(i, t) => "Science: "   + showVals("inst", i) + " " + showVals("telescope", t)
+      case SmartStep(i, t)   => s"Smart $t: " + showVals("inst", i)
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Partial Lenses: Step[I] @?> A
+  //
+  // The presence or absence of an A for a given step will depend on the step
+  // type.  For example, only Science steps have a TelescopeConfig component and only
+  // Gcal steps have a GcalConfig.
+  //
+  // You can compose these with individual property lenses to get partial
+  // lenses for instrument filters, etc.  For example:
+  //
+  //     Step.instrument[F2] >=> F2.FilterProp.lens.partial
+  //
+  // creates a partial lens:
+  //
+  //    Step[F2] @?> F2.FilterProp.B
+  // --------------------------------------------------------------------------
+
+  def instrument[I]: Step[I] @?> I = PLens.plensgf({
+      case BiasStep(_)               => (i: I) => BiasStep(i)
+      case DarkStep(_)               => (i: I) => DarkStep(i)
+      case GcalStep(_, gcal)         => (i: I) => GcalStep(i, gcal)
+      case ScienceStep(_, telescope) => (i: I) => ScienceStep(i, telescope)
+      case SmartStep(_, smart)       => (i: I) => SmartStep(i, smart)
+    }, {
+      case BiasStep(i)       => i
+      case DarkStep(i)       => i
+      case GcalStep(i, _)    => i
+      case ScienceStep(i, _) => i
+      case SmartStep(i, _)   => i
+    })
+
+  def gcal[I]: Step[I] @?> GcalConfig = PLens.plensgf({
+      case GcalStep(inst, _) => (g: GcalConfig) => GcalStep(inst, g)
+    }, { case GcalStep(_, g) => g })
+
+  def telescope[I]: Step[I] @?> TelescopeConfig = PLens.plensgf({
+      case ScienceStep(inst,_) => (t: TelescopeConfig) => ScienceStep(inst, t)
+    }, { case ScienceStep(_, t) => t })
+
+  def smartCal[I]: Step[I] @?> SmartCalConfig = PLens.plensgf({
+      case SmartStep(inst,_) => (s: SmartCalConfig) => SmartStep(inst, s)
+    }, { case SmartStep(_, s) => s})
+}
+
+
+
+trait BiasStepDescribe {
+  implicit def describeBiasStep[I: Describe]: Describe[BiasStep[I]] =
+    Describe[I].xmap[BiasStep[I]](
+      i => BiasStep(i),
+      s => s.instrument
+    )
+}
+
+trait DarkStepDescribe {
+  implicit def describeDarkStep[I: Describe]: Describe[DarkStep[I]] =
+    Describe[I].xmap[DarkStep[I]](
+      i => DarkStep(i),
+      s => s.instrument
+    )
+}
+
+trait GcalStepDescribe {
+  implicit def describeGcalStep[I: Describe]: Describe[GcalStep[I]] =
+    Describe[(I, GcalConfig)].xmap[GcalStep[I]](
+      t => GcalStep(t._1, t._2),
+      s => (s.instrument, s.gcal)
+    )
+}
+
+trait ScienceStepDescribe {
+  implicit def describeScienceStep[I: Describe]: Describe[ScienceStep[I]] =
+    Describe[(I, TelescopeConfig)].xmap[ScienceStep[I]](
+      t => ScienceStep(t._1, t._2),
+      s => (s.instrument, s.telescope)
+    )
+}
+
+trait SmartStepDescribe {
+  implicit def describeSmartStep[I: Describe]: Describe[SmartStep[I]] =
+    Describe[(I, SmartCalConfig)].xmap[SmartStep[I]](
+      t => SmartStep(t._1, t._2),
+      s => (s.instrument, s.smartCal)
+    )
+}
+
+
+

--- a/modules/describe/src/main/scala/gem/describe/TelescopeDescribe.scala
+++ b/modules/describe/src/main/scala/gem/describe/TelescopeDescribe.scala
@@ -1,0 +1,38 @@
+trait TelescopeDescribe {
+  val Lab = Label("Telescope")
+
+  def lab(name: String): Label = Label(Lab, name)
+
+  object OffsetPProp extends Prop[TelescopeConfig] {
+    type B = OffsetP
+    val eq: Equal[OffsetP]         = Equal[OffsetP]
+    val lens: TelescopeConfig @> OffsetP = Lens.lensu((a, b) => a.copy(p = b), _.p)
+
+    val meta = new TextMetadata[OffsetP](
+      Attrs(lab("p"), Science, SingleStep),
+      Some("arcsec"),
+      p => f"${p.arcsecs}%4.03f",
+      doubleParser("Offset p", _)(_.arcsecs[OffsetP])
+    )
+  }
+
+  object OffsetQProp extends Prop[TelescopeConfig] {
+    type B = OffsetQ
+    val eq: Equal[OffsetQ]         = Equal[OffsetQ]
+    val lens: TelescopeConfig @> OffsetQ = Lens.lensu((a, b) => a.copy(q = b), _.q)
+
+    val meta = new TextMetadata[OffsetQ](
+      Attrs(lab("q"), Science, SingleStep),
+      Some("arcsec"),
+      q => f"${q.arcsecs}%4.03f",
+      doubleParser("Offset q", _)(_.arcsecs[OffsetQ])
+    )
+  }
+
+  implicit val DescribeTelescope: Describe[TelescopeConfig] =
+    Describe.forProps(
+      Zero,
+      OffsetPProp, OffsetQProp
+    )
+    
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisCompression.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisCompression.scala
@@ -1,0 +1,147 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.math.{ Angle, Ephemeris, Offset }
+import gem.syntax.stream._
+
+import cats.implicits._
+
+import fs2.Pipe
+
+import java.time.Duration
+
+
+/** FS2 pipes for discarding ephemeris elements that differ one from the other
+  * by less than a given Δ velocity or accumulated acceleration.
+  */
+trait EphemerisCompression {
+
+  import EphemerisCompression._
+
+  /** Standard velocity threshold for compression, 0.1 arcsec/hour. */
+  val StandardVelocityLimitµas: Long =
+    Angle.milliarcseconds.reverseGet(100).toMicroarcseconds
+
+  /** An `fs2.Pipe` that passes only elements which differ by more than the
+    * provided delta velocity.
+    *
+    * @param µas difference in velocity below this threshold result in
+    *            skipping elements
+    */
+  def velocityCompression[F[_]](µas: Long): Pipe[F, Ephemeris.Element, Ephemeris.Element] = {
+    def Δv(e0: Element, e1: Element): Long = {
+      val dp = e0.µasP - e1.µasP
+      val dq = e0.µasQ - e1.µasQ
+      math.hypot(dp, dq).round
+    }
+
+    _.zipWithNext
+     .filterWithPrevious { case ((prev, _), (cur, onext)) =>
+       onext.forall { _ => Δv(prev, cur) > µas }
+     }.map(_._1)
+  }
+
+  /** An `fs2.Pipe` that passes only elements which differ by more than the
+    * standard delta velocity.
+    */
+  def standardVelocityCompression[F[_]]: Pipe[F, Ephemeris.Element, Ephemeris.Element] =
+    velocityCompression(StandardVelocityLimitµas)
+
+
+  /** Standard acceleration threshold for compression, 0.2 arcsec/hour^2. */
+  val StandardAccelerationLimitµas: Long =
+    Angle.milliarcseconds.reverseGet(200).toMicroarcseconds
+
+  /** An `fs2.Pipe` that passes only elements which sufficiently differ by an
+    * accumulated average acceleration.
+    *
+    * @param µas difference in acceleration below this threshold result in
+    *            skipping elements
+    */
+  def accelerationCompression[F[_]](µas: Long): Pipe[F, Element, Element] = {
+
+    final case class SumAvgs(a: AvgAcceleration, n: Int) {
+      def +(next: AvgAcceleration): SumAvgs =
+        SumAvgs(a + next, n + 1)
+
+      def keep: Boolean =
+        (0.5 * a.acceleration / n.toDouble * a.hours * a.hours).round > µas
+    }
+
+    val Zero = Option(SumAvgs(AvgAcceleration.Zero, 0))
+
+    // The fold function.  It is complicated by the use of Option to ensure that
+    // the first and last element are always included. The `oa` parameter below
+    // is `None` for the first and last element, which means the sum including
+    // `oa` is `None`, which the filter function `_.forall(_.keep)` passes.
+    def f(os: Option[SumAvgs], oa: Option[AvgAcceleration]): Option[SumAvgs] =
+      (os, oa).tupled.map { case (sum, a) => sum + a }
+
+    _.zipWithPreviousAndNext
+     .map {
+       case (None,       cur, _   ) => (Option.empty[AvgAcceleration],            cur) // First element (should always be included)
+       case (_,          cur, None) => (Option.empty[AvgAcceleration],            cur) // Last element (should always be included)
+       case (Some(prev), cur, _   ) => (Some(AvgAcceleration.between(prev, cur)), cur)
+    }.filterOnFold(Zero)((os, oe) => f(os, oe._1), _.forall(_.keep))
+     .map(_._2) // forget the avg acceleration and just extract the element
+  }
+
+  /** An `fs2.Pipe` that passes only elements which differ by more than the
+    * standard average acceleration.
+    */
+  def standardAccelerationCompression[F[_]]: Pipe[F, Ephemeris.Element, Ephemeris.Element] =
+    accelerationCompression(StandardAccelerationLimitµas)
+}
+
+object EphemerisCompression extends EphemerisCompression {
+
+  private type Element = Ephemeris.Element
+
+  private class ElementOps(val self: Element) extends AnyVal {
+    private def µas(f: Offset => Angle): Double =
+      Angle.signedMicroarcseconds.get(f(self._2.delta)).toDouble
+
+    // Extracts the velocity in p as decimal microarcseconds / hour
+    def µasP: Double =
+      µas(_.p.toAngle)
+
+    // Extracts the velocity in q as decimal microarcseconds / hour
+    def µasQ: Double =
+      µas(_.q.toAngle)
+  }
+
+  private implicit def ToElementOps(e: Element): ElementOps = new ElementOps(e)
+
+  /** Average acceleration and the time amount over which it is averaged.
+    *
+    * @param acceleration microarcseconds / hour / hour
+    * @param hours        decimal hours
+    */
+  private final case class AvgAcceleration(acceleration: Double, hours: Double) {
+
+    def +(that: AvgAcceleration): AvgAcceleration =
+      AvgAcceleration(acceleration + that.acceleration, hours + that.hours)
+  }
+
+  private object AvgAcceleration {
+
+    val Zero = AvgAcceleration(0.0, 0.0)
+
+    /** Calculates the average acceleration from one element to the next. */
+    def between(prev: Element, cur: Element): AvgAcceleration = {
+      // time since previous
+      val d = Duration.between(prev._1.toInstant, cur._1.toInstant)
+
+      // time since previous as decimal hours
+      val h = d.toMillis.toDouble / Duration.ofHours(1).toMillis.toDouble
+
+      val dp = (cur.µasP - prev.µasP)/h
+      val dq = (cur.µasQ - prev.µasQ)/h
+
+      AvgAcceleration(math.hypot(dp, dq), h)
+    }
+  }
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisContext.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisContext.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package horizons
+
+import gem.enum.Site
+import gem.util.Timestamp
+
+import cats.implicits._
+import scala.math.Ordering.Implicits._
+
+
+/** Collection of information related to an ephemeris.  Used to determine
+  * whether an update is needed.
+  *
+  * @param key  unique horizons id of the object
+  * @param site information valid for the given site
+  * @param meta associated ephemeris metadata, if any
+  * @param rnge earliest and latest ephemeris element times, if any
+  * @param soln current horizons solution reference from JPL, if any
+  */
+final case class EphemerisContext(
+  key:  EphemerisKey.Horizons,
+  site: Site,
+  meta: Option[EphemerisMeta],
+  rnge: Option[(Timestamp, Timestamp)],
+  soln: Option[HorizonsSolutionRef]
+) {
+
+  /** Determines whether the existing ephemeris, if any, covers the given
+    * semester.
+    */
+  def coversSemester(sem: Semester): Boolean =
+    rnge.exists { case (start, end) =>
+      (start.toInstant <= sem.start.atSite(site).toInstant) &&
+        (sem.end.atSite(site).toInstant <= end.toInstant)
+    }
+
+  /** Whether the database and latest horizons version data matches. */
+  val sameSolution: Boolean =
+    (meta.flatMap(_.solnRef), soln).tupled.exists { case (s0, s1) =>
+      s0 === s1
+    }
+
+  /** Determines whether updates are needed to obtain the latest ephemeris for
+    * the given semester.
+    */
+  def isUpToDateFor(sem: Semester): Boolean =
+    coversSemester(sem) && sameSolution
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
@@ -1,0 +1,141 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package horizons
+
+import gem.math.{ Angle, Ephemeris, EphemerisCoordinates, Offset }
+import gem.util.Timestamp
+
+import atto.ParseResult
+import atto.ParseResult.Done
+import atto.syntax.parser._
+
+import cats.implicits._
+
+import fs2.Pipe
+
+import scala.math.BigDecimal.RoundingMode.HALF_EVEN
+
+
+/** Horizons ephemeris parser.  Parses horizons output generated with the flags
+  *
+  *   `QUANTITIES=1; time digits=FRACSEC; extra precision=YES`
+  *
+  * into an `Ephemeris` object, or a `Stream[Ephemeris.Element]`.
+  */
+object EphemerisParser {
+
+  private object impl {
+
+    import atto._
+    import Atto._
+    import cats.implicits._
+    import gem.parser.CoordinateParsers._
+    import gem.parser.MiscParsers._
+    import gem.parser.TimeParsers._
+
+    val SOE           = "$$SOE"
+    val EOE           = "$$EOE"
+
+    val soe           = string(SOE)
+    val eoe           = string(EOE)
+    val skipPrefix    = manyUntil(anyChar, soe)  ~> verticalWhitespace
+    val skipEol       = skipMany(noneOf("\n\r")) ~> verticalWhitespace
+    val solarPresence = oneOf("*CNA ").void namedOpaque "solarPresence"
+    val lunarPresence = oneOf("mrts ").void namedOpaque "lunarPresence"
+
+    val deltaAngle    = bigDecimal.map { d =>
+      val µas = d.underlying.movePointRight(6).setScale(0, HALF_EVEN).longValue
+      Angle.fromMicroarcseconds(µas)
+    }
+
+    val utc: Parser[Timestamp] =
+      instantUTC(
+        genYMD(monthMMM, hyphen) named "yyyy-MMM-dd",
+        genLocalTime(colon)
+      ).flatMap(Timestamp.fromInstant(_).fold(err[Timestamp]("date out of range"))(ok))
+
+    val element: Parser[Ephemeris.Element] =
+      for {
+        _ <- space
+        i <- utc           <~ space
+        _ <- solarPresence
+        _ <- lunarPresence <~ spaces1
+        c <- coordinates   <~ spaces1
+        p <- deltaAngle    <~ spaces1
+        q <- deltaAngle
+      } yield (i, EphemerisCoordinates(c, Offset(Offset.P(p), Offset.Q(q))))
+
+    val elementLine: Parser[Ephemeris.Element] =
+      element <~ skipEol
+
+    val ephemeris: Parser[Ephemeris] =
+      skipPrefix ~> (
+        many(elementLine).map(Ephemeris.fromFoldable[List]) <~ eoe
+      )
+  }
+
+  import impl.{ element, ephemeris, SOE, EOE }
+
+  /** Parses an ephemeris file into an `Ephemeris` object in memory.
+    *
+    * @param s string containing the ephemeris data from horizons
+    *
+    * @return result of parsing the string into an `Ephemeris` object
+    */
+  def parse(s: String): ParseResult[Ephemeris] =
+    ephemeris.parseOnly(s)
+
+  /** An `fs2.Pipe` that converts a `Stream[F, String]` of ephemeris data from
+    * horizons into a `Stream[F, ParseResult[Ephemeris.Element]]`.
+    *
+    * @tparam F effect to use
+    *
+    * @return pipe for a `Stream[F, String]` into a `Stream[F, ParseResult[Ephemeris.Element]]`
+    */
+  def parsedElements[F[_]]: Pipe[F, String, ParseResult[Ephemeris.Element]] =
+    _.through(fs2.text.lines)
+     .dropWhile(_.trim =!= SOE)
+     .drop(1)
+     .takeWhile(_.trim =!= EOE)
+     .map(element.parseOnly)
+
+  /** An `fs2.Pipe` that converts a `Stream[F, String]` of ephemeris data from
+    * horizons into a `Stream[F, Either[String, Ephemeris.Element]]` where left
+    * values indicate parsing errors.
+    *
+    * @tparam F effect to use
+    *
+    * @return pipe for a `Stream[F, String]` into a `Stream[F, Either[String, Ephemeris.Element]]`
+    */
+  def eitherElements[F[_]]: Pipe[F, String, Either[String, Ephemeris.Element]] =
+    _.through(parsedElements)
+     .map(_.either)
+
+  /** An `fs2.Pipe` that converts a `Stream[F, String]` of ephemeris data from
+    * horizons into a `Stream[F, Ephemeris.Element]`.  If there is a parse
+    * error reading the data, the element that does not parse is skipped.
+    *
+    * @tparam F effect to use
+    *
+    * @return pipe for a `Stream[F, String]` into a `Stream[F, Ephemeris.Element]`
+    */
+  def validElements[F[_]]: Pipe[F, String, Ephemeris.Element] =
+    _.through(parsedElements)
+     .collect { case Done(_, e) => e }
+
+  /** An `fs2.Pipe` that converts a `Stream[F, String]` of ephemeris data from
+    * horizons into a `Stream[F, Ephemeris.Element]`.  If there is a parse
+    * error reading the data, the Stream raises an error.  See `Stream.onError`
+    * to handle this case.
+    *
+    * @tparam F effect to use
+    *
+    * @return pipe for a `Stream[F, String]` into a `Stream[F, Ephemeris.Element]`
+    */
+  def elements[F[_]]: Pipe[F, String, Ephemeris.Element] =
+    _.through(parsedElements)
+     .map(_.either.left.map(new RuntimeException(_)))
+     .rethrow
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsClient.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsClient.scala
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.enum.Site
+
+import cats.ApplicativeError
+import cats.data.Reader
+import cats.effect.IO
+import cats.implicits._
+
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.client.blaze.{ BlazeClientConfig, Http1Client }
+
+import fs2.Stream
+//import fs2.async.mutable.Semaphore
+import fs2.text.utf8Decode
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+import java.time.Instant
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeFormatter
+import java.util.Locale.US
+
+import scala.concurrent.duration._
+
+/** A client for interacting with the JPL horizons service.
+  */
+object HorizonsClient {
+
+  /** A global mutex for limiting concurrent connections to Horizons. */
+//  private val mutex: Semaphore[IO] =
+//    Semaphore[IO](1L)(implicitly, scala.concurrent.ExecutionContext.global).unsafeRunSync // note
+
+  /** A stream that emits a single client that will be shut down automatically. An global mutex
+    * ensures that only one such stream exists at a time.
+    */
+  val client: Stream[IO, Client[IO]] = {
+    // By using the singleton type here we prove that the mutex is a constant value. This guards
+    // against someone accidentally refactoring it into a method.
+//    val mutexʹ: mutex.type = mutex
+    val client = Http1Client.stream[IO](BlazeClientConfig.defaultConfig.copy(responseHeaderTimeout = 20.seconds))
+//    Stream.bracket(mutexʹ.decrement)(_ => client, _ => mutexʹ.increment)
+    client
+  }
+
+  /** Horizons service URL. */
+  val Url: String =
+    "https://ssd.jpl.nasa.gov/horizons_batch.cgi"
+
+  /** DateTimeFormatter that can format instants into the string expected by
+    * the horizons service: {{{yyyy-MMM-d HH:mm:ss.SSS}}}.
+    */
+  val DateFormat: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MMM-d HH:mm:ss.SSS", US).withZone(UTC)
+
+  val SharedParams: Map[String, String] =
+    Map(
+      "batch"       -> "1",
+      "CSV_FORMAT"  -> "NO",
+      "TABLE_TYPE"  -> "OBSERVER"
+    )
+
+  type ParamReader[A] = Reader[Map[String, String], A]
+
+  /** Format coordinates and altitude as expected by horizons.*/
+  def formatCoords(s: Site): String =
+    f"'${s.longitude.toDoubleDegrees}%1.5f,${s.latitude.toSignedDoubleDegrees}%1.6f,${s.altitude.toDouble/1000.0}%1.3f'"
+
+  /** Format an instant as expected by horizons. */
+  def formatInstant(i: Instant): String =
+    s"'${DateFormat.format(i)}'"
+
+  /** URL encodes query params. */
+  val formatQuery: ParamReader[String] =
+    Reader {
+      _.toList
+       .map { case (k, v) => s"$k=${URLEncoder.encode(v, UTF_8.name)}" }
+       .intercalate("&")
+    }
+
+  /** Computes the URL string that matches the given parameters. */
+  val urlString: ParamReader[String] =
+    formatQuery.map { s => s"$Url?$s" }
+
+  /** Creates an http4s Uri representing the request and lifts it into IO,
+    * raising an error if there is a problem parsing the request.
+    */
+  val uri: ParamReader[IO[Uri]] =
+    urlString.map(Uri.fromString).map(ApplicativeError[IO, Throwable].fromEither)
+
+  /** Creates an http4s Request representing the request. */
+  val request: ParamReader[IO[Request[IO]]] =
+    uri.map { _.map(Request(Method.GET, _)) }
+
+  /** Creates a `Stream` of results from the horizons server when executed. */
+  val stream: ParamReader[Stream[IO, String]] =
+    request.map { r => client.flatMap { _.streaming(r) { _.body.through(utf8Decode) } } }
+
+  /** Retrieves all the horizons server outout into a single String. */
+  val fetch: ParamReader[IO[String]] =
+    request.map { r =>
+      client.flatMap { c =>
+        Stream.eval(c.expect[String](r))
+      }.compile.last.map(_.getOrElse(sys.error("unpossible: empty stream")))
+    }
+
+}
+

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisQuery.scala
@@ -1,0 +1,216 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.{EphemerisKey, Semester}
+import gem.enum.Site
+import gem.math.Ephemeris
+import gem.syntax.time._
+
+import cats._
+import cats.effect.IO
+import cats.implicits._
+
+import fs2.Stream
+
+import java.time.{Duration, Instant, Period}
+
+import scala.math.Ordering.Implicits._
+
+
+/** Representation of an Horizons ephemeris query.
+  */
+sealed trait HorizonsEphemerisQuery {
+
+  /** Query start time.  The first element returned should have this time.
+    */
+  def startTime: Instant
+
+  /** Query end time.  The last element returned should have this time.
+    */
+  def endTime: Instant
+
+  /** Requested element limit.
+    */
+  def elementLimit: Int
+
+  /** URL string corresponding the the horizons request.
+    */
+  def urlString: String
+
+  /** A stream of ephemeris elements from horizons.
+    */
+  def streamEphemeris: Stream[IO, Ephemeris.Element]
+
+}
+
+object HorizonsEphemerisQuery {
+
+  type HorizonsDesignation = EphemerisKey.Horizons
+
+  /** Maximum number of elements that may be received by an Horizons ephemeris
+    * request.
+    */
+  val MaxElements: Int =
+    90024
+
+  /** The minimum time between elements supported by an horizons request.
+    */
+  val MinStepLen: Duration =
+    Duration.ofMillis(500)
+
+  private val FixedParams = HorizonsClient.SharedParams ++ Map(
+    "CENTER"      -> "coord",
+    "COORD_TYPE"  -> "GEODETIC",
+    "extra_prec"  -> "YES",
+    "MAKE_EPHEM"  -> "YES",
+    "QUANTITIES"  -> "'1,3'",   // RA/Dec (1) and rate of change (3)
+    "time_digits" -> "FRACSEC"  // millisecond precision
+  )
+
+  /** Constructs an horizons ephemeris query for the given key, site, start/stop
+    * time range, and element limit. Note that a successful query will contain
+    * no more than 90024 elements regardless of the requested limit since
+    * Horizons responses are capped at 90024.  It will also include at least two
+    * elements (at the start and stop times). Finally, all elements must be
+    * separated by at least 500ms or else the query fails.
+    *
+    * @param key   Unique Horizons designation for the non-sidereal target of
+    *              interest
+    * @param site  site to which the ephemeris data applies
+    * @param start time at which ephemeris data should start (inclusive)
+    * @param end   time at which ephemeris data should end (inclusive)
+    * @param limit maximum number of elements requested
+    *
+    * @return an Horizons query ready to be executed
+    */
+  def apply(key:   HorizonsDesignation,
+            site:  Site,
+            start: Instant,
+            end:   Instant,
+            limit: Int): HorizonsEphemerisQuery =
+
+    new HorizonsEphemerisQuery {
+
+      override val startTime: Instant =
+        start
+
+      override val endTime: Instant =
+        end
+
+      override val elementLimit: Int =
+        limit
+
+      val reqParams = Map(
+        "COMMAND"    -> s"'${key.queryString}'",
+        "SITE_COORD" -> HorizonsClient.formatCoords(site),
+        "START_TIME" -> s"${HorizonsClient.formatInstant(start)}",
+        "STEP_SIZE"  -> (((limit max 2) min MaxElements) - 1).toString, // horizons wants # intervals -- the gap count not the element count
+        "STOP_TIME"  -> s"${HorizonsClient.formatInstant(end)}"
+      ) ++ FixedParams
+
+      override val urlString: String =
+        HorizonsClient.urlString(reqParams)
+
+      override val streamEphemeris: Stream[IO, Ephemeris.Element] =
+        HorizonsClient.stream(reqParams).through(EphemerisParser.elements)
+    }
+
+
+  // Utility to calculate the integer ceiling of n/d.
+  private def intCeil(n: Long, d: Long): Long =
+    if (n >= 0) (n + d - 1L) / d else n / d
+
+  // Utility to round up a Duration up to the next ms.
+  private def roundUpMs(d: Duration): Duration =
+    (d.getNano % 1000000) match {
+      case 0 => d
+      case i => d.plusNanos(1000000L - i.toLong)
+    }
+
+  /** Constructs a List of queries for the given key, site, time range, and step
+    * size such that the entire range is covered by the combination of the
+    * returned queries. Horizons places a max element count limit on its results
+    * so this method provides a way to obtain all the queries necessary to cover
+    * a time range with a given step size.
+    *
+    * Note, Horizons requires a minimum step size of 500ms so 500ms will be used
+    * if a smaller value for `step` is requested and sub-millisecond fractions
+    * are rounded up to the next millisecond regardless.
+    *
+    * @param key   Unique Horizons designation for the non-sidereal target of
+    *              interest
+    * @param site  site to which the ephemeris data applies
+    * @param start start time for the first ephemeris element to be returned
+    * @param end   nominal end time (the actual last element may happen after
+    *              end if the step size doesn't evenly divide the total time)
+    * @param step  time (ms precision) between successive ephemeris elements (a
+    *              minimum of 500ms will be used if a smaller time is requested)
+    *
+    * @return List of queries that cover the entire time range
+    */
+  def paging(
+        key:   HorizonsDesignation,
+        site:  Site,
+        start: Instant,
+        end:   Instant,
+        step:  Duration): List[HorizonsEphemerisQuery] = {
+
+    // Horizons doesn't support a step length below 500 ms and FRACSEC gives
+    // only ms precision.
+    val stepʹ   = roundUpMs(step) max MinStepLen
+    val stepMsʹ = stepʹ.toMillis
+
+    // Total time covered by a single page with max elements.
+    val maxPage  = stepʹ * MaxElements.toLong
+
+    // Calculate (end time inclusive, element count) for a page starting at pStart.
+    def pageEnd(pStart: Instant): (Instant, Int) = {
+      val rem = roundUpMs(Duration.between(pStart, end))
+      val cnt = if (rem >= maxPage) MaxElements.toLong else intCeil(rem.toMillis, stepMsʹ) + 1L
+
+      (pStart + stepʹ * (cnt - 1), cnt.toInt)
+    }
+
+    Stream.unfold(start) { pStart =>
+      if (pStart >= end)
+        None
+      else {
+        val (pEnd, pCnt) = pageEnd(pStart)
+
+        // Horizons queries must return >= 2 elements.  If next page would have
+        // just 1 elem, shorten *this* query so that the next one has 2.
+        val (_,     nCnt ) = pageEnd(pStart + maxPage)
+        val (pEndʹ, pCntʹ) = if (nCnt === 1) (pEnd - stepʹ, pCnt - 1) else (pEnd, pCnt)
+
+        Some((HorizonsEphemerisQuery(key, site, pStart, pEndʹ, pCntʹ), pEndʹ + stepʹ))
+      }
+    }.toList
+  }
+
+  def pagingSemester(
+        key:      HorizonsDesignation,
+        site:     Site,
+        semester: Semester,
+        step:     Duration,
+        padding:  Period): List[HorizonsEphemerisQuery] = {
+
+    val start = semester.start.atSite(site).minus(padding).toInstant
+    val end   = semester.end.atSite(site).plus(padding).toInstant
+
+    paging(key, site, start, end, step)
+  }
+
+  def pagingCurrentSemester(
+        key:      HorizonsDesignation,
+        site:     Site,
+        step:     Duration,
+        padding:  Period): IO[List[HorizonsEphemerisQuery]] =
+
+    Semester.current(site).map(pagingSemester(key, site, _, step, padding))
+
+  def streamAll(qs: List[HorizonsEphemerisQuery]): Stream[IO, Ephemeris.Element] =
+    Monoid.combineAll(qs.map(_.streamEphemeris))
+}
+

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
@@ -1,0 +1,137 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+package horizons
+
+import gem.dao.EphemerisDao
+import gem.enum.Site
+import gem.math.Ephemeris
+import gem.util.Timestamp
+import gem.horizons.EphemerisCompression._
+
+import cats._
+import cats.effect._
+import cats.effect.implicits._
+import cats.implicits._
+
+import doobie._, doobie.implicits._
+
+import java.time.{ Duration, Period }
+
+import fs2.Stream
+
+
+/** Utility for inserting / updating en ephemeris. */
+final case class HorizonsEphemerisUpdater[M[_]: Monad: LiftIO](xa: Transactor[M]) {
+
+  import HorizonsEphemerisUpdater._
+
+  /** Constructs an action that when run will provide the current context
+    * information for an ephemeris.  This information can be used to determine
+    * whether an update is needed, to see when the last update was performed,
+    * and when the last update check happened.
+    */
+  def report(key:  EphemerisKey.Horizons, site: Site): M[EphemerisContext] =
+
+    (for {
+      meta <- EphemerisDao.selectMeta(key, site)
+      rnge <- EphemerisDao.selectTimes(key, site)
+      soln <- HorizonsSolutionRefQuery(key).lookup.liftIO[ConnectionIO]
+    } yield EphemerisContext(key, site, meta, rnge, soln)).transact(xa)
+
+
+  /** Constructs an action that when run will insert a new ephemeris or update
+    * an existing one if necessary.
+    */
+  def update(key: EphemerisKey.Horizons, site: Site): M[Unit] =
+
+    for {
+      time <- Timestamp.now.liftIO[M]
+      sem  <- Semester.current(site).liftIO[M]
+      ctx  <- report(key, site)
+      _    <- updateIfNecessary(ctx, time, sem).transact(xa)
+    } yield ()
+
+
+  private def insertMeta(key: EphemerisKey.Horizons, site: Site, m: EphemerisMeta): ConnectionIO[Unit] =
+    EphemerisDao.insertMeta(key, site, m).void
+
+  private def updateMeta(key: EphemerisKey.Horizons, site: Site, m: EphemerisMeta): ConnectionIO[Unit] =
+    EphemerisDao.updateMeta(key, site, m).void
+
+  private def streamEphemeris(
+    key:      EphemerisKey.Horizons,
+    site:     Site,
+    semester: Semester
+  ): Stream[ConnectionIO, Ephemeris.Element] = {
+
+    val qs = HorizonsEphemerisQuery.pagingSemester(key, site, semester, StepSize, Padding)
+
+    qs.foldMap(_.streamEphemeris)
+      .through(standardAccelerationCompression)
+      .translate(λ[IO ~> ConnectionIO](_.liftIO[ConnectionIO]))
+  }
+
+
+  private def updateIfNecessary(
+    ctx:  EphemerisContext,
+    time: Timestamp,
+    sem:  Semester
+  ): ConnectionIO[Unit] =
+
+    if (ctx.isUpToDateFor(sem)) recordUpdateCheck(ctx, time)
+    else doUpdate(ctx, time, sem)
+
+
+  private def recordUpdateCheck(
+    ctx:  EphemerisContext,
+    time: Timestamp
+  ): ConnectionIO[Unit] =
+
+    ctx.meta.fold(().pure[ConnectionIO]) { m =>
+      updateMeta(ctx.key, ctx.site, EphemerisMeta.lastUpdateCheck.set(time)(m))
+    }
+
+
+  private def doUpdate(
+    ctx:  EphemerisContext,
+    time: Timestamp,
+    sem:  Semester
+  ): ConnectionIO[Unit] = {
+
+    // Need to update both meta and ephemeris.  First the new
+    // metadata.
+    val mʹ   = EphemerisMeta(time, time, ctx.soln)
+
+    // The sink for writing the ephemeris to the database.  Have to pick either
+    // insert or update depending upon whether there is an existing ephemeris.
+    val sink = ctx.rnge.fold(EphemerisDao.streamInsert(ctx.key, ctx.site)) { _ =>
+      EphemerisDao.streamUpdate(ctx.key, ctx.site)
+    }
+
+    // Update the metadata and stream the ephemeris into the database.
+    for {
+      _ <- ctx.meta.fold(insertMeta(ctx.key, ctx.site, mʹ)) { _ =>
+             updateMeta(ctx.key, ctx.site, mʹ)
+           }
+      _ <- streamEphemeris(ctx.key, ctx.site, sem).to(sink).compile.drain
+    } yield ()
+  }
+
+}
+
+object HorizonsEphemerisUpdater {
+
+  /** Padding on either side of the semester to include in an ephemeris. */
+  val Padding: Period =
+    Period.ofMonths(1)
+
+  /** Maximum time between ephemeris elements, before removing points that
+    * should be interpolated.
+    */
+  val StepSize: Duration =
+    Duration.ofMinutes(1L)
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
@@ -1,0 +1,235 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.EphemerisKey
+
+import HorizonsNameQuery._
+
+import cats.data.EitherT
+import cats.effect.IO
+import cats.implicits._
+
+import scala.util.Either
+import scala.util.matching.Regex
+
+
+/** Horizons name-resolution query.
+  *
+  * {{{
+  *   import HorizonsNameQuery.Search.Comet
+  *
+  *   HorizonsNameQuery(Comet("Halley")).lookup.value.unsafeRunSync
+  * }}}
+  */
+sealed trait HorizonsNameQuery[A] {
+
+  /** URL string corresponding to the horizons request. */
+  def urlString: String
+
+  /** Returns a program that will perform the name lookup when executed,
+    * returing a List of ephemeris keys with their common name.
+    */
+  def lookup: Result[List[Resolution[A]]]
+}
+
+object HorizonsNameQuery {
+
+  /** Describes a non-sidereal target query of a specific type of object. */
+  sealed abstract class Search[A](val queryString: String) extends Product with Serializable
+
+  object Search {
+    final case class Comet(partial: String)     extends Search[EphemerisKey.Comet    ](s"NAME=$partial*;CAP")
+    final case class Asteroid(partial: String)  extends Search[EphemerisKey.Asteroid ](s"ASTNAM=$partial*"  )
+    final case class MajorBody(partial: String) extends Search[EphemerisKey.MajorBody](s"$partial"          )
+  }
+
+  sealed trait Error extends Product with Serializable
+
+  final case class HorizonsException(e: Throwable)                  extends Error
+  final case class ParseError(input: List[String], message: String) extends Error
+
+  /** Result of performing an horizons name resolution. */
+  type Result[A] = EitherT[IO, Error, A]
+
+  /** A human-readable name and its unique horizons ephemeris key. */
+  final case class Resolution[A](a: A, name: String)
+
+  /** Creates a NameQuery for the given search object. */
+  def apply[A](search: Search[A]): HorizonsNameQuery[A] =
+    new HorizonsNameQuery[A] {
+      import NameQueryImpl._
+
+      val reqParams = HorizonsClient.SharedParams ++ Map(
+        "MAKE_EPHEM" -> "NO",
+        "COMMAND"    -> s"'${search.queryString}'"
+      )
+
+      override val urlString: String =
+        HorizonsClient.urlString(reqParams)
+
+      override val lookup: Result[List[Resolution[A]]] =
+        EitherT(HorizonsClient.fetch(reqParams).map { s =>
+          val lines = s.split('\n').toList
+          parseResponse(search, lines).leftMap(ParseError(lines, _))
+        })
+    }
+
+  private object NameQueryImpl {
+
+    // Representation of column offsets as (start, end) pairs, as deduced
+    // from --- -------- --- -----
+    type Offsets = List[(Int, Int)]
+
+    // Parse many results based on an expected header pattern. This will read
+    // through the tail until --- separators are found, then parse the
+    // remaining lines (until a blank line is encountered) using the function
+    // constructed by `f`, if any (otherwise it is assumed that there were not
+    // enough columns found). Returns a list of values or an error message.
+    def parseMany[A](header: String, tail: List[String], headerPattern: Regex)(f: Offsets => Option[String => A]): Either[String, List[A]] =
+      headerPattern.findFirstMatchIn(header).toRight("Header pattern not found: " + headerPattern.regex) *>
+        (tail.dropWhile(s => !s.trim.startsWith("---")) match {
+          case Nil                => Nil.asRight // no column headers means no results!
+          case colHeaders :: rows =>             // we have a header row with data rows following
+            val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
+            try {
+              f(offsets).map(g => rows.takeWhile(_.trim.nonEmpty).map(g)).toRight("Not enough columns.")
+            } catch {
+              case    nfe: NumberFormatException           =>  ("Number format exception: " + nfe.getMessage).asLeft
+              case      _: StringIndexOutOfBoundsException =>   "Column value(s) not found.".asLeft
+            }
+        })
+
+
+    def parseHeader[A](lines: List[String])(f: (String, List[String]) => Either[String, List[A]]): Either[String, List[A]] =
+      lines match {
+        case _ :: h :: t => f(h, t)
+        case _           => "Fewer than 2 lines!".asLeft
+      }
+
+    def parseResponse[A](s: Search[A], lines: List[String]): Either[String, List[Resolution[A]]] =
+      parseHeader[Resolution[A]](lines) { case (header, tail) =>
+        s match {
+          case Search.Comet(_)     => parseComets(header, tail)
+          case Search.Asteroid(_)  => parseAsteroids(header, tail)
+          case Search.MajorBody(_) => parseMajorBodies(header, tail)
+        }
+      }
+
+    type ParsedResolutions[A] = Either[String, List[Resolution[A]]]
+    type ParsedComets         = ParsedResolutions[EphemerisKey.Comet]
+    type ParsedAsteroids      = ParsedResolutions[EphemerisKey.Asteroid]
+    type ParsedMajorBodies    = ParsedResolutions[EphemerisKey.MajorBody]
+
+    def parseComets(header: String, tail: List[String]): ParsedComets = {
+
+      // Common case is that we have many results, or none.
+      def case0: ParsedComets =
+        parseMany[Resolution[EphemerisKey.Comet]](header, tail, """  +Small-body Index Search Results  """.r) { offs =>
+          (offs.lift(2), offs.lift(3)).mapN {
+            case ((ods, ode), (ons, _)) => { row =>
+              val desig = row.substring(ods, ode).trim
+              val name  = row.substring(ons     ).trim // last column, so no end index because rows are ragged
+              Resolution(EphemerisKey.Comet(desig), name)
+            }
+          }
+        }
+
+      // Single result with form: JPL/HORIZONS      Hubble (C/1937 P1)     2015-Dec-31 11:40:21
+      def case1: ParsedComets =
+        """  +([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.Comet(m.group(2)), m.group(1)))
+        }.toRight("Could not match 'Hubble (C/1937 P1)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS         1P/Halley           2015-Dec-31 11:40:21
+      def case2: ParsedComets =
+        """  +([^/]+)/(.+?)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.Comet(m.group(1)), m.group(2)))
+        }.toRight("Could not match '1P/Halley' header pattern.")
+
+      // First one that works!
+      case0 orElse
+      case1 orElse
+      case2 orElse "Could not parse the header line as a comet".asLeft
+    }
+
+    // scalastyle:off method.length
+    def parseAsteroids(header: String, tail: List[String]): ParsedAsteroids = {
+
+      // Common case is that we have many results, or none.
+      def case0: ParsedAsteroids =
+        parseMany[Resolution[EphemerisKey.Asteroid]](header, tail, """  +Small-body Index Search Results  """.r) { offs =>
+          (offs.lift(0), offs.lift(1), offs.lift(2)).mapN {
+            case ((ors, ore), (ods, ode), (ons, _)) => { row =>
+              val rec   = row.substring(ors, ore).trim.toInt
+              val desig = row.substring(ods, ode).trim
+              val name  = row.substring(ons     ).trim // last column, so no end index because rows are ragged
+              desig match {
+                case "(undefined)" => Resolution(EphemerisKey.AsteroidOld(rec): EphemerisKey.Asteroid, name)
+                case des           => Resolution(EphemerisKey.AsteroidNew(des): EphemerisKey.Asteroid, name)
+              }
+            }
+          }
+        }
+
+      // Single result with form: JPL/HORIZONS      90377 Sedna (2003 VB12)     2015-Dec-31 11:40:21
+      def case1: ParsedAsteroids =
+        """  +\d+ ([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(2)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match '90377 Sedna (2003 VB12)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS      4 Vesta     2015-Dec-31 11:40:21
+      def case2: ParsedAsteroids =
+        """  +(\d+) ([^(]+?)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidOld(m.group(1).toInt) : EphemerisKey.Asteroid, m.group(2)))
+        }.toRight("Could not match '4 Vesta' header pattern.")
+
+      // Single result with form: JPL/HORIZONS    (2016 GB222)    2016-Apr-20 15:22:36
+      def case3: ParsedAsteroids =
+        """  +\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match '(2016 GB222)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS        418993 (2009 MS9)            2016-Sep-07 18:23:54
+      def case4: ParsedAsteroids =
+        """  +\d+\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match '418993 (2009 MS9)' header pattern.")
+
+      // First one that works!
+      case0 orElse
+      case1 orElse
+      case2 orElse
+      case3 orElse
+      case4 orElse "Could not parse the header line as an asteroid".asLeft
+    }
+    // scalastyle:on method.length
+
+    def parseMajorBodies(header: String, tail: List[String]): ParsedMajorBodies = {
+
+      // Common case is that we have many results, or none.
+      def case0: ParsedMajorBodies =
+        parseMany[Resolution[EphemerisKey.MajorBody]](header, tail, """Multiple major-bodies match string""".r) { offs =>
+          (offs.lift(0), offs.lift(1)).mapN {
+            case ((ors, ore), (ons, one)) => { row =>
+              val rec  = row.substring(ors, ore).trim.toInt
+              val name = row.substring(ons, one).trim
+              Resolution(EphemerisKey.MajorBody(rec.toInt), name)
+            }
+          }
+        }.map(_.filterNot(_.a.num < 0)) // filter out spacecraft
+
+      // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
+      def case1: ParsedMajorBodies =
+        """  +(.*?) / \((.+?)\)  +(\d+) *$""".r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.MajorBody(m.group(3).toInt), m.group(1)))
+        }.toRight("Could not match 'Charon / (Pluto)     901' header pattern.")
+
+      // First one that works, otherwise Nil because it falls through to small-body search
+      case0 orElse
+      case1 orElse Nil.asRight
+    }
+  }
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsSolutionRefQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsSolutionRefQuery.scala
@@ -1,0 +1,93 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import atto.Atto._
+import atto._
+import cats.effect.IO
+import gem.{EphemerisKey, HorizonsSolutionRef}
+
+/** Horizons solution reference query.  Horizons supports a version number, of
+  * sorts, for comet and asteriod ephemeris calculations.  The version is an
+  * opaque `String` that can be used to compare for equality against previous
+  * versions to determine if an update is required.  Unfortunately, major bodies
+  * do not include solution references.
+  *
+  * {{{
+  *   import gem.EphemerisKey
+  *   import gem.horizons.HorizonsSolutionRefQuery
+  *
+  *   HorizonsSolutionRefQuery(EphemerisKey.Comet("81P")).lookup.unsafeRunSync
+  * }}}
+  *
+  */
+sealed trait HorizonsSolutionRefQuery {
+
+  /** URL string corresponding to the horizons request. */
+  def urlString: String
+
+  /** Returns a program that will perform the solution reference lookup when
+    * executed.
+    */
+  def lookup: IO[Option[HorizonsSolutionRef]]
+
+}
+
+object HorizonsSolutionRefQuery {
+
+  private val FixedParams = HorizonsClient.SharedParams ++ Map(
+    "MAKE_EPHEM" -> "NO"  // We don't need actual ephemeris elements
+  )
+
+  // Comets and Asteroids have solution references.
+  private val SolnRefKey = "soln ref.="
+
+  private val solnRefParser: Parser[String] =
+    (manyUntil(anyChar, string(SolnRefKey)) ~> stringOf1(noneOf(",\n")))
+
+  // MajorBody objects don't have a solution reference proper, so we use the
+  // revision date.
+  private val RevisedKey = "Revised: "
+
+  private val revisionParser: Parser[String] =
+    (manyUntil(anyChar, string(RevisedKey)) ~> manyUntil(anyChar, string("  ")).map(_.mkString))
+
+  /** Parses the given string for a solution reference. For comets and asteroids,
+    * this will be an actual solution reference.  For major bodies it is a
+    * revision date.  Either way we treat this as opaque data only of interest
+    * for determining whether there is new data.
+    *
+    * @param k key used to determine the type of non-sidereal object
+    * @param s header for a non-sidereal object of this type
+    *
+    * @return a solution reference, if found in the header
+    */
+  def parseSolutionRef(k: EphemerisKey.Horizons, s: String): Option[HorizonsSolutionRef] = {
+    val parser = k match {
+      case EphemerisKey.MajorBody(_) => revisionParser
+      case _                         => solnRefParser
+    }
+
+    (parser.map(s => HorizonsSolutionRef(s.trim)) parseOnly s).option
+  }
+
+  /** Creates a query instance for the given ephemeris key.
+    */
+  def apply(key: EphemerisKey.Horizons): HorizonsSolutionRefQuery =
+
+    new HorizonsSolutionRefQuery {
+      val reqParams = Map(
+        "COMMAND" -> s"'${key.queryString}'"
+      ) ++ FixedParams
+
+      override val urlString: String =
+        HorizonsClient.urlString(reqParams)
+
+      override val lookup: IO[Option[HorizonsSolutionRef]] =
+        HorizonsClient
+          .fetch(reqParams)
+          .map(parseSolutionRef(key, _))
+    }
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
@@ -1,0 +1,94 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons.tcs
+
+import gem.EphemerisKey
+import gem.dao.EphemerisDao
+import gem.enum.Site
+import gem.util.Timestamp
+
+import cats.effect._
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+
+import fs2.Stream
+import fs2.text
+import fs2.io.file
+
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption.{ CREATE, TRUNCATE_EXISTING }
+
+/** Provides support for exporting ephemeris data to files that may be read by
+  * the TCS.
+  *
+  * @param xa transactor to use for working with the database
+  */
+final class TcsEphemerisExport[M[_]: Sync](xa: Transactor[M]) {
+  import TcsEphemerisExport.RowLimit
+
+  /** Produces the name of the corresponding .eph file. */
+  def fileName(k: EphemerisKey): String =
+    s"${EphemerisKey.fromString.reverseGet(k)}.eph"
+
+  /** Resolves the ephemeris file corresponding to the given key. */
+  def resolve(key: EphemerisKey, dir: Path): Path =
+    dir.resolve(fileName(key))
+
+  /** Exports up to `RowLimit` lines of ephemeris data associated with the given
+    * key, site, and time range.
+    *
+    * Unless the start or end exactly matches an ephemeris element, then an
+    * entry before start, and/or after end will also be included. This ensures
+    * that the time range is fully covered and a position at any point in the
+    * range can be inferred from the ephemeris.
+    *
+    * @param path  directory to which the ephemeris data should be written
+    * @param key   key corresponding to the object to export
+    * @param site  site for which the data is relevant
+    * @param start start time for ephemeris data; if there is an element at
+    *              exactly this time it will be the first element (otherwise,
+    *              the element immediately preceeding this time is included)
+    * @param end   end time for ephemeris data; if there is an element at
+    *              exactly this time it will be the last element (otherwise,
+    *              the element immediately following this time is included)
+    */
+  def exportOne(key: EphemerisKey, site: Site, start: Timestamp, end: Timestamp, dir: Path): M[Unit] = {
+    import EphemerisDao.{ bracketRange, streamRange }
+
+    Stream.eval(bracketRange(key, site, start, end))
+      .flatMap { case (s, e) => streamRange(key, site, s, e) }
+      .transact(xa)
+      .take(RowLimit.toLong)
+      .through(TcsFormat.ephemeris)
+      .intersperse("\n")
+      .append(Stream.emit("\n"))
+      .through(text.utf8Encode)
+      .to(file.writeAll(resolve(key, dir), List(CREATE, TRUNCATE_EXISTING)))
+      .compile
+      .drain
+  }
+
+  /** Exports all ephemerides for the given site for the given time period. File
+    * names are invented based upon the corresponding ephemeris key.  See
+    * `EphemerisKey.format`.
+    *
+    * @param dir   directory where the ephemerides will be written
+    * @param site  site to which the ephemerides correspond
+    * @param start start time for the ephemeris data, inclusive
+    * @param end   end time for the ephemeirs day, exclusive
+    */
+  def exportAll(site: Site, start: Timestamp, end: Timestamp, dir: Path): M[Unit] =
+    for {
+      ks <- EphemerisDao.selectKeys(site).transact(xa)
+      _  <- ks.toList.traverse(k => exportOne(k, site, start, end, resolve(k, dir))).void
+    } yield ()
+}
+
+object TcsEphemerisExport {
+
+  /** Max ephemeris elements supported by the TCS. */
+  val RowLimit: Int =
+    1440
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsFormat.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsFormat.scala
@@ -1,0 +1,98 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons.tcs
+
+import gem.math.{ Angle, Declination, Ephemeris, HourAngle, JulianDate, RightAscension }
+
+import cats._
+
+import fs2._
+
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeFormatter
+import java.util.Locale.US
+
+/** Formatting for TCS ephemeris files.  The TCS is very particular and
+  * unforgiving about the format, down to the column in which items start and
+  * the number of digits to the right of decimal places.
+  */
+object TcsFormat {
+
+  /** Exact header required by the TCS. */
+  val Header: String =
+    """***************************************************************************************
+      | Date__(UT)__HR:MN Date_________JDUT     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
+      |***************************************************************************************""".stripMargin
+
+  /** Marker for the start of ephemeris elements in the file. */
+  val Soe: String =
+    "$$SOE"
+
+  /** Marker for the end of ephemeris elements in the file. */
+  val Eoe: String =
+    "$$EOE"
+
+  /** Date format required by the TCS. */
+  val DateFormatPattern: String      =
+    "yyyy-MMM-dd HH:mm"
+
+  val DateFormat: DateTimeFormatter =
+    DateTimeFormatter.ofPattern(DateFormatPattern, US).withZone(UTC)
+
+  /** RA format, which requires 10th of a millisecond (and no more, and no less)
+    * precision.
+    */
+  def formatRa(ra: RightAscension): String = {
+    // Round to an even number of tenths of microseconds.
+    val µs         = ra.toHourAngle.toMicroseconds
+    val tenthsOfMs = (µs / 100) + ((µs % 100) + 50) / 100
+    val hms        = (HourAngle.microseconds.reverse composeIso HourAngle.hms).get(tenthsOfMs * 100)
+
+    f"${hms.hours}%02d ${hms.minutes}%02d ${hms.seconds}%02d.${hms.milliseconds}%03d${hms.microseconds/100}%01d"
+  }
+
+  /** Dec format, which requires millisecond (and no more, and no less)
+    * precision.  If positive, must have a leading space.
+    */
+  def formatDec(dec: Declination): String = {
+    val a    = dec.toAngle
+    val sµas = Angle.signedMicroarcseconds.get(a)
+
+    // Round to an even number of milliseconds
+    val µas  = (if (sµas < 0) -a else a).toMicroarcseconds
+    val mas  = (µas / 1000) + ((µas % 1000) + 500) / 1000
+    val dms  = (Angle.milliarcseconds.reverse composeIso Angle.dms).get(mas.toInt)
+
+    // -9 should format as "-09", 9 as " 09"
+    val sign = if (sµas < 0) "-" else " "
+    f"$sign${dms.degrees.abs}%02d ${dms.arcminutes}%02d ${dms.arcseconds}%02d.${dms.milliarcseconds}%03d"
+  }
+
+  def formatDeltaArcseconds(a: Angle): String =
+    f"${Angle.signedMicroarcseconds.get(a).toDouble / 1000000.0}%9.5f"
+
+  def formatElement(e: Ephemeris.Element): String = {
+    val (time, ephCoords) = e
+
+    // Time, Julian Date
+    val instant   = time.toInstant
+    val timeS     = DateFormat.format(instant)
+    val jdS       = f"${JulianDate.ofInstant(instant).toDouble}%.9f"
+
+    // Coordinates
+    val coords = ephCoords.coord
+    val coordS = s"${formatRa(coords.ra)} ${formatDec(coords.dec)}"
+    val Δ      = ephCoords.delta
+    val ΔraS   = formatDeltaArcseconds(Δ.p.toAngle)
+    val ΔdecS  = formatDeltaArcseconds(Δ.q.toAngle)
+
+    s" $timeS $jdS     $coordS $ΔraS $ΔdecS"
+  }
+
+  def elements[M[_]: Monad]: Pipe[M, Ephemeris.Element, String] =
+    _.map(formatElement)
+
+  def ephemeris[M[_]: Monad]: Pipe[M, Ephemeris.Element, String] =
+    s => Stream(Header, Soe) ++ s.map(formatElement) ++ Stream(Eoe)
+}

--- a/modules/ephemeris/src/test/resources/gem/horizons/borrelly-compressed.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/borrelly-compressed.eph
@@ -1,0 +1,165 @@
+*******************************************************************************
+JPL/HORIZONS                    19P/Borrelly               2017-Oct-03 07:55:49
+Rec #:900302          Soln.date: 2017-May-07_17:25:46   # obs: 2845 (1973-2017)
+
+IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+   A= 3.609665546424225    MA= 137.93043492053     ADIST= 5.859531354066144
+   PER= 6.8581765453391    N= .143715502           ANGMOM= .025557412
+   DAN= 1.36332            DDN= 5.79504            L= 69.6892033
+   B= -3.3504474           MOID= .377543           TP= 2001-Sep-14.2536303061
+
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+
+COMET comments
+1: soln ref.= JPL#K157/5, data arc: 1973-08-23 to 2017-03-30
+2: k1=17., k2=5., phase coef.=0.03;
+*******************************************************************************
+
+
+*******************************************************************************
+Ephemeris / WWW_USER Tue Oct  3 07:55:49 2017 Pasadena, USA      / Horizons
+*******************************************************************************
+Target body name: 19P/Borrelly                    {source: JPL#K157/5}
+Center body name: Earth (399)                     {source: DE431}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-15 00:00:00.0000 UT
+Stop  time      : A.D. 2017-Aug-15 23:59:00.0000 UT
+Step-size       : 50 steps
+*******************************************************************************
+Target pole/equ : IAU                             {East-longitude -}
+Target radii    : 4.2 x 4.2 x 4.2 km              {Equator, meridian, pole}
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: DE431}
+Rel. light bend : Sun, EARTH                      {source: DE431}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2
+Small-body perts: Yes                             {source: SB431-N16}
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL
+RTS-only print  : NO
+EOP file        : eop.171002.p171224
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-OCT-02. PREDICTS-> 2017-DEC-23
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )
+*******************************************************************************
+Initial IAU76/J2000 heliocentric ecliptic osculating elements (au, days, deg.):
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+  Equivalent ICRF heliocentric equatorial cartesian coordinates (au, au/d):
+   X=-2.901624145572271E+00  Y=-4.714098832558961E+00  Z=-1.011739942319315E+00
+  VX= 2.370889154078356E-03 VY=-2.679782026686279E-03 VZ=-3.223564467123717E-03
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
+****************************************************************************
+$$SOE
+ 2017-Aug-15 00:00:00.000     14 50 13.1823 -02 58 45.704 9.304921  -12.4881
+ 2017-Aug-15 01:26:20.400     14 50 14.0798 -02 59 03.686 9.417733  -12.4845
+ 2017-Aug-15 02:52:40.800     14 50 14.9897 -02 59 21.664 9.562654  -12.4830
+ 2017-Aug-15 03:50:14.400     14 50 15.6045 -02 59 33.649 9.668666  -12.4834
+ 2017-Aug-15 04:47:48.000     14 50 16.2262 -02 59 45.635 9.775534  -12.4851
+ 2017-Aug-15 05:45:21.600  m  14 50 16.8545 -02 59 57.624 9.877449  -12.4880
+ 2017-Aug-15 07:11:42.000  m  14 50 17.8085 -03 00 15.613 10.00918  -12.4944
+ 2017-Aug-15 09:06:49.200  m  14 50 19.0967 -03 00 39.616 10.12254  -12.5057
+ 2017-Aug-15 13:54:37.200 *m  14 50 22.3312 -03 01 39.724 10.02491  -12.5335
+ 2017-Aug-15 15:20:57.600 *m  14 50 23.2877 -03 01 57.778 9.917012  -12.5380
+ 2017-Aug-15 16:47:18.000 *   14 50 24.2333 -03 02 15.837 9.800988  -12.5397
+ 2017-Aug-15 18:13:38.400 *   14 50 25.1682 -03 02 33.896 9.696287  -12.5386
+ 2017-Aug-15 20:37:32.400 *   14 50 26.7084 -03 03 03.985 9.593623  -12.5320
+ 2017-Aug-15 23:59:00.000     14 50 28.8594 -03 03 46.075 9.675139  -12.5193
+$$EOE
+*******************************************************************************
+Column meaning:
+
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE WITH TARGET RISE/TRANSIT/SET MARKER (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by another marker symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+        'r'  Rise    (target body on or above cut-off RTS elevation)
+        't'  Transit (target body at or past local maximum RTS elevation)
+        's'  Set     (target body on or below cut-off RTS elevation)
+
+RTS MARKERS (TVH)
+  Rise and set are with respect to the reference ellipsoid true visual horizon
+defined by the elevation cut-off angle. Horizon dip and yellow-light refraction
+(Earth only) are considered. Accuracy is < or = to twice the requested search
+step-size.
+
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+ dRA*cosD d(DEC)/dt =
+    The rate of change of target center apparent RA and DEC (airless).
+d(RA)/dt is multiplied by the cosine of the declination.
+    Units: ARCSECONDS PER HOUR
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/resources/gem/horizons/borrelly-error.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/borrelly-error.eph
@@ -1,0 +1,202 @@
+*******************************************************************************
+JPL/HORIZONS                    19P/Borrelly               2017-Oct-03 07:55:49
+Rec #:900302          Soln.date: 2017-May-07_17:25:46   # obs: 2845 (1973-2017)
+
+IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+   A= 3.609665546424225    MA= 137.93043492053     ADIST= 5.859531354066144
+   PER= 6.8581765453391    N= .143715502           ANGMOM= .025557412
+   DAN= 1.36332            DDN= 5.79504            L= 69.6892033
+   B= -3.3504474           MOID= .377543           TP= 2001-Sep-14.2536303061
+
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+
+COMET comments
+1: soln ref.= JPL#K157/5, data arc: 1973-08-23 to 2017-03-30
+2: k1=17., k2=5., phase coef.=0.03;
+*******************************************************************************
+
+
+*******************************************************************************
+Ephemeris / WWW_USER Tue Oct  3 07:55:49 2017 Pasadena, USA      / Horizons
+*******************************************************************************
+Target body name: 19P/Borrelly                    {source: JPL#K157/5}
+Center body name: Earth (399)                     {source: DE431}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-15 00:00:00.0000 UT
+Stop  time      : A.D. 2017-Aug-15 23:59:00.0000 UT
+Step-size       : 50 steps
+*******************************************************************************
+Target pole/equ : IAU                             {East-longitude -}
+Target radii    : 4.2 x 4.2 x 4.2 km              {Equator, meridian, pole}
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: DE431}
+Rel. light bend : Sun, EARTH                      {source: DE431}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2
+Small-body perts: Yes                             {source: SB431-N16}
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL
+RTS-only print  : NO
+EOP file        : eop.171002.p171224
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-OCT-02. PREDICTS-> 2017-DEC-23
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )
+*******************************************************************************
+Initial IAU76/J2000 heliocentric ecliptic osculating elements (au, days, deg.):
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+  Equivalent ICRF heliocentric equatorial cartesian coordinates (au, au/d):
+   X=-2.901624145572271E+00  Y=-4.714098832558961E+00  Z=-1.011739942319315E+00
+  VX= 2.370889154078356E-03 VY=-2.679782026686279E-03 VZ=-3.223564467123717E-03
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
+****************************************************************************
+$$SOE
+ 2017-Aug-15 00:00:00.000     14 50 13.1823 -02 58 45.704 9.304921  -12.4881
+ 2017-Aug-15 00:28:46.800     14 50 13.4803 -02 58 51.699 9.338051  -12.4867
+ 2017-Aug-15 00:57:33.600 :)  14 50 13.7794 -02 58 57.693 9.375816  -12.4855
+ 2017-Aug-15 01:26:20.400     14 50 14.0798 -02 59 03.686 9.417733  -12.4845
+ 2017-Aug-15 01:55:07.200     14 50 14.3816 -02 59 09.679 9.463256  -12.4837
+ 2017-Aug-15 02:23:54.000     14 50 14.6849 -02 59 15.671 9.511780  -12.4832
+ 2017-Aug-15 02:52:40.800     14 50 14.9897 -02 59 21.664 9.562654  -12.4830
+ 2017-Aug-15 03:21:27.600     14 50 15.2963 -02 59 27.656 9.615187  -12.4830
+ 2017-Aug-15 03:50:14.400     14 50 15.6045 -02 59 33.649 9.668666  -12.4834
+ 2017-Aug-15 04:19:01.200  s  14 50 15.9145 -02 59 39.642 9.722359  -12.4841
+ 2017-Aug-15 04:47:48.000     14 50 16.2262 -02 59 45.635 9.775534  -12.4851
+ 2017-Aug-15 05:16:34.800  m  14 50 16.5395 -02 59 51.629 9.827466  -12.4864
+ 2017-Aug-15 05:45:21.600  m  14 50 16.8545 -02 59 57.624 9.877449  -12.4880
+ 2017-Aug-15 06:14:08.400  m  14 50 17.1711 -03 00 03.619 9.924809  -12.4899
+ 2017-Aug-15 06:42:55.200  m  14 50 17.4891 -03 00 09.616 9.968913  -12.4920
+ 2017-Aug-15 07:11:42.000  m  14 50 17.8085 -03 00 15.613 10.00918  -12.4944
+ 2017-Aug-15 07:40:28.800  m  14 50 18.1291 -03 00 21.612 10.04509  -12.4970
+ 2017-Aug-15 08:09:15.600  m  14 50 18.4507 -03 00 27.612 10.07619  -12.4997
+ 2017-Aug-15 08:38:02.400  m  14 50 18.7733 -03 00 33.613 10.10210  -12.5026
+ 2017-Aug-15 09:06:49.200  m  14 50 19.0967 -03 00 39.616 10.12254  -12.5057
+ 2017-Aug-15 09:35:36.000  m  14 50 19.4205 -03 00 45.621 10.13730  -12.5087
+ 2017-Aug-15 10:04:22.800 Am  14 50 19.7448 -03 00 51.627 10.14625  -12.5119
+ 2017-Aug-15 10:33:09.600 Nm  14 50 20.0693 -03 00 57.634 10.14938  -12.5150
+ 2017-Aug-15 11:01:56.400 Cm  14 50 20.3938 -03 01 03.643 10.14676  -12.5181
+ 2017-Aug-15 11:30:43.200 *m  14 50 20.7181 -03 01 09.653 10.13853  -12.5210
+ 2017-Aug-15 11:59:30.000 *m  14 50 21.0420 -03 01 15.665 10.12495  -12.5239
+ 2017-Aug-15 12:28:16.800 *m  14 50 21.3654 -03 01 21.678 10.10635  -12.5266
+ 2017-Aug-15 12:57:03.600 *m  14 50 21.6882 -03 01 27.692 10.08314  -12.5291
+ 2017-Aug-15 13:25:50.400 *m  14 50 22.0102 -03 01 33.708 10.05581  -12.5314
+ 2017-Aug-15 13:54:37.200 *m  14 50 22.3312 -03 01 39.724 10.02491  -12.5335
+ 2017-Aug-15 14:23:24.000 *m  14 50 22.6512 -03 01 45.741 9.991028  -12.5353
+ 2017-Aug-15 14:52:10.800 *m  14 50 22.9700 -03 01 51.760 9.954834  -12.5368
+ 2017-Aug-15 15:20:57.600 *m  14 50 23.2877 -03 01 57.778 9.917012  -12.5380
+ 2017-Aug-15 15:49:44.400 *r  14 50 23.6041 -03 02 03.798 9.878277  -12.5389
+ 2017-Aug-15 16:18:31.200 *m  14 50 23.9193 -03 02 09.817 9.839359  -12.5394
+ 2017-Aug-15 16:47:18.000 *   14 50 24.2333 -03 02 15.837 9.800988  -12.5397
+ 2017-Aug-15 17:16:04.800 *   14 50 24.5461 -03 02 21.857 9.763889  -12.5396
+ 2017-Aug-15 17:44:51.600 *   14 50 24.8576 -03 02 27.876 9.728765  -12.5393
+ 2017-Aug-15 18:13:38.400 *   14 50 25.1682 -03 02 33.896 9.696287  -12.5386
+ 2017-Aug-15 18:42:25.200 *   14 50 25.4777 -03 02 39.915 9.667085  -12.5377
+ 2017-Aug-15 19:11:12.000 *   14 50 25.7863 -03 02 45.933 9.641736  -12.5366
+ 2017-Aug-15 19:39:58.800 *   14 50 26.0942 -03 02 51.951 9.620757  -12.5352
+ 2017-Aug-15 20:08:45.600 *   14 50 26.4015 -03 02 57.968 9.604596  -12.5337
+ 2017-Aug-15 20:37:32.400 *   14 50 26.7084 -03 03 03.985 9.593623  -12.5320
+ 2017-Aug-15 21:06:19.200 *   14 50 27.0150 -03 03 10.000 9.588128  -12.5302
+ 2017-Aug-15 21:35:06.000 *   14 50 27.3216 -03 03 16.015 9.588312  -12.5284
+ 2017-Aug-15 22:03:52.800 *t  14 50 27.6282 -03 03 22.029 9.594287  -12.5265
+ 2017-Aug-15 22:32:39.600 C   14 50 27.9351 -03 03 28.042 9.606074  -12.5246
+ 2017-Aug-15 23:01:26.400 N   14 50 28.2425 -03 03 34.054 9.623602  -12.5227
+ 2017-Aug-15 23:30:13.200 A   14 50 28.5505 -03 03 40.065 9.646707  -12.5210
+ 2017-Aug-15 23:59:00.000     14 50 28.8594 -03 03 46.075 9.675139  -12.5193
+$$EOE
+*******************************************************************************
+Column meaning:
+
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE WITH TARGET RISE/TRANSIT/SET MARKER (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by another marker symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+        'r'  Rise    (target body on or above cut-off RTS elevation)
+        't'  Transit (target body at or past local maximum RTS elevation)
+        's'  Set     (target body on or below cut-off RTS elevation)
+
+RTS MARKERS (TVH)
+  Rise and set are with respect to the reference ellipsoid true visual horizon
+defined by the elevation cut-off angle. Horizon dip and yellow-light refraction
+(Earth only) are considered. Accuracy is < or = to twice the requested search
+step-size.
+
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+ dRA*cosD d(DEC)/dt =
+    The rate of change of target center apparent RA and DEC (airless).
+d(RA)/dt is multiplied by the cosine of the declination.
+    Units: ARCSECONDS PER HOUR
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/resources/gem/horizons/borrelly.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/borrelly.eph
@@ -1,0 +1,202 @@
+*******************************************************************************
+JPL/HORIZONS                    19P/Borrelly               2017-Oct-03 07:55:49
+Rec #:900302          Soln.date: 2017-May-07_17:25:46   # obs: 2845 (1973-2017)
+
+IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+   A= 3.609665546424225    MA= 137.93043492053     ADIST= 5.859531354066144
+   PER= 6.8581765453391    N= .143715502           ANGMOM= .025557412
+   DAN= 1.36332            DDN= 5.79504            L= 69.6892033
+   B= -3.3504474           MOID= .377543           TP= 2001-Sep-14.2536303061
+
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+
+COMET comments
+1: soln ref.= JPL#K157/5, data arc: 1973-08-23 to 2017-03-30
+2: k1=17., k2=5., phase coef.=0.03;
+*******************************************************************************
+
+
+*******************************************************************************
+Ephemeris / WWW_USER Tue Oct  3 07:55:49 2017 Pasadena, USA      / Horizons
+*******************************************************************************
+Target body name: 19P/Borrelly                    {source: JPL#K157/5}
+Center body name: Earth (399)                     {source: DE431}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-15 00:00:00.0000 UT
+Stop  time      : A.D. 2017-Aug-15 23:59:00.0000 UT
+Step-size       : 50 steps
+*******************************************************************************
+Target pole/equ : IAU                             {East-longitude -}
+Target radii    : 4.2 x 4.2 x 4.2 km              {Equator, meridian, pole}
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: DE431}
+Rel. light bend : Sun, EARTH                      {source: DE431}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2
+Small-body perts: Yes                             {source: SB431-N16}
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL
+RTS-only print  : NO
+EOP file        : eop.171002.p171224
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-OCT-02. PREDICTS-> 2017-DEC-23
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )
+*******************************************************************************
+Initial IAU76/J2000 heliocentric ecliptic osculating elements (au, days, deg.):
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+  Equivalent ICRF heliocentric equatorial cartesian coordinates (au, au/d):
+   X=-2.901624145572271E+00  Y=-4.714098832558961E+00  Z=-1.011739942319315E+00
+  VX= 2.370889154078356E-03 VY=-2.679782026686279E-03 VZ=-3.223564467123717E-03
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
+****************************************************************************
+$$SOE
+ 2017-Aug-15 00:00:00.000     14 50 13.1823 -02 58 45.704 9.304921  -12.4881
+ 2017-Aug-15 00:28:46.800     14 50 13.4803 -02 58 51.699 9.338051  -12.4867
+ 2017-Aug-15 00:57:33.600     14 50 13.7794 -02 58 57.693 9.375816  -12.4855
+ 2017-Aug-15 01:26:20.400     14 50 14.0798 -02 59 03.686 9.417733  -12.4845
+ 2017-Aug-15 01:55:07.200     14 50 14.3816 -02 59 09.679 9.463256  -12.4837
+ 2017-Aug-15 02:23:54.000     14 50 14.6849 -02 59 15.671 9.511780  -12.4832
+ 2017-Aug-15 02:52:40.800     14 50 14.9897 -02 59 21.664 9.562654  -12.4830
+ 2017-Aug-15 03:21:27.600     14 50 15.2963 -02 59 27.656 9.615187  -12.4830
+ 2017-Aug-15 03:50:14.400     14 50 15.6045 -02 59 33.649 9.668666  -12.4834
+ 2017-Aug-15 04:19:01.200  s  14 50 15.9145 -02 59 39.642 9.722359  -12.4841
+ 2017-Aug-15 04:47:48.000     14 50 16.2262 -02 59 45.635 9.775534  -12.4851
+ 2017-Aug-15 05:16:34.800  m  14 50 16.5395 -02 59 51.629 9.827466  -12.4864
+ 2017-Aug-15 05:45:21.600  m  14 50 16.8545 -02 59 57.624 9.877449  -12.4880
+ 2017-Aug-15 06:14:08.400  m  14 50 17.1711 -03 00 03.619 9.924809  -12.4899
+ 2017-Aug-15 06:42:55.200  m  14 50 17.4891 -03 00 09.616 9.968913  -12.4920
+ 2017-Aug-15 07:11:42.000  m  14 50 17.8085 -03 00 15.613 10.00918  -12.4944
+ 2017-Aug-15 07:40:28.800  m  14 50 18.1291 -03 00 21.612 10.04509  -12.4970
+ 2017-Aug-15 08:09:15.600  m  14 50 18.4507 -03 00 27.612 10.07619  -12.4997
+ 2017-Aug-15 08:38:02.400  m  14 50 18.7733 -03 00 33.613 10.10210  -12.5026
+ 2017-Aug-15 09:06:49.200  m  14 50 19.0967 -03 00 39.616 10.12254  -12.5057
+ 2017-Aug-15 09:35:36.000  m  14 50 19.4205 -03 00 45.621 10.13730  -12.5087
+ 2017-Aug-15 10:04:22.800 Am  14 50 19.7448 -03 00 51.627 10.14625  -12.5119
+ 2017-Aug-15 10:33:09.600 Nm  14 50 20.0693 -03 00 57.634 10.14938  -12.5150
+ 2017-Aug-15 11:01:56.400 Cm  14 50 20.3938 -03 01 03.643 10.14676  -12.5181
+ 2017-Aug-15 11:30:43.200 *m  14 50 20.7181 -03 01 09.653 10.13853  -12.5210
+ 2017-Aug-15 11:59:30.000 *m  14 50 21.0420 -03 01 15.665 10.12495  -12.5239
+ 2017-Aug-15 12:28:16.800 *m  14 50 21.3654 -03 01 21.678 10.10635  -12.5266
+ 2017-Aug-15 12:57:03.600 *m  14 50 21.6882 -03 01 27.692 10.08314  -12.5291
+ 2017-Aug-15 13:25:50.400 *m  14 50 22.0102 -03 01 33.708 10.05581  -12.5314
+ 2017-Aug-15 13:54:37.200 *m  14 50 22.3312 -03 01 39.724 10.02491  -12.5335
+ 2017-Aug-15 14:23:24.000 *m  14 50 22.6512 -03 01 45.741 9.991028  -12.5353
+ 2017-Aug-15 14:52:10.800 *m  14 50 22.9700 -03 01 51.760 9.954834  -12.5368
+ 2017-Aug-15 15:20:57.600 *m  14 50 23.2877 -03 01 57.778 9.917012  -12.5380
+ 2017-Aug-15 15:49:44.400 *r  14 50 23.6041 -03 02 03.798 9.878277  -12.5389
+ 2017-Aug-15 16:18:31.200 *m  14 50 23.9193 -03 02 09.817 9.839359  -12.5394
+ 2017-Aug-15 16:47:18.000 *   14 50 24.2333 -03 02 15.837 9.800988  -12.5397
+ 2017-Aug-15 17:16:04.800 *   14 50 24.5461 -03 02 21.857 9.763889  -12.5396
+ 2017-Aug-15 17:44:51.600 *   14 50 24.8576 -03 02 27.876 9.728765  -12.5393
+ 2017-Aug-15 18:13:38.400 *   14 50 25.1682 -03 02 33.896 9.696287  -12.5386
+ 2017-Aug-15 18:42:25.200 *   14 50 25.4777 -03 02 39.915 9.667085  -12.5377
+ 2017-Aug-15 19:11:12.000 *   14 50 25.7863 -03 02 45.933 9.641736  -12.5366
+ 2017-Aug-15 19:39:58.800 *   14 50 26.0942 -03 02 51.951 9.620757  -12.5352
+ 2017-Aug-15 20:08:45.600 *   14 50 26.4015 -03 02 57.968 9.604596  -12.5337
+ 2017-Aug-15 20:37:32.400 *   14 50 26.7084 -03 03 03.985 9.593623  -12.5320
+ 2017-Aug-15 21:06:19.200 *   14 50 27.0150 -03 03 10.000 9.588128  -12.5302
+ 2017-Aug-15 21:35:06.000 *   14 50 27.3216 -03 03 16.015 9.588312  -12.5284
+ 2017-Aug-15 22:03:52.800 *t  14 50 27.6282 -03 03 22.029 9.594287  -12.5265
+ 2017-Aug-15 22:32:39.600 C   14 50 27.9351 -03 03 28.042 9.606074  -12.5246
+ 2017-Aug-15 23:01:26.400 N   14 50 28.2425 -03 03 34.054 9.623602  -12.5227
+ 2017-Aug-15 23:30:13.200 A   14 50 28.5505 -03 03 40.065 9.646707  -12.5210
+ 2017-Aug-15 23:59:00.000     14 50 28.8594 -03 03 46.075 9.675139  -12.5193
+$$EOE
+*******************************************************************************
+Column meaning:
+
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE WITH TARGET RISE/TRANSIT/SET MARKER (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by another marker symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+        'r'  Rise    (target body on or above cut-off RTS elevation)
+        't'  Transit (target body at or past local maximum RTS elevation)
+        's'  Set     (target body on or below cut-off RTS elevation)
+
+RTS MARKERS (TVH)
+  Rise and set are with respect to the reference ellipsoid true visual horizon
+defined by the elevation cut-off angle. Horizon dip and yellow-light refraction
+(Earth only) are considered. Accuracy is < or = to twice the requested search
+step-size.
+
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+ dRA*cosD d(DEC)/dt =
+    The rate of change of target center apparent RA and DEC (airless).
+d(RA)/dt is multiplied by the cosine of the declination.
+    Units: ARCSECONDS PER HOUR
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisCompressionSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisCompressionSpec.scala
@@ -1,0 +1,168 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.EphemerisKey
+import gem.enum.Site.GN
+import gem.math.Ephemeris
+import gem.test.RespectIncludeTags
+import gem.test.Tags._
+
+import EphemerisCompression._
+
+import cats.effect.IO
+import cats.implicits._
+import cats.tests.CatsSuite
+
+import fs2.Pipe
+
+import java.time.{ LocalDate, Month }
+import java.time.temporal.ChronoUnit.MINUTES
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals"))
+final class EphemerisCompressionSpec extends CatsSuite with EphemerisTestSupport with RespectIncludeTags {
+  import EphemerisCompressionSpec._
+
+  test("compresses") {
+    val a = stream("borrelly")
+              .through(EphemerisParser.elements[IO])
+              .through(standardVelocityCompression)
+
+    val e = stream("borrelly-compressed")
+              .through(EphemerisParser.elements[IO])
+
+    val actual   = a.compile.toVector.unsafeRunSync
+    val expected = e.compile.toVector.unsafeRunSync
+
+    assert(actual == expected)
+  }
+
+  val Δv: Pipe[IO, Ephemeris.Element, Ephemeris.Element] = standardVelocityCompression
+  val ac: Pipe[IO, Ephemeris.Element, Ephemeris.Element] = standardAccelerationCompression
+
+  test("2014 UR Δv compresses to 100% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.SEPTEMBER, 15)
+    val end   = LocalDate.of(2015, Month.NOVEMBER,  15)
+
+    testCompression("2014 UR Δv", ur_2014, 1.00, start, end, Δv)
+  }
+
+  test("2014 UR a compresses to 10.1% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.SEPTEMBER, 15)
+    val end   = LocalDate.of(2015, Month.NOVEMBER,  15)
+
+    testCompression("2014 UR a", ur_2014, 0.101, start, end, ac)
+  }
+
+  test("2015 QT3 Δv compresses to 34% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.AUGUST,  1)
+    val end   = LocalDate.of(2015, Month.OCTOBER, 1)
+
+    testCompression("2015 QT3 Δv", qt3_2015, 0.342, start, end, Δv)
+  }
+
+  test("2015 QT3 a compresses to 5.6% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.AUGUST,  1)
+    val end   = LocalDate.of(2015, Month.OCTOBER, 1)
+
+    testCompression("2015 QT3 a", qt3_2015, 0.056, start, end, ac)
+  }
+
+  test("Churyumov-Gerasimenko Δv compresses to 4% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.DECEMBER, 15)
+    val end   = LocalDate.of(2016, Month.FEBRUARY, 15)
+
+    testCompression("Churyumov Δv", churyumov, 0.039, start, end, Δv)
+  }
+
+  test("Churyumov-Gerasimenko a compresses to 1.2% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.DECEMBER, 15)
+    val end   = LocalDate.of(2016, Month.FEBRUARY, 15)
+
+    testCompression("Churyumov a", churyumov, 0.012, start, end, ac)
+  }
+
+  test("Titan Δv compresses to 1% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.JULY  ,    1)
+    val end   = LocalDate.of(2015, Month.SEPTEMBER, 1)
+
+    testCompression("Titan Δv", titan, 0.008, start, end, Δv)
+  }
+
+  test("Titan a compresses to 0.6% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.JULY  ,    1)
+    val end   = LocalDate.of(2015, Month.SEPTEMBER, 1)
+
+    testCompression("Titan a", titan, 0.006, start, end, ac)
+  }
+
+  test("Beer Δv compresses to 5% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.OCTOBER,  1)
+    val end   = LocalDate.of(2015, Month.DECEMBER, 1)
+
+    testCompression("Beer Δv", beer, 0.046, start, end, Δv)
+  }
+
+  test("Beer a compresses to 1.4% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.OCTOBER,  1)
+    val end   = LocalDate.of(2015, Month.DECEMBER, 1)
+
+    testCompression("Beer a", beer, 0.014, start, end, ac)
+  }
+
+  test("Io Δv compresses to 24% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.MARCH, 1)
+    val end   = LocalDate.of(2015, Month.MAY,   1)
+
+    testCompression("Io Δv", io, 0.237, start, end, Δv)
+  }
+
+  test("Io a compresses to 3.2% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.MARCH, 1)
+    val end   = LocalDate.of(2015, Month.MAY,   1)
+
+    testCompression("Io a", io, 0.032, start, end, ac)
+  }
+
+  def testCompression(
+        name:          String,
+        key:           EphemerisKey.Horizons,
+        expectedRatio: Double,
+        start:         LocalDate,
+        end:           LocalDate,
+        pipe:          Pipe[IO, Ephemeris.Element, Ephemeris.Element]): org.scalatest.Assertion = {
+
+    // Start and end at midnight local time.
+    val zstart = start.atTime(0, 0).atZone(GN.timezone)
+    val zend   = end.atTime(0, 0).atZone(GN.timezone)
+
+    // One element per minute
+    val elems  = zstart.until(zend, MINUTES).toInt
+
+    val e      = HorizonsEphemerisQuery(key, GN, zstart.toInstant, zend.toInstant, elems).exec(pipe)
+    val size   = e.toMap.size
+    val ratio  = size.toDouble / elems.toDouble
+
+    println(f"$name%-12s $key%-21s => $size%5d / $elems%5d elements, ${ratio * 100.0}%5.2f%% of original")
+
+    assert((ratio >= expectedRatio - 0.001) &&
+           (ratio <= expectedRatio + 0.001))
+  }
+}
+
+object EphemerisCompressionSpec {
+  private val beer      = EphemerisKey.AsteroidNew("1971 UC1")
+  private val churyumov = EphemerisKey.Comet("67P")
+  private val io        = EphemerisKey.MajorBody(501)
+  private val titan     = EphemerisKey.MajorBody(606)
+  private val qt3_2015  = EphemerisKey.AsteroidNew("2015 QT3")
+  private val ur_2014   = EphemerisKey.AsteroidNew("2014 UR")
+
+  implicit class QueryOps(q: HorizonsEphemerisQuery) {
+    def exec(compression: Pipe[IO, Ephemeris.Element, Ephemeris.Element]): Ephemeris = {
+      val s = q.streamEphemeris.through(compression)
+      Ephemeris.fromFoldable[Vector](s.compile.toVector.unsafeRunSync)
+    }
+  }
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.math.{ Ephemeris, EphemerisCoordinates }
+import gem.syntax.treemap._
+import gem.util.Timestamp
+
+import cats.effect.IO
+import cats.tests.CatsSuite
+
+import fs2.Stream
+
+import scala.collection.immutable.TreeMap
+
+
+/** Not really a spec per se, but rather a way to exercise the ephemeris parser
+  * with a few fixed examples and get a sense of whether it works.
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Equals"))
+final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
+
+  test("Must parse") {
+
+    val head = eph(
+      "2017-Aug-15 00:00:00.000" -> (("14 50 13.1823 -02 58 45.704", "9.304921", "-12.4881")),
+      "2017-Aug-15 00:28:46.800" -> (("14 50 13.4803 -02 58 51.699", "9.338051", "-12.4867")),
+      "2017-Aug-15 00:57:33.600" -> (("14 50 13.7794 -02 58 57.693", "9.375816", "-12.4855"))
+    )
+
+    val tail = eph(
+      "2017-Aug-15 23:01:26.400" -> (("14 50 28.2425 -03 03 34.054", "9.623602", "-12.5227")),
+      "2017-Aug-15 23:30:13.200" -> (("14 50 28.5505 -03 03 40.065", "9.646707", "-12.5210")),
+      "2017-Aug-15 23:59:00.000" -> (("14 50 28.8594 -03 03 46.075", "9.675139", "-12.5193"))
+    )
+
+    checkParse("borrelly", head, tail)
+  }
+
+  private def checkParse(
+    name: String,
+    head: TreeMap[Timestamp, EphemerisCoordinates],
+    tail: TreeMap[Timestamp, EphemerisCoordinates]
+  ): org.scalatest.Assertion = {
+
+    val e = EphemerisParser.parse(load(name)).option.getOrElse(Ephemeris.empty)
+
+    // This works but the error message isn't helpful when it fails.  There
+    // should be a way to combine shouldEqual assertions ...
+    assert(
+      (e.toMap.size                == 51  ) &&
+      (e.toMap.to(head.lastKey)    == head) &&
+      (e.toMap.from(tail.firstKey) == tail)
+    )
+  }
+
+  test("Must stream") {
+    val head = eph(
+      "2017-Aug-15 00:00:00.000" -> (("14 50 13.1823 -02 58 45.704", "9.304921", "-12.4881")),
+      "2017-Aug-15 00:28:46.800" -> (("14 50 13.4803 -02 58 51.699", "9.338051", "-12.4867")),
+      "2017-Aug-15 00:57:33.600" -> (("14 50 13.7794 -02 58 57.693", "9.375816", "-12.4855"))
+    )
+
+    val s = stream("borrelly").through(EphemerisParser.elements[IO])
+    val m = TreeMap.fromFoldable(s.take(head.size.toLong).compile.toVector.unsafeRunSync)
+
+    assert(m == head)
+  }
+
+  test("Must handle errors") {
+    val z = Timestamp.Min -> EphemerisCoordinates.Zero
+    val s = stream("borrelly-error")
+             .through(EphemerisParser.elements[IO])
+             .handleErrorWith(_ => Stream(z))
+    assert(Vector(Some(z)) == s.last.compile.toVector.unsafeRunSync)
+  }
+
+  test("Must stream eitherElements") {
+    val head = Vector[Either[String, Ephemeris.Element]](
+      Right(time("2017-Aug-15 00:00:00.000") -> ephCoords("14 50 13.1823 -02 58 45.704", "9.304921", "-12.4881")),
+      Right(time("2017-Aug-15 00:28:46.800") -> ephCoords("14 50 13.4803 -02 58 51.699", "9.338051", "-12.4867")),
+      Left("Failure reading:solarPresence")
+    )
+
+    val s = stream("borrelly-error").through(EphemerisParser.eitherElements[IO])
+    val m = s.take(head.size.toLong).compile.toVector.unsafeRunSync()
+
+    assert(m == head)
+  }
+
+  test("Must stream validElements") {
+    val head = eph(
+      "2017-Aug-15 00:00:00.000" -> (("14 50 13.1823 -02 58 45.704", "9.304921", "-12.4881")), // 0
+      "2017-Aug-15 00:28:46.800" -> (("14 50 13.4803 -02 58 51.699", "9.338051", "-12.4867")), // 1
+      "2017-Aug-15 01:26:20.400" -> (("14 50 14.0798 -02 59 03.686", "9.417733", "-12.4845"))  // 3 (skipping 2)
+    )
+
+    val s = stream("borrelly-error").through(EphemerisParser.validElements[IO])
+    val m = TreeMap.fromFoldable(s.take(head.size.toLong).compile.toVector.unsafeRunSync)
+
+    assert(m == head)
+  }
+
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.math.{ Angle, Coordinates, EphemerisCoordinates, Offset }
+import gem.syntax.treemap._
+import gem.util.Timestamp
+
+import cats.effect.IO
+import fs2.Stream
+
+import java.io.InputStream
+import java.time.{ LocalDateTime, ZoneOffset }
+import java.time.format.DateTimeFormatter
+
+import scala.collection.immutable.TreeMap
+import scala.io.Source
+
+
+trait EphemerisTestSupport {
+  val TimeFormat: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss.SSS")
+
+  def time(s: String): Timestamp =
+    Timestamp.unsafeFromInstant(LocalDateTime.parse(s, TimeFormat).toInstant(ZoneOffset.UTC))
+
+  def coords(s: String): Coordinates =
+    Coordinates.fromHmsDms.getOption(s).getOrElse(Coordinates.Zero)
+
+  def arcsec(s: String): Angle =
+    Angle.fromMicroarcseconds(BigDecimal(s).underlying.movePointRight(6).longValueExact)
+
+  def offsetp(s: String): Offset.P =
+    Offset.P(arcsec(s))
+
+  def offsetq(s: String): Offset.Q =
+    Offset.Q(arcsec(s))
+
+  def ephCoords(c: String, p: String, q: String): EphemerisCoordinates =
+    EphemerisCoordinates(coords(c), Offset(offsetp(p), offsetq(q)))
+
+  def eph(elems: (String, (String, String, String))*): TreeMap[Timestamp, EphemerisCoordinates] =
+    TreeMap.fromList(elems.toList.map { case (i, (c, p, q)) => time(i) -> ephCoords(c, p, q) })
+
+  def inputStream(n: String): InputStream =
+    getClass.getResourceAsStream(s"$n.eph")
+
+  def stream(n: String): Stream[IO, String] =
+    fs2.io.readInputStream(IO(inputStream(n)), 128)
+          .through(fs2.text.utf8Decode)
+
+  def load(n: String): String =
+    Source.fromInputStream(inputStream(n)).mkString
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsClientSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsClientSpec.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import cats.effect.IO
+import cats.tests.CatsSuite
+import fs2.Stream
+
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Equals"))
+final class HorizonsClientSpec extends CatsSuite {
+
+  def exclusionTest(s: Stream[IO, _]): Boolean = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val count = 20
+    val instrumented = { var x = 0; s.flatMap(_ => Stream.eval(IO { x += 1; Thread.sleep(10); x })) }
+    val cs = Stream(instrumented).repeat.covary[IO].take(count.toLong)
+    cs.joinUnbounded.compile.toVector.unsafeRunSync == (1 to count).toList
+  }
+
+  test("Arbitrary IO should be parallel.") {
+    assert(!exclusionTest(Stream.eval(IO.unit)))
+  }
+
+  // Have to turn this off for now
+//  test("Access to client should be serial.") {
+//    assert(exclusionTest(HorizonsClient.client))
+//  }
+
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQueryPagingPropSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQueryPagingPropSpec.scala
@@ -1,0 +1,92 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.EphemerisKey
+import gem.arb.ArbTime._
+import gem.enum.Site.GS
+import gem.syntax.time._
+
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Arbitrary.arbitrary
+
+import org.scalatest._
+import org.scalatest.prop._
+import org.scalatest.Matchers._
+
+import java.time.{ Duration, Instant }
+
+import scala.math.Ordering.Implicits._
+
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals"))
+class HorizonsEphemerisQueryPagingPropSpec extends PropSpec with PropertyChecks {
+
+  import HorizonsEphemerisQueryPagingPropSpec._
+
+  case class TestCase(start: Instant, end: Instant, step: Duration) {
+
+    val paging: List[HorizonsEphemerisQuery] =
+      HorizonsEphemerisQuery.paging(titan, GS, start, end, step)
+  }
+
+  // Generate reasonable test cases that don't ask for trillions of queries
+  implicit val arbTestCase: Arbitrary[TestCase] =
+    Arbitrary {
+      for {
+        s <- arbitrary[Instant]
+        d <- arbitrary[Duration].map(_.abs)
+        c <- Gen.choose(1, 1000000) // steps
+        f <- Gen.choose(0.0, 1.0)
+        dʹ = HorizonsEphemerisQuery.MinStepLen max (d / ms.toNanos * ms.toNanos)
+        e  = s + dʹ * c.toLong + Duration.ofMillis((dʹ.toMillis * f).round)
+      } yield TestCase(s, e, dʹ)
+    }
+
+  property("queries should be contiguous") {
+    forAll { (t: TestCase) =>
+      val times = t.paging.map(q => (q.startTime, q.endTime))
+
+      (times.zip(times.drop(1)).forall { case ((_, e), (s, _)) =>
+          e + t.step == s
+      }) shouldBe true
+    }
+  }
+
+  property("last element should be less than one step size away from end") {
+    forAll { (t: TestCase) =>
+      t.paging.lastOption match {
+        case None    => fail
+        case Some(q) => q.endTime should (be >= t.end and be <= (t.end + t.step))
+      }
+    }
+  }
+
+  property("first element should be exactly at start time") {
+    forAll { (t: TestCase) =>
+      t.paging.headOption match {
+        case None    => fail
+        case Some(q) => q.startTime shouldEqual t.start
+      }
+    }
+  }
+
+  property("each element is spaced exactly by duration") {
+    forAll { (t: TestCase) =>
+      val stepMs = t.step.toMillis
+      val ds     = t.paging.map(q => (Duration.between(q.startTime, q.endTime).toMillis, q.elementLimit))
+
+      (ds.forall { case (dMs, cnt) =>
+        (dMs % stepMs == 0) && ((dMs / stepMs) + 1 == cnt.toLong)
+      }) shouldBe true
+    }
+  }
+}
+
+object HorizonsEphemerisQueryPagingPropSpec {
+
+  private val titan = EphemerisKey.MajorBody(606)
+  private val ms    = Duration.ofMillis(1)
+
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
@@ -1,0 +1,176 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.EphemerisKey
+import gem.enum.Site.GS
+import gem.math.Ephemeris
+import gem.syntax.time._
+import gem.test.RespectIncludeTags
+import gem.test.Tags._
+import gem.util.Timestamp
+
+import cats.implicits._
+import cats.tests.CatsSuite
+
+import java.time.{ Duration, Instant, LocalDateTime, Month }
+import java.time.ZoneOffset.UTC
+import java.time.temporal.ChronoUnit.DAYS
+
+/** Exercises HorizonsEphemerisQuery.  Because the tests require accessing an
+  * external service, they are tagged with "RequiresNetwork" and usually skipped
+  * See the build.sbt where RequiresNetwork tests are excluded via the setting:
+  *
+  *     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork")
+  *
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Equals"))
+final class HorizonsEphemerisQuerySpec extends CatsSuite with EphemerisTestSupport with RespectIncludeTags {
+
+  import HorizonsEphemerisQuerySpec._
+
+  test("simple query should work", RequiresNetwork) {
+    val e = HorizonsEphemerisQuery(titan, GS, start, end, 60).exec()
+
+    assert(
+      e.first.exists(_ == (startM -> startCoords)) &&
+      e.last .exists(_ == (endM   -> endCoords  )) &&
+      e.toMap.size == 60
+    )
+  }
+
+  test("at least 2 values are returned (start and end)", RequiresNetwork) {
+    val e = HorizonsEphemerisQuery(titan, GS, start, end, -1).exec()
+
+    assert(
+      e.first.exists(_ == (startM -> startCoords)) &&
+      e.last .exists(_ == (endM   -> endCoords  )) &&
+      e.toMap.size == 2
+    )
+  }
+
+  test("caps requests at MaxElements", RequiresNetwork, Slow) {
+    val e = HorizonsEphemerisQuery(titan, GS, start, end.plus(182, DAYS), HorizonsEphemerisQuery.MaxElements + 1).exec()
+
+    assert(e.toMap.size == HorizonsEphemerisQuery.MaxElements)
+  }
+
+  test("returns nothing if end comes before start", RequiresNetwork) {
+    val e = HorizonsEphemerisQuery(titan, GS, end, start, 60).exec()
+
+    assert(e.toMap.size == 0)
+  }
+
+  private def checkPaging(start: Instant, end: Instant, expected: HorizonsEphemerisQuery*): org.scalatest.Assertion = {
+    val as = HorizonsEphemerisQuery.paging(titan, GS, start, end, OneMinute)
+    val es = expected.toList
+
+    assert(es.size == as.size && es.zip(as).forall { case (e, a) =>
+      e.startTime    == a.startTime    &&
+      e.endTime      == a.endTime      &&
+      e.elementLimit == a.elementLimit
+    })
+  }
+
+  val Max: Int = HorizonsEphemerisQuery.MaxElements
+
+  test("paging a negative time amount should be empty") {
+    checkPaging(end, start)
+  }
+
+  test("paging a zero time amount should be empty") {
+    checkPaging(start, start)
+  }
+
+  test("paging less time than the step size should produce two elements, one query") {
+    checkPaging(
+      start,
+      start + Duration.ofNanos(1),
+      HorizonsEphemerisQuery(titan, GS, start, start + OneMinute, 2)
+    )
+  }
+
+  test("paging a time that requires < MaxElements should result in one query") {
+    checkPaging(
+      start,
+      end,
+      HorizonsEphemerisQuery(titan, GS, start, end, 61)
+    )
+  }
+
+  test("paging exactly MaxElements should result in a single query") {
+    val end = start + OneMinute * (Max.toLong - 1L) // remember *inclusive*
+
+    checkPaging(
+      start,
+      end,
+      HorizonsEphemerisQuery(titan, GS, start, end, Max)
+    )
+  }
+
+  test("paging MaxElements + 1 should result in two queries") {
+
+    // Produces Max + 1 elements because end is inclusive.
+    val end = start + OneMinute * Max.toLong
+
+    checkPaging(
+      start,
+      end,
+      // Here the first query is shortened so that the last query will have at
+      // least two elements.  There's no way to query for just one element.
+      HorizonsEphemerisQuery(titan, GS, start,           end - OneMinute * 2L, Max - 1),
+      HorizonsEphemerisQuery(titan, GS, end - OneMinute, end,                  2      )
+    )
+  }
+
+  test("paging MaxElements + 2 should result in two queries") {
+
+    // Produces Max + 2 elements because end is inclusive
+    val end = start + OneMinute * (Max + 1).toLong
+
+    checkPaging(
+      start,
+      end,
+      // The first query can contain a full MaxElements page because the second
+      // query will pick up the remaining two.
+      HorizonsEphemerisQuery(titan, GS, start,           end - OneMinute * 2L, Max),
+      HorizonsEphemerisQuery(titan, GS, end - OneMinute, end,                  2  )
+    )
+  }
+
+  test("paging MaxElements + 3 should result in two queries") {
+
+    // Produces Max + 3 elements because end is inclusive
+    val end = start + OneMinute * (Max + 2).toLong
+
+    checkPaging(
+      start,
+      end,
+      // The first query can contain a full MaxElements page because the second
+      // query will pick up the remaining three.
+      HorizonsEphemerisQuery(titan, GS, start,                end - OneMinute * 3L, Max),
+      HorizonsEphemerisQuery(titan, GS, end - OneMinute * 2L, end,                  3  )
+    )
+  }
+}
+
+object HorizonsEphemerisQuerySpec extends EphemerisTestSupport {
+  private val titan = EphemerisKey.MajorBody(606)
+
+  private val start = LocalDateTime.of(2017, Month.AUGUST, 15, 1, 0).toInstant(UTC)
+  private val end   = LocalDateTime.of(2017, Month.AUGUST, 15, 2, 0).toInstant(UTC)
+
+  private val startM      = Timestamp.unsafeFromInstant(start)
+  private val endM        = Timestamp.unsafeFromInstant(end)
+
+  private val startCoords = ephCoords("17:21:29.110300 -21:55:46.509000", "-2.85225", "-1.61124")
+  private val endCoords   = ephCoords("17:21:28.904000 -21:55:48.103000", "-2.87880", "-1.58756")
+
+  private val OneMinute   = Duration.ofMinutes(1)
+
+  implicit class QueryOps(q: HorizonsEphemerisQuery) {
+    def exec(): Ephemeris =
+      Ephemeris.fromFoldable[Vector](q.streamEphemeris.compile.toVector.unsafeRunSync)
+  }
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsNameQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsNameQuerySpec.scala
@@ -1,0 +1,117 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.test.RespectIncludeTags
+import gem.test.Tags._
+
+import gem.{ EphemerisKey => EK }
+
+import cats.tests.CatsSuite
+
+import scala.util.Either
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals"))
+final class HorizonsNameQuerySpec extends CatsSuite with RespectIncludeTags {
+  import HorizonsNameQuery._
+
+  def runSearch[A](s: Search[A]): Either[Error, List[Resolution[A]]] =
+    HorizonsNameQuery(s).lookup.value.unsafeRunSync
+
+  test("comet search should handle empty results", RequiresNetwork) {
+    runSearch(Search.Comet("covfefe")) shouldEqual Nil.asRight
+  }
+
+  test("comet search should handle multiple results", RequiresNetwork) {
+    runSearch(Search.Comet("hu")).map(_.take(5)) shouldEqual List(
+      Resolution(EK.Comet("67P"), "Churyumov-Gerasimenko"),
+      Resolution(EK.Comet("106P"), "Schuster"),
+      Resolution(EK.Comet("130P"), "McNaught-Hughes"),
+      Resolution(EK.Comet("178P"), "Hug-Bell"),
+      Resolution(EK.Comet("C/1880 Y1"), "Pechule")
+    ).asRight
+  }
+
+  test("comet search should handle single result (Format 1) Hubble (C/1937 P1)", RequiresNetwork) {
+    runSearch(Search.Comet("hubble")) shouldEqual List(
+      Resolution(EK.Comet("C/1937 P1"), "Hubble")
+    ).asRight
+  }
+
+  test("comet search should handle single result (Format 2) 1P/Halley pattern", RequiresNetwork) {
+    runSearch(Search.Comet("halley")) shouldEqual List(
+      Resolution(EK.Comet("1P"), "Halley")
+    ).asRight
+  }
+
+  test("asteroid search should handle empty results", RequiresNetwork) {
+    runSearch(Search.Asteroid("covfefe")) shouldEqual Nil.asRight
+  }
+
+  test("asteroid search should handle multiple results", RequiresNetwork) {
+    runSearch(Search.Asteroid("her")).map(_.take(5)) shouldEqual List(
+      Resolution(EK.AsteroidOld(103), "Hera"),
+      Resolution(EK.AsteroidOld(121), "Hermione"),
+      Resolution(EK.AsteroidOld(135), "Hertha"),
+      Resolution(EK.AsteroidOld(206), "Hersilia"),
+      Resolution(EK.AsteroidOld(214), "Aschera")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 1) 90377 Sedna (2003 VB12)", RequiresNetwork) {
+    runSearch(Search.Asteroid("sedna")) shouldEqual List(
+      Resolution(EK.AsteroidNew("2003 VB12"), "Sedna")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 2) 29 Amphitrite", RequiresNetwork) {
+    runSearch(Search.Asteroid("amphitrite")) shouldEqual List(
+      Resolution(EK.AsteroidOld(29), "Amphitrite")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 3) (2016 GB222)", RequiresNetwork) {
+    runSearch(Search.Asteroid("2016 GB222")) shouldEqual List(
+      Resolution(EK.AsteroidNew("2016 GB222"), "2016 GB222")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 4) 418993 (2009 MS9)", RequiresNetwork) {
+    runSearch(Search.Asteroid("2009 MS9")) shouldEqual List(
+      Resolution(EK.AsteroidNew("2009 MS9"), "2009 MS9")
+    ).asRight
+  }
+
+  test("major body search should handle empty results", RequiresNetwork) {
+    runSearch(Search.MajorBody("covfefe")) shouldEqual Nil.asRight
+  }
+
+  test("major body search should handle empty results with small-body fallthrough (many)", RequiresNetwork) {
+    runSearch(Search.MajorBody("hu")) shouldEqual Nil.asRight
+  }
+
+  test("major body search should handle empty results with small-body fallthrough (single)", RequiresNetwork) {
+    runSearch(Search.MajorBody("hermione")) shouldEqual Nil.asRight
+  }
+
+  test("major body search should handle multiple results", RequiresNetwork) {
+    runSearch(Search.MajorBody("mar")).map(_.take(5)) shouldEqual List(
+      Resolution(EK.MajorBody(4), "Mars Barycenter"),
+      Resolution(EK.MajorBody(499), "Mars"),
+      Resolution(EK.MajorBody(723), "Margaret")
+    ).asRight
+  }
+
+  test("major body search should handle single result with trailing space (!)", RequiresNetwork) {
+    runSearch(Search.MajorBody("charon")) shouldEqual List(
+      Resolution(EK.MajorBody(901), "Charon")
+    ).asRight
+  }
+
+  test("major body search should handle single result without trailing space", RequiresNetwork) {
+    runSearch(Search.MajorBody("europa")) shouldEqual List(
+      Resolution(EK.MajorBody(502), "Europa")
+    ).asRight
+  }
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsSolutionRefQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsSolutionRefQuerySpec.scala
@@ -1,0 +1,130 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.{ EphemerisKey, HorizonsSolutionRef }
+
+import gem.test.RespectIncludeTags
+import gem.test.Tags.RequiresNetwork
+
+import cats.tests.CatsSuite
+
+final class HorizonsSolutionRefQuerySpec extends CatsSuite with RespectIncludeTags {
+
+  import HorizonsSolutionRefQuerySpec._
+
+  test("parse solution ref terminated by comma") {
+    HorizonsSolutionRefQuery.parseSolutionRef(wild2, wild2Header) shouldEqual Some(HorizonsSolutionRef("JPL#K162/5"))
+  }
+
+  test("parse solution ref terminated by newline") {
+    HorizonsSolutionRefQuery.parseSolutionRef(beer, beerHeader) shouldEqual Some(HorizonsSolutionRef("JPL#23"))
+  }
+
+  test("parse a major body without solution ref") {
+    HorizonsSolutionRefQuery.parseSolutionRef(titan, titanHeader) shouldEqual Some(HorizonsSolutionRef("JUn 17, 2016"))
+  }
+
+  test("runs comet solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(wild2).lookup.unsafeRunSync.isDefined shouldBe true
+  }
+
+  test("runs asteroid solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(beer).lookup.unsafeRunSync.isDefined shouldBe true
+  }
+
+  test("runs major body solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(titan).lookup.unsafeRunSync.isDefined shouldBe true
+  }
+}
+
+object HorizonsSolutionRefQuerySpec {
+
+  val wild2: EphemerisKey.Horizons =
+    EphemerisKey.Comet("81P")
+
+  val wild2Header: String =
+    """
+      |*******************************************************************************
+      |JPL/HORIZONS                     81P/Wild 2                2017-Sep-27 12:26:51
+      |Rec #:900817 (+COV)   Soln.date: 2017-Jul-06_14:39:31   # obs: 4021 (2008-2017)
+      |
+      |IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+      |
+      |  EPOCH=  2455772.5 ! 2011-Jul-30.0000000 (TDB)    RMSW= n.a.
+      |   EC= .5370816286507473   QR= 1.597991694337067   TP= 2455250.0788030997
+      |   OM= 136.0976955732219   W= 41.75965127535293    IN= 3.237207856138221
+      |   A= 3.451994548584135    MA= 80.282282601105     ADIST= 5.305997402831204
+      |   PER= 6.4137697671158    N= .153673474           ANGMOM= .026959831
+      |   DAN= 1.75367            DDN= 4.09807            L= 177.8118934
+      |   B= 2.1553656            MOID= .60296798         TP= 2010-Feb-22.5788030997
+      |
+      |Comet physical (GM= km^3/s^2; RAD= km):
+      |   GM= n.a.                RAD= 2.
+      |   M1=  8.8      M2=  13.1     k1=  14.    k2=  5.      PHCOF=  .030
+      |
+      |Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+      |   AMRAT=  0.                                      DT=  0.
+      |   A1= 1.811725646257E-9   A2= 3.974820487201E-11  A3= 0.
+      | Standard model:
+      |   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+      |
+      |COMET comments
+      |1: soln ref.= JPL#K162/5, data arc: 2008-10-20 to 2017-06-24
+      |2: k1=14., k2=5., phase coef.=0.03;
+      |*******************************************************************************
+    """.stripMargin
+
+  val beer: EphemerisKey.Horizons =
+    EphemerisKey.AsteroidNew("1971 UC1")
+
+  val beerHeader: String =
+    """
+      |*******************************************************************************
+      |JPL/HORIZONS                1896 Beer (1971 UC1)           2017-Sep-27 13:57:35
+      |Rec #:  1896 (+COV)   Soln.date: 2017-May-15_14:17:06   # obs: 1566 (1949-2017)
+      |
+      |IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+      |
+      |  EPOCH=  2455763.5 ! 2011-Jul-21.00 (TDB)         Residual RMS= .33782
+      |   EC= .2217996492354765   QR= 1.842496797109042   TP= 2455815.8047106094
+      |   OM= 182.1795820773458   W=  180.1210417236072   IN= 2.220651628945542
+      |   A= 2.367638096409141    MA= 345.8494963260648   ADIST= 2.892779395709239
+      |   PER= 3.64318            N= .270539749           ANGMOM= .02580981
+      |   DAN= 2.89278            DDN= 1.8425             L= 2.3005429
+      |   B= -.0046903            MOID= .83910203         TP= 2011-Sep-11.3047106094
+      |
+      |Asteroid physical parameters (km, seconds, rotational period in hours):
+      |   GM= n.a.                RAD= 2.6885             ROTPER= 3.3278
+      |   H= 13.8                 G= .150                 B-V= n.a.
+      |                           ALBEDO= .202            STYP= n.a.
+      |
+      |ASTEROID comments:
+      |1: soln ref.= JPL#23
+      |2: source=ORB
+      |*******************************************************************************
+    """.stripMargin
+
+  val titan: EphemerisKey.Horizons =
+    EphemerisKey.MajorBody(606)
+
+  val titanHeader: String =
+    """
+      |*******************************************************************************
+      | Revised: JUn 17, 2016              Titan / (Saturn)                        606
+      |                         http://ssd.jpl.nasa.gov/?sat_phys_par
+      |                           http://ssd.jpl.nasa.gov/?sat_elem
+      |
+      | SATELLITE PHYSICAL PROPERTIES:
+      |  Mean Radius (km)       = 2575.5   +-  2.0  Density (g/cm^3) =  1.880 +- 0.004
+      |  Mass (10^19 kg)        = 13455.3           Geometric Albedo =  0.2
+      |  GM (km^3/s^2)          = 8978.13  +-  0.06  V(1,0)          = -1.2
+      |
+      | SATELLITE ORBITAL DATA:
+      |  Semi-major axis, a (km)= 1221.87 (10^3)  Orbital period     = 15.945421 d
+      |  Eccentricity, e        = 0.0288          Rotational period  =
+      |  Inclination, i  (deg)  = 0.28
+      |*******************************************************************************
+    """.stripMargin
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/tcs/TcsFormatSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/tcs/TcsFormatSpec.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+package tcs
+
+import cats.tests.CatsSuite
+
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.TraversableOps"))
+final class TcsFormatSpec extends CatsSuite with EphemerisTestSupport {
+
+  private val Eph = eph(
+    "2018-Jan-08 09:43:00.000" -> (("15 02 51.4497 -16 08 04.858",  "26.51632", "-8.34743")),
+    "2018-Jan-08 09:44:00.000" -> (("01 30 59.1212  08 54 25.405",   "0.76957",  "0.35575")),
+    "2018-Jan-08 09:45:00.000" -> (("22 59 58.5440 -16 25 54.600", "-57.80276", "29.71677"))
+  )
+
+  private val Str = List(
+    " 2018-Jan-08 09:43 2458126.904861111     15 02 51.4497 -16 08 04.858  26.51632  -8.34743",
+    " 2018-Jan-08 09:44 2458126.905555556     01 30 59.1212  08 54 25.405   0.76957   0.35575",
+    " 2018-Jan-08 09:45 2458126.906250000     22 59 58.5440 -16 25 54.600 -57.80276  29.71677"
+  )
+
+  test("formatting elements") {
+    Eph.toList.zip(Str).foreach { case (e, s) =>
+      assert(TcsFormat.formatElement(e) == s)
+    }
+  }
+}

--- a/modules/json/src/main/scala/gem/json.scala
+++ b/modules/json/src/main/scala/gem/json.scala
@@ -1,0 +1,225 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.data.OneAnd
+import gem.enum.{ GcalArc, ProgramRole }
+import gem.config.GcalConfig.GcalArcs
+import gem.config.GmosConfig._
+import gem.math._
+import gem.optics.Format
+import gem.util._
+import gem.syntax.prism._
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import java.time.{ Duration, Instant }
+import monocle.Prism
+import scala.collection.immutable.TreeMap
+
+// These json codecs are provided for primitive types that have no natural mapping that would
+// otherwise be inferred via argonaut-shapeless. For now we'll treat the JSON format as an
+// internal concern rather than a public or long-term storage format. If we decide that we *do*
+// want to use JSON externally then auto-derivation becomes dangerous because renaming fields
+// will cause the serial format to change.
+package object json extends Instances
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+trait Instances {
+
+  implicit val coordinatesEncoder: Encoder[Coordinates] = deriveEncoder
+  implicit val coordinatesDecoder: Decoder[Coordinates] = deriveDecoder
+
+  implicit val offsetEncoder: Encoder[Offset] = deriveEncoder
+  implicit val offsetDecoder: Decoder[Offset] = deriveDecoder
+
+  implicit val radialVelocityEncoder: Encoder[RadialVelocity] = deriveEncoder
+  implicit val radialVelocityDecoder: Decoder[RadialVelocity] = deriveDecoder
+
+  implicit val userEncoder: Encoder[User[ProgramRole]] = deriveEncoder
+  implicit val userDecoder: Decoder[User[ProgramRole]] = deriveDecoder
+
+  private implicit class MoreAngleOps(a: Angle) {
+    private def moveRight(n: Int): BigDecimal =
+      new java.math.BigDecimal(a.toMicroarcseconds).movePointRight(n)
+
+    def toSignedArcseconds: BigDecimal =
+      moveRight(6)
+
+    def toSignedMilliarcseconds: BigDecimal =
+      moveRight(3)
+  }
+  private implicit class MoreAngleCompanionOps(comp: Angle.type) {
+    private def moveLeft(b: BigDecimal, n: Int): Angle =
+      comp.fromMicroarcseconds(b.underlying.movePointLeft(n).longValue)
+
+    def fromSignedArcseconds(b: BigDecimal): Angle =
+      moveLeft(b, 6)
+
+    def fromSignedMilliarcseconds(b: BigDecimal): Angle =
+      moveLeft(b, 3)
+  }
+
+  private implicit class PrismOps[A: Encoder: Decoder, B](p: Prism[A, B]) {
+    def toCodec: (Encoder[B], Decoder[B]) = (
+      Encoder[A].contramap(p.reverseGet),
+      Decoder[A].map(p.unsafeGet(_))
+    )
+  }
+
+  private implicit class FormatOps[A: Encoder: Decoder, B](p: Format[A, B]) {
+    def toCodec: (Encoder[B], Decoder[B]) = (
+      Encoder[A].contramap(p.reverseGet),
+      Decoder[A].map(p.unsafeGet(_))
+    )
+  }
+
+  // Angle mapping to signed arcseconds. NOT implicit.
+  val AngleAsSignedArcsecondsEncoder: Encoder[Angle] = Encoder[BigDecimal].contramap(_.toSignedArcseconds)
+  val AngleAsSignedArcsecondsDecoder: Decoder[Angle] = Decoder[BigDecimal].map(Angle.fromSignedArcseconds)
+
+  // Angle mapping to signed milliarcseconds. NOT implicit.
+  val AngleAsSignedMilliarcsecondsEncoder: Encoder[Angle] = Encoder[BigDecimal].contramap(_.toSignedMilliarcseconds)
+  val AngleAsSignedMilliarcsecondsDecoder: Decoder[Angle] = Decoder[BigDecimal].map(Angle.fromSignedMilliarcseconds)
+
+  // Index to Short.
+  implicit val (
+    observationIndexEncoder: Encoder[Index],
+    observationIndexDecoder: Decoder[Index]
+   ) =
+    Index.fromShort.toCodec
+
+  // Coadds to Short
+  implicit val (
+    coAddsEncoder: Encoder[CoAdds],
+    coAddsIndexDecoder: Decoder[CoAdds]
+  ) =
+    CoAdds.fromShort.toCodec
+
+  // Wavelength mapping to integral Angstroms.
+  implicit val (
+    wavelengthEncoderAngstroms: Encoder[Wavelength],
+    wavelengthDecoderAngstroms: Decoder[Wavelength]
+  ) =
+    Wavelength.fromAngstroms.toCodec
+
+  // Duration as a record with seconds and nanoseconds
+  implicit val DurationEncoder: Encoder[Duration] = d =>
+    Json.obj(
+      "seconds"     -> d.getSeconds.asJson,
+      "nanoseconds" -> d.getNano.asJson
+    )
+  implicit val DurationDecoder: Decoder[Duration] = c =>
+    for {
+      ss <- c.downField("seconds")    .as[Long]
+      ns <- c.downField("nanoseconds").as[Long]
+    } yield Duration.ofSeconds(ss, ns)
+
+  // Instant as a record with epoch seconds and nanosecond-of-second
+  implicit val InstantEncoder: Encoder[Instant] = i =>
+    Json.obj(
+      "seconds"     -> i.getEpochSecond.asJson,
+      "nanoseconds" -> i.getNano.asJson
+    )
+  implicit val InstantDecoder: Decoder[Instant] = c =>
+    for {
+      ss <- c.downField("seconds")    .as[Long]
+      ns <- c.downField("nanoseconds").as[Long]
+    } yield Instant.ofEpochSecond(ss, ns)
+
+  // Timestamp
+  implicit val TimestampEncoder: Encoder[Timestamp] = Encoder[Instant].contramap(_.toInstant)
+  implicit val TimestampDecoder: Decoder[Timestamp] = Decoder[Instant].map(Timestamp.unsafeFromInstant)
+
+  // Enumerated as a tag
+  implicit def enumeratedEncoder[A](implicit ev: Enumerated[A]): Encoder[A] = Encoder[String].contramap(ev.tag)
+  implicit def enumeratedDecoder[A](implicit ev: Enumerated[A]): Decoder[A] = Decoder[String].map(ev.unsafeFromTag)
+
+  // Program ID in canonical form
+  implicit val (
+    programIdEncoder: Encoder[Program.Id],
+    programIdDecoder: Decoder[Program.Id]
+   ) =
+    Program.Id.fromString.toCodec
+
+  // Right Ascension in canonical form
+  implicit val (
+    rightAscensionEncoder: Encoder[RightAscension],
+    rightAscensionDecoder: Decoder[RightAscension]
+  ) =
+    RightAscension.fromStringHMS.toCodec
+
+  // Declination in canonical form
+  implicit val (
+    declinationEncoder: Encoder[Declination],
+    declinationDecoder: Decoder[Declination]
+  ) =
+    Declination.fromStringSignedDMS.toCodec
+
+  // Epoch in canonical form
+  implicit val (
+    epochEncoder: Encoder[Epoch],
+    epochDecoder: Decoder[Epoch]
+  ) =
+    Epoch.fromString.toCodec
+
+  // Proper Motion. Made difficult by the parallax, which requires an explicit Angle encoding.
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  implicit val ProperMotionEncoder: Encoder[ProperMotion] = p =>
+    Json.obj(
+      "baseCoordinates" -> p.baseCoordinates.asJson,
+      "epoch"           -> p.epoch.asJson,
+      "properVelocity"  -> p.properVelocity.asJson,
+      "radialVelocity"  -> p.radialVelocity.asJson,
+      "parallax"        -> Encoder.encodeOption(AngleAsSignedMilliarcsecondsEncoder)(p.parallax)
+    )
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  implicit val ProperMotionDecoder: Decoder[ProperMotion] = c =>
+    for {
+      bc <- c.downField("baseCoordinates").as[Coordinates]
+      ep <- c.downField("epoch")          .as[Epoch]
+      pv <- c.downField("properVelocity") .as[Option[Offset]]
+      rv <- c.downField("radialVelocity") .as[Option[RadialVelocity]]
+      px <- c.downField("parallax")       .as[Option[Angle]](Decoder.decodeOption(AngleAsSignedMilliarcsecondsDecoder))
+    } yield ProperMotion(bc, ep, pv, rv, px)
+
+  // Offset.P maps to a signed angle in arcseconds
+  implicit val OffsetPEncoder: Encoder[Offset.P] = AngleAsSignedArcsecondsEncoder.contramap(_.toAngle)
+  implicit val OffsetPDecoder: Decoder[Offset.P] = AngleAsSignedArcsecondsDecoder.map(Offset.P.apply)
+
+  // Offset.Q maps to a signed angle in arcseconds
+  implicit val OffsetQEncoder: Encoder[Offset.Q] = AngleAsSignedArcsecondsEncoder.contramap(_.toAngle)
+  implicit val OffsetQDecoder: Decoder[Offset.Q] = AngleAsSignedArcsecondsDecoder.map(Offset.Q.apply)
+
+  // Codec for GcalArcs
+  implicit val GcalArcsEncoder: Encoder[GcalArcs] = Encoder[OneAnd[Set, GcalArc]].contramap(_.arcs)
+  implicit val GcalArcsDecoder: Decoder[GcalArcs] = Decoder[OneAnd[Set, GcalArc]].map(oa => GcalArcs(oa.head, oa.tail.toList))
+
+  // Codec for maps keyed by Program.Id
+  implicit def programIdKeyedMapEncoder[A: Encoder]: Encoder[Map[Program.Id, A]] =
+    Encoder[Map[String, A]].contramap(_.map { case (k, v) => (Program.Id.fromString.reverseGet(k), v) })
+  implicit def programIdKeyedMapDecoder[A: Decoder]: Decoder[Map[Program.Id, A]] =
+    Decoder[Map[String, A]].map(_.map { case (k, v) => (Program.Id.fromString.unsafeGet(k), v) })
+
+  // Codec for maps keyed by Index
+  implicit def observationIndexMapEncoder[A: Encoder]: Encoder[TreeMap[Index, A]] =
+    Encoder[TreeMap[Short, A]].contramap(_.map { case (k, v) => (k.toShort, v) })
+  implicit def observationIndexMapDecoder[A: Decoder]: Decoder[TreeMap[Index, A]] =
+    Decoder[TreeMap[Short, A]].map(_.map { case (k, v) => (Index.fromShort.unsafeGet(k), v) })
+
+  // GmosCustomRoiEntry as a quad of shorts
+  implicit val GmosCustomRoiEntryEncoder: Encoder[GmosCustomRoiEntry] =
+    Encoder[(Short, Short, Short, Short)].contramap(r => (r.xMin, r.yMin, r.xRange, r.yRange))
+  implicit val GmosCustomRoiEntryDecoder: Decoder[GmosCustomRoiEntry] =
+    Decoder[(Short, Short, Short, Short)].map((GmosCustomRoiEntry.unsafeFromDescription _).tupled)
+
+  // GmosShuffleOffset as integer detector rows
+  implicit def GmosShuffleOffsetEncoder: Encoder[GmosShuffleOffset] = Encoder[Int].contramap(_.detectorRows)
+  implicit def GmosShuffleOffsetDecoder: Decoder[GmosShuffleOffset] = Decoder[Int].map(GmosShuffleOffset.unsafeFromRowCount)
+
+  // GmosShuffleCycles as integer cycle count
+  implicit def GmosShuffleCyclesEncoder: Encoder[GmosShuffleCycles] = Encoder[Int].contramap(_.toInt)
+  implicit def GmosShuffleCyclesDecoder: Decoder[GmosShuffleCycles] = Decoder[Int].map(GmosShuffleCycles.unsafeFromCycleCount)
+
+}

--- a/modules/json/src/test/scala/gem/json/CompilationTest.scala
+++ b/modules/json/src/test/scala/gem/json/CompilationTest.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// package gem
+// package json
+
+// import io.circe._
+// import gem.config._
+// import gem.enum._
+// import gem.util.Enumerated
+
+// // N.B. lots of false warnings from codec derivation.
+// @SuppressWarnings(Array(
+//   "org.wartremover.warts.NonUnitStatements",
+//   "org.wartremover.warts.Null",
+//   "org.wartremover.warts.PublicInference",
+//   "org.wartremover.warts.Option2Iterable"
+// )) trait CompilatonTests {
+
+//   // Use this to assert a codec for a given type
+//   def assertCodec[A](
+//     implicit en: Encoder[A],
+//              de: Decoder[A]
+//   ): (Encoder[A], Decoder[A]) = (en, de)
+
+//   // Ensure that generic derivations will work for parameterized types
+//   def enumerated[E: Enumerated] = assertCodec[E]
+
+//   // Sanity checks
+//   assertCodec[User[ProgramRole]]
+//   // assertCodec[StaticConfig]
+//   // assertCodec[DynamicConfig]
+//   // assertCodec[Target]
+//   // assertCodec[Asterism]
+//   // assertCodec[TargetEnvironment]
+//   // assertCodec[Step]
+
+// }

--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.main
+
+import cats.data.StateT
+import cats.effect.IO
+import gem.dao.{ DatabaseConfiguration => DBC }
+import fs2.{ Stream, StreamApp }
+
+/** Main entry point for gem. Starts up web and telnet servers. */
+object Main extends StreamApp[IO] {
+  import StreamApp.ExitCode
+
+  // When we start the app with docker we pass a few config values as environment variables, which
+  // we substitute over the default properties. We will eventually plug in a real config layer here.
+  def config: IO[MainConfiguration] = {
+
+    // The env variables we know about.
+    val ENV_GEM_DB_URL : String = "GEM_DB_URL"
+    val ENV_GEM_DB_USER: String = "GEM_DB_USER"
+    val ENV_GEM_DB_PASS: String = "GEM_DB_PASS"
+
+    // Update a DatabaseConfiguration from an env variable if it's defined.
+    def update(env: String, f: (DBC, String) => DBC): StateT[IO, DBC, Unit] =
+      StateT(a => IO(sys.env.get(env).fold((a, ()))(s => (f(a, s), ()))))
+
+    // A program to update all configurable properties, where defined.
+    val updateAll: StateT[IO, DBC, Unit] =
+      for {
+        _ <- update(ENV_GEM_DB_URL,  (a, b) => a.copy(connectUrl = b))
+        _ <- update(ENV_GEM_DB_USER, (a, b) => a.copy(userName = b))
+        _ <- update(ENV_GEM_DB_PASS, (a, b) => a.copy(password = b))
+      } yield ()
+
+    // Test configuration with its database hunk updated, perhaps.
+    val cfg = MainConfiguration.forTesting
+    updateAll.runS(cfg.database).map(a => cfg.copy(database = a))
+
+  }
+
+  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] =
+    for {
+      cfg <- Stream.eval(config)
+      _   <- MainServer.stream(cfg)
+      _   <- Stream.eval(IO(Console.println("Press a key to exit."))) // scalastyle:off
+      _   <- Stream.eval(IO(scala.io.StdIn.readLine()))
+      _   <- Stream.eval(requestShutdown)
+    } yield ExitCode(0)
+
+}

--- a/modules/main/src/main/scala/MainConfiguration.scala
+++ b/modules/main/src/main/scala/MainConfiguration.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.main
+
+import gem.web.WebConfiguration
+import gem.dao.DatabaseConfiguration
+import gem.telnetd.TelnetdConfiguration
+
+final case class MainConfiguration(
+  database: DatabaseConfiguration,
+  web:      WebConfiguration,
+  telnetd:  TelnetdConfiguration
+)
+
+object MainConfiguration {
+
+  val forTesting: MainConfiguration =
+    apply(
+      DatabaseConfiguration.forTesting,
+      WebConfiguration.forTesting,
+      TelnetdConfiguration.forTesting
+    )
+
+}

--- a/modules/main/src/main/scala/MainServer.scala
+++ b/modules/main/src/main/scala/MainServer.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.main
+
+import cats.effect.IO
+import gem.dao.DatabaseConfiguration
+import gem.web.WebServer
+import gem.telnetd.TelnetServer
+import fs2.Stream
+import org.flywaydb.core.Flyway
+
+object MainServer {
+
+  // Run flyway migrations
+  private def migrate(db: DatabaseConfiguration): IO[Int] =
+    IO {
+      val flyway = new Flyway()
+      flyway.setDataSource(db.connectUrl, db.userName, db.password);
+      flyway.migrate()
+    }
+
+  /** A single-element stream that starts the server up and shuts it down on exit. */
+  def stream(cfg: MainConfiguration): Stream[IO, Unit] =
+    for {
+      _   <- Stream.eval(migrate(cfg.database))
+      _   <- TelnetServer.stream(cfg.database, cfg.telnetd)
+      _   <- WebServer.stream(cfg.web, cfg.database)
+    } yield ()
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -1,0 +1,230 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ocs2
+
+import cats.implicits._
+import gem.{ Dataset, EphemerisKey, Observation, Program, Step, Target }
+import gem.config._
+import gem.enum._
+import gem.math._
+import gem.ocs2.pio.PioPath._
+import gem.ocs2.pio.{ PioDecoder, PioError, PioPath }
+import gem.ocs2.pio.PioError.ParseError
+import gem.ocs2.pio.PioDecoder.fromParse
+import gem.syntax.all._
+
+import java.time.Instant
+
+import scala.collection.immutable.{ TreeMap, TreeSet }
+import scala.xml.Node
+
+
+/** `PioDecoder` instances for our model types.
+  */
+object Decoders {
+
+  implicit val MagnitudeSystemDecoder: PioDecoder[MagnitudeSystem] =
+    fromParse { Parsers.magnitudeSystem }
+
+  implicit val MagnitudeBandDecoder: PioDecoder[MagnitudeBand] =
+    fromParse { Parsers.magnitudeBand }
+
+  implicit val RightAscensionDecoder: PioDecoder[RightAscension] =
+    fromParse { Parsers.ra }
+
+  implicit val DeclinationDecoder: PioDecoder[Declination] =
+    fromParse { Parsers.dec }
+
+  implicit val CoordinatesDecoder: PioDecoder[Coordinates] =
+    PioDecoder { n =>
+      for {
+        r <- (n \! "#ra" ).decode[RightAscension]
+        d <- (n \! "#dec").decode[Declination]
+      } yield Coordinates(r, d)
+    }
+
+  implicit val EpochDecoder: PioDecoder[Epoch] =
+    fromParse { Parsers.epoch }
+
+  implicit val ProperMotionDecoder: PioDecoder[ProperMotion] =
+    PioDecoder { n =>
+      for {
+        c  <- (n \! "&coordinates").decode[Coordinates]
+        e  <- (n \? "&proper-motion" \! "#epoch"    ).decodeOrElse[Epoch](Epoch.J2000)
+        dr <- (n \? "&proper-motion" \! "#delta-ra" ).decode[Double]
+        dd <- (n \? "&proper-motion" \! "#delta-dec").decode[Double]
+        pv  = dr.flatMap { r =>
+          dd.map { d =>
+            Offset(
+              Offset.P(Angle.fromMicroarcseconds((r * 1000).round)),
+              Offset.Q(Angle.fromMicroarcseconds((d * 1000).round))
+            )
+          }
+        }
+        dz <- (n \? "#redshift").decode[Double]
+        rv  = dz.map(RadialVelocity.fromRedshift)
+        dp <- (n \? "#parallax").decode[Double]
+        p   = dp.map(d => Angle.fromMicroarcseconds((d * 1000).round))
+      } yield ProperMotion(c, e, pv, rv, p)
+    }
+
+  implicit val EphemerisKeyTypeDecoder: PioDecoder[EphemerisKeyType] =
+    fromParse { Parsers.ephemerisKeyType }
+
+  implicit val EphemerisKeyDecoder: PioDecoder[EphemerisKey] = {
+      def fromDes(des: String, tag: EphemerisKeyType): Either[PioError, EphemerisKey] =
+        tag match {
+          case EphemerisKeyType.AsteroidNew  =>
+            Right(EphemerisKey.AsteroidNew(des))
+
+          case EphemerisKeyType.AsteroidOld  =>
+            des.parseIntOption.toRight(PioError.ParseError(des, "AsteroidOld")).map(EphemerisKey.AsteroidOld(_))
+
+          case EphemerisKeyType.Comet        =>
+            Right(EphemerisKey.Comet(des))
+
+          case EphemerisKeyType.MajorBody    =>
+            des.parseIntOption.toRight(PioError.ParseError(des, "MajorBody")).map(EphemerisKey.MajorBody(_))
+
+          case EphemerisKeyType.UserSupplied =>
+            Left(ParseError(des, "EphemerisKey"))
+        }
+
+      PioDecoder { n =>
+        for {
+          des <- (n \! "#des").decode[String]
+          tag <- (n \! "#tag").decode[EphemerisKeyType]
+          key <- fromDes(des, tag)
+        } yield key
+      }
+    }
+
+  implicit val TrackDecoder: PioDecoder[Either[EphemerisKey, ProperMotion]] =
+    PioDecoder { n =>
+      (n \! "#tag").decode[String].flatMap {
+        case "nonsidereal" => (n \! "&horizons-designation").decode[EphemerisKey].map(Left(_))
+        case "sidereal"    => PioDecoder[ProperMotion].decode(n).map(Right(_))
+        case tag           => Left(ParseError(tag, "Track"))
+      }
+    }
+
+
+  implicit val TargetDecoder: PioDecoder[Target] =
+    PioDecoder { n =>
+      for {
+        name  <- (n \! "#name").decode[String]
+        track <- PioDecoder[Either[EphemerisKey, ProperMotion]].decode(n)
+      } yield Target(name, track)
+    }
+
+  implicit val UserTargetTypeDecoder: PioDecoder[UserTargetType] =
+    fromParse { Parsers.userTargetType }
+
+  implicit val UserTargetDecoder: PioDecoder[UserTarget] =
+    PioDecoder { n =>
+      for {
+        t <- (n \! "&spTarget" \! "&target").decode[Target]
+        y <- (n \! "#type"                 ).decode[UserTargetType]
+      } yield UserTarget(t, y)
+    }
+
+  implicit val DatasetLabelDecoder: PioDecoder[Dataset.Label] =
+    fromParse { Parsers.datasetLabel }
+
+  implicit val ObservationIdDecoder: PioDecoder[Observation.Id] =
+    fromParse { Parsers.obsId }
+
+  implicit val ProgramIdDecoder: PioDecoder[Program.Id] =
+    fromParse { Parsers.progId }
+
+  implicit val InstrumentDecoder: PioDecoder[Instrument] =
+    fromParse { Parsers.instrument }
+
+  implicit val DatasetDecoder: PioDecoder[Dataset] =
+    PioDecoder { n =>
+      for {
+        l <- (n \! "#datasetLabel").decode[Dataset.Label]
+        f <- (n \! "#dhsFilename" ).decode[String]
+        t <- (n \! "#timestamp"   ).decode[Instant]
+      } yield Dataset(l, f, t)
+    }
+
+  // Decodes all the datasets in either a program or observation node.  We have
+  // to explicitly specify that we want the "dataset" elements within a
+  // "datasets" paramset because they are duplicated in the event data.
+  implicit val DatasetsDecoder: PioDecoder[List[Dataset]] =
+    PioDecoder { n =>
+      (n \\* "obsExecLog" \\* "&datasets" \\* "&dataset").decode[Dataset]
+    }
+
+  implicit val ObservationIndexDecoder: PioDecoder[Index] =
+    PioDecoder { n =>
+      (n \! "@name").decode[Observation.Id].map(_.index)
+    }
+
+  def targetEnvironmentDecoder(i: Instrument): PioDecoder[TargetEnvironment] = {
+    import gem.enum.TrackType
+
+    def trackType(targetNode: scala.xml.Node): Option[TrackType] =
+      (targetNode \? "#tag").decode[String].toOption.flatten.collect {
+        case "sidereal"    => TrackType.Sidereal: TrackType
+        case "nonsidereal" => TrackType.Nonsidereal: TrackType
+      }
+
+    // filter out "too" and empty non-sidereal (that is, w/o horizons id) for now
+    def validTargets(lst: PioPath.Listing)(f: Node => PioPath.Required): PioPath.Listing =
+      lst.copy(node = lst.node.map { ns =>
+        ns.filter { n =>
+
+          // We have to drill down to the target node for this filter and
+          // extract the track type
+          val ty = for {
+            t <- f(n).node.toOption // "target" node
+            y <- trackType(t)       // track type
+          } yield (t, y)
+
+          // Sidereal targets or non-sidereal with an horizons id are ok
+          ty.exists { case (t, y) =>
+            (y === TrackType.Sidereal) || (t \? "&horizons-designation").node.isDefined.getOrElse(false)
+          }
+        }
+      })
+
+    PioDecoder { n =>
+      for {
+        a <- validTargets(n \* "&asterism" \! "&target")(_.toRequired).decode[Target]
+        // g <- guideEnvironment
+        u <- validTargets(n \? "&userTargets" \* "&userTarget")(_ \! "&spTarget" \! "&target").decode[UserTarget]
+      } yield {
+        a.headOption.map(Asterism.unsafeFromSingleTarget(_, i)) match {
+          case None    => TargetEnvironment.fromInstrument(i, TreeSet.fromList(u))
+          case Some(a) => TargetEnvironment.fromAsterism(a, TreeSet.fromList(u))
+        }
+      }
+    }
+  }
+
+  implicit val ObservationDecoder: PioDecoder[Observation] =
+    PioDecoder { n =>
+      for {
+        t <- (n \! "data" \? "#title"                   ).decodeOrZero[String]
+        s <- (n \! "sequence"                           ).decode[StaticConfig](StaticDecoder)
+        d <- (n \! "sequence"                           ).decode[List[Step]](SequenceDecoder)
+        i  = Instrument.forStaticConfig(s) // stable identifier needed below
+        e <- (n \? "telescope" \! "data" \! "&targetEnv").decodeOrElse(TargetEnvironment.fromInstrument(i, TreeSet.empty))(targetEnvironmentDecoder(i))
+      } yield Observation.unsafeAssemble(t, e, s, d)
+    }
+
+  implicit val ProgramDecoder: PioDecoder[Program] =
+    PioDecoder { n =>
+      for {
+        id <- (n \!  "@name"           ).decode[Program.Id]
+        t  <- (n \!  "data" \? "#title").decodeOrZero[String]
+        is <- (n \\* "observation"     ).decode[Index]
+        os <- (n \\* "observation"     ).decode[Observation]
+      } yield Program(id, t, TreeMap.fromList(is.zip(os)))
+    }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.effect.Effect
+import cats.implicits._
+import doobie._, doobie.implicits._
+import gem.dao.meta._
+import doobie.postgres.implicits._
+import java.util.logging.{ Level, Logger }
+
+/** Shared support for import applications using Doobie. */
+trait DoobieClient extends ProgramIdMeta with IndexMeta {
+
+  def configureLogging[M[_]: Effect]: M[Unit] =
+    Effect[M].delay(
+      List("edu.gemini.spModel.type.SpTypeUtil")
+        .map(Logger.getLogger)
+        .foreach(_.setLevel(Level.OFF))
+    )
+
+  def ignoreUniqueViolation(fa: ConnectionIO[Int]): ConnectionIO[Int] =
+    for {
+      s <- HC.setSavepoint
+      n <- fa.onUniqueViolation(HC.rollback(s).as(0)) guarantee HC.releaseSavepoint(s)
+    } yield n
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.effect.IO, cats.implicits._
+import doobie._, doobie.implicits._
+import gem.{ Dataset, Log, Program, User }
+import gem.dao.{ DatabaseConfiguration, UserDao }
+import gem.ocs2.Decoders._
+import gem.ocs2.pio.PioDecoder
+import java.io.File
+import org.flywaydb.core.Flyway
+import scala.xml.{XML, Elem}
+
+
+/** Imports OCS2 program files exported to the same format sent by the
+  * Ocs3ExportServlet at http://g[ns]odb:8442/ocs3/fetch/programId or
+  * by using the OSGi shell command "exportOcs3" from the ODB shell.
+  */
+object FileImporter extends DoobieClient {
+
+  private val conf = DatabaseConfiguration.forTesting
+  private val xa   = conf.transactor[IO]
+
+  val dir: File = new File("archive")
+
+  val checkArchive: IO[Unit] =
+    IO(dir.isDirectory).flatMap { b =>
+      IO(if (b) () else sys.error("""
+        |
+        |** Root of project needs an archive/ dir with program xml files in it.
+        |** Try ln -s /path/to/some/stuff archive
+        |""".stripMargin))
+    }
+
+  val clean: IO[Int] =
+    IO {
+      val flyway = new Flyway()
+      flyway.setDataSource(conf.connectUrl, conf.userName, conf.password)
+      flyway.clean()
+      flyway.migrate()
+    }
+
+  def read(f: File): IO[Elem] =
+    IO(XML.loadFile(f))
+
+  def readAndInsert(u: User[_], f: File, log: Log[ConnectionIO]): IO[Unit] =
+    read(f).flatMap { elem =>
+      PioDecoder[(Program, List[Dataset])].decode(elem) match {
+        case Left(err)      => sys.error(s"Problem parsing ${f.getName}: $err")
+        case Right((p, ds)) => log.log(u, s"insert ${p.id}")(Importer.importProgram(p, ds)).transact(xa)
+      }
+    }.handleErrorWith(e => IO(e.printStackTrace))
+
+  def xmlFiles(num: Int): IO[List[File]] =
+    IO(dir.listFiles.toList.filter(_.getName.toLowerCase.endsWith(".xml"))).map(_.take(num))
+
+  def readAndInsertAll(u: User[_], num: Int, log: Log[ConnectionIO]): IO[Unit] =
+    xmlFiles(num).flatMap(_.traverse_(readAndInsert(u, _, log)))
+
+  def runl(args: List[String]): IO[Unit] =
+    for {
+      u <- UserDao.selectRootUser.transact(xa)
+      l <- Log.newLog[ConnectionIO]("importer", xa).transact(xa)
+      n <- IO(args.headOption.map(_.toInt).getOrElse(Int.MaxValue))
+      _ <- checkArchive
+      _ <- configureLogging[IO]
+      _ <- clean
+      _ <- readAndInsertAll(u, n, l)
+      _ <- l.shutdown(5 * 1000).transact(xa) // if we're not done soon something is wrong
+      _ <- IO(Console.println("Done.")) // scalastyle:off console.io
+    } yield ()
+
+  def main(args: Array[String]): Unit =
+    runl(args.toList).unsafeRunSync
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
@@ -1,0 +1,93 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ocs2
+
+import cats.effect.IO
+import cats.implicits._
+import fs2.{Stream, StreamApp}
+import gem.dao.DatabaseConfiguration
+import org.http4s._
+import org.http4s.dsl.io._
+import org.http4s.server.blaze.BlazeBuilder
+
+import java.util.logging.Logger
+
+import scala.concurrent.ExecutionContext
+
+/** A server that accepts HTTP requests to import observations or programs from
+  * an OCS2 ODB.  If the corresponding observation or program has already been
+  * loaded, it is deleted and wholly replaced by the latest version from the
+  * ODB.
+  */
+final class ImportServer(ocsHost: String) {
+
+  private val xa = DatabaseConfiguration.forTesting.transactor[IO]
+
+  private def badRequest(id: String, idType: String): IO[Response[IO]] =
+    BadRequest(s"Could not parse $idType id '$id'")
+
+  private def importRemote[A](
+    idStr:     String,
+    parseFun:  String => Option[A],
+    typeName:  String,
+    importFun: A => IO[Either[String, Unit]]
+  ): IO[Response[IO]] =
+    parseFun(idStr).toRight(badRequest(idStr, typeName)).map { id =>
+      importFun(id).map {
+        case Left(msg) => InternalServerError(s"Error parsing $idStr: $msg")
+        case Right(_)  => Ok(s"Imported $idStr")
+      }.flatten
+    }.merge
+
+  def importObservation(obsIdStr: String): IO[Response[IO]] =
+    importRemote[Observation.Id](
+      obsIdStr,
+      Observation.Id.fromString,
+      "observation",
+      OdbClient.importObservation(ocsHost, _, xa)
+    )
+
+  def importProgram(pidStr: String): IO[Response[IO]] = {
+    importRemote[Program.Id](
+      pidStr,
+      ProgramId.fromString.getOption,
+      "program",
+      OdbClient.importProgram(ocsHost, _, xa)
+    )
+  }
+}
+
+object ImportServer extends StreamApp[IO] {
+  private val Log = Logger.getLogger(ImportServer.getClass.getName)
+
+  // Port where our http service will run.
+  val port: Int = 8989
+
+  def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, StreamApp.ExitCode] = {
+
+    val hostName = args match {
+      case Nil       => "localhost"
+      case host :: _ => host
+    }
+
+    Log.info(s"Starting import server on port $port connecting to $hostName")
+
+    val importServer = new ImportServer(hostName)
+
+    val service = HttpService[IO] {
+      case GET -> Root / "obs" / obsId =>
+        importServer.importObservation(obsId)
+
+      case GET -> Root / "prog" / progId =>
+        importServer.importProgram(progId)
+    }
+
+    BlazeBuilder[IO]
+      .bindHttp(8989, "localhost")
+      .mountService(service, "/import")
+      .serve(implicitly, ExecutionContext.global)
+
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ocs2
+
+import gem.dao._
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+
+import scala.collection.immutable.TreeMap
+
+
+/** Support for writing programs and observations to the database.
+  */
+object Importer extends DoobieClient {
+
+  object datasets {
+    def lookupStepIds(oid: Observation.Id): ConnectionIO[List[Int]] =
+      sql"SELECT step_id FROM step WHERE program_id = ${oid.pid} AND observation_index = ${oid.index} ORDER BY location".query[Int].to[List]
+
+    def tuples(sids: List[Int], ds: List[Dataset]): List[(Int, Dataset)] = {
+      val sidMap = sids.zipWithIndex.map(_.swap).toMap
+      ds.flatMap { d => sidMap.get(d.label.index - 1).map(_ -> d).toList }
+    }
+
+    def write(oid: Observation.Id, ds: List[Dataset]): ConnectionIO[Unit] =
+      for {
+        sids <- lookupStepIds(oid)
+        _    <- tuples(sids, ds).traverse_ { case (sid, d) => DatasetDao.insert(sid, d) }
+      } yield ()
+  }
+
+  def importObservation(oid: Observation.Id, o: Observation, ds: List[Dataset]): ConnectionIO[Unit] = {
+
+    val rmObservation: ConnectionIO[Unit] =
+      sql"DELETE FROM observation WHERE program_id = ${oid.pid} AND observation_index = ${oid.index}".update.run.void
+
+    for {
+      _ <- ignoreUniqueViolation(ProgramDao.insertFlat(Program(oid.pid, "", TreeMap.empty)).as(1))
+      _ <- rmObservation
+      _ <- ObservationDao.insert(oid, o)
+      _ <- datasets.write(oid, ds)
+    } yield ()
+  }
+
+  def importProgram(p: Program, ds: List[Dataset]): ConnectionIO[Unit] = {
+
+    val rmProgram: ConnectionIO[Unit] =
+      sql"DELETE FROM program WHERE program_id = ${p.id}".update.run.void
+
+    val dsMap = ds.groupBy(_.label.observationId).withDefaultValue(List.empty[Dataset])
+
+    for {
+      _ <- rmProgram
+      _ <- ProgramDao.insert(p)
+      _ <- p.observations.toList.traverse_ { case (i, _) =>
+             val oid = Observation.Id(p.id, i)
+             datasets.write(oid, dsMap(oid))
+           }
+    } yield ()
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
@@ -1,0 +1,166 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.implicits._
+import gem.ocs2.pio.PioError._
+import gem.ocs2.pio.{PioError, PioOptional, PioParse}
+
+import scala.reflect.runtime.universe.TypeTag
+
+
+/** Legacy system (telescope, instrument, observe, calibration) key and parser
+  * definitions.
+  */
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object Legacy {
+  sealed abstract class System(val system: String) {
+
+    final class Key[A](val name: String, val parseString: PioParse[A])(implicit ev: TypeTag[A]) {
+
+      val path: String = s"$system:$name"
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      val tpe:  String = Key.clean(ev.tpe.toString)
+
+      def rawValue(cm: ConfigMap): Either[PioError, String] =
+        cm.get(path) toRight missingKey(name)
+
+      def parse(cm: ConfigMap): Either[PioError, A] =
+        rawValue(cm).flatMap { s => parseString(s) toRight parseError(s, tpe) }
+
+      def cparse(cm: ConfigMap): Either[PioError, Option[A]] =
+        parse(cm) match {
+          case Left(MissingKey(_)) => None.asRight
+          case Left(err)           => err.asLeft
+          case Right(a)            => Some(a).asRight
+        }
+
+      def cparseOrElse(cm: ConfigMap, a: => A): Either[PioError, A] =
+        cparse(cm).map { _.getOrElse(a) }
+
+      def oparse(cm: ConfigMap): PioOptional[A] =
+        PioOptional(cparse(cm))
+
+      override def toString: String =
+        s"Key[$tpe]($path)"
+
+    }
+
+    protected object Key {
+      // Clean up classnames in toString, which tells you the type of the key, which should be
+      // helpful for debugging.
+      private def clean(s: String) =
+        s.replace("edu.gemini.spModel.core.", "")
+         .replace("java.lang.", "")
+         .replace("java.time.", "")
+         .replace("gem.", "")
+
+      def apply[A: TypeTag](name: String)(parse: PioParse[A]): Key[A] =
+        new Key(name, parse)
+    }
+  }
+
+  case object Telescope extends System("telescope") {
+    val P = Key("p")(Parsers.offsetP)
+    val Q = Key("q")(Parsers.offsetQ)
+  }
+
+  case object Observe extends System("observe") {
+    val ObserveType  = Key("observeType" )(PioParse.string )
+    val ExposureTime = Key("exposureTime")(PioParse.seconds)
+  }
+
+  case object Ocs extends System("ocs") {
+    val ObservationId = Key("observationId")(Parsers.obsId)
+  }
+
+  case object Instrument extends System("instrument") {
+    val Instrument    = Key("instrument"   )(Parsers.instrument   )
+    val MosPreImaging = Key("mosPreimaging")(Parsers.mosPreImaging)
+
+    object Flamingos2 {
+      import Parsers.Flamingos2._
+      val Disperser   = Key("disperser"  )(disperser  )
+      val Filter      = Key("filter"     )(filter     )
+      val Fpu         = Key("fpu"        )(fpu        )
+      val LyotWheel   = Key("lyotWheel"  )(lyotWheel  )
+      val ReadMode    = Key("readMode"   )(readMode   )
+      val WindowCover = Key("windowCover")(windowCover)
+    }
+
+    object Gmos {
+      import Parsers.Gmos._
+      val Adc             = Key("adc"                    )(adc            )
+      val AmpCount        = Key("ampCount"               )(ampCount       )
+      val AmpGain         = Key("gainChoice"             )(ampGain        )
+      val AmpReadMode     = Key("ampReadMode"            )(ampReadMode    )
+      val CustomMaskMdf   = Key("fpuCustomMask"          )(PioParse.string)
+      val CustomSlitWidth = Key("customSlitWidth"        )(customSlitWidth)
+      val Detector        = Key("detectorManufacturer"   )(detector       )
+      val DisperserOrder  = Key("disperserOrder"         )(disperserOrder )
+      val DisperserLambda = Key("disperserLambda"        )(disperserLambda)
+      val Dtax            = Key("dtaXOffset"             )(dtax           )
+      val EOffsetting     = Key("useElectronicOffsetting")(nsEOffsetting  )
+      val NsBeamAp        = Key("nsBeamA-p"              )(Parsers.offsetP)
+      val NsBeamAq        = Key("nsBeamA-q"              )(Parsers.offsetQ)
+      val NsBeamBp        = Key("nsBeamB-p"              )(Parsers.offsetP)
+      val NsBeamBq        = Key("nsBeamB-q"              )(Parsers.offsetQ)
+      val NsCycles        = Key("nsNumCycles"            )(nsCycles       )
+      val NsShuffle       = Key("nsDetectorRows"         )(nsShuffle      )
+      val Roi             = Key("builtinROI"             )(roi            )
+      val XBinning        = Key("ccdXBinning"            )(xBinning       )
+      val YBinning        = Key("ccdYBinning"            )(yBinning       )
+
+      def roiKey(i: Int, n: String): Key[Short] =
+        Key(s"customROI$i$n")(PioParse.positiveShort)
+
+      def roiXMin(i: Int):   Key[Short] = roiKey(i, "Xmin"  )
+      def roiYMin(i: Int):   Key[Short] = roiKey(i, "Ymin"  )
+      def roiXRange(i: Int): Key[Short] = roiKey(i, "XRange")
+      def roiYRange(i: Int): Key[Short] = roiKey(i, "YRange")
+    }
+
+    object GmosNorth {
+      import Parsers.GmosNorth._
+      val Disperser       = Key("disperser")(disperser)
+      val Filter          = Key("filter"   )(filter   )
+      val Fpu             = Key("fpu"      )(fpu      )
+      val StageMode       = Key("stageMode")(stageMode)
+    }
+
+    object GmosSouth {
+      import Parsers.GmosSouth._
+      val Disperser       = Key("disperser")(disperser)
+      val Filter          = Key("filter"   )(filter   )
+      val Fpu             = Key("fpu"      )(fpu      )
+      val StageMode       = Key("stageMode")(stageMode)
+    }
+
+    object Gnirs {
+      import Parsers.Gnirs._
+      val AcquisitionMirror = Key("acquisitionMirror")(acquisitionMirror)
+      val Camera            = Key("camera"           )(camera)
+      val CoAdds            = Key("coadds"           )(Parsers.coadds)
+      val Decker            = Key("decker"           )(decker)
+      val Disperser         = Key("disperser"        )(disperser)
+      val Filter            = Key("filter"           )(filter)
+      val Fpu               = Key("slitWidth"        )(fpu)
+      val Prism             = Key("crossDispersed"   )(prism)
+      val ReadMode          = Key("readMode"         )(readMode)
+      val Wavelength        = Key("centralWavelength")(centralWavelength)
+      val WellDepth         = Key("wellDepth"        )(wellDepth)
+    }
+  }
+
+  object Calibration extends System("calibration") {
+    import Parsers.Calibration._
+    val Lamp         = Key("lamp"        )(lamp            )
+    val Filter       = Key("filter"      )(filter          )
+    val Diffuser     = Key("diffuser"    )(diffuser        )
+    val Shutter      = Key("shutter"     )(shutter         )
+    val ExposureTime = Key("exposureTime")(PioParse.seconds)
+    val CoAdds       = Key("coadds"      )(Parsers.coadds)
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/OdbClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/OdbClient.scala
@@ -1,0 +1,94 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ocs2
+
+import gem.ocs2.Decoders._
+
+import gem.ocs2.pio.{ PioDecoder, PioError }
+import gem.ocs2.pio.PioError._
+
+import doobie._
+import doobie.implicits._
+import cats.effect._
+import cats.implicits._
+import fs2.Stream
+import org.http4s.client.blaze.Http1Client
+import org.http4s.scalaxml.xml
+
+import java.net.URLEncoder
+
+import scala.xml.Elem
+
+
+/** ODB observation/program fetch client.
+  */
+object OdbClient {
+
+  /** Fetches an observation from an ODB. */
+  def fetchObservation[M[_]: Effect](
+    host: String,
+    id:   Observation.Id
+  ): M[Either[String, (Observation, List[Dataset])]] =
+    fetch[Observation, M](host, id.format)
+
+  /** Fetches a program from the ODB. */
+  def fetchProgram[M[_]: Effect](
+    host: String,
+    id:   Program.Id
+  ): M[Either[String, (Program, List[Dataset])]] =
+    fetch[Program, M](host, Program.Id.fromString.reverseGet(id))
+
+  /** Fetches an observation from the ODB and stores it in the database. */
+  def importObservation[M[_]: Effect](
+    host: String,
+    id:   Observation.Id,
+    xa:   Transactor[M]
+  ): M[Either[String, Unit]] =
+    fetchObservation(host, id).flatMap { _.traverse { case (o, ds) =>
+      Importer.importObservation(id, o, ds).transact(xa)
+    }}
+
+  /** Fetches a program from the ODB and stores it in the database. */
+  def importProgram[M[_]: Effect](
+    host: String,
+    id:   Program.Id,
+    xa:   Transactor[M]
+  ): M[Either[String, Unit]] =
+    fetchProgram(host, id).flatMap { _.traverse { case (p, ds) =>
+      Importer.importProgram(p, ds).transact(xa)
+    }}
+
+  private def fetchServiceUrl(host: String): String =
+    s"http://$host:8442/ocs3/fetch"
+
+  private def uri(host: String, id: String): String =
+    s"${fetchServiceUrl(host)}/${URLEncoder.encode(id, "UTF-8")}"
+
+  private def errorMessage(e: PioError): String =
+    e match {
+      case MissingKey(name)            => s"missing '$name'"
+      case ParseError(value, dataType) => s"could not parse '$value' as '$dataType'"
+    }
+
+  private def fetch[A: PioDecoder, M[_]: Effect](
+    host: String,
+    id:   String
+  ): M[Either[String, (A, List[Dataset])]] = {
+
+    val s = Http1Client.stream().flatMap { c =>
+      Stream.eval {
+        c.expect[Elem](uri(host, id))
+         .map(PioDecoder[(A, List[Dataset])].decode(_).leftMap(errorMessage))
+         .attempt
+         .map(_.leftMap(ex => s"Problem fetching '$id': ${ex.getMessage}").flatten)
+      }
+    }
+
+    s.compile
+     .last
+     .map(_.getOrElse("Impossible empty stream".asLeft[(A, List[Dataset])]))
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Parsers.scala
@@ -1,0 +1,714 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.implicits._
+import gem.{ CoAdds, Dataset, Observation, Program }
+import gem.enum._
+import gem.config.GcalConfig.GcalLamp
+import gem.math._
+
+/** String parsers for our model types.
+  */
+object Parsers {
+
+  import gem.ocs2.pio.PioParse
+  import gem.ocs2.pio.PioParse._
+
+  val yesNo: PioParse[Boolean] = enum(
+    "No"  -> false,
+    "Yes" -> true
+  )
+
+  val mosPreImaging: PioParse[MosPreImaging] = enum(
+    "No"  -> MosPreImaging.IsNotMosPreImaging,
+    "Yes" -> MosPreImaging.IsMosPreImaging
+  )
+
+  val arcsec: PioParse[Angle] =
+    double.map(Angle.fromDoubleArcseconds)
+
+  val angstroms: PioParse[Wavelength] =
+    int.map(n => Wavelength.fromAngstroms.unsafeGet(n))
+
+  val magnitudeSystem: PioParse[MagnitudeSystem] =
+    enumFromTag(MagnitudeSystem.all)
+
+  val magnitudeBand: PioParse[MagnitudeBand] = enum(
+    "u"  -> MagnitudeBand.SloanU,
+    "g"  -> MagnitudeBand.SloanG,
+    "r"  -> MagnitudeBand.SloanR,
+    "i"  -> MagnitudeBand.SloanI,
+    "z"  -> MagnitudeBand.SloanZ,
+    "U"  -> MagnitudeBand.U,
+    "B"  -> MagnitudeBand.B,
+    "V"  -> MagnitudeBand.V,
+    "UC" -> MagnitudeBand.Uc,
+    "R"  -> MagnitudeBand.R,
+    "I"  -> MagnitudeBand.I,
+    "Y"  -> MagnitudeBand.Y,
+    "J"  -> MagnitudeBand.J,
+    "H"  -> MagnitudeBand.H,
+    "K"  -> MagnitudeBand.K,
+    "L"  -> MagnitudeBand.L,
+    "M"  -> MagnitudeBand.M,
+    "N"  -> MagnitudeBand.N,
+    "Q"  -> MagnitudeBand.Q,
+    "AP" -> MagnitudeBand.Ap
+  )
+
+  val ra: PioParse[RightAscension] =
+    double.map(Angle.fromDoubleDegrees)
+          .map(Angle.hourAngle.get)
+          .map(RightAscension.fromHourAngle.get)
+
+  val dec: PioParse[Declination] =
+    double.map(Angle.fromDoubleDegrees)
+          .map(Declination.fromAngle.unsafeGet)
+
+  // Anything else blows up, which is ok since we don't support anything else
+  val epoch: PioParse[Epoch] = enum(
+    "1950.0" -> Epoch.B1950,
+    "2000.0" -> Epoch.J2000
+  )
+
+  val ephemerisKeyType: PioParse[EphemerisKeyType] = enum(
+    "asteroid"           -> EphemerisKeyType.AsteroidNew,
+    "asteroid-old-style" -> EphemerisKeyType.AsteroidOld,
+    "comet"              -> EphemerisKeyType.Comet,
+    "major-body"         -> EphemerisKeyType.MajorBody
+  )
+
+  val instrument: PioParse[Instrument] = enum(
+    "AcqCam"     -> gem.enum.Instrument.AcqCam,
+    "bHROS"      -> gem.enum.Instrument.Bhros,
+    "BHROS"      -> gem.enum.Instrument.Bhros,
+    "Flamingos2" -> gem.enum.Instrument.Flamingos2,
+    "GMOS"       -> gem.enum.Instrument.GmosN,
+    "GMOS-N"     -> gem.enum.Instrument.GmosN,
+    "GMOSSouth"  -> gem.enum.Instrument.GmosS,
+    "GMOS-S"     -> gem.enum.Instrument.GmosS,
+    "GNIRS"      -> gem.enum.Instrument.Gnirs,
+    "GPI"        -> gem.enum.Instrument.Gpi,
+    "GSAOI"      -> gem.enum.Instrument.Gsaoi,
+    "Michelle"   -> gem.enum.Instrument.Michelle,
+    "NICI"       -> gem.enum.Instrument.Nici,
+    "NIFS"       -> gem.enum.Instrument.Nifs,
+    "NIRI"       -> gem.enum.Instrument.Niri,
+    "Phoenix"    -> gem.enum.Instrument.Phoenix,
+    "TReCS"      -> gem.enum.Instrument.Trecs,
+    "Visitor"    -> gem.enum.Instrument.Visitor,
+    "Visitor Instrument" -> gem.enum.Instrument.Visitor
+  )
+
+  val progId: PioParse[Program.Id] =
+    PioParse(Program.Id.fromString.getOption)
+
+  val obsId: PioParse[Observation.Id] =
+    PioParse(Observation.Id.fromString)
+
+  val datasetLabel: PioParse[Dataset.Label] =
+    PioParse(Dataset.Label.fromString.getOption)
+
+  val offsetP: PioParse[Offset.P] =
+    arcsec.map(Offset.P.apply)
+
+  val offsetQ: PioParse[Offset.Q] =
+    arcsec.map(Offset.Q.apply)
+
+  val userTargetType: PioParse[UserTargetType] = enum(
+    "blindOffset" -> UserTargetType.BlindOffset,
+    "offAxis"     -> UserTargetType.OffAxis,
+    "tuningStar"  -> UserTargetType.TuningStar,
+    "other"       -> UserTargetType.Other
+  )
+
+  val coadds: PioParse[CoAdds] = positiveShort.map(CoAdds.fromShort.unsafeGet)
+
+  object Calibration {
+
+    val lamp: PioParse[GcalLamp] = {
+      import GcalArc._
+      import GcalContinuum._
+
+      val lampToContinuum = Map[String, GcalContinuum](
+        "IR grey body - high" -> IrGreyBodyHigh,
+        "IR grey body - low"  -> IrGreyBodyLow,
+        "Quartz Halogen"      -> QuartzHalogen
+      ).lift
+
+      val lampToArc       = Map[String, GcalArc](
+        "Ar arc"              -> ArArc,
+        "CuAr arc"            -> CuArArc,
+        "ThAr arc"            -> ThArArc,
+        "Xe arc"              -> XeArc
+      ).lift
+
+      PioParse(lamps => {
+        val (continuum, arc) = ((List.empty[GcalContinuum], List.empty[GcalArc])/:lamps.split(',')) {
+          case ((cs,as), s) =>
+            val cs2 = lampToContinuum(s).fold(cs) { _ :: cs }
+            val as2 = lampToArc(s).fold(as) { _ :: as }
+            (cs2, as2)
+        }
+        GcalLamp.fromConfig(continuum.headOption, arc.tupleRight(true): _*)
+      })
+    }
+
+    val filter: PioParse[GcalFilter] = enum(
+      "none"         -> GcalFilter.None,
+      "ND1.0"        -> GcalFilter.Nd10,
+      "ND1.6"        -> GcalFilter.Nd16,
+      "ND2.0"        -> GcalFilter.Nd20,
+      "ND3.0"        -> GcalFilter.Nd30,
+      "ND4.0"        -> GcalFilter.Nd40,
+      "ND4-5"        -> GcalFilter.Nd45,
+      "ND5.0"        -> GcalFilter.Nd50,
+      "GMOS balance" -> GcalFilter.Gmos,
+      "HROS balance" -> GcalFilter.Hros,
+      "NIR balance"  -> GcalFilter.Nir
+    )
+
+    val diffuser: PioParse[GcalDiffuser] = enum(
+      "IR"      -> GcalDiffuser.Ir,
+      "visible" -> GcalDiffuser.Visible
+    )
+
+    val shutter: PioParse[GcalShutter] = enum(
+      "Closed" -> GcalShutter.Closed,
+      "Open"   -> GcalShutter.Open
+    )
+
+    val baseline: PioParse[GcalBaselineType] = enum(
+      "DAY"   -> GcalBaselineType.Day,
+      "NIGHT" -> GcalBaselineType.Night
+    )
+  }
+
+  object Flamingos2 {
+
+    import F2Disperser._
+
+    val disperser: PioParse[Option[F2Disperser]] = enum(
+      "NONE"    -> None,
+      "R1200HK" -> Some(R1200HK),
+      "R1200JH" -> Some(R1200JH),
+      "R3000"   -> Some(R3000)
+    )
+
+
+    import F2Filter._
+
+    val filter: PioParse[F2Filter] = enum(
+      "OPEN"    -> Open,
+      "DARK"    -> Dark,
+      "F1056"   -> F1056,
+      "F1063"   -> F1063,
+      "H"       -> H,
+      "HK"      -> HK,
+      "J"       -> J,
+      "J_LOW"   -> JLow,
+      "JH"      -> JH,
+      "K_LONG"  -> KLong,
+      "K_SHORT" -> KShort,
+      "K_BLUE"  -> KBlue,
+      "K_RED"   -> KRed,
+      "Y"       -> Y
+    )
+
+    import F2Fpu._
+    import gem.config.F2Config.F2FpuChoice
+    import gem.config.F2Config.F2FpuChoice.{ Builtin, Custom }
+
+    val fpu: PioParse[Option[F2FpuChoice]] = enum(
+      "PINHOLE"         -> Some(Builtin(Pinhole)),
+      "SUBPIX_PINHOLE"  -> Some(Builtin(SubPixPinhole)),
+      "FPU_NONE"        -> None,
+      "CUSTOM_MASK"     -> Some(Custom),
+      "LONGSLIT_1"      -> Some(Builtin(LongSlit1)),
+      "LONGSLIT_2"      -> Some(Builtin(LongSlit2)),
+      "LONGSLIT_3"      -> Some(Builtin(LongSlit3)),
+      "LONGSLIT_4"      -> Some(Builtin(LongSlit4)),
+      "LONGSLIT_6"      -> Some(Builtin(LongSlit6)),
+      "LONGSLIT_8"      -> Some(Builtin(LongSlit8))
+    )
+
+    import F2LyotWheel._
+
+    val lyotWheel: PioParse[F2LyotWheel] = enum(
+      "GEMS"       -> F33Gems,
+      "GEMS_OVER"  -> GemsUnder,
+      "GEMS_UNDER" -> GemsOver,
+      "H1"         -> HartmannA,
+      "H2"         -> HartmannB,
+      "HIGH"       -> F32High,
+      "LOW"        -> F32Low,
+      "OPEN"       -> F16
+    )
+
+    import F2ReadMode._
+    val readMode: PioParse[F2ReadMode] = enum(
+      "BRIGHT_OBJECT_SPEC" -> Bright,
+      "MEDIUM_OBJECT_SPEC" -> Medium,
+      "FAINT_OBJECT_SPEC"  -> Faint
+    )
+
+    val windowCover: PioParse[F2WindowCover] = enum(
+      "CLOSE" -> F2WindowCover.Close,
+      "OPEN"  -> F2WindowCover.Open
+    )
+  }
+
+
+  object Gmos {
+    import GmosAdc._
+
+    val adc: PioParse[Option[GmosAdc]] = enum(
+      "No Correction"          -> Option.empty[GmosAdc],
+      "Best Static Correction" -> Some(BestStatic),
+      "Follow During Exposure" -> Some(Follow)
+    )
+
+    import GmosAmpCount._
+
+    val ampCount: PioParse[GmosAmpCount] = enum(
+      "Three"  -> Three,
+      "Six"    -> Six,
+      "Twelve" -> Twelve
+    )
+
+    import GmosAmpGain._
+
+    val ampGain: PioParse[GmosAmpGain] = enum(
+      "Low"  -> Low,
+      "High" -> High
+    )
+
+    import GmosAmpReadMode._
+
+    val ampReadMode: PioParse[GmosAmpReadMode] = enum(
+      "Slow" -> Slow,
+      "Fast" -> Fast
+    )
+
+    import GmosCustomSlitWidth._
+
+    val customSlitWidth: PioParse[Option[GmosCustomSlitWidth]] = enum(
+      "OTHER"             -> Option.empty[GmosCustomSlitWidth],
+      "CUSTOM_WIDTH_0_25" -> Some(CustomWidth_0_25),
+      "CUSTOM_WIDTH_0_50" -> Some(CustomWidth_0_50),
+      "CUSTOM_WIDTH_0_75" -> Some(CustomWidth_0_75),
+      "CUSTOM_WIDTH_1_00" -> Some(CustomWidth_1_00),
+      "CUSTOM_WIDTH_1_50" -> Some(CustomWidth_1_50),
+      "CUSTOM_WIDTH_2_00" -> Some(CustomWidth_2_00),
+      "CUSTOM_WIDTH_5_00" -> Some(CustomWidth_5_00)
+    )
+
+    import GmosDetector._
+
+    val detector: PioParse[GmosDetector] = enum(
+      "E2V"       -> E2V,
+      "HAMAMATSU" -> HAMAMATSU
+    )
+
+    val disperserOrder: PioParse[GmosDisperserOrder] = enum(
+      "0" -> GmosDisperserOrder.Zero,
+      "1" -> GmosDisperserOrder.One,
+      "2" -> GmosDisperserOrder.Two
+    )
+
+    val disperserLambda: PioParse[Wavelength] =
+      double.map(d => Wavelength.fromAngstroms.unsafeGet((d * 10.0).round.toInt))
+
+    val dtax: PioParse[GmosDtax] = enum(
+      "-6" -> GmosDtax.MinusSix,
+      "-5" -> GmosDtax.MinusFive,
+      "-4" -> GmosDtax.MinusFour,
+      "-3" -> GmosDtax.MinusThree,
+      "-2" -> GmosDtax.MinusTwo,
+      "-1" -> GmosDtax.MinusOne,
+      "0"  -> GmosDtax.Zero,
+      "1"  -> GmosDtax.One,
+      "2"  -> GmosDtax.Two,
+      "3"  -> GmosDtax.Three,
+      "4"  -> GmosDtax.Four,
+      "5"  -> GmosDtax.Five,
+      "6"  -> GmosDtax.Six
+    )
+
+    val nsEOffsetting: PioParse[GmosEOffsetting] = enum(
+      "true"  -> GmosEOffsetting.On,
+      "false" -> GmosEOffsetting.Off
+    )
+
+    import gem.config.GmosConfig.GmosShuffleOffset
+
+    val nsShuffle: PioParse[GmosShuffleOffset] =
+      positiveInt.map(GmosShuffleOffset.unsafeFromRowCount)
+
+    import gem.config.GmosConfig.GmosShuffleCycles
+
+    val nsCycles: PioParse[GmosShuffleCycles] =
+      positiveInt.map(GmosShuffleCycles.unsafeFromCycleCount)
+
+    import GmosRoi._
+
+    val roi: PioParse[GmosRoi] = enum(
+      "Custom ROI"         -> Custom,
+      "Full Frame Readout" -> FullFrame,
+      "CCD 2"              -> Ccd2,
+      "Central Spectrum"   -> CentralSpectrum,
+      "Central Stamp"      -> CentralStamp,
+      "Top Spectrum"       -> TopSpectrum,
+      "Bottom Spectrum"    -> BottomSpectrum
+    )
+
+    val xBinning: PioParse[GmosXBinning] = enum(
+      "1" -> GmosXBinning.One,
+      "2" -> GmosXBinning.Two,
+      "4" -> GmosXBinning.Four
+    )
+
+    val yBinning: PioParse[GmosYBinning] = enum(
+      "1" -> GmosYBinning.One,
+      "2" -> GmosYBinning.Two,
+      "4" -> GmosYBinning.Four
+    )
+  }
+
+  object GmosNorth {
+    import GmosNorthDisperser._
+
+    val disperser: PioParse[Option[GmosNorthDisperser]] = enum(
+      "Mirror"      -> Option.empty[GmosNorthDisperser],
+      "B1200_G5301" -> Some(B1200_G5301),
+      "R831_G5302"  -> Some(R831_G5302 ),
+      "B600_G5303"  -> Some(B600_G5303 ),
+      "B600_G5307"  -> Some(B600_G5307 ),
+      "R600_G5304"  -> Some(R600_G5304 ),
+      "R400_G5305"  -> Some(R400_G5305 ),
+      "R150_G5306"  -> Some(R150_G5306 ),
+      "R150_G5308"  -> Some(R150_G5308 )
+    )
+
+    import GmosNorthFilter._
+
+    val filter: PioParse[Option[GmosNorthFilter]] = enum(
+      "None"                      -> Option.empty[GmosNorthFilter],
+      "g_G0301"                   -> Some(GPrime),
+      "r_G0303"                   -> Some(RPrime),
+      "i_G0302"                   -> Some(IPrime),
+      "z_G0304"                   -> Some(ZPrime),
+      "Z_G0322"                   -> Some(Z),
+      "Y_G0323"                   -> Some(Y),
+      "GG455_G0305"               -> Some(GG455),
+      "OG515_G0306"               -> Some(OG515),
+      "RG610_G0307"               -> Some(RG610),
+      "CaT_G0309"                 -> Some(CaT),
+      "Ha_G0310"                  -> Some(Ha),
+      "HaC_G0311"                 -> Some(HaC),
+      "DS920_G0312"               -> Some(DS920),
+      "SII_G0317"                 -> Some(SII),
+      "OIII_G0318"                -> Some(OIII),
+      "OIIIC_G0319"               -> Some(OIIIC),
+      "HeII_G0320"                -> Some(HeII),
+      "HeIIC_G0321"               -> Some(HeIIC),
+      "HartmannA_G0313 + r_G0303" -> Some(HartmannA_RPrime),
+      "HartmannB_G0314 + r_G0303" -> Some(HartmannB_RPrime),
+      "g_G0301 + GG455_G0305"     -> Some(GPrime_GG455),
+      "g_G0301 + OG515_G0306"     -> Some(GPrime_OG515),
+      "r_G0303 + RG610_G0307"     -> Some(RPrime_RG610),
+      "i_G0302 + CaT_G0309"       -> Some(IPrime_CaT),
+      "z_G0304 + CaT_G0309"       -> Some(ZPrime_CaT),
+      "u_G0308"                   -> Some(UPrime)
+    )
+
+    import GmosNorthFpu._
+
+    val fpu: PioParse[Option[GmosNorthFpu]] = enum(
+      "None"                 -> Option.empty[GmosNorthFpu],
+      "Longslit 0.25 arcsec" -> Some(LongSlit_0_25),
+      "Longslit 0.50 arcsec" -> Some(LongSlit_0_50),
+      "Longslit 0.75 arcsec" -> Some(LongSlit_0_75),
+      "Longslit 1.00 arcsec" -> Some(LongSlit_1_00),
+      "Longslit 1.50 arcsec" -> Some(LongSlit_1_50),
+      "Longslit 2.00 arcsec" -> Some(LongSlit_2_00),
+      "Longslit 5.00 arcsec" -> Some(LongSlit_5_00),
+      "IFU 2 Slits"          -> Some(Ifu1),
+      "IFU Left Slit (blue)" -> Some(Ifu2),
+      "IFU Right Slit (red)" -> Some(Ifu3),
+      "N and S 0.25 arcsec"  -> Some(Ns0),
+      "N and S 0.50 arcsec"  -> Some(Ns1),
+      "N and S 0.75 arcsec"  -> Some(Ns2),
+      "N and S 1.00 arcsec"  -> Some(Ns3),
+      "N and S 1.50 arcsec"  -> Some(Ns4),
+      "N and S 2.00 arcsec"  -> Some(Ns5),
+      "Custom Mask"          -> Option.empty[GmosNorthFpu]
+    )
+
+    import GmosNorthStageMode._
+
+    val stageMode: PioParse[GmosNorthStageMode] = enum(
+      "Do Not Follow"        -> NoFollow,
+      "Follow in XYZ(focus)" -> FollowXyz,
+      "Follow in XY"         -> FollowXy,
+      "Follow in Z Only"     -> FollowZ
+    )
+  }
+
+  object GmosSouth {
+    import GmosSouthDisperser._
+
+    val disperser: PioParse[Option[GmosSouthDisperser]] = enum(
+      "Mirror"      -> Option.empty[GmosSouthDisperser],
+      "B1200_G5321" -> Some(B1200_G5321),
+      "R831_G5322"  -> Some(R831_G5322 ),
+      "B600_G5323"  -> Some(B600_G5323 ),
+      "R600_G5324"  -> Some(R600_G5324 ),
+      "R400_G5325"  -> Some(R400_G5325 ),
+      "R150_G5326"  -> Some(R150_G5326 )
+    )
+
+    import GmosSouthFilter._
+
+    val filter: PioParse[Option[GmosSouthFilter]] = enum(
+      "None"                      -> Option.empty[GmosSouthFilter],
+      "u_G0332"                   -> Some(UPrime),
+      "g_G0325"                   -> Some(GPrime),
+      "r_G0326"                   -> Some(RPrime),
+      "i_G0327"                   -> Some(IPrime),
+      "z_G0328"                   -> Some(ZPrime),
+      "Z_G0343"                   -> Some(Z),
+      "Y_G0344"                   -> Some(Y),
+      "GG455_G0329"               -> Some(GG455),
+      "OG515_G0330"               -> Some(OG515),
+      "RG610_G0331"               -> Some(RG610),
+      "RG780_G0334"               -> Some(RG780),
+      "CaT_G0333"                 -> Some(CaT),
+      "HartmannA_G0337 + r_G0326" -> Some(HartmannA_RPrime),
+      "HartmannB_G0338 + r_G0326" -> Some(HartmannB_RPrime),
+      "g_G0325 + GG455_G0329"     -> Some(GPrime_GG455),
+      "g_G0325 + OG515_G0330"     -> Some(GPrime_OG515),
+      "r_G0326 + RG610_G0331"     -> Some(RPrime_RG610),
+      "i_G0327 + RG780_G0334"     -> Some(IPrime_RG780),
+      "i_G0327 + CaT_G0333"       -> Some(IPrime_CaT),
+      "z_G0328 + CaT_G0333"       -> Some(ZPrime_CaT),
+      "Ha_G0336"                  -> Some(Ha),
+      "SII_G0335"                 -> Some(SII),
+      "HaC_G0337"                 -> Some(HaC),
+      "OIII_G0338"                -> Some(OIII),
+      "OIIIC_G0339"               -> Some(OIIIC),
+      "HeII_G0340"                -> Some(HeII),
+      "HeIIC_G0341"               -> Some(HeIIC),
+      "Lya395_G0342"              -> Some(Lya395)
+    )
+
+    import GmosSouthFpu._
+
+    val fpu: PioParse[Option[GmosSouthFpu]] = enum(
+      "None"                         -> Option.empty[GmosSouthFpu],
+      "Longslit 0.25 arcsec"         -> Some(LongSlit_0_25),
+      "Longslit 0.50 arcsec"         -> Some(LongSlit_0_50),
+      "Longslit 0.75 arcsec"         -> Some(LongSlit_0_75),
+      "Longslit 1.00 arcsec"         -> Some(LongSlit_1_00),
+      "Longslit 1.50 arcsec"         -> Some(LongSlit_1_50),
+      "Longslit 2.00 arcsec"         -> Some(LongSlit_2_00),
+      "Longslit 5.00 arcsec"         -> Some(LongSlit_5_00),
+      "IFU 2 Slits"                  -> Some(Ifu1),
+      "IFU Left Slit (blue)"         -> Some(Ifu2),
+      "IFU Right Slit (red)"         -> Some(Ifu3),
+      "bHROS"                        -> Some(Bhros),
+      "IFU N and S 2 Slits"          -> Some(IfuN),
+      "IFU N and S Left Slit (blue)" -> Some(IfuNB),
+      "IFU N and S Right Slit (red)" -> Some(IfuNR),
+      "N and S 0.50 arcsec"          -> Some(Ns1),
+      "N and S 0.75 arcsec"          -> Some(Ns2),
+      "N and S 1.00 arcsec"          -> Some(Ns3),
+      "N and S 1.50 arcsec"          -> Some(Ns4),
+      "N and S 2.00 arcsec"          -> Some(Ns5),
+      "Custom Mask"                  -> Option.empty[GmosSouthFpu]
+    )
+
+    import GmosSouthStageMode._
+
+    val stageMode: PioParse[GmosSouthStageMode] = enum(
+      "Do Not Follow"        -> NoFollow,
+      "Follow in XYZ(focus)" -> FollowXyz,
+      "Follow in XY"         -> FollowXy,
+      "Follow in Z Only"     -> FollowZ
+    )
+  }
+
+  object Gnirs {
+
+    val acquisitionMirror: PioParse[GnirsAcquisitionMirror] = {
+
+      import GnirsAcquisitionMirror._
+
+      enum(
+        "in"  -> In,
+        "out" -> Out
+      )
+    }
+
+    val camera: PioParse[GnirsCamera] = {
+
+      import GnirsCamera._
+
+      enum(
+        "short blue" -> ShortBlue,
+        "long blue"  -> LongBlue,
+        "short red"  -> ShortRed,
+        "long red"   -> LongRed
+      )
+    }
+
+    val decker: PioParse[GnirsDecker] = {
+
+      import GnirsDecker._
+
+      enum(
+        "acquisition"            -> Acquisition,
+        "pupil viewer"           -> PupilViewer,
+        "short camera long slit" -> ShortCamLongSlit,
+        "short camera x-disp"    -> ShortCamCrossDispersed,
+        "long camera x-disp"     -> LongCamCrossDispersed,
+        "IFU"                    -> Ifu,
+        "long camera long slit"  -> LongCamLongSlit,
+        "wollaston"              -> Wollaston
+      )
+
+    }
+
+    val disperser: PioParse[GnirsDisperser] = {
+
+      import GnirsDisperser._
+
+      enum(
+        "10 l/mm grating"  -> D10,
+        "32 l/mm grating"  -> D32,
+        "111 l/mm grating" -> D111
+      )
+
+    }
+
+    val filter: PioParse[GnirsFilter] = {
+
+      import GnirsFilter._
+
+      enum(
+        "x-dispersed" -> CrossDispersed,
+        "order 6 (X)" -> Order6,
+        "order 5 (J)" -> Order5,
+        "order 4 (H)" -> Order4,
+        "order 3 (K)" -> Order3,
+        "order 2 (L)" -> Order2,
+        "order 1 (M)" -> Order1,
+        "H2: 2.12um"  -> H2,
+        "H + ND100X"  -> HNd100x,
+        "H2 + ND100X" -> H2Nd100x,
+        "PAH: 3.3um"  -> PAH,
+        "Y: 1.03um"   -> Y,
+        "J: 1.25um"   -> J,
+        "K: 2.20um"   -> K
+      )
+
+    }
+
+    val fpu: PioParse[Either[GnirsFpuOther, GnirsFpuSlit]] = {
+
+      import GnirsFpuSlit._
+      import GnirsFpuOther._
+
+      enum(
+        "0.10 arcsec"  -> Right(LongSlit_0_10),
+        "0.15 arcsec"  -> Right(LongSlit_0_15),
+        "0.20 arcsec"  -> Right(LongSlit_0_20),
+        "0.30 arcsec"  -> Right(LongSlit_0_30),
+        "0.45 arcsec"  -> Right(LongSlit_0_45),
+        "0.675 arcsec" -> Right(LongSlit_0_675),
+        "1.0 arcsec"   -> Right(LongSlit_1_00),
+        "3.0 arcsec"   -> Right(LongSlit_3_00),
+        "IFU"          -> Left(Ifu),
+        "acquisition"  -> Left(Acquisition),
+        "pupil viewer" -> Left(PupilViewer),
+        "pinhole 0.1"  -> Left(Pinhole1),
+        "pinhole 0.3"  -> Left(Pinhole3)
+      )
+
+    }
+
+    val prism: PioParse[GnirsPrism] = {
+
+      import GnirsPrism._
+
+      enum(
+        "No"  -> Mirror,
+        "SXD" -> Sxd,
+        "LXD" -> Lxd
+      )
+
+    }
+
+    val readMode: PioParse[GnirsReadMode] = {
+
+      import GnirsReadMode._
+
+      enum(
+        "Very Bright/Acq./High Bckgrd." -> VeryBright,
+        "Bright Objects"                -> Bright,
+        "Faint Objects"                 -> Faint,
+        "Very Faint Objects"            -> VeryFaint
+      )
+
+    }
+
+    val centralWavelength: PioParse[Wavelength] = {
+      bigDecimal.map(w =>
+        Wavelength.fromAngstroms.unsafeGet(
+          w.underlying.movePointRight(4).intValue
+        )
+      )
+    }
+
+
+    val wellDepth: PioParse[GnirsWellDepth] = {
+
+      import GnirsWellDepth._
+
+      enum(
+        "SHALLOW" -> Shallow,
+        "DEEP"    -> Deep
+      )
+
+    }
+
+    object SmartGcal {
+
+      val mode: PioParse[GnirsAcquisitionMirror] = {
+
+        import GnirsAcquisitionMirror._
+
+        enum(
+          "IMAGING"      -> In,
+          "SPECTROSCOPY" -> Out
+        )
+
+      }
+
+      val pixelScale: PioParse[GnirsPixelScale] = {
+
+        import GnirsPixelScale._
+
+        enum(
+          "0.05\"/pix" -> PixelScale_0_05,
+          "0.15\"/pix" -> PixelScale_0_15
+        )
+
+      }
+
+    }
+
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
@@ -1,0 +1,193 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.implicits._
+import gem._
+import gem.config._
+import gem.enum._
+import gem.math.Offset
+import gem.ocs2.pio._
+
+import java.time.Duration
+
+import scala.xml.Node
+
+/** Decoder for the OCS2 sequence XML.
+  */
+object SequenceDecoder extends PioDecoder[List[Step]] {
+
+  def decode(n: Node): Either[PioError, List[Step]] =
+    (n \ "step").toList.scanLeft(EmptyConfigMap) { (m, stepNode) =>
+      stepNode.addStepConfig(m)
+    }.drop(1).traverse(parseStep)
+
+  private def parseStep(cm: ConfigMap): Either[PioError, Step] = {
+    def go(observeType: String, dc: DynamicConfig): Either[PioError, Step] =
+      observeType match {
+        case "BIAS" =>
+          dc.toStep(Step.Base.Bias).asRight
+
+        case "DARK" =>
+          dc.toStep(Step.Base.Dark).asRight
+
+        case "OBJECT" | "CAL" =>
+          for {
+            p <- Legacy.Telescope.P.cparseOrElse(cm, Offset.P.Zero)
+            q <- Legacy.Telescope.Q.cparseOrElse(cm, Offset.Q.Zero)
+          } yield dc.toStep(Step.Base.Science(TelescopeConfig(p, q)))
+
+        case "ARC" | "FLAT" =>
+          import Legacy.Calibration._
+          for {
+            l <- Lamp.parse(cm)
+            f <- Filter.parse(cm)
+            d <- Diffuser.parse(cm)
+            s <- Shutter.parse(cm)
+            e <- ExposureTime.parse(cm)
+            c <- CoAdds.parse(cm)
+          } yield dc.toStep(Step.Base.Gcal(GcalConfig(l, f, d, s, e, c)))
+
+        case x =>
+          PioError.parseError(x, "ObserveType").asLeft
+      }
+
+    for {
+      o <- Legacy.Observe.ObserveType.cparseOrElse(cm, "OBJECT")
+      i <- Legacy.Instrument.Instrument.parse(cm)
+      c <- parseInstConfig(i, cm)
+      s <- go(o, c)
+    } yield s
+  }
+
+  private def parseInstConfig(i: Instrument, cm: ConfigMap): Either[PioError, DynamicConfig] =
+    i match {
+      case Instrument.AcqCam     => DynamicConfig.AcqCam()  .asRight
+      case Instrument.Bhros      => DynamicConfig.Bhros()   .asRight
+
+      case Instrument.Flamingos2 => Flamingos2.parse(cm)
+      case Instrument.Ghost      => DynamicConfig.Ghost()   .asRight
+      case Instrument.GmosN      => Gmos.parseNorth(cm)
+      case Instrument.GmosS      => Gmos.parseSouth(cm)
+      case Instrument.Gnirs      => Gnirs.parse(cm)
+
+      case Instrument.Gpi        => DynamicConfig.Gpi()     .asRight
+      case Instrument.Gsaoi      => DynamicConfig.Gsaoi()   .asRight
+      case Instrument.Michelle   => DynamicConfig.Michelle().asRight
+      case Instrument.Nici       => DynamicConfig.Nici()    .asRight
+      case Instrument.Nifs       => DynamicConfig.Nifs()    .asRight
+      case Instrument.Niri       => DynamicConfig.Niri()    .asRight
+      case Instrument.Phoenix    => DynamicConfig.Phoenix() .asRight
+      case Instrument.Trecs      => DynamicConfig.Trecs()   .asRight
+      case Instrument.Visitor    => DynamicConfig.Visitor() .asRight
+    }
+
+  private object Flamingos2 {
+    def parse(cm: ConfigMap): Either[PioError, DynamicConfig] = {
+      import Legacy.Instrument.Flamingos2._
+      for {
+        d <- Disperser.parse(cm)
+        e <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Duration.ofMillis(0))
+        f <- Filter.parse(cm)
+        u <- Fpu.parse(cm)
+        l <- LyotWheel.parse(cm)
+        r <- ReadMode.parse(cm)
+        w <- WindowCover.cparseOrElse(cm, F2WindowCover.Close)
+      } yield DynamicConfig.Flamingos2(d, e, f, u, l, r, w)
+    }
+  }
+
+  private object Gmos {
+    import gem.config.GmosConfig.{ GmosCcdReadout, GmosCommonDynamicConfig, GmosCustomMask, GmosGrating }
+    import DynamicConfig.{ GmosN, GmosS }
+
+    def common(cm: ConfigMap): Either[PioError, GmosCommonDynamicConfig] = {
+      import Legacy.Instrument.Gmos._
+
+      for {
+        x  <- XBinning.parse(cm)
+        y  <- YBinning.parse(cm)
+        ac <- AmpCount.parse(cm)
+        ag <- AmpGain.parse(cm)
+        ar <- AmpReadMode.parse(cm)
+        dx <- Dtax.parse(cm)
+        e  <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Duration.ofMillis(0))
+        r  <- Roi.parse(cm)
+      } yield GmosCommonDynamicConfig(GmosCcdReadout(x, y, ac, ag, ar), dx, e, r)
+    }
+
+    def customMask(cm: ConfigMap): Either[PioError, Option[GmosCustomMask]] = {
+      import gem.ocs2.Legacy.Instrument.Gmos.{CustomMaskMdf, CustomSlitWidth}
+
+      (for {
+        f <- CustomMaskMdf.oparse(cm)
+        s <- PioOptional(CustomSlitWidth.parse(cm))
+      } yield GmosCustomMask(f, s)).value
+    }
+
+    def parseNorth(cm: ConfigMap): Either[PioError, DynamicConfig] = {
+      import Legacy.Instrument.Gmos._
+      import Legacy.Instrument.GmosNorth._
+
+      val grating: Either[PioError, Option[GmosGrating[GmosNorthDisperser]]] =
+        (for {
+          d <- PioOptional(Disperser.parse(cm))
+          o <- DisperserOrder.oparse(cm)
+          w <- DisperserLambda.oparse(cm)
+        } yield GmosGrating(d, o, w)).value
+
+      for {
+        c <- common(cm)
+        g <- grating
+        f <- Filter.parse(cm)
+        u <- Fpu.cparse(cm).map(_.flatten)
+        m <- customMask(cm)
+        fpu = u.map(_.asRight[GmosCustomMask]) orElse m.map(_.asLeft[GmosNorthFpu])
+      } yield GmosN(c, g, f, fpu)
+    }
+
+    def parseSouth(cm: ConfigMap): Either[PioError, DynamicConfig] = {
+      import Legacy.Instrument.Gmos._
+      import Legacy.Instrument.GmosSouth._
+
+      val grating: Either[PioError, Option[GmosGrating[GmosSouthDisperser]]] =
+        (for {
+          d <- PioOptional(Disperser.parse(cm))
+          o <- DisperserOrder.oparse(cm)
+          w <- DisperserLambda.oparse(cm)
+        } yield GmosGrating(d, o, w)).value
+
+      for {
+        c <- common(cm)
+        g <- grating
+        f <- Filter.parse(cm)
+        u <- Fpu.cparse(cm).map(_.flatten)
+        m <- customMask(cm)
+        fpu = u.map(_.asRight[GmosCustomMask]) orElse m.map(_.asLeft[GmosSouthFpu])
+      } yield GmosS(c, g, f, fpu)
+    }
+  }
+
+  private object Gnirs {
+    def parse(cm: ConfigMap): Either[PioError, DynamicConfig] = {
+      import Legacy.Instrument.Gnirs._
+      import gem.config.DynamicConfig.Gnirs.Default
+
+      for {
+        a <- AcquisitionMirror.parse(cm)
+        b <- Camera.parse(cm)
+        c <- CoAdds.parse(cm)
+        d <- Decker.cparseOrElse(cm, Default.decker)
+        e <- Disperser.parse(cm)
+        f <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Default.exposureTime)
+        g <- Filter.cparseOrElse(cm, Default.filter)
+        h <- Fpu.parse(cm)
+        i <- Prism.parse(cm)
+        j <- ReadMode.parse(cm)
+        k <- Wavelength.parse(cm)
+      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j, k)
+    }
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
@@ -1,0 +1,241 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.effect.IO
+import cats.implicits._
+import fs2.Stream
+import fs2.{io, text}
+import gem.Log
+import gem.config.GcalConfig
+import gem.config.SmartGcalKey
+import gem.dao.{DatabaseConfiguration, SmartGcalDao, UserDao}
+import gem.enum.{GcalBaselineType, GcalLampType}
+import gem.ocs2.pio.PioParse
+import gem.math.Wavelength
+
+import java.io.File
+import java.time.Duration
+import doobie._
+import doobie.implicits._
+
+import scala.reflect.runtime.universe._
+
+
+/** Importer for SmartGcal CSV files.  Note, these files use display values in
+  * some cases instead of the seqexec values since they were meant to be edited
+  * by science staff.
+  */
+object SmartGcalImporter extends DoobieClient {
+
+  private val xa = DatabaseConfiguration.forTesting.transactor[IO]
+
+  implicit class ParseOps(s: String) {
+    def parseAs[A: TypeTag](parse: PioParse[A]): A =
+      parse(s).getOrElse {
+        sys.error(s"Could not parse '$s' as ${typeOf[A]}")
+      }
+  }
+
+  // KeyParser accepts a list of String entries, parses the first n entries
+  // into a SmartGcalDefinitionKey and returns it along with the remaining
+  // entries.
+  type KeyParser[K]       = (List[String]) => (K, List[String])
+  type SmartGcalLine[K]   = (GcalLampType, GcalBaselineType, K, GcalConfig)
+  type SmartGcalWriter[K] = (Vector[SmartGcalLine[K]]) => Stream[ConnectionIO, Int]
+
+  // --------------------------------------------------------------------------
+  // Add your instruments here.
+  // --------------------------------------------------------------------------
+
+  def importAllInst: IO[Unit] = {
+    import SmartGcalDao._
+
+    for {
+      _ <- importInst("Flamingos2", parseF2,        dropIndexF2,        bulkInsertF2,        createIndexF2       )
+      _ <- importInst("GMOS-N",     parseGmosNorth, dropIndexGmosNorth, bulkInsertGmosNorth, createIndexGmosNorth)
+      _ <- importInst("GMOS-S",     parseGmosSouth, dropIndexGmosSouth, bulkInsertGmosSouth, createIndexGmosSouth)
+      _ <- importInst("GNIRS",      parseGnirs,     dropIndexGnirs,     bulkInsertGnirs,     createIndexGnirs)
+    } yield ()
+  }
+
+  def parseF2(input: List[String]): (SmartGcalKey.Flamingos2, List[String]) = {
+    import Parsers.Flamingos2._
+
+    val disperserS :: filterS :: fpuS :: gcal = input
+
+    val d = disperserS.parseAs(disperser)
+    val f = filterS   .parseAs(filter   )
+    val u = fpuS      .parseAs(fpu      ).flatMap(_.toBuiltin)
+
+    (SmartGcalKey.Flamingos2(d, f, u), gcal)
+  }
+
+  def parseGmosNorth(input: List[String]): (SmartGcalKey.GmosNorthDefinition, List[String]) = {
+    import Parsers.Gmos._
+    import Parsers.GmosNorth._
+
+    val disperserS :: filterS :: fpuS :: xBinS :: yBinS :: _ :: ampGainS :: wavelengthMinS :: wavelengthMaxS :: gcal = input
+
+    val d = disperserS.parseAs(disperser)
+    val f = filterS   .parseAs(filter   )
+    val u = fpuS      .parseAs(fpu)
+    val x = xBinS     .parseAs(xBinning)
+    val y = yBinS     .parseAs(yBinning)
+    val a = ampGainS  .parseAs(ampGain)
+
+    val c = SmartGcalKey.GmosCommon(d, f, u, x, y, a)
+
+    val wmin = wavelengthMinS.parseAs(Parsers.angstroms)
+    val wmax = parseMaxWavelength(wavelengthMaxS)
+
+    (SmartGcalKey.GmosDefinition(c, (wmin, wmax)), gcal)
+  }
+
+  def parseGmosSouth(input: List[String]): (SmartGcalKey.GmosSouthDefinition, List[String]) = {
+    import Parsers.Gmos._
+    import Parsers.GmosSouth._
+
+    val disperserS :: filterS :: fpuS :: xBinS :: yBinS :: _ :: ampGainS :: wavelengthMinS :: wavelengthMaxS :: gcal = input
+
+    val d = disperserS.parseAs(disperser)
+    val f = filterS   .parseAs(filter   )
+    val u = fpuS      .parseAs(fpu)
+    val x = xBinS     .parseAs(xBinning)
+    val y = yBinS     .parseAs(yBinning)
+    val a = ampGainS  .parseAs(ampGain)
+
+    val c = SmartGcalKey.GmosCommon(d, f, u, x, y, a)
+
+    val wmin = wavelengthMinS.parseAs(Parsers.angstroms)
+    val wmax = parseMaxWavelength(wavelengthMaxS)
+
+    (SmartGcalKey.GmosDefinition(c, (wmin, wmax)), gcal)
+  }
+
+  def parseGnirs(input: List[String]): (SmartGcalKey.GnirsDefinition, List[String]) = {
+    import Parsers.Gnirs._
+    import Parsers.Gnirs.SmartGcal
+
+    val modeS :: pixelScaleS :: disperserS :: crossDispersedS :: slitWidthS :: wellDepthS :: wavelengthMinS :: wavelengthMaxS :: gcal = input
+
+    val a = modeS          .parseAs(SmartGcal.mode)
+    val b = pixelScaleS    .parseAs(SmartGcal.pixelScale)
+    val c = disperserS     .parseAs(disperser)
+    val d = slitWidthS     .parseAs(fpu)
+    val e = crossDispersedS.parseAs(prism)
+    val f = wellDepthS     .parseAs(wellDepth)
+
+    val k = SmartGcalKey.Gnirs(a, b, c, d, e, f)
+
+    val wmin = wavelengthMinS.parseAs(Parsers.angstroms)
+    val wmax = parseMaxWavelength(wavelengthMaxS)
+
+    (SmartGcalKey.GnirsDefinition(k, (wmin, wmax)), gcal)
+
+  }
+
+  // -------------------------------------------------------------------------
+  // Implementation Details
+  // -------------------------------------------------------------------------
+
+  // Where to look for smart gcal csv files.
+  val dir: File = new File("smartgcal")
+
+  /** Obtains the file name to use for the given instrument name and lamp type.
+    *
+    * @param prefix file name prefix, which is extended with "_ARC.csv" and
+    *               "_FLAT.csv" to create the full file names.
+    * @param lampType flat or arc
+    * @return corresponding .csv file
+    */
+  def fileName(prefix: String, lampType: GcalLampType): String =
+    s"${prefix}_${lampType.tag.toUpperCase}.csv"
+
+  val checkSmartDir: IO[Unit] =
+    IO(dir.isDirectory).flatMap { b =>
+      IO(if (b) () else sys.error(
+        """
+          |** Root of project needs a "smartgcal/" dir with smart gcal config files in it.
+          |** Try ln -s /path/to/some/smart/gcal smartgcal
+          |** (for example ~/.ocs15/Gemini\ OT\ 2017A.1.1.1_mac/data/jsky.app.ot/smartgcal)
+        """.stripMargin))
+    }
+
+  /** Truncates all the smart gcal tables. */
+  val clean: ConnectionIO[Unit] =
+    sql"TRUNCATE gcal CASCADE".update.run.void
+
+  def parseMaxWavelength(s: String): Wavelength =
+    s match {
+      case "MAX" => Wavelength.Max
+      case _     => s.parseAs(Parsers.angstroms)
+    }
+
+  def parseGcal(input: List[String]): (GcalBaselineType, GcalConfig) = {
+    import Parsers.Calibration._
+
+    val _ :: filterS :: diffuserS :: lampS :: shutterS :: expS :: coaddsS :: baselineS :: Nil = input
+
+    val l = lampS.replaceAll(";", ",").parseAs(lamp)
+    val f = filterS  .parseAs(filter  )
+    val d = diffuserS.parseAs(diffuser)
+    val s = shutterS .parseAs(shutter )
+    val e = Duration.ofMillis(expS.parseAs(PioParse.long))
+    val c = coaddsS  .parseAs(Parsers.coadds)
+
+    val b = baselineS.parseAs(baseline)
+
+    (b, GcalConfig(l, f, d, s, e, c))
+  }
+
+
+  def parseLine[K](input: List[String], l: GcalLampType, parser: KeyParser[K]): SmartGcalLine[K] = {
+    val (k, r) = parser(input)
+    val (b, g) = parseGcal(r)
+    (l, b, k, g)
+  }
+
+  def importInst[K](instFilePrefix: String,
+                    parser:         KeyParser[K],
+                    unindexer:      ConnectionIO[Int],
+                    writer:         SmartGcalWriter[K],
+                    indexer:        ConnectionIO[Int]): IO[Unit] = {
+
+    def lines(l: GcalLampType): Stream[IO, SmartGcalLine[K]] =
+      io.file.readAll[IO](new File(dir, fileName(instFilePrefix, l)).toPath, 4096)
+          .through(text.utf8Decode)
+          .through(text.lines)
+          .filter(_.trim.nonEmpty)
+          .map(_.split(',').map(_.trim).toList)
+          .map(parseLine(_, l, parser))
+
+    val prog = (lines(GcalLampType.Arc) ++ lines(GcalLampType.Flat))
+      .segmentN(4096)
+      .flatMap { v => writer(v.force.toVector).transact(xa) }
+
+    for {
+      _ <- IO(println(s"Importing $instFilePrefix ...")) // scalastyle:ignore
+      _ <- unindexer.transact(xa)
+      _ <- prog.compile.drain
+      _ <- indexer.transact(xa)
+    } yield ()
+  }
+
+  def runc: IO[Unit] =
+    for {
+      u <- UserDao.selectRootUser.transact(xa)
+      l <- Log.newLog[IO]("smartgcal importer", xa)
+      _ <- checkSmartDir
+      _ <- configureLogging[IO]
+      _ <- clean.transact(xa)
+      _ <- importAllInst
+      _ <- l.shutdown(5 * 1000)
+      _ <- IO(println("Done.")) // scalastyle:ignore
+    } yield ()
+
+  def main(args: Array[String]): Unit =
+    runc.unsafeRunSync
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/StaticDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/StaticDecoder.scala
@@ -1,0 +1,113 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.implicits._
+
+import gem.config._
+import gem.enum._
+import gem.math.Offset
+import gem.ocs2.pio._
+import gem.ocs2.pio.PioError.missingKey
+
+import scala.xml.Node
+
+/** Decoder for the OCS2 static configuration XML.
+  */
+object StaticDecoder extends PioDecoder[StaticConfig] {
+
+  def decode(n: Node): Either[PioError, StaticConfig] =
+    for {
+      cm <- ((n \ "step").headOption toRight missingKey("step")).map(_.toStepConfig)
+      i  <- Legacy.Instrument.Instrument.parse(cm)
+      sc <- parseStaticConfig(i, cm)
+    } yield sc
+
+
+  private def parseStaticConfig(i: Instrument, cm: ConfigMap): Either[PioError, StaticConfig] =
+    i match {
+      case Instrument.AcqCam     => StaticConfig.AcqCam()  .asRight
+      case Instrument.Bhros      => StaticConfig.Bhros()   .asRight
+
+      case Instrument.Flamingos2 => Flamingos2.parse(cm)
+      case Instrument.Ghost      => StaticConfig.Ghost()   .asRight
+      case Instrument.GmosN      => Gmos.parseNorth(cm)
+      case Instrument.GmosS      => Gmos.parseSouth(cm)
+      case Instrument.Gnirs      => Gnirs.parse(cm)
+
+      case Instrument.Gpi        => StaticConfig.Gpi()     .asRight
+      case Instrument.Gsaoi      => StaticConfig.Gsaoi()   .asRight
+      case Instrument.Michelle   => StaticConfig.Michelle().asRight
+      case Instrument.Nici       => StaticConfig.Nici()    .asRight
+      case Instrument.Nifs       => StaticConfig.Nifs()    .asRight
+      case Instrument.Niri       => StaticConfig.Niri()    .asRight
+      case Instrument.Phoenix    => StaticConfig.Phoenix() .asRight
+      case Instrument.Trecs      => StaticConfig.Trecs()   .asRight
+      case Instrument.Visitor    => StaticConfig.Visitor() .asRight
+    }
+
+  private object Flamingos2 {
+    def parse(cm: ConfigMap): Either[PioError, StaticConfig] =
+      Legacy.Instrument.MosPreImaging.parse(cm).map(StaticConfig.Flamingos2(_))
+  }
+
+  private object Gmos {
+    import gem.config.GmosConfig.{ GmosCommonStaticConfig, GmosCustomRoiEntry, GmosNodAndShuffle }
+    import StaticConfig.{ GmosN, GmosS }
+
+    def parseCustomRoiEntry(cm: ConfigMap, index: Int): Either[PioError, Option[GmosCustomRoiEntry]] = {
+      import Legacy.Instrument.Gmos._
+
+      (for {
+        xMin <- roiXMin(index).oparse(cm)
+        yMin <- roiYMin(index).oparse(cm)
+        xRng <- roiXRange(index).oparse(cm)
+        yRng <- roiYRange(index).oparse(cm)
+      } yield GmosCustomRoiEntry.unsafeFromDescription(xMin, yMin, xRng, yRng)).value
+    }
+
+    def parseCustomRoiEntries(cm: ConfigMap): Either[PioError, Set[GmosCustomRoiEntry]] =
+      (1 to 5).toList.traverse(parseCustomRoiEntry(cm, _)).map(_.flatMap(_.toList).toSet)
+
+    def parseNodAndShuffle(cm: ConfigMap): Either[PioError, Option[GmosNodAndShuffle]] = {
+      import Legacy.Instrument.Gmos._
+
+      (for {
+        ap <- NsBeamAp.oparse(cm)
+        aq <- NsBeamAq.oparse(cm)
+        bp <- NsBeamBp.oparse(cm)
+        bq <- NsBeamBq.oparse(cm)
+        eo <- EOffsetting.oparse(cm)
+        sf <- NsShuffle.oparse(cm)
+        cy <- NsCycles.oparse(cm)
+      } yield GmosNodAndShuffle(Offset(ap, aq), Offset(bp, bq), eo, sf, cy)).value
+    }
+
+    def parseCommonStatic(cm: ConfigMap): Either[PioError, GmosCommonStaticConfig] =
+      for {
+        d <- Legacy.Instrument.Gmos.Detector.parse(cm)
+        m <- Legacy.Instrument.MosPreImaging.parse(cm)
+        n <- parseNodAndShuffle(cm)
+        r <- parseCustomRoiEntries(cm)
+      } yield GmosCommonStaticConfig(d, m, n, r)
+
+    def parseNorth(cm: ConfigMap): Either[PioError, StaticConfig] =
+      for {
+        c <- parseCommonStatic(cm)
+        s <- Legacy.Instrument.GmosNorth.StageMode.parse(cm)
+      } yield GmosN(c, s)
+
+    def parseSouth(cm: ConfigMap): Either[PioError, StaticConfig] =
+      for {
+        c <- parseCommonStatic(cm)
+        s <- Legacy.Instrument.GmosSouth.StageMode.parse(cm)
+      } yield GmosS(c, s)
+  }
+
+  private object Gnirs {
+    def parse(cm: ConfigMap): Either[PioError, StaticConfig] =
+      Legacy.Instrument.Gnirs.WellDepth.parse(cm).map(StaticConfig.Gnirs(_))
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/package.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/package.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import scala.collection.immutable.TreeMap
+import scala.xml.Node
+
+package object ocs2 {
+  type ConfigMap = TreeMap[String, String]
+
+  val EmptyConfigMap: TreeMap[String, String] =
+    TreeMap.empty
+
+  /** Adds support for parsing steps into ConfigMap.  This is required by the
+    * SequenceDecoder and the StaticDecoder.
+    */
+  implicit class StepNodeOps(step: Node) {
+
+    /** Adds the configuration contained in this step node to the given
+      * ConfigMap, updating any values there as necessary.
+      */
+    def addStepConfig(cm: ConfigMap): ConfigMap = {
+      def addSysConfig(cm: ConfigMap, sys: Node): ConfigMap = {
+        val sysName = (sys \ "@name").text
+
+        (sys \ "param").foldLeft(cm) { (map, param) =>
+          val paramName  = (param \ "@name" ).text
+          val paramValue = (param \ "@value").text
+          map + (s"$sysName:$paramName" -> paramValue)
+        }
+      }
+
+      (step \ "system").foldLeft(cm)(addSysConfig)
+    }
+
+    /** Creates a ConfigMap containing just the configuration at this step.
+      */
+    def toStepConfig: ConfigMap =
+      addStepConfig(EmptyConfigMap)
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioDecoder.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2.pio
+
+import cats.Functor
+import java.time.Instant
+import shapeless.Typeable
+import scala.xml.Node
+
+import PioError._
+
+/** Typeclass for decoders of PIO-ish XML exported from an OCS2 database.
+  */
+trait PioDecoder[A] {
+  def decode(n: Node): Either[PioError, A]
+}
+
+object PioDecoder {
+
+  // N.B. as of 2.12 we can also us this method to *construct* a decoder by passing a
+  // `Node => Either[PioError, A])` which conforms with SAM interface PioDecoder[A] (!)
+  def apply[A](implicit ev: PioDecoder[A]): PioDecoder[A] = ev
+
+  def enum[A: Typeable](m: (String, A)*): PioDecoder[A] =
+    fromParseFunction[A] { m.toMap.lift }
+
+  def fromParse[A: Typeable](parse: PioParse[A]): PioDecoder[A] =
+    fromParseFunction(parse.run)
+
+  def fromParseFunction[A](parse: String => Option[A])(implicit ev: Typeable[A]): PioDecoder[A] =
+    new PioDecoder[A] {
+      def decode(n: Node): Either[PioError, A] =
+        parse(n.text) toRight ParseError(n.text, ev.describe)
+    }
+
+  implicit val FunctorPioDecoder: Functor[PioDecoder] =
+    new Functor[PioDecoder] {
+      def map[A, B](da: PioDecoder[A])(f: A => B): PioDecoder[B] =
+        PioDecoder(n => da.decode(n).map(f))
+    }
+
+  implicit def decode2[A, B](implicit da: PioDecoder[A], db: PioDecoder[B]): PioDecoder[(A, B)] =
+    PioDecoder { n =>
+      for {
+        a <- da.decode(n)
+        b <- db.decode(n)
+      } yield (a, b)
+    }
+
+  implicit def decode3[A, B, C](implicit da: PioDecoder[A], db: PioDecoder[B], dc: PioDecoder[C]): PioDecoder[(A, B, C)] =
+    PioDecoder { n =>
+      for {
+        a <- da.decode(n)
+        b <- db.decode(n)
+        c <- dc.decode(n)
+      } yield (a, b, c)
+    }
+
+  implicit val DoubleDecoder: PioDecoder[Double]   = fromParse(PioParse.double )
+  implicit val StringDecoder: PioDecoder[String]   = fromParse(PioParse.string )
+  implicit val IntDecoder: PioDecoder[Int]         = fromParse(PioParse.int    )
+  implicit val LongDecoder: PioDecoder[Long]       = fromParse(PioParse.long   )
+  implicit val InstantDecoder: PioDecoder[Instant] = fromParse(PioParse.instant)
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioError.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioError.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2.pio
+
+sealed trait PioError extends Product with Serializable
+
+object PioError {
+  final case class MissingKey(name: String)                    extends PioError
+  final case class ParseError(value: String, dataType: String) extends PioError
+
+  def missingKey(name: String): PioError                    = MissingKey(name)
+  def parseError(value: String, dataType: String): PioError = ParseError(value, dataType)
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioParse.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioParse.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2.pio
+
+import gem.syntax.string._
+import gem.util.Enumerated
+
+import cats.Functor
+import cats.implicits._
+import java.time.{ Duration, Instant }
+
+final case class PioParse[A](run: String => Option[A]) {
+  def apply(s: String): Option[A] = run(s)
+}
+
+object PioParse {
+
+  implicit val FunctorPioParse: Functor[PioParse] =
+    new Functor[PioParse] {
+      def map[A, B](pa: PioParse[A])(f: A => B): PioParse[B] =
+        PioParse(pa.run andThen (_.map(f)))
+    }
+
+  def enum[A](dictionary: (String, A)*): PioParse[A] =
+    PioParse(dictionary.toMap.lift)
+
+  /** Builds a PioParse for an `Enumerated` instance, assuming that the enum
+    * tags will be used as the lookup keys.  In other words, this is an option
+    * for enumerations whose OCS2 export happen to match the new model enum
+    * tags.
+    */
+  def enumFromTag[A](as: List[A])(implicit ev: Enumerated[A]): PioParse[A] =
+    PioParse(as.map(a => ev.tag(a) -> a).toMap.lift)
+
+  // ********  Primitives
+
+  val bigDecimal: PioParse[BigDecimal] =
+    PioParse(_.parseBigDecimalOption)
+
+  val boolean: PioParse[Boolean] =
+    PioParse(_.parseBooleanOption)
+
+  val double: PioParse[Double] =
+    PioParse(_.parseDoubleOption)
+
+  val short: PioParse[Short] =
+    PioParse(_.parseShortOption)
+
+  val int: PioParse[Int] =
+    PioParse(_.parseIntOption)
+
+  val positiveInt: PioParse[Int] =
+    PioParse(_.parseIntOption.filter(_ > 0))
+
+  val positiveShort: PioParse[Short] =
+    PioParse(_.parseShortOption.filter(_ > 0))
+
+  val long: PioParse[Long] =
+    PioParse(_.parseLongOption)
+
+  val string: PioParse[String] =
+    PioParse(_.pure[Option])
+
+
+  // ********  Java
+
+  val instant: PioParse[Instant] =
+    long.map(Instant.ofEpochMilli)
+
+  val seconds: PioParse[Duration] =
+    double.map { d => Duration.ofMillis((d * 1000).round) }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioPath.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioPath.scala
@@ -1,0 +1,270 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2.pio
+
+import cats.Monoid
+import cats.implicits._
+import gem.ocs2.pio.PioError._
+
+import scala.xml.{Node, NodeSeq}
+
+/** PioPath provides a simplistic DSL for working with the OCS3 export format
+  * for OCS2 data. The language consists of an operator:
+  *
+  *  - `\!`  - required element
+  *  - `\?`  - optional element
+  *  - `\*`  - list of immediate child elements
+  *  - `\\*` - list of descendent elements
+  *
+  *  and a corresponding match string where the initial character is:
+  *
+  *  - '@' - attribute element
+  *  - '#' - `param` element with the given name
+  *  - '&' - `paramset` element with the given name
+  *  - ``  - (i.e., no special character) child element
+  *
+  * Example:
+  *
+  * {{{
+  *  (n \?  "instrument" \! "@type")
+  * }}}
+  *
+  * Node with an optional <instrument>` element that, if it exists, has a
+  * required "type" attribute.  When decoded, any path that included a `?`
+  * but not a `*` will produce an `Option` result.  Any path including a
+  * `*` will produce a `List`.
+  *
+  * If a required element is missing, the result will be `MissingKey`
+  * `PioError` when decoded.
+  */
+object PioPath {
+
+  implicit class NodeOps(n: Node) {
+    def decode[A](implicit ev: PioDecoder[A]): Either[PioError, A] =
+      ev.decode(n)
+
+    def attr(name: String): Option[Node] =
+      (n \ s"@$name").headOption
+
+    def name: Option[String] =
+      Some((n \ "@name").text).filterNot(_.isEmpty)
+
+    def value: Option[Node] =
+      (n \ "value").headOption orElse (n \ "@value").headOption
+
+    private def filterByName(ns: NodeSeq, name: String): List[Node] =
+      ns.filter(_.name.contains(name)).toList
+
+    private def lookupParamValues(ns: NodeSeq, name: String): List[Node] =
+      for {
+        p <- filterByName(ns, name)
+        v <- p.value.toList
+      } yield v
+
+    def param(name: String): Option[Node] =
+      lookupParamValues(n \ "param", name).headOption
+
+    def params(name: String): List[Node] =
+      lookupParamValues(n \ "param", name)
+
+    def deepParams(name: String): List[Node] =
+      lookupParamValues(n \\ "param", name)
+
+    def paramset(name: String): Option[Node] =
+      paramsets(name).headOption
+
+    def paramsets(name: String): List[Node] =
+      filterByName(n \ "paramset", name)
+
+    def deepParamsets(name: String): List[Node] =
+      filterByName(n \\ "paramset", name)
+
+    def toRequired: Required =
+      Required(EmptySearchPath, n.asRight)
+
+    private val root: Required = toRequired
+
+    def \!  (matchString: String): Required  = root \!  matchString
+    def \?  (matchString: String): Optional  = root \?  matchString
+    def \*  (matchString: String): Listing   = root \*  matchString
+    def \\* (matchString: String): Listing   = root \\* matchString
+  }
+
+  sealed trait SearchPath {
+    protected def append(symbol: String, matchString: String): SearchPath
+
+    def \!  (matchString: String): SearchPath = append("\\!",   matchString)
+    def \?  (matchString: String): SearchPath = append("\\?",   matchString)
+    def \*  (matchString: String): SearchPath = append("\\*",   matchString)
+    def \\* (matchString: String): SearchPath = append("\\\\*", matchString)
+
+    final override def toString: String =
+      this match {
+        case EmptySearchPath          => ""
+        case NonEmptySearchPath(path) => path
+      }
+
+  }
+
+  final case object EmptySearchPath extends SearchPath {
+    protected def append(symbol: String, matchString: String): SearchPath =
+      NonEmptySearchPath(s"$symbol $matchString")
+  }
+
+  final case class NonEmptySearchPath(path: String) extends SearchPath {
+    protected def append(symbol: String, matchString: String): SearchPath =
+      NonEmptySearchPath(s"$path $symbol $matchString")
+  }
+
+  trait Lookup {
+    def optional: Node => Option[Node]
+    def list:     Node => List[Node]
+    def deepList: Node => List[Node]
+  }
+
+  object Lookup {
+    def apply(s: String): Lookup =
+      s.splitAt(1) match {
+        case ("@", name) => Attr(name)
+        case ("#", name) => Param(name)
+        case ("&", name) => Paramset(name)
+        case _           => Child(s)
+      }
+  }
+
+  final case class Attr(name: String) extends Lookup {
+    def optional: Node => Option[Node] = _.attr(name)
+    def list:     Node => List[Node]   = _.child.toList.flatMap(_.attr(name).toList)
+    def deepList: Node => List[Node]   = _.descendant.toList.flatMap(_.attr(name).toList)
+  }
+
+  final case class Param(name: String) extends Lookup {
+    def optional: Node => Option[Node] = _.param(name)
+    def list:     Node => List[Node]   = _.params(name)
+    def deepList: Node => List[Node]   = _.deepParams(name)
+  }
+
+  final case class Paramset(name: String) extends Lookup {
+    def optional: Node => Option[Node] = _.paramset(name)
+    def list:     Node => List[Node]   = _.paramsets(name)
+    def deepList: Node => List[Node]   = _.deepParamsets(name)
+  }
+
+  final case class Child(name: String) extends Lookup {
+    def optional: Node => Option[Node] = n => (n \ name).headOption
+    def list:     Node => List[Node]   = n => (n \ name).toList
+    def deepList: Node => List[Node]   = n => (n \\ name).toList
+  }
+
+  final case class Required(path: SearchPath, node: Either[PioError, Node]) {
+
+    def decode[A](implicit ev: PioDecoder[A]): Either[PioError, A] =
+      node.flatMap(ev.decode)
+
+    def \! (matchString: String): Required = {
+      val pathʹ = path \! matchString
+      val nodeʹ = node.flatMap { n =>
+        Lookup(matchString).optional(n) toRight missingKey(pathʹ.toString)
+      }
+      Required(pathʹ, nodeʹ)
+    }
+
+    def \? (matchString: String): Optional = {
+      val pathʹ = path \? matchString
+      val nodeʹ = PioOptional(node.map(Lookup(matchString).optional))
+      Optional(pathʹ, nodeʹ)
+    }
+
+    def \* (matchString: String): Listing = {
+      val pathʹ = path \* matchString
+      val nodeʹ = node.map(Lookup(matchString).list)
+      Listing(pathʹ, nodeʹ)
+    }
+
+    def \\* (matchString: String): Listing = {
+      val pathʹ = path \\* matchString
+      val nodeʹ = node.map(Lookup(matchString).deepList)
+      Listing(pathʹ, nodeʹ)
+    }
+  }
+
+
+  final case class Optional(path: SearchPath, node: PioOptional[Node]) {
+
+    def decode[A](implicit ev: PioDecoder[A]): Either[PioError, Option[A]] =
+      node.semiflatMap(ev.decode).value
+
+    def decodeOrZero[A : PioDecoder : Monoid]: Either[PioError, A] =
+      decode[A].map { _.orEmpty }
+
+    def decodeOrElse[A](a: => A)(implicit ev: PioDecoder[A]): Either[PioError, A] =
+      decode[A].map { _.getOrElse(a) }
+
+    def \! (matchString: String): Optional = {
+      val pathʹ = path \! matchString
+      val nodeʹ = node.semiflatMap { n =>
+        Lookup(matchString).optional(n) toRight missingKey(pathʹ.toString)
+      }
+      Optional(pathʹ, nodeʹ)
+    }
+
+    def \? (matchString: String): Optional = {
+      val pathʹ = path \? matchString
+      val nodeʹ = node.flatMap { n =>
+        PioOptional.fromOption(Lookup(matchString).optional(n))
+      }
+      Optional(pathʹ, nodeʹ)
+    }
+
+    private def listing(f: Node => List[Node]): Either[PioError, List[Node]] =
+      node.value.map(_.toList.flatMap(f))
+
+    def \* (matchString: String): Listing = {
+      val pathʹ = path \* matchString
+      val nodeʹ = listing(Lookup(matchString).list)
+      Listing(pathʹ, nodeʹ)
+    }
+
+    def \\* (matchString: String): Listing = {
+      val pathʹ = path \\* matchString
+      val nodeʹ = listing(Lookup(matchString).deepList)
+      Listing(pathʹ, nodeʹ)
+    }
+  }
+
+
+  final case class Listing(path: SearchPath, node: Either[PioError, List[Node]]) {
+
+    def decode[A](implicit ev: PioDecoder[A]): Either[PioError, List[A]] =
+      node.flatMap { _.traverse(ev.decode) }
+
+    def \! (matchString: String): Listing = {
+      val pathʹ = path \! matchString
+      val f     = (n: Node) => Lookup(matchString).optional(n) toRight missingKey(pathʹ.toString)
+      val nodeʹ = node.flatMap { _.traverse(f) }
+      Listing(pathʹ, nodeʹ)
+    }
+
+    private def listing(f: Node => List[Node]): Either[PioError, List[Node]] =
+      node.map { _.flatMap(f) }
+
+    def \? (matchString: String): Listing = {
+      val pathʹ = path \? matchString
+      val nodeʹ = listing((n: Node) => Lookup(matchString).optional(n).toList)
+      Listing(pathʹ, nodeʹ)
+    }
+
+    def \* (matchString: String): Listing = {
+      val pathʹ = path \* matchString
+      val nodeʹ = listing(Lookup(matchString).list)
+      Listing(pathʹ, nodeʹ)
+    }
+
+    def \\* (matchString: String): Listing = {
+      val pathʹ = path \\* matchString
+      val nodeʹ = listing(Lookup(matchString).deepList)
+      Listing(pathʹ, nodeʹ)
+    }
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/package.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/package.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.data._, cats.implicits._
+
+package object pio {
+  type PioOptional[A] = OptionT[Either[PioError, ?], A]
+
+  object PioOptional {
+    def apply[A](a: Either[PioError, Option[A]]): PioOptional[A] =
+      OptionT[Either[PioError, ?], A](a)
+
+    def fromOption[A](oa: Option[A]): PioOptional[A] =
+      OptionT[Either[PioError, ?], A](oa.asRight)
+
+    def none[A]: PioOptional[A] =
+      OptionT.none[Either[PioError, ?], A]
+
+    def some[A](a: A): PioOptional[A] =
+      OptionT.some[Either[PioError, ?]](a)
+  }
+}

--- a/modules/ocs2/src/test/scala/gem/ocs2/TargetDecodersTest.scala
+++ b/modules/ocs2/src/test/scala/gem/ocs2/TargetDecodersTest.scala
@@ -1,0 +1,160 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import gem.{ EphemerisKey, Target }
+import gem.math._
+import gem.ocs2.Decoders._
+import gem.ocs2.pio._
+import gem.ocs2.pio.PioError.{ MissingKey, ParseError }
+
+import cats.tests.CatsSuite
+
+import scala.xml._
+
+// Basic sanity checks for target decoding
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals", "org.wartremover.warts.OptionPartial"))
+final class TargetDecodersTest extends CatsSuite {
+  import TargetDecodersTest._
+
+  test("Fully specified ProperMotion") {
+    PioDecoder[ProperMotion].decode(SiderealNode) match {
+      case Right(actual) => assert(actual == SiderealProperMotion)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+
+  test("Missing redshift") {
+    val xml = delete("redshift", SiderealNode)
+    val exp = SiderealProperMotion.copy(radialVelocity = None)
+    PioDecoder[ProperMotion].decode(xml) match {
+      case Right(actual) => assert(actual == exp)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+
+  test("Missing proper-motion") {
+    val xml = delete("proper-motion", SiderealNode)
+    val exp = SiderealProperMotion.copy(properVelocity = None)
+    PioDecoder[ProperMotion].decode(xml) match {
+      case Right(actual) => assert(actual == exp)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+
+  test("Missing delta-ra") {
+    val xml = delete("delta-ra", SiderealNode)
+    PioDecoder[ProperMotion].decode(xml) match {
+      case Left(MissingKey(m)) => assert(m.contains("delta-ra"))
+      case Right(_)            => fail("delta-ra is required if proper-motion is present")
+      case other               => fail(s"unexpected: $other")
+    }
+  }
+
+  test("Unexpected epoch year") {
+    val xml = setValue("epoch", "2017", SiderealNode)
+    PioDecoder[ProperMotion].decode(xml) match {
+      case Left(ParseError("2017", "Epoch")) => succeed
+      case Right(_)                          => fail("cannot handle epoch 2017")
+      case other                             => fail(s"unexpected: $other")
+    }
+  }
+
+  test("Sidereal target") {
+    PioDecoder[Target].decode(SiderealNode) match {
+      case Right(actual) => assert(actual == SiderealTarget)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+
+  test("Nonsidereal target") {
+    PioDecoder[Target].decode(NonsiderealNode) match {
+      case Right(actual) => assert(actual == NonsiderealTarget)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.OptionPartial"))
+object TargetDecodersTest {
+  val SiderealNode: Elem =
+    <paramset name="target">
+      <param name="name" value="Example"/>
+      <param name="redshift" value="4.0"/>
+      <param name="parallax" value="1.0"/>
+      <paramset name="magnitude">
+        <param name="value" value="17.0"/>
+        <param name="band" value="r"/>
+        <param name="system" value="AB"/>
+      </paramset>
+      <paramset name="coordinates">
+        <param name="ra" value="55.291666666666686"/>
+        <param name="dec" value="11.550000000000011"/>
+      </paramset>
+      <paramset name="proper-motion">
+        <param name="delta-ra" value="2.0"/>
+        <param name="delta-dec" value="3.0"/>
+        <param name="epoch" value="2000.0"/>
+      </paramset>
+      <param name="tag" value="sidereal"/>
+    </paramset>
+
+  val SiderealProperMotion: ProperMotion = {
+    val ra  = RightAscension.fromStringHMS.unsafeGet("03:41:10.000")
+    val dec = Declination.fromStringSignedDMS.unsafeGet("11:33:00.00")
+    val c   = Coordinates(ra, dec)
+
+    val off = Offset(
+                Offset.P(Angle.milliarcseconds.reverseGet(2)),
+                Offset.Q(Angle.milliarcseconds.reverseGet(3))
+              )
+
+    val rv  = RadialVelocity.fromRedshift(4.0)
+
+    val px  = Angle.milliarcseconds.reverseGet(1)
+
+    ProperMotion(c, Epoch.J2000, Some(off), Some(rv), Some(px))
+  }
+
+  val SiderealTarget: Target =
+    Target("Example", Right(SiderealProperMotion))
+
+  val NonsiderealNode: Elem =
+    <paramset name="target">
+      <param name="name" value="Oumuamua"/>
+      <paramset name="horizons-designation">
+        <param name="des" value="C/1937 P1"/>
+        <param name="tag" value="comet"/>
+      </paramset>
+      <param name="tag" value="nonsidereal"/>
+    </paramset>
+
+  val NonsiderealTarget: Target =
+    Target("Oumuamua", Left(EphemerisKey.Comet("C/1937 P1")))
+
+  // Deletes all instances of params and paramsets that have the given name.
+  private def delete(name: String, e: Elem): Elem = {
+    val children = e.child.filter(c => (c \ "@name").text != name)
+    e.copy(child = children.map {
+      case c: Elem => delete(name, c)
+      case other   => other
+    })
+  }
+
+  // Sets the value of a named "param" anywhere within the given element
+  private def setValue(name: String, value: String, e: Elem): Elem = {
+    val children = e.child.map {
+      case e: Elem if e.label == "param" && (e \ "@name").text == name =>
+          e.copy(attributes = new UnprefixedAttribute("name", name, new UnprefixedAttribute("value", value, Null)))
+
+      case otherChild: Elem =>
+        setValue(name, value, otherChild)
+
+      case otherNode        =>
+        otherNode
+    }
+    e.copy(child = children)
+  }
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client
 
 import diode.RootModelR
-import diode.data.{Empty, Pot, RefTo}
+import diode.data._
 import seqexec.model.UserDetails
 import seqexec.model.Model._
 import seqexec.model.events._
@@ -25,10 +25,15 @@ object model {
 
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
-  implicit def eqPot[A: Eq]: Eq[Pot[A]] = Eq.instance { (a, b) =>
-    if (a.nonEmpty && b.nonEmpty)
-      a.get  === b.get
-    else (a == b)
+  implicit def eqPot[A: Eq]: Eq[Pot[A]] = Eq.instance {
+    case (Empty, Empty)                           => true
+    case (Unavailable, Unavailable)               => true
+    case (Pending(a), Pending(b))                 => a === b
+    case (Ready(a), Ready(b))                     => a === b
+    case (PendingStale(a, b), PendingStale(c, d)) => a === c && b === d
+    case (Failed(a), Failed(b))                   => a == b
+    case (FailedStale(a, b), FailedStale(c, d))   => a === c && b == d
+    case _                                        => false
   }
 
   // Pages

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -64,14 +64,14 @@ trait ArbitrariesWebClient {
     Arbitrary(Gen.oneOf(Gen.const(Empty), Gen.const(Unavailable), arbitrary[A].map(Ready.apply), Gen.const(Pending()), arbitrary[A].map(PendingStale(_)), arbitrary[Throwable].map(Failed(_)), arbitrary[(A, Throwable)].map{ case (a, t) => FailedStale(a, t)}))
 
   implicit def potCogen[A: Cogen]: Cogen[Pot[A]] =
-    Cogen[Option[Option[Option[Either[A, Either[(A, Long), Either[Throwable, (A, Throwable)]]]]]]].contramap {
+    Cogen[Option[Option[Either[Long, Either[A, Either[(A, Long), Either[Throwable, (A, Throwable)]]]]]]].contramap {
       case Empty              => None
       case Unavailable        => Some(None)
-      case Pending(_)         => Some(Some(None))
-      case Ready(a)           => Some(Some(Some(Left(a))))
-      case PendingStale(a, l) => Some(Some(Some(Right(Left((a, l))))))
-      case Failed(t)          => Some(Some(Some(Right(Right(Left(t))))))
-      case FailedStale(a, t)  => Some(Some(Some(Right(Right(Right((a, t)))))))
+      case Pending(a)         => Some(Some(Left(a)))
+      case Ready(a)           => Some(Some(Right(Left(a))))
+      case PendingStale(a, l) => Some(Some(Right(Right(Left((a, l))))))
+      case Failed(t)          => Some(Some(Right(Right(Right(Left(t))))))
+      case FailedStale(a, t)  => Some(Some(Right(Right(Right(Right((a, t)))))))
     }
 
   implicit val arbWebSocketConnection: Arbitrary[WebSocketConnection] =

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -17,8 +17,8 @@ import diode.data._
 final class ModelSpec extends CatsSuite with ArbitrariesWebClient {
 
   checkAll("Eq[OffsetsDisplay]", EqTests[OffsetsDisplay].eqv)
-  checkAll("Eq[WebSocket]", EqTests[WebSocket].eqv)
+  // checkAll("Eq[WebSocket]", EqTests[WebSocket].eqv)
   checkAll("Eq[Pot[A]]", EqTests[Pot[Int]].eqv)
-  checkAll("Eq[WebSocketConnection]", EqTests[WebSocketConnection].eqv)
+  // checkAll("Eq[WebSocketConnection]", EqTests[WebSocketConnection].eqv)
   checkAll("Eq[ClientStatus]", EqTests[ClientStatus].eqv)
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -17,8 +17,8 @@ import diode.data._
 final class ModelSpec extends CatsSuite with ArbitrariesWebClient {
 
   checkAll("Eq[OffsetsDisplay]", EqTests[OffsetsDisplay].eqv)
-  // checkAll("Eq[WebSocket]", EqTests[WebSocket].eqv)
+  checkAll("Eq[WebSocket]", EqTests[WebSocket].eqv)
   checkAll("Eq[Pot[A]]", EqTests[Pot[Int]].eqv)
-  // checkAll("Eq[WebSocketConnection]", EqTests[WebSocketConnection].eqv)
+  checkAll("Eq[WebSocketConnection]", EqTests[WebSocketConnection].eqv)
   checkAll("Eq[ClientStatus]", EqTests[ClientStatus].eqv)
 }

--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -1,0 +1,124 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.implicits._
+import cats.effect._
+import cats.effect.implicits._
+import doobie._, doobie.implicits._
+import gem.dao._
+import gem.enum._
+import gem.horizons.EphemerisContext
+import gem.util.Timestamp
+import monocle.Lens
+
+import java.nio.file.Path
+
+
+final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], val log: Log[M], val user: User[ProgramRole]) {
+
+  /**
+   * Construct a program that yields a list of `(Program.Id, String)` whose name or id contains the
+   * given substring (case-insensitive), up to a provided maximum length.
+   */
+  def queryProgramsByName(substr: String, max: Int): M[List[(Program.Id, String)]] =
+    log.log(user, s"""queryProgramsByName("$substr", $max)""") {
+      ProgramDao.selectBySubstring(s"%$substr%", max).transact(xa)
+    }
+
+  /**
+   * Construct a program that attempts to change the user's password, yielding `true` on success.
+   */
+  def changePassword(oldPassword: String, newPassword: String): M[Boolean] =
+    log.log(user, "changePassword(***, ***)") {
+      UserDao.changePassword(user.id, oldPassword, newPassword).transact(xa)
+    }
+
+  object ephemeris {
+
+    private val exporter = new gem.horizons.tcs.TcsEphemerisExport(xa)
+    private val updater  = gem.horizons.HorizonsEphemerisUpdater(xa)
+
+    /** Constructs a program that writes an ephemeris file, returning the path
+      * of the file written.
+      */
+    def export(key: EphemerisKey, site: Site, start: Timestamp, end: Timestamp, dir: Path): M[Path] =
+      log.log(user, s"ephemeris.export($key, $site, $start, $end, $dir)") {
+        exporter.exportOne(key, site, start, end, dir).as(exporter.resolve(key, dir))
+      }
+
+    /** Constructs a program that obtains ephemeris context information. */
+    def report(key: EphemerisKey.Horizons, site: Site): M[EphemerisContext] =
+      log.log(user, s"ephemeris.status($key, $site)") {
+        updater.report(key, site)
+      }
+
+    /** Constructs a program that attempts to update ephemeris information,
+      * yielding ephemeris context.
+      */
+    def update(key: EphemerisKey.Horizons, site: Site): M[EphemerisContext] =
+      log.log(user, s"ephemeris.update($key, $site)") {
+        updater.update(key, site) *> updater.report(key, site)
+      }
+  }
+
+  object ocs2 {
+
+    import gem.ocs2.{ Importer, OdbClient }
+
+    /** Constructs a program that fetches the corresponding observation from the
+      * indicated ODB and then stores it in the database, replacing any
+      * existing observation with the same id.
+      */
+    def importObservation(host: String, oid: Observation.Id): M[Either[String, Unit]] =
+      log.log(user, s"ocs2.importObservation($host, $oid)") {
+        OdbClient.fetchObservation[IO](host, oid).liftIO[M].flatMap { _.traverse { case (o, ds) =>
+          Importer.importObservation(oid, o, ds).transact(xa)
+        }}
+      }
+
+    /** Constructs a program that fetches the corresponding science program from
+      * the indicated ODB and then stores it in the database, replacing any
+      * existing program with the same id.
+      */
+    def importProgram(host: String, pid: Program.Id): M[Either[String, Unit]] =
+      log.log(user, s"ocs2.importProgram($host, $pid") {
+        OdbClient.fetchProgram[IO](host, pid).liftIO[M].flatMap { _.traverse { case (p, ds) =>
+          Importer.importProgram(p, ds).transact(xa)
+        }}
+      }
+  }
+}
+
+object Service {
+
+  def user[M[_]: Sync: LiftIO]: Lens[Service[M], User[ProgramRole]] =
+    Lens[Service[M], User[ProgramRole]](_.user)(a => b => new Service(b.xa, b.log, a))
+
+  def apply[M[_]: Sync: LiftIO](xa: Transactor[M], log: Log[M], user: User[ProgramRole]): Service[M] =
+    new Service(xa, log, user)
+
+  /**
+   * Construct a program that verifies a user's id and password and returns a `Service`.
+   */
+  def tryLogin[M[_]: Sync: LiftIO](
+    user: User.Id, pass: String, xa: Transactor[M], log: Log[M]
+  ): M[Option[Service[M]]] =
+    xa.trans.apply(UserDao.selectUserʹ(user, pass)).map {
+      case None    => Option.empty[Service[M]]
+      case Some(u) => Some(Service[M](xa, log, u))
+    }
+
+  /**
+   * Like `tryLogin`, but for previously-authenticated users.
+   */
+  def service[M[_]: Sync: LiftIO](
+    user: User.Id, xa: Transactor[M], log: Log[M]
+  ): M[Option[Service[M]]] =
+    xa.trans.apply(UserDao.selectUser(user)).map {
+      case None    => Option.empty[Service[M]]
+      case Some(u) => Some(Service[M](xa, log, u))
+    }
+
+}

--- a/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
+++ b/modules/sql/src/main/resources/db/migration/V001__Initial_Setup.sql
@@ -1,0 +1,1195 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.5.4
+-- Dumped by pg_dump version 9.5.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner:
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner:
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
+-- Name: tsm_system_time; Type: EXTENSION; Schema: -; Owner:
+--
+
+CREATE EXTENSION IF NOT EXISTS tsm_system_time WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION tsm_system_time; Type: COMMENT; Schema: -; Owner:
+--
+
+COMMENT ON EXTENSION tsm_system_time IS 'TABLESAMPLE method which accepts time in milliseconds as a limit';
+
+
+SET search_path = public, pg_catalog;
+
+--
+-- Name: f2_decker; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE f2_decker AS ENUM (
+    'Imaging',
+    'Long Slit',
+    'MOS'
+);
+
+
+ALTER TYPE f2_decker OWNER TO postgres;
+
+--
+-- Name: identifier; Type: DOMAIN; Schema: public; Owner: postgres
+--
+
+CREATE DOMAIN identifier AS character varying(32)
+	CONSTRAINT identifier_check CHECK (((VALUE)::text ~ '^[A-Z][A-Za-z0-9_]*$'::text));
+
+
+ALTER DOMAIN identifier OWNER TO postgres;
+
+
+--
+-- Name: coadds; Type: DOMAIN; Schema: public; Owner: postgres
+--
+
+CREATE DOMAIN coadds AS smallint
+    DEFAULT    1
+    CONSTRAINT coadds_check CHECK (VALUE > 0);
+
+ALTER DOMAIN coadds OWNER TO postgres;
+
+
+--
+-- Name: milliseconds; Type: DOMAIN; Schema: public; Owner: postgres
+--
+
+CREATE DOMAIN milliseconds AS integer
+    DEFAULT    0
+    CONSTRAINT miliseconds_check CHECK (VALUE >= 0);
+
+ALTER DOMAIN milliseconds OWNER TO postgres;
+
+
+--
+-- Name: index; Type: DOMAIN; Schema: public; Owner: postgres
+--
+
+CREATE DOMAIN id_index AS smallint
+    DEFAULT    1
+    CONSTRAINT id_index_check CHECK (VALUE > 0);
+
+ALTER DOMAIN id_index OWNER TO postgres;
+
+
+--
+-- Name: log_level; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE log_level AS ENUM (
+    'FINEST',
+    'FINER',
+    'FINE',
+    'CONFIG',
+    'INFO',
+    'WARNING',
+    'SEVERE'
+);
+
+
+ALTER TYPE log_level OWNER TO postgres;
+
+--
+-- Name: step_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE step_type AS ENUM (
+    'Bias',
+    'Dark',
+    'Gcal',
+    'Science',
+    'SmartGcal'
+);
+
+
+ALTER TYPE step_type OWNER TO postgres;
+
+--
+-- Name: smart_gcal_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE smart_gcal_type AS ENUM (
+    'Arc',
+    'Flat',
+    'DayBaseline',
+    'NightBaseline'
+);
+
+ALTER TYPE smart_gcal_type OWNER TO postgres;
+
+
+--
+-- Name: target_type; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE target_type AS ENUM (
+    'sidereal',
+    'nonsidereal'
+);
+
+
+ALTER TYPE target_type OWNER TO postgres;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: e_f2_disperser; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_f2_disperser (
+    id          identifier            PRIMARY KEY,
+    wavelength  double precision,
+    short_name  character varying(20) NOT NULL,
+    long_name   character varying(64) NOT NULL
+);
+
+
+ALTER TABLE e_f2_disperser OWNER TO postgres;
+
+--
+-- Name: e_f2_filter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_f2_filter (
+    id         identifier            PRIMARY KEY,
+    wavelength double precision,
+    short_name character varying(20) NOT NULL,
+    long_name  character varying(20) NOT NULL,
+    obsolete   boolean               NOT NULL
+);
+
+
+ALTER TABLE e_f2_filter OWNER TO postgres;
+
+--
+-- Name: e_f2_fpunit; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_f2_fpunit (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(20) NOT NULL,
+    slit_width smallint              NOT NULL,
+    decker     f2_decker             NOT NULL,
+    long_name  character varying(20) NOT NULL,
+    obsolete   boolean               NOT NULL
+);
+
+
+ALTER TABLE e_f2_fpunit OWNER TO postgres;
+
+--
+-- Name: e_f2_lyot_wheel; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_f2_lyot_wheel (
+    id          identifier            PRIMARY KEY,
+    short_name  character varying(20) NOT NULL,
+    plate_scale double precision      NOT NULL,
+    pixel_scale double precision      NOT NULL,
+    obsolete    boolean               NOT NULL,
+    long_name   character varying(32) NOT NULL
+);
+
+
+ALTER TABLE e_f2_lyot_wheel OWNER TO postgres;
+
+
+--
+-- Name: e_f2_read_mode; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_f2_read_mode (
+    id                        identifier            PRIMARY KEY,
+    short_name                character varying(8)  NOT NULL,
+    long_name                 character varying(20) NOT NULL,
+    description               character varying(20) NOT NULL,
+    minimum_exposure_time     milliseconds          NOT NULL,
+    recommended_exposure_time milliseconds          NOT NULL,
+    readout_time              milliseconds          NOT NULL,
+    read_count                smallint              NOT NULL,
+    read_noise                double precision      NOT NULL
+);
+
+
+ALTER TABLE e_f2_read_mode OWNER TO postgres;
+
+
+--
+-- Name: e_f2_window_cover; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_f2_window_cover (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(20) NOT NULL,
+    long_name  character varying(20) NOT NULL
+);
+
+
+ALTER TABLE e_f2_window_cover OWNER TO postgres;
+
+--
+-- Name: e_gcal_filter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gcal_filter (
+    id         character varying(20) PRIMARY KEY,
+    short_name character varying(20) NOT NULL,
+    obsolete   boolean               NOT NULL,
+    long_name  character varying(20) NOT NULL
+);
+
+
+ALTER TABLE e_gcal_filter OWNER TO postgres;
+
+--
+-- Name: e_gcal_continuum; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gcal_continuum (
+    id         character varying(20) PRIMARY KEY,
+    short_name character varying(20) NOT NULL,
+    long_name  character varying(20) NOT NULL,
+    obsolete   boolean               NOT NULL
+);
+
+
+ALTER TABLE e_gcal_continuum OWNER TO postgres;
+
+--
+-- Name: e_gcal_arc; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gcal_arc (
+    id         character varying(20) PRIMARY KEY,
+    short_name character varying(20) NOT NULL,
+    long_name  character varying(20) NOT NULL,
+    obsolete   boolean               NOT NULL
+);
+
+
+ALTER TABLE e_gcal_arc OWNER TO postgres;
+
+--
+-- Name: e_gcal_diffuser; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gcal_diffuser (
+    id         character varying(20) PRIMARY KEY,
+    short_name character varying(20) NOT NULL,
+    obsolete   boolean               NOT NULL,
+    long_name  character varying(20) NOT NULL
+);
+
+ALTER TABLE e_gcal_diffuser OWNER TO postgres;
+
+--
+-- Name: e_gcal_shutter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gcal_shutter (
+    id         character varying(20) PRIMARY KEY,
+    short_name character varying(20) NOT NULL,
+    obsolete   boolean               NOT NULL,
+    long_name  character varying(20) NOT NULL
+);
+
+ALTER TABLE e_gcal_shutter OWNER TO postgres;
+
+--
+-- Name: e_instrument; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_instrument (
+    id identifier PRIMARY KEY,
+    short_name character varying(20) NOT NULL,
+    long_name character varying(64) NOT NULL,
+    obsolete boolean NOT NULL
+);
+
+
+ALTER TABLE e_instrument OWNER TO postgres;
+
+--
+-- Name: e_program_role; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_program_role (
+    id identifier NOT NULL,
+    short_name character varying(32),
+    long_name character varying(64)
+);
+
+
+ALTER TABLE e_program_role OWNER TO postgres;
+
+--
+-- Name: e_program_type; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_program_type (
+    id identifier NOT NULL,
+    short_name character varying(32) NOT NULL,
+    long_name character varying(64) NOT NULL,
+    obsolete boolean NOT NULL
+);
+
+
+ALTER TABLE e_program_type OWNER TO postgres;
+
+--
+-- Name: COLUMN e_program_type.id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_program_type.id IS 'enum identifier';
+
+
+--
+-- Name: COLUMN e_program_type.short_name; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_program_type.short_name IS 'short name, ''SV''';
+
+
+--
+-- Name: COLUMN e_program_type.long_name; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_program_type.long_name IS 'long name, ''Classical''';
+
+
+--
+-- Name: COLUMN e_program_type.obsolete; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_program_type.obsolete IS 'true if no longer available';
+
+
+--
+-- Name: e_site; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_site (
+    id identifier NOT NULL,
+    long_name character varying(20) NOT NULL,
+    mountain character varying(20) NOT NULL,
+    longitude real NOT NULL,
+    latitude real NOT NULL,
+    altitude smallint NOT NULL,
+    timezone character varying(20) NOT NULL,
+    short_name character varying(20) NOT NULL
+);
+
+
+ALTER TABLE e_site OWNER TO postgres;
+
+--
+-- Name: TABLE e_site; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE e_site IS 'Lookup table for site information.';
+
+
+--
+-- Name: COLUMN e_site.id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_site.id IS 'enum identifier';
+
+
+--
+-- Name: COLUMN e_site.long_name; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_site.long_name IS 'long name, ''Gemini South''';
+
+
+--
+-- Name: COLUMN e_site.mountain; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_site.mountain IS 'name of mountain, ''Mauna Kea''';
+
+
+--
+-- Name: COLUMN e_site.longitude; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_site.longitude IS 'longitude in degrees';
+
+
+--
+-- Name: COLUMN e_site.latitude; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_site.latitude IS 'latitude in degrees';
+
+
+--
+-- Name: COLUMN e_site.altitude; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_site.altitude IS 'altitude in meters';
+
+
+--
+-- Name: COLUMN e_site.timezone; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_site.timezone IS 'key for java.util.TimeZone.getTimeZone';
+
+
+--
+-- Name: COLUMN e_site.short_name; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN e_site.short_name IS 'short name, ''GS''';
+
+
+--
+-- Name: e_template; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_template (
+    id identifier NOT NULL,
+    short_name character varying(32) NOT NULL,
+    long_name character varying(64) NOT NULL,
+    obsolete boolean NOT NULL
+);
+
+
+ALTER TABLE e_template OWNER TO postgres;
+
+--
+-- Name: gem_user; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE gem_user (
+    id character varying(20) NOT NULL,
+    first character varying(20) NOT NULL,
+    last character varying(20) NOT NULL,
+    md5 character(32) NOT NULL,
+    email character varying(40) NOT NULL,
+    staff boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE gem_user OWNER TO postgres;
+
+--
+-- Name: gem_user_program; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE gem_user_program (
+    user_id character varying(20) NOT NULL,
+    program_id character varying(32) NOT NULL,
+    program_role identifier NOT NULL
+);
+
+
+ALTER TABLE gem_user_program OWNER TO postgres;
+
+--
+-- Name: log; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE log (
+    "timestamp" timestamp(5) with time zone NOT NULL,
+    level log_level NOT NULL,
+    program character varying(32),
+    message character varying(255) NOT NULL,
+    stacktrace text,
+    elapsed bigint,
+    user_id character varying
+);
+
+
+ALTER TABLE log OWNER TO postgres;
+
+--
+-- Name: observation; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE observation (
+    program_id character varying(32) NOT NULL,
+    observation_index id_index NOT NULL,
+    title character varying(255),
+    observation_id character varying(40) PRIMARY KEY,
+    instrument identifier,
+    CONSTRAINT observation_id_check CHECK (((observation_id)::text = (((program_id)::text || '-'::text) || observation_index)))
+);
+
+
+ALTER TABLE observation OWNER TO postgres;
+
+--
+-- Name: program; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE program (
+    program_id character varying(32) NOT NULL,
+    semester_id character varying(20),
+    site identifier,
+    program_type identifier,
+    index id_index,
+    day date,
+    title character varying(255) DEFAULT '«Untitled»'::character varying NOT NULL
+);
+
+
+ALTER TABLE program OWNER TO postgres;
+
+--
+-- Name: TABLE program; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE program IS 'TODO: constraint that requires structured data to be consistent with the program id, when present';
+
+
+--
+-- Name: semester; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE semester (
+    semester_id character varying(20) NOT NULL,
+    year smallint NOT NULL,
+    half character(1) NOT NULL,
+    CONSTRAINT check_semester_id CHECK (((semester_id)::text = (year || (half)::text)))
+);
+
+
+ALTER TABLE semester OWNER TO postgres;
+
+--
+-- Name: TABLE semester; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE semester IS '// TODO: start/end dates for site';
+
+
+--
+-- Name: step; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step (
+    step_id        SERIAL                PRIMARY KEY,
+    observation_id character varying(40) NOT NULL REFERENCES observation(observation_id) ON UPDATE CASCADE ON DELETE CASCADE,
+    location       integer[]             NOT NULL,
+    instrument     identifier            NOT NULL REFERENCES e_instrument,
+    step_type      step_type             NOT NULL,
+    UNIQUE (observation_id, location)
+);
+
+ALTER TABLE step OWNER TO postgres;
+
+--
+-- Name: step_bias; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_bias (
+    step_bias_id integer PRIMARY KEY REFERENCES step ON DELETE CASCADE
+);
+
+
+ALTER TABLE step_bias OWNER TO postgres;
+
+--
+-- Name: step_dark; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_dark (
+    step_dark_id integer PRIMARY KEY REFERENCES step ON DELETE CASCADE
+);
+
+
+ALTER TABLE step_dark OWNER TO postgres;
+
+--
+-- Name: step_f2; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_f2 (
+    step_f2_id     integer       PRIMARY KEY REFERENCES step              ON DELETE CASCADE,
+    disperser      identifier    NOT NULL    REFERENCES e_f2_disperser    ON DELETE CASCADE,
+    exposure_time  milliseconds  NOT NULL,
+    filter         identifier    NOT NULL    REFERENCES e_f2_filter       ON DELETE CASCADE,
+    fpu            identifier    NOT NULL    REFERENCES e_f2_fpunit       ON DELETE CASCADE,
+    lyot_wheel     identifier    NOT NULL    REFERENCES e_f2_lyot_wheel   ON DELETE CASCADE,
+    mos_preimaging boolean       NOT NULL,
+    read_mode      identifier    NOT NULL    REFERENCES e_f2_read_mode    ON DELETE CASCADE,
+    window_cover   identifier    NOT NULL    REFERENCES e_f2_window_cover ON DELETE CASCADE
+);
+
+
+ALTER TABLE step_f2 OWNER TO postgres;
+
+
+--
+-- Name: step_gcal; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE gcal (
+    gcal_id       SERIAL       PRIMARY KEY,
+    step_id       integer                             REFERENCES step             ON DELETE CASCADE,
+    continuum     identifier                          REFERENCES e_gcal_continuum ON DELETE CASCADE,
+    ar_arc        boolean      NOT NULL DEFAULT FALSE,
+    cuar_arc      boolean      NOT NULL DEFAULT FALSE,
+    thar_arc      boolean      NOT NULL DEFAULT FALSE,
+    xe_arc        boolean      NOT NULL DEFAULT FALSE,
+    filter        identifier   NOT NULL                REFERENCES e_gcal_filter    ON DELETE CASCADE,
+    diffuser      identifier   NOT NULL                REFERENCES e_gcal_diffuser  ON DELETE CASCADE,
+    shutter       identifier   NOT NULL                REFERENCES e_gcal_shutter   ON DELETE CASCADE,
+    exposure_time milliseconds NOT NULL,
+    coadds        coadds       NOT NULL,
+    CONSTRAINT check_lamp CHECK ((continuum IS NULL) = (ar_arc OR cuar_arc OR thar_arc OR xe_arc))
+);
+
+
+ALTER TABLE gcal OWNER TO postgres;
+
+
+--
+-- Name: step_gcal; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_gcal (
+    step_gcal_id  integer PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    gcal_id       integer NOT NULL    REFERENCES gcal ON DELETE CASCADE
+);
+
+
+ALTER TABLE step_gcal OWNER TO postgres;
+
+--
+-- Name: step_gcal; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_smart_gcal (
+    step_smart_gcal_id integer PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    type               smart_gcal_type NOT NULL
+);
+
+
+ALTER TABLE step_smart_gcal OWNER TO postgres;
+
+--
+-- Name: step_science; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_science (
+    step_science_id integer      PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    offset_p        numeric(9,3) NOT NULL,
+    offset_q        numeric(9,3) NOT NULL
+);
+
+
+ALTER TABLE step_science OWNER TO postgres;
+
+
+--
+-- Data for Name: dataset; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+CREATE TABLE dataset (
+    dataset_label   character varying(46)        PRIMARY KEY,
+    observation_id  character varying(40)        REFERENCES observation ON DELETE CASCADE,
+    dataset_index   id_index                     NOT NULL,
+    step_id         integer                      REFERENCES step        ON DELETE CASCADE,
+    filename        character varying(24)        NOT NULL,
+    "timestamp"     timestamp (5) WITH TIME ZONE NOT NULL
+    CONSTRAINT dataset_id_check CHECK ((dataset_label)::text = (((observation_id)::text || '-'::text) || trim(leading from to_char(dataset_index, '9000'))))
+);
+
+
+
+--
+-- Data for Name: e_f2_disperser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_f2_disperser (id, wavelength, short_name, long_name) FROM stdin;
+R1200JH	1.3899999999999999	R1200JH	R=1200 (J + H) grism
+R1200HK	1.871	R1200HK	R=1200 (H + K) grism
+R3000	1.64999999999999991	R3000	R=3000 (J or H or K) grism
+NoDisperser	\N	None	None
+\.
+
+
+--
+-- Data for Name: e_f2_filter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_f2_filter (id, wavelength, short_name, long_name, obsolete) FROM stdin;
+Open	1.60000000000000009	Open	Open	f
+Y	1.02000000000000002	Y	Y (1.02 um)	f
+F1056	1.05600000000000005	F1056	F1056 (1.056 um)	f
+J	1.25	J	J (1.25 um)	f
+H	1.64999999999999991	H	H (1.65 um)	f
+JH	1.3899999999999999	JH	JH (spectroscopic)	f
+HK	1.871	HK	HK (spectroscopic)	f
+JLow	1.14999999999999991	J-low	J-low (1.15 um)	f
+KLong	2.20000000000000018	K-long	K-long (2.20 um)	f
+KShort	2.14999999999999991	K-short	K-short (2.15 um)	f
+F1063	1.06299999999999994	F1063	F1063 (1.063 um)	f
+Dark	\N	Dark	Dark	f
+\.
+
+
+--
+-- Data for Name: e_f2_fpunit; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_f2_fpunit (id, short_name, slit_width, decker, long_name, obsolete) FROM stdin;
+Pinhole	Pinhole	0	Imaging	2-Pixel Pinhole Grid	f
+SubPixPinhole	Sub-Pix Pinhole	0	Imaging	Sub-Pixel Pinhole Gr	f
+None	None	0	Imaging	Imaging (none)	f
+Custom	Custom	0	MOS	Custom Mask	f
+LongSlit1	Long Slit 1px	1	Long Slit	1-Pixel Long Slit	f
+LongSlit2	Long Slit 2px	2	Long Slit	2-Pixel Long Slit	f
+LongSlit3	Long Slit 3px	3	Long Slit	3-Pixel Long Slit	f
+LongSlit4	Long Slit 4px	4	Long Slit	4-Pixel Long Slit	f
+LongSlit6	Long Slit 6px	6	Long Slit	6-Pixel Long Slit	f
+LongSlit8	Long Slit 8px	8	Long Slit	8-Pixel Long Slit	f
+\.
+
+
+--
+-- Data for Name: e_f2_lyot_wheel; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_f2_lyot_wheel (id, short_name, plate_scale, pixel_scale, obsolete, long_name) FROM stdin;
+F16	f/16	1.6100000000000001	0.179999999999999993	f	f/16 (Open)
+F32High	f/32 High	0.805000000000000049	0.0899999999999999967	t	f/32 MCAO high background
+F32Low	f/32 Low	0.805000000000000049	0.0899999999999999967	t	f/32 MCAO low background
+F33Gems	f/33 GeMS	0.78400000000000003	0.0899999999999999967	t	f/33 (GeMS)
+GemsUnder	GeMS Under	0.78400000000000003	0.0899999999999999967	f	f/33 (GeMS under-sized)
+GemsOver	GeMS Over	0.78400000000000003	0.0899999999999999967	f	f/33 (GeMS over-sized)
+HartmannA	Hartmann A (H1)	0	0	f	Hartmann A (H1)
+HartmannB	Hartmann B (H2)	0	0	f	Hartmann B (H2)
+\.
+
+
+--
+-- Data for Name: e_f2_read_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_f2_read_mode (id, short_name, long_name, description, minimum_exposure_time, recommended_exposure_time, readout_time, read_count, read_noise) FROM stdin;
+Bright	bright	Bright Object	Strong Source	1500	5000	8000	1	11.7
+Medium	medium	Medium Object	Medium Source	6000	21000	14000	4	6.0
+Faint	faint	Faint Object	Weak Source	12000	85000	20000	8	5.0
+\.
+
+
+--
+-- Data for Name: e_f2_window_cover; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_f2_window_cover (id, short_name, long_name) FROM stdin;
+Open	Open	Open
+Close	Close	Close
+\.
+
+
+--
+-- Data for Name: e_gcal_filter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gcal_filter (id, short_name, obsolete, long_name) FROM stdin;
+None	none	f	none
+Gmos	GMOS balance	f	GMOS balance
+Hros	HROS balance	t	HROS balance
+Nir	NIR balance	f	NIR balance
+Nd10	ND1.0	f	ND1.0
+Nd16	ND1.6	t	ND1.6
+Nd20	ND2.0	f	ND2.0
+Nd30	ND3.0	f	ND3.0
+Nd40	ND4.0	f	ND4.0
+Nd45	ND4-5	f	ND4-5
+Nd50	ND5.0	t	ND5.0
+\.
+
+
+--
+-- Data for Name: e_gcal_continuum; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gcal_continuum (id, short_name, long_name, obsolete) FROM stdin;
+IrGreyBodyLow	IR grey body - low	IR grey body - low	f
+IrGreyBodyHigh	IR grey body - high	IR grey body - high	f
+QuartzHalogen	Quartz Halogen	Quartz Halogen	f
+\.
+
+
+--
+-- Data for Name: e_gcal_arc; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gcal_arc (id, short_name, long_name, obsolete) FROM stdin;
+ArArc	Ar arc	Ar arc	f
+ThArArc	ThAr arc	ThAr arc	f
+CuArArc	CuAr arc	CuAr arc	f
+XeArc	Xe arc	Xe arc	f
+\.
+
+
+--
+-- Data for Name: e_gcal_diffuser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gcal_diffuser (id, short_name, obsolete, long_name) FROM stdin;
+Ir	IR	f	IR
+Visible	Visible	f	Visible
+\.
+
+
+--
+-- Data for Name: e_gcal_shutter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gcal_shutter (id, short_name, obsolete, long_name) FROM stdin;
+Open	Open	f	Open
+Closed	Closed	f	Closed
+\.
+
+
+--
+-- Data for Name: e_instrument; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_instrument (id, short_name, long_name, obsolete) FROM stdin;
+Phoenix	Phoenix	Phoenix	f
+Michelle	Michelle	Michelle	f
+Gnirs	GNIRS	GNIRS	f
+Niri	NIRI	NIRI	f
+Trecs	TReCS	TReCS	f
+Nici	NICI	NICI	f
+Nifs	NIFS	NIFS	f
+Gpi	GPI	GPI	f
+Gsaoi	GSAOI	GSAOI	f
+GmosS	GMOS-S	GMOS South	f
+AcqCam	AcqCam	Acquisition Camera	f
+GmosN	GMOS-N	GMOS North	f
+Bhros	bHROS	bHROS	t
+Visitor	Visitor Instrument	Visitor Instrument	f
+Flamingos2	Flamingos2	Flamingos 2	f
+\.
+
+
+--
+-- Data for Name: e_program_role; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_program_role (id, short_name, long_name) FROM stdin;
+PI	PI	Principal Investigator
+GEM	GEM	Gemini Contact
+NGO	NGO	NGO Contact
+\.
+
+
+--
+-- Data for Name: e_program_type; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_program_type (id, short_name, long_name, obsolete) FROM stdin;
+CAL	CAL	Calibration	f
+C	C	Classical	f
+DS	DS	Demo Science	f
+DD	DD	Director's Time	f
+ENG	ENG	Engineering	f
+FT	FT	Fast Turnaround	f
+LP	LP	Large Program	f
+Q	Q	Queue	f
+SV	SV	System Verification	f
+\.
+
+
+--
+-- Data for Name: e_site; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_site (id, long_name, mountain, longitude, latitude, altitude, timezone, short_name) FROM stdin;
+GN	Gemini North	Mauna Kea	-155.469055	19.8238068	4213	Pacific/Honolulu	GN
+GS	Gemini South	Cerro Pachon	-70.7366867	-30.2407494	2722	America/Santiago	GS
+\.
+
+
+--
+-- Data for Name: e_template; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_template (id, short_name, long_name, obsolete) FROM stdin;
+\.
+
+
+--
+-- Data for Name: gem_user; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY gem_user (id, first, last, md5, email, staff) FROM stdin;
+root			                                	 	t
+\.
+
+
+--
+-- Data for Name: gem_user_program; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY gem_user_program (user_id, program_id, program_role) FROM stdin;
+\.
+
+
+--
+-- Data for Name: log; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY log ("timestamp", level, program, message, stacktrace, elapsed, user_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: observation; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY observation (program_id, observation_index, title, observation_id, instrument) FROM stdin;
+\.
+
+
+--
+-- Data for Name: program; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY program (program_id, semester_id, site, program_type, index, day, title) FROM stdin;
+\.
+
+
+--
+-- Data for Name: semester; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY semester (semester_id, year, half) FROM stdin;
+2006A	2006	A
+2006B	2006	B
+2007B	2007	B
+2012B	2012	B
+\.
+
+
+--
+-- Name: e_program_role_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY e_program_role
+    ADD CONSTRAINT e_program_role_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e_program_role_short_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY e_program_role
+    ADD CONSTRAINT e_program_role_short_name_key UNIQUE (short_name);
+
+
+--
+-- Name: e_program_type_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY e_program_type
+    ADD CONSTRAINT e_program_type_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e_site_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY e_site
+    ADD CONSTRAINT e_site_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gen_user_program_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY gem_user_program
+    ADD CONSTRAINT gen_user_program_pkey PRIMARY KEY (user_id, program_id, program_role);
+
+
+--
+-- Name: observation_instrument_observation_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY observation
+    ADD CONSTRAINT observation_instrument_observation_id_key UNIQUE (instrument, observation_id);
+
+
+--
+-- Name: program_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY program
+    ADD CONSTRAINT program_pkey PRIMARY KEY (program_id);
+
+
+--
+-- Name: semester_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY semester
+    ADD CONSTRAINT semester_pkey PRIMARY KEY (semester_id);
+
+
+--
+-- Name: user_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY gem_user
+    ADD CONSTRAINT user_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ix_observation_instrument; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_observation_instrument ON observation USING btree (instrument);
+
+
+--
+-- Name: ix_observation_program_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_observation_program_id ON observation USING btree (program_id);
+
+
+--
+-- Name: ix_program_id; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_program_id ON program USING btree (program_id);
+
+
+--
+-- Name: ix_step; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_step ON step USING btree (observation_id, location);
+
+
+--
+-- Name: ix_step_oid; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_step_oid ON step USING btree (observation_id);
+
+
+--
+-- Name: ix_timestamp; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX ix_timestamp ON log USING btree ("timestamp" DESC);
+
+
+--
+-- Name: FK_gen_user_program_1; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY gem_user_program
+    ADD CONSTRAINT "FK_gen_user_program_1" FOREIGN KEY (user_id) REFERENCES gem_user(id);
+
+
+--
+-- Name: FK_gen_user_program_2; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY gem_user_program
+    ADD CONSTRAINT "FK_gen_user_program_2" FOREIGN KEY (program_id) REFERENCES program(program_id);
+
+
+--
+-- Name: FK_gen_user_program_3; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY gem_user_program
+    ADD CONSTRAINT "FK_gen_user_program_3" FOREIGN KEY (program_role) REFERENCES e_program_role(id);
+
+
+--
+-- Name: FK_observation_1; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY observation
+    ADD CONSTRAINT "FK_observation_1" FOREIGN KEY (program_id) REFERENCES program(program_id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: FK_program_1; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY program
+    ADD CONSTRAINT "FK_program_1" FOREIGN KEY (semester_id) REFERENCES semester(semester_id);
+
+
+--
+-- Name: log_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY log
+    ADD CONSTRAINT log_user_id_fkey FOREIGN KEY (user_id) REFERENCES gem_user(id);
+
+
+--
+-- Name: observation_instrument_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY observation
+    ADD CONSTRAINT observation_instrument_fkey FOREIGN KEY (instrument) REFERENCES e_instrument(id);
+
+
+--
+-- Name: program_site_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY program
+    ADD CONSTRAINT program_site_fkey FOREIGN KEY (site) REFERENCES e_site(id);
+
+
+--
+-- Name: public; Type: ACL; Schema: -; Owner: postgres
+--
+
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM postgres;
+GRANT ALL ON SCHEMA public TO postgres;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- PostgreSQL database dump complete
+--

--- a/modules/sql/src/main/resources/db/migration/V002__Add_Event_Log.sql
+++ b/modules/sql/src/main/resources/db/migration/V002__Add_Event_Log.sql
@@ -1,0 +1,33 @@
+
+CREATE TYPE evt_type AS ENUM (
+    'StartSequence',
+    'EndSequence',
+    'StartSlew',
+    'EndSlew',
+    'StartVisit',
+    'EndVisit',
+    'StartIntegration',
+    'EndIntegration',
+    'Abort',
+    'Continue',
+    'Pause',
+    'Stop'
+);
+
+CREATE TABLE log_observe_event
+(
+   id              SERIAL,
+   "timestamp"     timestamp (5) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+   event           evt_type NOT NULL,
+   observation_id  text NOT NULL,
+   step            integer CHECK (step > 0),
+   CONSTRAINT check_step CHECK ((event IN ('StartIntegration', 'EndIntegration') AND step iS NOT NULL) OR
+                                (event NOT IN ('StartIntegration', 'EndIntegration') AND step IS NULL))
+);
+
+ALTER TABLE log_observe_event OWNER TO postgres;
+
+ALTER TABLE ONLY log_observe_event
+    ADD CONSTRAINT log_observe_event_pkey PRIMARY KEY (id);
+
+CREATE INDEX ix_log_observe_event_timestamp ON log_observe_event USING btree ("timestamp" DESC);

--- a/modules/sql/src/main/resources/db/migration/V003__Add_Root_User.sql
+++ b/modules/sql/src/main/resources/db/migration/V003__Add_Root_User.sql
@@ -1,0 +1,7 @@
+
+-- Set the root user's password to '' if it hasn't been set. This will allow the
+-- first administrator to log in.
+UPDATE gem_user
+SET    md5 = md5('')
+WHERE  id  = 'root'
+AND    md5 = ''

--- a/modules/sql/src/main/resources/db/migration/V004__Add_SmartGcal_Support.sql
+++ b/modules/sql/src/main/resources/db/migration/V004__Add_SmartGcal_Support.sql
@@ -1,0 +1,46 @@
+--
+-- SmartGcal Support
+--
+
+--
+-- Name: baseline; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE gcal_baseline_type AS ENUM (
+    'Day',
+    'Night'
+);
+
+
+ALTER TYPE gcal_baseline_type OWNER TO postgres;
+
+--
+-- Name: gcal_lamp; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE gcal_lamp_type AS ENUM (
+    'Arc',
+    'Flat'
+);
+
+
+ALTER TYPE gcal_lamp_type OWNER TO postgres;
+
+
+--
+-- Name: smart_f2; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE smart_f2 (
+  lamp      gcal_lamp_type     NOT NULL,
+  baseline  gcal_baseline_type NOT NULL,
+  disperser identifier         NOT NULL REFERENCES e_f2_disperser ON DELETE CASCADE,
+  filter    identifier         NOT NULL REFERENCES e_f2_filter    ON DELETE CASCADE,
+  fpu       identifier         NOT NULL REFERENCES e_f2_fpunit    ON DELETE CASCADE,
+  gcal_id   integer            NOT NULL REFERENCES gcal           ON DELETE CASCADE
+);
+
+ALTER TABLE smart_f2 OWNER TO postgres;
+
+
+

--- a/modules/sql/src/main/resources/db/migration/V005__Add_SmartGcal_F2.sql
+++ b/modules/sql/src/main/resources/db/migration/V005__Add_SmartGcal_F2.sql
@@ -1,0 +1,225 @@
+--
+-- Data for Name: gcal; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY gcal (gcal_id, step_id, continuum, ar_arc, cuar_arc, thar_arc, xe_arc, filter, diffuser, shutter, exposure_time, coadds) FROM stdin;
+1	\N	\N	t	f	f	f	Nir	Ir	Closed	30000	1
+2	\N	\N	t	f	f	f	Nir	Ir	Closed	30000	1
+3	\N	\N	t	f	f	f	Nir	Ir	Closed	15000	1
+4	\N	\N	t	f	f	f	Nir	Ir	Closed	15000	1
+5	\N	\N	t	f	f	f	Nir	Ir	Closed	8000	1
+6	\N	\N	t	f	f	f	Nir	Ir	Closed	8000	1
+7	\N	\N	t	f	f	f	Nir	Ir	Closed	90000	1
+8	\N	\N	t	f	f	f	Nir	Ir	Closed	90000	1
+9	\N	\N	t	f	f	f	Nir	Ir	Closed	90000	1
+10	\N	\N	t	f	f	f	Nir	Ir	Closed	40000	1
+11	\N	\N	t	f	f	f	Nir	Ir	Closed	40000	1
+12	\N	\N	t	f	f	f	Nir	Ir	Closed	40000	1
+13	\N	\N	t	f	f	f	Nir	Ir	Closed	60000	1
+14	\N	\N	t	f	f	f	Nir	Ir	Closed	60000	1
+15	\N	\N	t	f	f	f	Nir	Ir	Closed	30000	1
+16	\N	\N	t	f	f	f	Nir	Ir	Closed	30000	1
+17	\N	\N	t	f	f	f	Nir	Ir	Closed	15000	1
+18	\N	\N	t	f	f	f	Nir	Ir	Closed	15000	1
+19	\N	\N	t	f	f	f	Nir	Ir	Closed	60000	1
+20	\N	\N	t	f	f	f	Nir	Ir	Closed	60000	1
+21	\N	\N	t	f	f	f	Nir	Ir	Closed	30000	1
+22	\N	\N	t	f	f	f	Nir	Ir	Closed	30000	1
+23	\N	\N	t	f	f	f	Nir	Ir	Closed	15000	1
+24	\N	\N	t	f	f	f	Nir	Ir	Closed	15000	1
+25	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+26	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+27	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+28	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+29	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+30	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+31	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+32	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+33	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+34	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+35	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+36	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+37	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+38	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+39	\N	\N	t	f	f	f	Nir	Ir	Closed	180000	1
+40	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+41	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+42	\N	\N	t	f	f	f	Nir	Ir	Closed	80000	1
+43	\N	IrGreyBodyHigh	f	f	f	f	Nd40	Ir	Open	20000	1
+44	\N	IrGreyBodyHigh	f	f	f	f	Nd40	Ir	Closed	20000	1
+45	\N	IrGreyBodyHigh	f	f	f	f	Nd40	Ir	Open	4000	1
+46	\N	IrGreyBodyHigh	f	f	f	f	Nd40	Ir	Closed	4000	1
+47	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Open	60000	1
+48	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Closed	60000	1
+49	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Open	3000	1
+50	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Closed	3000	1
+51	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Closed	3000	1
+52	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Open	2000	1
+53	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Closed	2000	1
+54	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Closed	2000	1
+55	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	20000	1
+56	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	8000	1
+57	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	5000	1
+58	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	4000	1
+59	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	3000	1
+60	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	3000	1
+61	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	10000	1
+62	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	4000	1
+63	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	3000	1
+64	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Open	80000	1
+65	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Open	60000	1
+66	\N	IrGreyBodyHigh	f	f	f	f	Nd45	Ir	Open	40000	1
+67	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	50000	1
+68	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	25000	1
+69	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	15000	1
+70	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	12000	1
+71	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	8000	1
+72	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	6000	1
+73	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	10000	1
+74	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	5000	1
+75	\N	IrGreyBodyHigh	f	f	f	f	Nd10	Ir	Open	25000	1
+76	\N	IrGreyBodyHigh	f	f	f	f	Nd10	Ir	Open	20000	1
+77	\N	IrGreyBodyHigh	f	f	f	f	Nd10	Ir	Open	12000	1
+78	\N	IrGreyBodyHigh	f	f	f	f	Nd10	Ir	Open	10000	1
+79	\N	IrGreyBodyHigh	f	f	f	f	Nd10	Ir	Open	6000	1
+80	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	50000	1
+81	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	40000	1
+82	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	25000	1
+83	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	20000	1
+84	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	15000	1
+85	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	32000	1
+86	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	16000	1
+87	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	12000	1
+88	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	9000	1
+89	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	6000	1
+90	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	4000	1
+91	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	80000	1
+92	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	50000	1
+93	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	30000	1
+94	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	20000	1
+95	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	15000	1
+96	\N	IrGreyBodyHigh	f	f	f	f	None	Ir	Open	12000	1
+97	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	32000	1
+98	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	16000	1
+99	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	12000	1
+100	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	9000	1
+101	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	6000	1
+102	\N	IrGreyBodyHigh	f	f	f	f	Nd20	Ir	Open	4000	1
+\.
+
+--
+-- Name: gcal_gcal_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('gcal_gcal_id_seq', 103, true);
+
+
+--
+-- Data for Name: smart_f2; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY smart_f2 (lamp, baseline, disperser, filter, fpu, gcal_id) FROM stdin;
+Arc	Night	R1200JH	JH	LongSlit1	1
+Arc	Night	R1200JH	JH	LongSlit2	2
+Arc	Night	R1200JH	JH	LongSlit3	3
+Arc	Night	R1200JH	JH	LongSlit4	4
+Arc	Night	R1200JH	JH	LongSlit6	5
+Arc	Night	R1200JH	JH	LongSlit8	6
+Arc	Night	R1200HK	HK	LongSlit1	7
+Arc	Night	R1200HK	HK	LongSlit2	8
+Arc	Night	R1200HK	HK	LongSlit3	9
+Arc	Night	R1200HK	HK	LongSlit4	10
+Arc	Night	R1200HK	HK	LongSlit6	11
+Arc	Night	R1200HK	HK	LongSlit8	12
+Arc	Night	R3000	JLow	LongSlit1	13
+Arc	Night	R3000	JLow	LongSlit2	14
+Arc	Night	R3000	JLow	LongSlit3	15
+Arc	Night	R3000	JLow	LongSlit4	16
+Arc	Night	R3000	JLow	LongSlit6	17
+Arc	Night	R3000	JLow	LongSlit8	18
+Arc	Night	R3000	J	LongSlit1	19
+Arc	Night	R3000	J	LongSlit2	20
+Arc	Night	R3000	J	LongSlit3	21
+Arc	Night	R3000	J	LongSlit4	22
+Arc	Night	R3000	J	LongSlit6	23
+Arc	Night	R3000	J	LongSlit8	24
+Arc	Night	R3000	H	LongSlit1	25
+Arc	Night	R3000	H	LongSlit2	26
+Arc	Night	R3000	H	LongSlit3	27
+Arc	Night	R3000	H	LongSlit4	28
+Arc	Night	R3000	H	LongSlit6	29
+Arc	Night	R3000	H	LongSlit8	30
+Arc	Night	R3000	KShort	LongSlit1	31
+Arc	Night	R3000	KShort	LongSlit2	32
+Arc	Night	R3000	KShort	LongSlit3	33
+Arc	Night	R3000	KShort	LongSlit4	34
+Arc	Night	R3000	KShort	LongSlit6	35
+Arc	Night	R3000	KShort	LongSlit8	36
+Arc	Night	R3000	KLong	LongSlit1	37
+Arc	Night	R3000	KLong	LongSlit2	38
+Arc	Night	R3000	KLong	LongSlit3	39
+Arc	Night	R3000	KLong	LongSlit4	40
+Arc	Night	R3000	KLong	LongSlit6	41
+Arc	Night	R3000	KLong	LongSlit8	42
+Flat	Day	NoDisperser	Y	None	43
+Flat	Day	NoDisperser	Y	None	44
+Flat	Day	NoDisperser	JLow	None	45
+Flat	Day	NoDisperser	JLow	None	46
+Flat	Day	NoDisperser	J	None	47
+Flat	Day	NoDisperser	J	None	48
+Flat	Day	NoDisperser	H	None	49
+Flat	Day	NoDisperser	H	None	50
+Flat	Day	NoDisperser	KShort	None	51
+Flat	Day	NoDisperser	JH	None	52
+Flat	Day	NoDisperser	JH	None	53
+Flat	Day	NoDisperser	HK	None	54
+Flat	Night	R1200JH	JH	LongSlit1	55
+Flat	Night	R1200JH	JH	LongSlit2	56
+Flat	Night	R1200JH	JH	LongSlit3	57
+Flat	Night	R1200JH	JH	LongSlit4	58
+Flat	Night	R1200JH	JH	LongSlit6	59
+Flat	Night	R1200JH	JH	LongSlit8	60
+Flat	Night	R1200HK	HK	LongSlit1	61
+Flat	Night	R1200HK	HK	LongSlit2	62
+Flat	Night	R1200HK	HK	LongSlit3	63
+Flat	Night	R1200HK	HK	LongSlit4	64
+Flat	Night	R1200HK	HK	LongSlit6	65
+Flat	Night	R1200HK	HK	LongSlit8	66
+Flat	Night	R3000	JLow	LongSlit1	67
+Flat	Night	R3000	JLow	LongSlit2	68
+Flat	Night	R3000	JLow	LongSlit3	69
+Flat	Night	R3000	JLow	LongSlit4	70
+Flat	Night	R3000	JLow	LongSlit6	71
+Flat	Night	R3000	JLow	LongSlit8	72
+Flat	Night	R3000	J	LongSlit1	73
+Flat	Night	R3000	J	LongSlit2	74
+Flat	Night	R3000	J	LongSlit3	75
+Flat	Night	R3000	J	LongSlit4	76
+Flat	Night	R3000	J	LongSlit6	77
+Flat	Night	R3000	J	LongSlit8	78
+Flat	Night	R3000	H	LongSlit1	79
+Flat	Night	R3000	H	LongSlit2	80
+Flat	Night	R3000	H	LongSlit3	81
+Flat	Night	R3000	H	LongSlit4	82
+Flat	Night	R3000	H	LongSlit6	83
+Flat	Night	R3000	H	LongSlit8	84
+Flat	Night	R3000	KShort	LongSlit1	85
+Flat	Night	R3000	KShort	LongSlit2	86
+Flat	Night	R3000	KShort	LongSlit3	87
+Flat	Night	R3000	KShort	LongSlit4	88
+Flat	Night	R3000	KShort	LongSlit6	89
+Flat	Night	R3000	KShort	LongSlit8	90
+Flat	Night	R3000	Y	LongSlit1	91
+Flat	Night	R3000	Y	LongSlit2	92
+Flat	Night	R3000	Y	LongSlit3	93
+Flat	Night	R3000	Y	LongSlit4	94
+Flat	Night	R3000	Y	LongSlit6	95
+Flat	Night	R3000	Y	LongSlit8	96
+Flat	Night	R3000	KLong	LongSlit1	97
+Flat	Night	R3000	KLong	LongSlit2	98
+Flat	Night	R3000	KLong	LongSlit3	99
+Flat	Night	R3000	KLong	LongSlit4	100
+Flat	Night	R3000	KLong	LongSlit6	101
+Flat	Night	R3000	KLong	LongSlit8	102
+\.
+

--- a/modules/sql/src/main/resources/db/migration/V006__Add_Gmos.sql
+++ b/modules/sql/src/main/resources/db/migration/V006__Add_Gmos.sql
@@ -1,0 +1,266 @@
+--
+-- Name: e_gmos_detector; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_detector (
+    id               identifier            PRIMARY KEY,
+    short_name       character varying(10) NOT NULL,
+    long_name        character varying(10) NOT NULL,
+    north_pixel_size numeric(5,4)          NOT NULL,
+    south_pixel_size numeric(5,4)          NOT NULL,
+    shuffle_offset   smallint              NOT NULL,
+    x_size           smallint              NOT NULL,
+    y_size           smallint              NOT NULL,
+    max_rois         smallint              NOT NULL
+);
+
+ALTER TABLE e_gmos_detector OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_detector; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_detector (id, short_name, long_name, north_pixel_size, south_pixel_size, shuffle_offset, x_size, y_size, max_rois) FROM stdin;
+E2V	E2V	E2V	0.0727	0.0730	1536	6144	4608	4
+HAMAMATSU	Hamamatsu	Hamamatsu	0.0809	0.0809	1392	6144	4224	5
+\.
+
+
+--
+-- Name: e_gmos_north_disperser; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_north_disperser (
+    id             identifier            PRIMARY KEY,
+    short_name     character varying(10) NOT NULL,
+    long_name      character varying(20) NOT NULL,
+    ruling_density smallint              NOT NULL,
+    obsolete       boolean               NOT NULL
+);
+
+ALTER TABLE e_gmos_north_disperser OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_north_disperser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_north_disperser (id, short_name, long_name, ruling_density, obsolete) FROM stdin;
+B1200_G5301	B1200	B1200_G5301	1200	f
+R831_G5302	R831	R831_G5302	831	f
+B600_G5303	B600	B600_G5303	600	t
+B600_G5307	B600	B600_G5307	600	f
+R600_G5304	R600	R600_G5304	600	f
+R400_G5305	R400	R400_G5305	400	f
+R150_G5306	R150	R150_G5306	150	f
+R150_G5308	R150	R150_G5308	150	f
+\.
+
+
+--
+-- Name: e_gmos_north_filter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_north_filter (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(10) NOT NULL,
+    long_name  character varying(30) NOT NULL,
+    wavelength numeric(4,3)          NOT NULL,
+    obsolete   boolean               NOT NULL
+);
+
+ALTER TABLE e_gmos_north_filter OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_north_filter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_north_filter(id, short_name, long_name, wavelength, obsolete) FROM stdin;
+GPrime	g	g_G0301	0.475	f
+RPrime	r	r_G0303	0.630	f
+IPrime	i	i_G0302	0.780	f
+ZPrime	z	z_G0304	0.925	f
+Z	Z	Z_G0322	0.876	f
+Y	Y	Y_G0323	1.01	f
+GG455	GG455	GG455_G0305	0.680	f
+OG515	OG515	OG515_G0306	0.710	f
+RG610	RG610	RG610_G0307	0.750	f
+CaT	CaT	CaT_G0309	0.860	f
+Ha	Ha	Ha_G0310	0.655	f
+HaC	HaC	HaC_G0311	0.662	f
+DS920	DS920	DS920_G0312	0.920	f
+SII	SII	SII_G0317	0.672	f
+OIII	OIII	OIII_G0318	0.499	f
+OIIIC	OIIIC	OIIIC_G0319	0.514	f
+HeII	HeII	HeII_G0320	0.468	f
+HeIIC	HeIIC	HeIIC_G0321	0.478	f
+HartmannA_RPrime	r+HartA	HartmannA_G0313 + r_G0303	0.630	f
+HartmannB_RPrime	r+HartB	HartmannB_G0314 + r_G0303	0.630	f
+GPrime_GG455	g+GG455	g_G0301 + GG455_G0305	0.506	f
+GPrime_OG515	g+OG515	g_G0301 + OG515_G0306	0.536	f
+RPrime_RG610	r+RG610	r_G0303 + RG610_G0307	0.657	f
+IPrime_CaT	i+CaT	i_G0302 + CaT_G0309	0.815	f
+ZPrime_CaT	z+CaT	z_G0304 + CaT_G0309	0.890	f
+UPrime	u	u_G0308	0.350	t
+\.
+
+
+--
+-- Name: e_gmos_north_fpu; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_north_fpu (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(12) NOT NULL,
+    long_name  character varying(30) NOT NULL,
+    slit_width numeric(3,2)
+);
+
+ALTER TABLE e_gmos_north_fpu OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_north_fpu; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_north_fpu (id, short_name, long_name, slit_width) FROM stdin;
+Longslit1	0.25arcsec	Longslit 0.25 arcsec	0.25
+Longslit2	0.50arcsec	Longslit 0.50 arcsec	0.50
+Longslit3	0.75arcsec	Longslit 0.75 arcsec	0.75
+Longslit4	1.0arcsec	Longslit 1.00 arcsec	1.00
+Longslit5	1.5arcsec	Longslit 1.50 arcsec	1.50
+Longslit6	2.0arcsec	Longslit 2.00 arcsec	2.00
+Longslit7	5.0arcsec	Longslit 5.00 arcsec	5.00
+Ifu1	IFU-2	IFU 2 Slits	\N
+Ifu2	IFU-B	IFU Left Slit (blue)	\N
+Ifu3	IFU-R	IFU Right Slit (red)	\N
+Ns0	NS0.25arcsec	N and S 0.25 arcsec	0.25
+Ns1	NS0.5arcsec	N and S 0.50 arcsec	0.50
+Ns2	NS0.75arcsec	N and S 0.75 arcsec	0.75
+Ns3	NS1.0arcsec	N and S 1.00 arcsec	1.00
+Ns4	NS1.5arcsec	N and S 1.50 arcsec	1.50
+Ns5	NS2.0arcsec	N and S 2.00 arcsec	2.00
+\.
+
+
+--
+-- Name: e_gmos_south_disperser; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_south_disperser (
+    id             identifier            PRIMARY KEY,
+    short_name     character varying(10) NOT NULL,
+    long_name      character varying(20) NOT NULL,
+    ruling_density smallint              NOT NULL,
+    obsolete       boolean               NOT NULL
+);
+
+ALTER TABLE e_gmos_south_disperser OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_south_disperser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_south_disperser (id, short_name, long_name, ruling_density, obsolete) FROM stdin;
+B1200_G5321	B1200	B1200_G5321	1200	f
+R831_G5322	R831	R831_G5322	831	f
+B600_G5323	B600	B600_G5323	600	f
+R600_G5324	R600	R600_G5324	600	f
+R400_G5325	R400	R400_G5325	400	f
+R150_G5326	R150	R150_G5326	150	f
+\.
+
+
+--
+-- Name: e_gmos_south_filter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_south_filter (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(10) NOT NULL,
+    long_name  character varying(30) NOT NULL,
+    wavelength numeric(4,3)          NOT NULL,
+    obsolete   boolean               NOT NULL
+);
+
+ALTER TABLE e_gmos_south_filter OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_south_filter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_south_filter(id, short_name, long_name, wavelength, obsolete) FROM stdin;
+UPrime	u	u_G0332	0.350	f
+GPrime	g	g_G0325	0.475	f
+RPrime	r	r_G0326	0.630	f
+IPrime	i	i_G0327	0.780	f
+ZPrime	z	z_G0328	0.925	f
+Z	Z	Z_G0343	0.876	f
+Y	Y	Y_G0344	1.01	f
+GG455	GG455	GG455_G0329	0.680	f
+OG515	OG515	OG515_G0330	0.710	f
+RG610	RG610	RG610_G0331	0.750	f
+RG780	RG780	RG780_G0334	0.850	f
+CaT	CaT	CaT_G0333	0.860	f
+HartmannA_RPrime	r+HartA	HartmannA_G0337 + r_G0326	0.630	f
+HartmannB_RPrime	r+HartB	HartmannB_G0338 + r_G0326	0.630	f
+GPrime_GG455	g+GG455	g_G0325 + GG455_G0329	0.506	f
+GPrime_OG515	g+OG515	g_G0325 + OG515_G0330	0.536	f
+RPrime_RG610	r+RG610	r_G0326 + RG610_G0331	0.657	f
+IPrime_RG780	i+RG780	i_G0327 + RG780_G0334	0.819	f
+IPrime_CaT	i+CaT	i_G0327 + CaT_G0333	0.815	f
+ZPrime_CaT	z+Cat	z_G0328 + CaT_G0333	0.890	f
+Ha	Ha	Ha_G0336	0.656	f
+SII	SII	SII_G0335	0.672	f
+HaC	HaC	HaC_G0337	0.662	f
+OIII	OIII	OIII_G0338	0.499	f
+OIIIC	OIIIC	OIIIC_G0339	0.514	f
+HeII	HeII	HeII_G0340	0.468	f
+HeIIC	HeIIC	HeIIC_G0341	0.478	f
+Lya395	Lya395	Lya395_G0342	0.3955	f
+\.
+
+
+--
+-- Name: e_gmos_south_fpu; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_south_fpu (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(12) NOT NULL,
+    long_name  character varying(30) NOT NULL,
+    slit_width numeric(3,2)
+);
+
+ALTER TABLE e_gmos_south_fpu OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_south_disperser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_south_fpu (id, short_name, long_name, slit_width) FROM stdin;
+Longslit1	0.25arcsec	Longslit 0.25 arcsec	0.25
+Longslit2	0.50arcsec	Longslit 0.50 arcsec	0.50
+Longslit3	0.75arcsec	Longslit 0.75 arcsec	0.75
+Longslit4	1.0arcsec	Longslit 1.00 arcsec	1.00
+Longslit5	1.5arcsec	Longslit 1.50 arcsec	1.50
+Longslit6	2.0arcsec	Longslit 2.00 arcsec	2.00
+Longslit7	5.0arcsec	Longslit 5.00 arcsec	5.00
+Ifu1	IFU-2	IFU 2 Slits	\N
+Ifu2	IFU-B	IFU Left Slit (blue)	\N
+Ifu3	IFU-R	IFU Right Slit (red)	\N
+Bhros	bHROS	bHROS	\N
+IfuN	IFU-NS-2	IFU N and S 2 Slits	\N
+IfuNB	IFU-NS-B	IFU N and S Left Slit (blue)	\N
+IfuNR	IFU-NS-R	IFU N and S Right Slit (red)	\N
+Ns1	NS0.5arcsec	N and S 0.50 arcsec	0.50
+Ns2	NS0.75arcsec	N and S 0.75 arcsec	0.75
+Ns3	NS1.0arcsec	N and S 1.00 arcsec	1.00
+Ns4	NS1.5arcsec	N and S 1.50 arcsec	1.50
+Ns5	NS2.0arcsec	N and S 2.00 arcsec	2.00
+\.

--- a/modules/sql/src/main/resources/db/migration/V007__GCal_ExposureTime_Type.sql
+++ b/modules/sql/src/main/resources/db/migration/V007__GCal_ExposureTime_Type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE gcal
+  ALTER COLUMN exposure_time TYPE bigint

--- a/modules/sql/src/main/resources/db/migration/V008__Observation_Title_NotNull.sql
+++ b/modules/sql/src/main/resources/db/migration/V008__Observation_Title_NotNull.sql
@@ -1,0 +1,2 @@
+ALTER TABLE observation
+  ALTER COLUMN title SET NOT NULL

--- a/modules/sql/src/main/resources/db/migration/V009__F2_ExposureTime_Type.sql
+++ b/modules/sql/src/main/resources/db/migration/V009__F2_ExposureTime_Type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE step_f2
+  ALTER COLUMN exposure_time TYPE bigint

--- a/modules/sql/src/main/resources/db/migration/V010__F2_2017B_Filter_Updates.sql
+++ b/modules/sql/src/main/resources/db/migration/V010__F2_2017B_Filter_Updates.sql
@@ -1,0 +1,7 @@
+
+COPY e_f2_filter (id, wavelength, short_name, long_name, obsolete) FROM stdin;
+KBlue	2.06	K-blue	K-blue (2.06 um)	f
+KRed	2.31	K-red	K-red (2.31 um)	f
+\.
+
+UPDATE e_f2_filter SET obsolete = 't' WHERE id = 'Open' OR id = 'Dark';

--- a/modules/sql/src/main/resources/db/migration/V011__Observation_Instrument_NotNull.sql
+++ b/modules/sql/src/main/resources/db/migration/V011__Observation_Instrument_NotNull.sql
@@ -1,0 +1,2 @@
+ALTER TABLE observation
+  ALTER COLUMN instrument SET NOT NULL

--- a/modules/sql/src/main/resources/db/migration/V012__Static_Config.sql
+++ b/modules/sql/src/main/resources/db/migration/V012__Static_Config.sql
@@ -1,0 +1,68 @@
+--
+-- This migration adds support for separating the static vs. dynamic (step)
+-- parts of the instrument configuration.  Each observation must have an
+-- instrument and its static configuration.
+--
+
+-- At this point we have just one instrument, F2, and it has just one bit of
+-- static configuration: the mos_preimaging flag.  In this migration we'll move
+-- that flag from it's previous home in the dynamic (step) configuration to a
+-- new static_f2 table.
+ALTER TABLE step_f2
+  DROP COLUMN mos_preimaging;
+
+-- static_config houses a unique id for each static configuation.  Though the
+-- id is sufficient for a primary key, we add the corresponding instrument as a
+-- discriminant.  Over in observation, the static_id and instrument will be a
+-- non-null foreign key into this table.  That ensures that the observation has
+-- a static component and that it uses the same instrument as the observation
+-- itself.
+CREATE TABLE static_config (
+    static_id  SERIAL,
+    instrument identifier NOT NULL REFERENCES e_instrument,
+    PRIMARY KEY (static_id, instrument)
+);
+
+ALTER TABLE static_config OWNER TO postgres;
+
+-- Each instrument will have its own static configuration table.  This is the
+-- static configuration table for F2, which has a payload of a single boolean
+-- mos-preimaging flag.  We have the same (static_id, instrument) foreign key
+-- into the static_config table and furthermore guarantee that the instrument
+-- is always Flamingos2.
+CREATE TABLE static_f2 (
+    static_id       integer,
+    instrument      identifier NOT NULL,
+    mos_preimaging  boolean    NOT NULL,
+    PRIMARY KEY (static_id, instrument),
+    FOREIGN KEY (static_id, instrument) REFERENCES static_config ON DELETE CASCADE,
+    CONSTRAINT is_f2 CHECK (instrument = 'Flamingos2')
+);
+
+ALTER TABLE static_f2 OWNER TO postgres;
+
+-- Observation already has instrument, but we need to add the static_id and set
+-- it up as a foreign key.
+ALTER TABLE observation
+  ADD static_id integer NOT NULL;
+
+ALTER TABLE observation
+  ADD FOREIGN KEY (static_id, instrument) REFERENCES static_config ON DELETE CASCADE;
+
+ALTER TABLE observation
+  ADD CONSTRAINT unique_static_per_obs UNIQUE (static_id);
+
+-- Observation has a foreign key pointing to static_config, but if an
+-- observation is deleted the corresponding static_config stays around.  This
+-- trigger takes care of deleting the matching static_config when an observation
+-- is deleted.  (Note the converse -- deleting a row in static_config -- will
+-- cascade to observation and the static_f2 table.)
+CREATE FUNCTION delete_static_config() RETURNS trigger AS $delete_static_config$
+  BEGIN
+    DELETE FROM static_config WHERE static_id = OLD.static_id;
+    RETURN OLD;
+  END;
+$delete_static_config$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delete_static_config AFTER DELETE ON observation
+  FOR EACH ROW EXECUTE PROCEDURE delete_static_config();

--- a/modules/sql/src/main/resources/db/migration/V013__Add_Gmos_2.sql
+++ b/modules/sql/src/main/resources/db/migration/V013__Add_Gmos_2.sql
@@ -1,0 +1,387 @@
+--
+-- Name: e_gmos_adc; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_adc (
+    id               identifier            PRIMARY KEY,
+    short_name       character varying(11) NOT NULL,
+    long_name        character varying(22) NOT NULL
+);
+
+ALTER TABLE e_gmos_adc OWNER TO postgres;
+
+--
+-- Data for Name: e_gmos_adc; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_adc (id, short_name, long_name) FROM stdin;
+BestStatic	Best Static	Best Static Correction
+Follow	Follow	Follow During Exposure
+\.
+
+
+--
+-- Name: e_gmos_amp_count; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_amp_count (
+    id               identifier            PRIMARY KEY,
+    short_name       character varying(10) NOT NULL,
+    long_name        character varying(10) NOT NULL
+);
+
+ALTER TABLE e_gmos_amp_count OWNER TO postgres;
+
+--
+-- Data for Name: e_gmos_amp_count; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_amp_count (id, short_name, long_name) FROM stdin;
+Three	Three	Three
+Six	Six	Six
+Twelve	Twelve	Twelve
+\.
+
+
+--
+-- Name: e_gmos_amp_gain; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_amp_gain (
+    id               identifier            PRIMARY KEY,
+    short_name       character varying(10) NOT NULL,
+    long_name        character varying(10) NOT NULL
+);
+
+ALTER TABLE e_gmos_amp_gain OWNER TO postgres;
+
+--
+-- Data for Name: e_gmos_amp_gain; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_amp_gain (id, short_name, long_name) FROM stdin;
+Low	Low	Low
+High	High	High
+\.
+
+
+--
+-- Name: e_gmos_amp_read_mode; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_amp_read_mode (
+    id               identifier           PRIMARY KEY,
+    short_name       character varying(4) NOT NULL,
+    long_name        character varying(4) NOT NULL
+);
+
+ALTER TABLE e_gmos_amp_read_mode OWNER TO postgres;
+
+--
+-- Data for Name: e_gmos_amp_read_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_amp_read_mode (id, short_name, long_name) FROM stdin;
+Slow	slow	Slow
+Fast	fast	Fast
+\.
+
+
+--
+-- Name: e_gmos_binning; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_binning (
+    id               identifier           PRIMARY KEY,
+    short_name       character varying(4) NOT NULL,
+    long_name        character varying(4) NOT NULL,
+    count            smallint             NOT NULL
+);
+
+ALTER TABLE e_gmos_binning OWNER TO postgres;
+
+--
+-- Data for Name: e_gmos_binning ; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_binning (id, short_name, long_name, count) FROM stdin;
+One	1	One	1
+Two	2	Two	2
+Four	4	Four	4
+\.
+
+
+--
+-- Name: e_gmos_custom_slit_width; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_custom_slit_width (
+    id               identifier            PRIMARY KEY,
+    short_name       character varying(5)  NOT NULL,
+    long_name        character varying(11) NOT NULL,
+    width            numeric(3,2)          NOT NULL
+);
+
+ALTER TABLE e_gmos_custom_slit_width OWNER TO postgres;
+
+--
+-- Data for Name: e_gmos_custom_slit_width; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_custom_slit_width (id, short_name, long_name, width) FROM stdin;
+CustomWidth_0_25	0.25	0.25 arcsec	0.25
+CustomWidth_0_50	0.50	0.50 arcsec	0.50
+CustomWidth_0_75	0.75	0.75 arcsec	0.75
+CustomWidth_1_00	1.00	1.00 arcsec	1.00
+CustomWidth_1_50	1.50	1.50 arcsec	1.50
+CustomWidth_2_00	2.00	2.00 arcsec	2.00
+CustomWidth_5_00	5.00	5.00 arcsec	5.00
+\.
+
+
+
+--
+-- Name: e_gmos_builtin_roi; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_builtin_roi (
+    id               identifier            PRIMARY KEY,
+    short_name       character varying(5)  NOT NULL,
+    long_name        character varying(18) NOT NULL,
+    x_start          smallint              NOT NULL,
+    y_start          smallint              NOT NULL,
+    x_size           smallint              NOT NULL,
+    y_size           smallint              NOT NULL,
+    obsolete         boolean               NOT NULL
+);
+
+ALTER TABLE e_gmos_builtin_roi OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_builtin_roi; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_builtin_roi (id, short_name, long_name, x_start, y_start, x_size, y_size, obsolete) FROM stdin;
+FullFrame	full	Full Frame Readout	1	1	6144	4608	f
+Ccd2	ccd2	CCD 2	2049	1	2048	4608	f
+CentralSpectrum	cspec	Central Spectrum	1	1792	6144	1024	f
+CentralStamp	stamp	Central Stamp	2922	2154	300	300	f
+TopSpectrum	tspec	Top Spectrum	1	3328	6144	1024	t
+BottomSpectrum	bspec	Bottom Spectrum	1	256	6144	1024	t
+\.
+
+
+--
+-- Name: e_gmos_disperser_order; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_disperser_order (
+    id               identifier            PRIMARY KEY,
+    short_name       character varying(10) NOT NULL,
+    long_name        character varying(10) NOT NULL,
+    count            smallint              NOT NULL
+);
+
+ALTER TABLE e_gmos_disperser_order OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_detector_order; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_disperser_order (id, short_name, long_name, count) FROM stdin;
+Zero	0	Zero	0
+One	1	One	1
+Two	2	Two	2
+\.
+
+
+--
+-- Name: e_gmos_dtax; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_dtax (
+    id         identifier           PRIMARY KEY,
+    short_name character varying(2) NOT NULL,
+    long_name  character varying(2) NOT NULL,
+    dtax       smallint             NOT NULL
+);
+
+ALTER TABLE e_gmos_dtax OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_dtax; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_dtax (id, short_name, long_name, dtax) FROM stdin;
+MinusSix	-6	-6	-6
+MinusFive	-5	-5	-5
+MinusFour	-4	-4	-4
+MinusThree	-3	-3	-3
+MinusTwo	-2	-2	-2
+MinusOne	-1	-1	-1
+Zero	0	0	0
+One	1	1	1
+Two	2	2	2
+Three	3	3	3
+Four	4	4	4
+Five	5	5	5
+Six	6	6	6
+\.
+
+
+--
+-- Name: e_gmos_north_stage_mode; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_north_stage_mode (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(10) NOT NULL,
+    long_name  character varying(20) NOT NULL,
+    obsolete   boolean               NOT NULL
+);
+
+ALTER TABLE e_gmos_north_stage_mode OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_north_stage_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_north_stage_mode (id, short_name, long_name, obsolete) FROM stdin;
+NoFollow	No Follow	Do Not Follow	f
+FollowXyz	Follow XYZ	Follow in XYZ(focus)	t
+FollowXy	Follow XY	Follow in XY	f
+FollowZ	Follow Z	Follow in Z Only	t
+\.
+
+
+
+--
+-- Name: e_gmos_south_stage_mode; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gmos_south_stage_mode (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(12) NOT NULL,
+    long_name  character varying(30) NOT NULL,
+    obsolete   boolean               NOT NULL
+);
+
+ALTER TABLE e_gmos_south_stage_mode OWNER TO postgres;
+
+
+--
+-- Data for Name: e_gmos_south_stage_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gmos_south_stage_mode (id, short_name, long_name, obsolete) FROM stdin;
+NoFollow	No Follow	Do Not Follow	f
+FollowXyz	Follow XYZ	Follow in XYZ(focus)	f
+FollowXy	Follow XY	Follow in XY	t
+FollowZ	Follow Z	Follow in Z Only	f
+\.
+
+
+
+
+--
+-- Name: static_gmos_north; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE static_gmos_north (
+    static_id       integer,
+    instrument      identifier NOT NULL,
+    detector        identifier NOT NULL REFERENCES e_gmos_detector,
+    mos_preimaging  boolean    NOT NULL,
+    stage_mode      identifier NOT NULL REFERENCES e_gmos_north_stage_mode,
+    PRIMARY KEY (static_id, instrument),
+    FOREIGN KEY (static_id, instrument) REFERENCES static_config ON DELETE CASCADE,
+    CONSTRAINT is_gmosn CHECK (instrument = 'GmosN')
+);
+
+ALTER TABLE static_gmos_north OWNER TO postgres;
+
+
+--
+-- Name: static_gmos_south; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE static_gmos_south (
+    static_id       integer,
+    instrument      identifier NOT NULL,
+    detector        identifier NOT NULL REFERENCES e_gmos_detector,
+    mos_preimaging  boolean    NOT NULL,
+    stage_mode      identifier NOT NULL REFERENCES e_gmos_south_stage_mode,
+    PRIMARY KEY (static_id, instrument),
+    FOREIGN KEY (static_id, instrument) REFERENCES static_config ON DELETE CASCADE,
+    CONSTRAINT is_gmoss CHECK (instrument = 'GmosS')
+);
+
+ALTER TABLE static_gmos_south OWNER TO postgres;
+
+
+--
+-- Name: step_gmos_common; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_gmos_common (
+    step_id       integer      PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    x_binning     identifier   NOT NULL    REFERENCES e_gmos_binning,
+    y_binning     identifier   NOT NULL    REFERENCES e_gmos_binning,
+    amp_count     identifier   NOT NULL    REFERENCES e_gmos_amp_count,
+    amp_gain      identifier   NOT NULL    REFERENCES e_gmos_amp_gain,
+    amp_read_mode identifier   NOT NULL    REFERENCES e_gmos_amp_read_mode,
+    dtax          identifier   NOT NULL    REFERENCES e_gmos_dtax,
+    exposure_time bigint       NOT NULL
+);
+
+ALTER TABLE step_gmos_common OWNER TO postgres;
+
+--
+-- Name: step_gmos_north; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_gmos_north (
+    step_id           integer      PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    disperser         identifier               REFERENCES e_gmos_north_disperser,
+    disperser_order   identifier               REFERENCES e_gmos_disperser_order,
+    wavelength        numeric(6,2),
+    filter            identifier               REFERENCES e_gmos_north_filter,
+    mdf_file_name     character varying(32),
+    custom_slit_width identifier               REFERENCES e_gmos_custom_slit_width,
+    fpu               identifier               REFERENCES e_gmos_north_fpu,
+    CONSTRAINT grating_all_or_none
+      CHECK ((disperser IS     NULL AND disperser_order IS     NULL AND wavelength IS     NULL) OR
+             (disperser IS NOT NULL AND disperser_order IS NOT NULL AND wavelength IS NOT NULL)),
+    CONSTRAINT custom_mask_all_or_none
+      CHECK ((mdf_file_name IS     NULL AND custom_slit_width IS     NULL) OR
+             (mdf_file_name IS NOT NULL AND custom_slit_width IS NOT NULL))
+);
+
+ALTER TABLE step_gmos_north OWNER TO postgres;
+
+--
+-- Name: step_gmos_south; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_gmos_south (
+    step_id           integer      PRIMARY KEY REFERENCES step ON DELETE CASCADE,
+    disperser         identifier               REFERENCES e_gmos_south_disperser,
+    disperser_order   identifier               REFERENCES e_gmos_disperser_order,
+    wavelength        numeric(6,2),
+    filter            identifier               REFERENCES e_gmos_south_filter,
+    mdf_file_name     character varying(32),
+    custom_slit_width identifier               REFERENCES e_gmos_custom_slit_width,
+    fpu               identifier               REFERENCES e_gmos_south_fpu,
+    CONSTRAINT grating_all_or_none
+      CHECK ((disperser IS     NULL AND disperser_order IS     NULL AND wavelength IS     NULL) OR
+             (disperser IS NOT NULL AND disperser_order IS NOT NULL AND wavelength IS NOT NULL)),
+    CONSTRAINT custom_mask_all_or_none
+      CHECK ((mdf_file_name IS     NULL AND custom_slit_width IS     NULL) OR
+             (mdf_file_name IS NOT NULL AND custom_slit_width IS NOT NULL))
+);
+
+ALTER TABLE step_gmos_south OWNER TO postgres;

--- a/modules/sql/src/main/resources/db/migration/V014__MosPreImagingType.sql
+++ b/modules/sql/src/main/resources/db/migration/V014__MosPreImagingType.sql
@@ -1,0 +1,51 @@
+--
+-- Adds an e_mos_preimaging type and migrates existing mos_preimaging columns
+-- to use that type instead of boolean.
+--
+
+
+CREATE TABLE e_mos_preimaging (
+    id          identifier            PRIMARY KEY,
+    description character varying(22) NOT NULL,
+    to_boolean  boolean               NOT NULL UNIQUE
+);
+
+ALTER TABLE e_mos_preimaging OWNER TO postgres;
+
+COPY e_mos_preimaging (id, description, to_boolean) FROM stdin;
+IsMosPreImaging	Is MOS Pre-imaging	true
+IsNotMosPreImaging	Is Not MOS Pre-Imaging	false
+\.
+
+CREATE OR REPLACE FUNCTION toMosPreImaging (
+  isPreImaging boolean
+) RETURNS identifier AS $$
+BEGIN
+  IF isPreImaging THEN
+    RETURN 'IsMosPreImaging';
+  ELSE
+    RETURN 'IsNotMosPreImaging';
+  END IF;
+END;
+$$ LANGUAGE 'plpgsql';
+
+ALTER TABLE static_f2
+  ALTER COLUMN mos_preimaging TYPE identifier
+  USING toMosPreImaging(mos_preimaging);
+
+ALTER TABLE static_f2
+  ADD CONSTRAINT FK_e_mos_preimaging_id FOREIGN KEY (mos_preimaging) REFERENCES e_mos_preimaging;
+
+ALTER TABLE static_gmos_north
+  ALTER COLUMN mos_preimaging TYPE identifier
+  USING toMosPreImaging(mos_preimaging);
+
+ALTER TABLE static_gmos_north
+  ADD CONSTRAINT FK_e_mos_preimaging_id FOREIGN KEY (mos_preimaging) REFERENCES e_mos_preimaging;
+
+ALTER TABLE static_gmos_south
+  ALTER COLUMN mos_preimaging TYPE identifier
+  USING toMosPreImaging(mos_preimaging);
+
+ALTER TABLE static_gmos_south
+  ADD CONSTRAINT FK_e_mos_preimaging_id FOREIGN KEY (mos_preimaging) REFERENCES e_mos_preimaging;

--- a/modules/sql/src/main/resources/db/migration/V015__half.sql
+++ b/modules/sql/src/main/resources/db/migration/V015__half.sql
@@ -1,0 +1,8 @@
+CREATE TYPE half AS ENUM (
+    'A', 'B'
+);
+
+ALTER TABLE semester
+  ALTER COLUMN half
+    TYPE half
+    USING half::half

--- a/modules/sql/src/main/resources/db/migration/V016__Add_Gmos_SmartGcal.sql
+++ b/modules/sql/src/main/resources/db/migration/V016__Add_Gmos_SmartGcal.sql
@@ -1,0 +1,30 @@
+--
+-- Smart Gcal Tables for GMOS
+--
+
+CREATE TABLE smart_gmos_north (
+  lamp           gcal_lamp_type     NOT NULL,
+  baseline       gcal_baseline_type NOT NULL,
+  disperser      identifier                  REFERENCES e_gmos_north_disperser ON DELETE CASCADE,
+  filter         identifier                  REFERENCES e_gmos_north_filter    ON DELETE CASCADE,
+  fpu            identifier                  REFERENCES e_gmos_north_fpu       ON DELETE CASCADE,
+  x_binning      identifier         NOT NULL REFERENCES e_gmos_binning         ON DELETE CASCADE,
+  y_binning      identifier         NOT NULL REFERENCES e_gmos_binning         ON DELETE CASCADE,
+  min_wavelength int                NOT NULL CHECK (min_wavelength >= 0),
+  max_wavelength int                NOT NULL CHECK (max_wavelength >= 0),
+  amp_gain       identifier         NOT NULL REFERENCES e_gmos_amp_gain        ON DELETE CASCADE,
+  gcal_id        integer            NOT NULL REFERENCES gcal                   ON DELETE CASCADE,
+  CHECK (min_wavelength <= max_wavelength)
+);
+
+ALTER TABLE smart_gmos_north OWNER TO postgres;
+
+--
+-- Store wavelength in integer angstroms instead of double nm
+--
+
+ALTER TABLE step_gmos_north
+  ALTER COLUMN wavelength SET DATA TYPE integer USING round(wavelength * 10.0);
+
+ALTER TABLE step_gmos_south
+  ALTER COLUMN wavelength SET DATA TYPE integer USING round(wavelength * 10.0);

--- a/modules/sql/src/main/resources/db/migration/V017__Split_gcal_Table.sql
+++ b/modules/sql/src/main/resources/db/migration/V017__Split_gcal_Table.sql
@@ -1,0 +1,25 @@
+--
+-- Currently the gcal table is used to store both manual gcal step
+-- configurations and smart gcal mappings.  In this migration we will update
+-- the step_gcal table to include all the gcal config columns instead of having
+-- a foreign key into gcal.  Then we will drop the step_id column from gcal. At
+-- that point, step_gcal will directly house gcal configurations for manual
+-- gcal steps while the gcal table only holds smart gcal values.
+--
+
+ALTER TABLE step_gcal
+       DROP COLUMN     gcal_id,
+        ADD COLUMN     continuum     identifier                         REFERENCES e_gcal_continuum ON DELETE CASCADE,
+        ADD COLUMN     ar_arc        boolean    NOT NULL DEFAULT FALSE,
+        ADD COLUMN     cuar_arc      boolean    NOT NULL DEFAULT FALSE,
+        ADD COLUMN     thar_arc      boolean    NOT NULL DEFAULT FALSE,
+        ADD COLUMN     xe_arc        boolean    NOT NULL DEFAULT FALSE,
+        ADD COLUMN     filter        identifier NOT NULL                REFERENCES e_gcal_filter    ON DELETE CASCADE,
+        ADD COLUMN     diffuser      identifier NOT NULL                REFERENCES e_gcal_diffuser  ON DELETE CASCADE,
+        ADD COLUMN     shutter       identifier NOT NULL                REFERENCES e_gcal_shutter   ON DELETE CASCADE,
+        ADD COLUMN     exposure_time bigint     NOT NULL,
+        ADD COLUMN     coadds        coadds     NOT NULL,
+        ADD CONSTRAINT check_lamp CHECK ((continuum IS NULL) = (ar_arc OR cuar_arc OR thar_arc OR xe_arc));
+
+ALTER TABLE gcal
+       DROP step_id;

--- a/modules/sql/src/main/resources/db/migration/V018__Add_GmosS_SmartGcal.sql
+++ b/modules/sql/src/main/resources/db/migration/V018__Add_GmosS_SmartGcal.sql
@@ -1,0 +1,20 @@
+--
+-- Smart Gcal Tables for GMOS-S
+--
+
+CREATE TABLE smart_gmos_south (
+  lamp           gcal_lamp_type     NOT NULL,
+  baseline       gcal_baseline_type NOT NULL,
+  disperser      identifier                  REFERENCES e_gmos_south_disperser ON DELETE CASCADE,
+  filter         identifier                  REFERENCES e_gmos_south_filter    ON DELETE CASCADE,
+  fpu            identifier                  REFERENCES e_gmos_south_fpu       ON DELETE CASCADE,
+  x_binning      identifier         NOT NULL REFERENCES e_gmos_binning         ON DELETE CASCADE,
+  y_binning      identifier         NOT NULL REFERENCES e_gmos_binning         ON DELETE CASCADE,
+  min_wavelength int                NOT NULL CHECK (min_wavelength >= 0),
+  max_wavelength int                NOT NULL CHECK (max_wavelength >= 0),
+  amp_gain       identifier         NOT NULL REFERENCES e_gmos_amp_gain        ON DELETE CASCADE,
+  gcal_id        integer            NOT NULL REFERENCES gcal                   ON DELETE CASCADE,
+  CHECK (min_wavelength <= max_wavelength)
+);
+
+ALTER TABLE smart_gmos_south OWNER TO postgres;

--- a/modules/sql/src/main/resources/db/migration/V019__Blowfish.sql
+++ b/modules/sql/src/main/resources/db/migration/V019__Blowfish.sql
@@ -1,0 +1,13 @@
+
+-- We need the stamdard crypto extensions.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Hash column needs to be wider, and renamed.
+ALTER TABLE gem_user ALTER  md5 TYPE text;
+ALTER TABLE gem_user RENAME md5 TO hash;
+
+-- Reset the root password to the empty string.
+-- Other users can no longer log in, but there shouldn't be any.
+UPDATE gem_user
+  SET   hash = crypt('', gen_salt('bf', 10))
+  WHERE id   = 'root'

--- a/modules/sql/src/main/resources/db/migration/V020__Gmos_Nod_And_Shuffle.sql
+++ b/modules/sql/src/main/resources/db/migration/V020__Gmos_Nod_And_Shuffle.sql
@@ -1,0 +1,31 @@
+--
+-- Adds support for GMOS nod and shuffle configuration.
+--
+
+CREATE TABLE e_gmos_e_offsetting(
+    id          identifier            PRIMARY KEY,
+    description character varying(33) NOT NULL,
+    to_boolean  boolean               NOT NULL UNIQUE
+);
+
+ALTER TABLE e_gmos_e_offsetting OWNER TO postgres;
+
+COPY e_gmos_e_offsetting (id, description, to_boolean) FROM stdin;
+On	Electronic Offsetting On	true
+Off	Electronic Offsetting Off	false
+\.
+
+CREATE TABLE gmos_nod_and_shuffle(
+    static_id   integer,
+    instrument  identifier   NOT NULL,
+    a_offset_p  numeric(9,3) NOT NULL,
+    a_offset_q  numeric(9,3) NOT NULL,
+    b_offset_p  numeric(9,3) NOT NULL,
+    b_offset_q  numeric(9,3) NOT NULL,
+    e_offset    identifier   NOT NULL REFERENCES e_gmos_e_offsetting ON DELETE CASCADE,
+    offset_rows integer      NOT NULL CHECK (offset_rows > 0),
+    cycles      integer      NOT NULL CHECK (cycles      > 0),
+    PRIMARY KEY (static_id, instrument),
+    FOREIGN KEY (static_id, instrument) REFERENCES static_config ON DELETE CASCADE,
+    CONSTRAINT is_gmos CHECK ((instrument = 'GmosN') OR (instrument = 'GmosS'))
+);

--- a/modules/sql/src/main/resources/db/migration/V021__Gmos_Regions_of_Interest.sql
+++ b/modules/sql/src/main/resources/db/migration/V021__Gmos_Regions_of_Interest.sql
@@ -1,0 +1,46 @@
+--
+-- Adds support for GMOS Regions of Interest
+--
+
+-- Drop e_gmos_builtin_roi and use e_gmo_roi instead (including custom roi)
+
+DROP TABLE e_gmos_builtin_roi;
+
+CREATE TABLE e_gmos_roi(
+    id          identifier            PRIMARY KEY,
+    short_name  character varying(33) NOT NULL,
+    long_name   character varying(44) NOT NULL,
+    obsolete    boolean               NOT NULL
+);
+
+ALTER TABLE e_gmos_roi OWNER TO postgres;
+
+COPY e_gmos_roi (id, short_name, long_name, obsolete) FROM stdin;
+FullFrame	full	Full Frame Readout	f
+Ccd2	ccd2	CCD 2	f
+CentralSpectrum	cspec	Central Spectrum	f
+CentralStamp	stamp	Central Stamp	f
+TopSpectrum	tspec	Top Spectrum	t
+BottomSpectrum	bspec	Bottom Spectrum	t
+Custom	custom	Custom ROI	f
+\.
+
+
+-- Create a table to hold the ROI(s) for an observation.
+
+CREATE TABLE gmos_custom_roi(
+    id         SERIAL     PRIMARY KEY,
+    static_id  integer,
+    instrument identifier NOT NULL,
+    x_min      smallint   NOT NULL CHECK (x_min   > 0),
+    y_min      smallint   NOT NULL CHECK (y_min   > 0),
+    x_range    smallint   NOT NULL check (x_range > 0),
+    y_range    smallint   NOT NULL check (y_range > 0),
+    FOREIGN KEY (static_id, instrument) REFERENCES static_config ON DELETE CASCADE,
+    CONSTRAINT is_gmos CHECK ((instrument = 'GmosN') OR (instrument = 'GmosS'))
+);
+
+ALTER TABLE gmos_custom_roi OWNER TO postgres;
+
+ALTER TABLE step_gmos_common
+  ADD COLUMN roi identifier NOT NULL REFERENCES e_gmos_roi ON DELETE CASCADE;

--- a/modules/sql/src/main/resources/db/migration/V022__F2_Consistency.sql
+++ b/modules/sql/src/main/resources/db/migration/V022__F2_Consistency.sql
@@ -1,0 +1,41 @@
+--
+-- Updates to F2 to make it consistent with GMOS
+--
+
+-- Remove the "NoDisperser" option.
+DELETE FROM e_f2_disperser
+      WHERE id = 'NoDisperser';
+
+-- The disperser wavelength should be precise μm and not nullable.
+ALTER TABLE e_f2_disperser
+      ALTER COLUMN wavelength TYPE NUMERIC(4,3),
+      ALTER COLUMN wavelength SET NOT NULL;
+
+COMMENT ON COLUMN e_f2_disperser.wavelength IS 'μm';
+
+-- F2 dynamic config may or may not have a disperser.
+ALTER TABLE step_f2
+      ALTER COLUMN disperser DROP NOT NULL;
+
+-- Make the FPU table name match the corresponding gmos versions.
+ALTER TABLE e_f2_fpunit RENAME TO e_f2_fpu;
+
+-- Remove the None and Custom "FPUs".
+DELETE FROM e_f2_fpu
+      WHERE id = 'None' OR id = 'Custom';
+
+COMMENT ON COLUMN e_f2_fpu.slit_width IS 'pixels';
+
+-- The builtin FPU is now optional and the choice to use a custom mask may
+-- be registered.  If a builtin is set, custom_mask must be false.
+ALTER TABLE step_f2
+      ALTER COLUMN fpu DROP NOT NULL,
+        ADD COLUMN custom_mask boolean NOT NULL,
+	ADD CONSTRAINT f2_fpu_check CHECK ((fpu IS NULL) OR (custom_mask = 'f'));
+
+-- The filter wavelength should be precise μm.
+ALTER TABLE e_f2_filter
+      ALTER COLUMN wavelength TYPE NUMERIC(4,3);
+
+COMMENT ON COLUMN e_f2_filter.wavelength IS 'μm';
+

--- a/modules/sql/src/main/resources/db/migration/V023__F2_SmartF2_Constraints.sql
+++ b/modules/sql/src/main/resources/db/migration/V023__F2_SmartF2_Constraints.sql
@@ -1,0 +1,7 @@
+--
+-- Fix constraints in smart_f2, since disperser and fpu are now optional.
+--
+
+ALTER TABLE smart_f2
+      ALTER COLUMN disperser DROP NOT NULL,
+      ALTER COLUMN fpu       DROP NOT NULL;

--- a/modules/sql/src/main/resources/db/migration/V024__Horizons_Type.sql
+++ b/modules/sql/src/main/resources/db/migration/V024__Horizons_Type.sql
@@ -1,0 +1,21 @@
+
+--
+-- Horizons non-sidereal target types.
+--
+
+CREATE TABLE e_horizons_type (
+    id         identifier            PRIMARY KEY,
+    short_name character varying(12) NOT NULL,
+    long_name  character varying(21) NOT NULL
+);
+
+ALTER TABLE e_horizons_type OWNER TO postgres;
+
+
+COPY e_horizons_type (id, short_name, long_name) FROM stdin;
+Comet	Comet	Comet
+AsteroidNew	Asteroid New	Asteroid (New Format)
+AsteroidOld	Asteroid Old	Asteroid (Old Format)
+MajorBody	Major Body	Major Body
+\.
+

--- a/modules/sql/src/main/resources/db/migration/V025__Ephemeris_Type.sql
+++ b/modules/sql/src/main/resources/db/migration/V025__Ephemeris_Type.sql
@@ -1,0 +1,23 @@
+
+---------------------------
+-- Ephemeris Key Types
+---------------------------
+
+DROP TABLE e_horizons_type;
+
+CREATE TABLE e_ephemeris_type (
+    id         identifier PRIMARY KEY,
+    short_name text       NOT NULL,
+    long_name  text       NOT NULL
+);
+
+ALTER TABLE e_ephemeris_type OWNER TO postgres;
+
+
+COPY e_ephemeris_type (id, short_name, long_name) FROM stdin;
+Comet	Comet	Horizons Comet
+AsteroidNew	Asteroid New	Horizons Asteroid (New Format)
+AsteroidOld	Asteroid Old	Horizons Asteroid (Old Format)
+MajorBody	Major Body	Horizons Major Body
+UserSupplied	User Supplied	User Supplied
+\.

--- a/modules/sql/src/main/resources/db/migration/V026__Ephemeris_Table.sql
+++ b/modules/sql/src/main/resources/db/migration/V026__Ephemeris_Table.sql
@@ -1,0 +1,42 @@
+
+--
+-- Ephemeris
+--
+-- RA and dec are represented in both numeric (µs, µas respectively) and
+-- formatted string representation.  Internally we use the numeric value,
+-- but the string representation is provided as well for human consumption.
+--
+
+CREATE TABLE ephemeris (
+    key_type   identifier REFERENCES e_ephemeris_type ON DELETE CASCADE,
+    key        text        NOT NULL,
+    timestamp  timestamptz NOT NULL,
+    ra         bigint      NOT NULL,
+    dec        bigint      NOT NULL,
+    ra_str     varchar(15) NOT NULL,
+    dec_str    varchar(16) NOT NULL,
+    CONSTRAINT ra_str_check  CHECK (ra_str  ~     '^\d\d:\d\d:\d\d\.\d\d\d\d\d\d$'),
+    CONSTRAINT dec_str_check CHECK (dec_str ~ '^[+-]\d\d:\d\d:\d\d\.\d\d\d\d\d\d$'),
+    PRIMARY KEY (key_type, key, timestamp)
+);
+
+ALTER TABLE ephemeris OWNER TO postgres;
+
+COMMENT ON COLUMN ephemeris.ra      IS 'µs';
+COMMENT ON COLUMN ephemeris.dec     IS 'µas';
+COMMENT ON COLUMN ephemeris.ra_str  IS 'HH:MM:SS.µµµµµµ';
+COMMENT ON COLUMN ephemeris.dec_str IS '[+-]DD:MM:SS.µµµµµµ';
+
+
+--
+-- Sequence for UserSupplied keys.  Here we set the max value to Int.MaxValue
+-- so that we can store the resulting value in an Int.
+--
+
+CREATE SEQUENCE user_ephemeris_id
+    MINVALUE 0
+    MAXVALUE 2147483647
+    START WITH 0
+    NO CYCLE;
+
+ALTER SEQUENCE user_ephemeris_id OWNER TO postgres;

--- a/modules/sql/src/main/resources/db/migration/V027__Ephemeris_Site.sql
+++ b/modules/sql/src/main/resources/db/migration/V027__Ephemeris_Site.sql
@@ -1,0 +1,11 @@
+
+--
+-- Adds a site column to the ephemeris table (and makes it part of its
+-- primary key).
+--
+
+ALTER TABLE ephemeris
+    DROP CONSTRAINT ephemeris_pkey,
+    ADD COLUMN site identifier NOT NULL REFERENCES e_site ON DELETE CASCADE,
+    ADD PRIMARY KEY (key_type, key, site, timestamp);
+

--- a/modules/sql/src/main/resources/db/migration/V028__Target.sql
+++ b/modules/sql/src/main/resources/db/migration/V028__Target.sql
@@ -1,0 +1,77 @@
+-- Track type, which is used as a tag. This is not strictly necessary but will make it easier to
+-- write queries later on.
+
+CREATE TYPE e_track_type AS ENUM ('Sidereal', 'Nonsidereal');
+
+-- Target table, which is mostly the Track encoding as a coproduct. So either the proper motion
+-- columns will be all NULL or the ephemeris key columns will be all NULL. A check constraint
+-- guarantees this. A tag tells us which to expect.
+
+CREATE TABLE target (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(64) NOT NULL,
+
+  -- tag
+  track_type e_track_type  NOT NULL,
+
+  -- proper motion base coordinates, human-readable
+  ra_str     VARCHAR(15)   NULL,
+  dec_str    VARCHAR(16)   NULL,
+
+  CONSTRAINT ra_str_check  CHECK (ra_str  ~     '^\d\d:\d\d:\d\d\.\d\d\d\d\d\d$'),
+  CONSTRAINT dec_str_check CHECK (dec_str ~ '^[+-]\d\d:\d\d:\d\d\.\d\d\d\d\d\d$'),
+
+  -- proper motion columns
+  ra         BIGINT        NULL,
+  dec        BIGINT        NULL,
+  epoch      VARCHAR(9)    NULL,
+  pv_ra      BIGINT        NULL,
+  pv_dec     BIGINT        NULL,
+  rv         INT           NULL,
+  px         BIGINT        NULL,
+
+  -- ephemeris columns
+  e_key_type identifier    NULL REFERENCES e_ephemeris_type,
+  e_key      text          NULL,
+
+  -- ensure that the coproduct encoding is consistent
+  CONSTRAINT target_coproduct CHECK ((
+    track_type = 'Sidereal'
+      AND e_key_type IS NULL
+      AND e_key      IS NULL
+      AND ra_str     IS NOT NULL
+      AND dec_str    IS NOT NULL
+      AND ra         IS NOT NULL
+      AND dec        IS NOT NULL
+      AND epoch      IS NOT NULL
+      -- remaining columns can be null
+  ) OR (
+    track_type = 'Nonsidereal'
+      AND e_key_type IS NOT NULL
+      AND e_key      IS NOT NULL
+      AND ra_str     IS NULL
+      AND dec_str    IS NULL
+      AND ra         IS NULL
+      AND dec        IS NULL
+      AND epoch      IS NULL
+      AND pv_ra      IS NULL
+      AND pv_dec     IS NULL
+      AND rv         IS NULL
+      AND px         IS NULL
+  ))
+
+);
+
+COMMENT ON COLUMN target.name       IS 'human-readable target name';
+COMMENT ON COLUMN target.track_type IS 'track type, which determines nullability of following columns';
+COMMENT ON COLUMN target.ra_str     IS '(sidereal) human-readable right ascension as hh:mm:ss.µµµµµµ';
+COMMENT ON COLUMN target.dec_str    IS '(sidereal) human-readable declination as +dd:mm:ss.µµµµµµ';
+COMMENT ON COLUMN target.ra         IS '(sidereal) right ascension in microseconds';
+COMMENT ON COLUMN target.dec        IS '(sidereal) declination in microarcseconds';
+COMMENT ON COLUMN target.epoch      IS '(sidereal) epoch as J2000.123';
+COMMENT ON COLUMN target.pv_ra      IS '(sidereal) proper velocity in right ascension, in microarcseconds per year';
+COMMENT ON COLUMN target.pv_dec     IS '(sidereal) proper velocity in declination, in microarcseconds per year';
+COMMENT ON COLUMN target.rv         IS '(sidereal) radial velocity in km/sec, positive if receding';
+COMMENT ON COLUMN target.px         IS '(sidereal) parallax in microarcseconds';
+COMMENT ON COLUMN target.e_key_type IS '(nonsidereal) ephemeris key type';
+COMMENT ON COLUMN target.e_key_type IS '(nonsidereal) ephemeris key';

--- a/modules/sql/src/main/resources/db/migration/V029__Ephemeris_Meta.sql
+++ b/modules/sql/src/main/resources/db/migration/V029__Ephemeris_Meta.sql
@@ -1,0 +1,20 @@
+
+--
+-- Ephemeris metadata used to report upon last update times and, for comets
+-- and asteroids, avoid unnecessary updates.
+--
+
+CREATE TABLE ephemeris_meta (
+    key_type          identifier  REFERENCES e_ephemeris_type,
+    key               text        NOT NULL,
+    site              identifier  REFERENCES e_site,
+    last_update       timestamptz NOT NULL,
+    last_update_check timestamptz NOT NULL,
+    horizons_soln_ref text,
+    PRIMARY KEY (key_type, key, site)
+);
+
+ALTER TABLE ephemeris_meta OWNER TO postgres;
+
+COMMENT ON COLUMN ephemeris_meta.horizons_soln_ref IS 'horizons-defined version for comet and asteroid ephemeris calculations';
+

--- a/modules/sql/src/main/resources/db/migration/V030__Ephemeris_Velocity.sql
+++ b/modules/sql/src/main/resources/db/migration/V030__Ephemeris_Velocity.sql
@@ -1,0 +1,16 @@
+
+--
+-- Ephemeris
+--
+-- RA and dec are represented in both numeric (µs, µas respectively) and
+-- formatted string representation.  Internally we use the numeric value,
+-- but the string representation is provided as well for human consumption.
+--
+
+ALTER TABLE ephemeris
+   ADD COLUMN delta_ra  NUMERIC(10,6) NOT NULL,
+   ADD COLUMN delta_dec NUMERIC(10,6) NOT NULL;
+
+
+COMMENT ON COLUMN ephemeris.delta_ra  IS 'arcsec / hour * cos(dec)';
+COMMENT ON COLUMN ephemeris.delta_dec IS 'arcsec / hour';

--- a/modules/sql/src/main/resources/db/migration/V031__Comments.sql
+++ b/modules/sql/src/main/resources/db/migration/V031__Comments.sql
@@ -1,0 +1,213 @@
+--
+-- Adds comments to various tables, columns, types.
+--
+
+COMMENT ON COLUMN e_f2_lyot_wheel.pixel_scale              IS
+  'arcsec/pixel';
+
+COMMENT ON COLUMN e_f2_lyot_wheel.plate_scale              IS
+  'arcsec/nm';
+
+COMMENT ON COLUMN e_f2_read_mode.minimum_exposure_time     IS
+  'ms';
+
+COMMENT ON COLUMN e_f2_read_mode.recommended_exposure_time IS
+  'ms';
+
+COMMENT ON COLUMN e_f2_read_mode.read_noise                IS
+  'e- @ 77K';
+
+COMMENT ON COLUMN e_f2_read_mode.readout_time              IS
+  'ms';
+
+COMMENT ON COLUMN e_gmos_custom_slit_width.width           IS
+  'arcsec';
+
+COMMENT ON COLUMN e_gmos_detector.north_pixel_size         IS
+  'arcsec/pixel';
+
+COMMENT ON COLUMN e_gmos_detector.south_pixel_size         IS
+  'arcsec/pixel';
+
+COMMENT ON COLUMN e_gmos_detector.shuffle_offset           IS
+  'pixels';
+
+COMMENT ON COLUMN e_gmos_detector.x_size                   IS
+  'pixels';
+
+COMMENT ON COLUMN e_gmos_detector.y_size                   IS
+  'pixels';
+
+COMMENT ON COLUMN e_gmos_detector.max_rois                 IS
+  'maximum regions of interest';
+
+COMMENT ON COLUMN e_gmos_disperser_order.count             IS
+  'Corresponding numeric value.  E.g., 0, 1, 2';
+
+COMMENT ON COLUMN e_gmos_dtax.dtax                         IS
+  'Detector Translation Assembly X-Offset Value';
+
+COMMENT ON COLUMN e_gmos_north_disperser.ruling_density    IS
+  'lines/mm';
+
+COMMENT ON COLUMN e_gmos_north_filter.wavelength           IS
+  'µm';
+
+COMMENT ON COLUMN e_gmos_north_fpu.slit_width              IS
+  'arcsec';
+
+COMMENT ON COLUMN e_gmos_south_disperser.ruling_density    IS
+  'lines/mm';
+
+COMMENT ON COLUMN e_gmos_south_filter.wavelength           IS
+  'µm';
+
+COMMENT ON COLUMN e_gmos_south_fpu.slit_width              IS
+  'arcsec';
+
+COMMENT ON COLUMN ephemeris_meta.horizons_soln_ref         IS
+  'JPL Horizons ephemeris calc version';
+
+COMMENT ON COLUMN gcal.exposure_time                       IS
+  'ms';
+
+COMMENT ON COLUMN gmos_custom_roi.x_min                    IS
+  'pixel index';
+
+COMMENT ON COLUMN gmos_custom_roi.y_min                    IS
+  'pixel index';
+
+COMMENT ON COLUMN gmos_custom_roi.x_range                  IS
+  'pixel count';
+
+COMMENT ON COLUMN gmos_custom_roi.y_range                  IS
+  'pixel count';
+
+COMMENT ON COLUMN gmos_nod_and_shuffle.a_offset_p          IS
+  'arcsec, A offset position, offset in p';
+
+COMMENT ON COLUMN gmos_nod_and_shuffle.a_offset_q          IS
+  'arcsec, A offset position, offset in q';
+
+COMMENT ON COLUMN gmos_nod_and_shuffle.b_offset_p          IS
+  'arcsec, B offset position, offset in p';
+
+COMMENT ON COLUMN gmos_nod_and_shuffle.b_offset_q          IS
+  'arcsec, B offset position, offset in q';
+
+COMMENT ON COLUMN gmos_nod_and_shuffle.e_offset            IS
+  'whether to use electronic offsetting';
+
+COMMENT ON COLUMN gmos_nod_and_shuffle.offset_rows         IS
+  'detector rows';
+
+COMMENT ON COLUMN gmos_nod_and_shuffle.cycles              IS
+  'Nod and shuffle cycles';
+
+COMMENT ON COLUMN smart_gmos_north.min_wavelength          IS
+  'nm';
+
+COMMENT ON COLUMN smart_gmos_north.max_wavelength          IS
+  'nm';
+
+COMMENT ON COLUMN smart_gmos_south.min_wavelength          IS
+  'nm';
+
+COMMENT ON COLUMN smart_gmos_south.max_wavelength          IS
+  'nm';
+
+COMMENT ON COLUMN step.location                            IS
+  'Used to order steps, step.location values are sortable and it is always possible to insert new values between any two existing locations';
+
+COMMENT ON COLUMN step.step_type                           IS
+  'Step type distinguishes between various kinds of steps: bias, dark, science, smart GCAL, etc.';
+
+COMMENT ON COLUMN step_f2.exposure_time                    IS
+  'ms';
+
+COMMENT ON COLUMN step_gcal.exposure_time                  IS
+  'ms';
+
+COMMENT ON COLUMN step_gmos_common.exposure_time           IS
+  'ms';
+
+COMMENT ON COLUMN step_gmos_north.wavelength               IS
+  'nm';
+
+COMMENT ON COLUMN step_gmos_south.wavelength               IS
+  'nm';
+
+COMMENT ON COLUMN step_science.offset_p                    IS
+  'arcsec';
+
+COMMENT ON COLUMN step_science.offset_q                    IS
+  'arcsec';
+
+COMMENT ON DOMAIN coadds                                   IS
+  'Coadd count constrained to positive, non-zero';
+
+COMMENT ON DOMAIN id_index                                 IS
+  'Index of program and observation ids, constrained to positive, non-zero';
+
+COMMENT ON DOMAIN identifier                               IS
+  'Enumeration value constrained to a valid Scala id';
+
+COMMENT ON DOMAIN milliseconds                             IS
+  'Non-negative milliseconds';
+
+COMMENT ON SEQUENCE static_config_static_id_seq            IS
+  'Ever increasing id for static instrument configurations (see static_config table)';
+
+COMMENT ON SEQUENCE step_step_id_seq                       IS
+  'Ever increasing id for dynamic instrument configuration steps (see step table)';
+
+COMMENT ON TABLE e_ephemeris_type                          IS
+  'Type of ephemeris data / non-sidereal object, e.g. Comet';
+
+COMMENT ON TABLE e_gmos_dtax                               IS
+  'GMOS Detector Translation Assembly X-Offset [-6, 6]';
+
+COMMENT ON TABLE e_gmos_e_offsetting                       IS
+  'Values of a boolean flag determining whether to use electronic offsetting';
+
+COMMENT ON TABLE e_gmos_roi                                IS
+  'GMOS Detector Region of Interest';
+
+COMMENT ON TABLE e_mos_preimaging                          IS
+  'Values of a boolean flag determining whether an observation is for creating MOS masks';
+
+COMMENT ON TABLE ephemeris_meta                            IS
+  'Information used to determine whether an ephemeris update is necessary';
+
+COMMENT ON TABLE gmos_custom_roi                           IS
+  'GMOS detector custom region of interest description';
+
+COMMENT ON TABLE smart_f2                                  IS
+  'F2 instrument configuration key for Smart GCal lookups';
+
+COMMENT ON TABLE smart_gmos_north                          IS
+  'GMOS North instrument configuration key for Smart GCal lookups';
+
+COMMENT ON TABLE smart_gmos_south                          IS
+  'GMOS South instrument configuration key for Smart GCal lookups';
+
+COMMENT ON TABLE static_config                             IS
+  'Used to link an observation to its instrument''s static configuration';
+
+COMMENT ON TABLE static_f2                                 IS
+  'Unchangable F2 configuration for an observation';
+
+COMMENT ON TABLE static_gmos_north                         IS
+  'Unchangable GMOS North configuration for an observation';
+
+COMMENT ON TABLE static_gmos_south                         IS
+  'Unchangable GMOS South configuration for an observation';
+
+COMMENT ON TABLE step                                      IS
+  'Used to link an observation to each step of its instrument''s dynamic configuration';
+
+COMMENT ON TABLE step_gmos_common                          IS
+  'Common sequence step configuration across GMOS North and GMOS South';
+
+COMMENT ON TYPE   evt_type                                 IS
+  'Observing Event Type';

--- a/modules/sql/src/main/resources/db/migration/V032__DontCascade.sql
+++ b/modules/sql/src/main/resources/db/migration/V032__DontCascade.sql
@@ -1,0 +1,96 @@
+--
+-- Remove "ON DELETE CASCADE" for foreign key references of enum tables.  When
+-- an enum value is removed, we need to carefully migrate data.
+--
+
+ALTER TABLE ephemeris
+  DROP CONSTRAINT ephemeris_key_type_fkey,
+  ADD  CONSTRAINT ephemeris_key_type_fkey FOREIGN KEY (key_type) REFERENCES e_ephemeris_type(id),
+  DROP CONSTRAINT ephemeris_site_fkey,
+  ADD  CONSTRAINT ephemeris_site_fkey     FOREIGN KEY (site)     REFERENCES e_site(id);
+
+ALTER TABLE ephemeris_meta
+  DROP CONSTRAINT ephemeris_meta_key_type_fkey,
+  ADD  CONSTRAINT ephemeris_meta_key_type_fkey FOREIGN KEY (key_type) REFERENCES e_ephemeris_type(id),
+  DROP CONSTRAINT ephemeris_meta_site_fkey,
+  ADD  CONSTRAINT ephemeris_meta_site_fkey     FOREIGN KEY (site)     REFERENCES e_site(id);
+
+ALTER TABLE gcal
+  DROP CONSTRAINT gcal_continuum_fkey,
+  ADD  CONSTRAINT gcal_continuum_fkey FOREIGN KEY (continuum) REFERENCES e_gcal_continuum(id),
+  DROP CONSTRAINT gcal_diffuser_fkey,
+  ADD  CONSTRAINT gcal_diffuser_fkey  FOREIGN KEY (diffuser)  REFERENCES e_gcal_diffuser(id),
+  DROP CONSTRAINT gcal_filter_fkey,
+  ADD  CONSTRAINT gcal_filter_fkey    FOREIGN KEY (filter)    REFERENCES e_gcal_filter(id),
+  DROP CONSTRAINT gcal_shutter_fkey,
+  ADD  CONSTRAINT gcal_shutter_fkey   FOREIGN KEY (shutter)   REFERENCES e_gcal_shutter(id);
+
+ALTER TABLE gmos_nod_and_shuffle
+  DROP CONSTRAINT gmos_nod_and_shuffle_e_offset_fkey,
+  ADD  CONSTRAINT gmos_nod_and_shuffle_e_offset_fkey FOREIGN KEY (e_offset) REFERENCES e_gmos_e_offsetting(id);
+
+ALTER TABLE smart_f2
+  DROP CONSTRAINT smart_f2_disperser_fkey,
+  ADD  CONSTRAINT smart_f2_disperser_fkey FOREIGN KEY (disperser) REFERENCES e_f2_disperser(id),
+  DROP CONSTRAINT smart_f2_filter_fkey,
+  ADD  CONSTRAINT smart_f2_filter_fkey    FOREIGN KEY (filter)    REFERENCES e_f2_filter(id),
+  DROP CONSTRAINT smart_f2_fpu_fkey,
+  ADD  CONSTRAINT smart_f2_fpu_fkey       FOREIGN KEY (fpu)       REFERENCES e_f2_fpu(id);
+
+ALTER TABLE smart_gmos_north
+  DROP CONSTRAINT smart_gmos_north_amp_gain_fkey,
+  ADD  CONSTRAINT smart_gmos_north_amp_gain_fkey  FOREIGN KEY (amp_gain)  REFERENCES e_gmos_amp_gain(id),
+  DROP CONSTRAINT smart_gmos_north_disperser_fkey,
+  ADD  CONSTRAINT smart_gmos_north_disperser_fkey FOREIGN KEY (disperser) REFERENCES e_gmos_north_disperser(id),
+  DROP CONSTRAINT smart_gmos_north_filter_fkey,
+  ADD  CONSTRAINT smart_gmos_north_filter_fkey    FOREIGN KEY (filter)    REFERENCES e_gmos_north_filter(id),
+  DROP CONSTRAINT smart_gmos_north_fpu_fkey,
+  ADD  CONSTRAINT smart_gmos_north_fpu_fkey       FOREIGN KEY (fpu)       REFERENCES e_gmos_north_fpu(id),
+  DROP CONSTRAINT smart_gmos_north_x_binning_fkey,
+  ADD  CONSTRAINT smart_gmos_north_x_binning_fkey FOREIGN KEY (x_binning) REFERENCES e_gmos_binning(id),
+  DROP CONSTRAINT smart_gmos_north_y_binning_fkey,
+  ADD  CONSTRAINT smart_gmos_north_y_binning_fkey FOREIGN KEY (y_binning) REFERENCES e_gmos_binning(id);
+
+ALTER TABLE smart_gmos_south
+  DROP CONSTRAINT smart_gmos_south_amp_gain_fkey,
+  ADD  CONSTRAINT smart_gmos_south_amp_gain_fkey  FOREIGN KEY (amp_gain)  REFERENCES e_gmos_amp_gain(id),
+  DROP CONSTRAINT smart_gmos_south_disperser_fkey,
+  ADD  CONSTRAINT smart_gmos_south_disperser_fkey FOREIGN KEY (disperser) REFERENCES e_gmos_south_disperser(id),
+  DROP CONSTRAINT smart_gmos_south_filter_fkey,
+  ADD  CONSTRAINT smart_gmos_south_filter_fkey    FOREIGN KEY (filter)    REFERENCES e_gmos_south_filter(id),
+  DROP CONSTRAINT smart_gmos_south_fpu_fkey,
+  ADD  CONSTRAINT smart_gmos_south_fpu_fkey       FOREIGN KEY (fpu)       REFERENCES e_gmos_south_fpu(id),
+  DROP CONSTRAINT smart_gmos_south_x_binning_fkey,
+  ADD  CONSTRAINT smart_gmos_south_x_binning_fkey FOREIGN KEY (x_binning) REFERENCES e_gmos_binning(id),
+  DROP CONSTRAINT smart_gmos_south_y_binning_fkey,
+  ADD  CONSTRAINT smart_gmos_south_y_binning_fkey FOREIGN KEY (y_binning) REFERENCES e_gmos_binning(id);
+
+ALTER TABLE step_f2
+  DROP CONSTRAINT step_f2_disperser_fkey,
+  ADD  CONSTRAINT step_f2_disperser_fkey    FOREIGN KEY (disperser)    REFERENCES e_f2_disperser(id),
+  DROP CONSTRAINT step_f2_filter_fkey,
+  ADD  CONSTRAINT step_f2_filter_fkey       FOREIGN KEY (filter)       REFERENCES e_f2_filter(id),
+  DROP CONSTRAINT step_f2_fpu_fkey,
+  ADD  CONSTRAINT step_f2_fpu_fkey          FOREIGN KEY (fpu)          REFERENCES e_f2_fpu(id),
+  DROP CONSTRAINT step_f2_lyot_wheel_fkey,
+  ADD  CONSTRAINT step_f2_lyot_wheel_fkey   FOREIGN KEY (lyot_wheel)   REFERENCES e_f2_lyot_wheel(id),
+  DROP CONSTRAINT step_f2_read_mode_fkey,
+  ADD  CONSTRAINT step_f2_read_mode_fkey    FOREIGN KEY (read_mode)    REFERENCES e_f2_read_mode(id),
+  DROP CONSTRAINT step_f2_window_cover_fkey,
+  ADD  CONSTRAINT step_f2_window_cover_fkey FOREIGN KEY (window_cover) REFERENCES e_f2_window_cover(id);
+
+ALTER TABLE step_gcal
+  DROP CONSTRAINT step_gcal_continuum_fkey,
+  ADD  CONSTRAINT step_gcal_continuum_fkey FOREIGN KEY (continuum) REFERENCES e_gcal_continuum(id),
+  DROP CONSTRAINT step_gcal_diffuser_fkey,
+  ADD  CONSTRAINT step_gcal_diffuser_fkey  FOREIGN KEY (diffuser)  REFERENCES e_gcal_diffuser(id),
+  DROP CONSTRAINT step_gcal_filter_fkey,
+  ADD  CONSTRAINT step_gcal_filter_fkey    FOREIGN KEY (filter)    REFERENCES e_gcal_filter(id),
+  DROP CONSTRAINT step_gcal_shutter_fkey,
+  ADD  CONSTRAINT step_gcal_shutter_fkey   FOREIGN KEY (shutter)   REFERENCES e_gcal_shutter(id);
+
+ALTER TABLE step_gmos_common
+  DROP CONSTRAINT step_gmos_common_roi_fkey,
+  ADD  CONSTRAINT step_gmos_common_roi_fkey FOREIGN KEY (roi) REFERENCES e_gmos_roi(id);
+
+

--- a/modules/sql/src/main/resources/db/migration/V033__Magnitude_Band.sql
+++ b/modules/sql/src/main/resources/db/migration/V033__Magnitude_Band.sql
@@ -1,0 +1,60 @@
+--
+-- Name: magnitude_system; Type: TYPE; Schema: public; Owner: postgres
+--
+
+-- Note: this may need to be turned into a table once we start taking into
+-- account the units needed for ITC Watts and Ergs.
+CREATE TYPE magnitude_system AS ENUM (
+    'Vega',
+    'AB',
+    'Jy'
+);
+
+ALTER TYPE magnitude_system OWNER TO postgres;
+
+COMMENT ON TYPE magnitude_system IS 'Integrated brightness units';
+
+--
+-- Name: e_magnitude_band; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_magnitude_band (
+    id             identifier            PRIMARY KEY,
+    short_name     character varying(2)  NOT NULL,
+    long_name      character varying(14) NOT NULL,
+    center         integer               NOT NULL,
+    width          integer               NOT NULL,
+    default_system magnitude_system      NOT NULL
+);
+
+ALTER TABLE e_magnitude_band OWNER TO postgres;
+
+COMMENT ON COLUMN e_magnitude_band.center IS 'nm';
+COMMENT ON COLUMN e_magnitude_band.width  IS 'nm';
+
+--
+-- Data for Name: e_magnitude_band; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_magnitude_band (id, short_name, long_name, center, width, default_system) FROM stdin;
+SloanU	u	UV	356	46	AB
+SloanG	g	Green	483	99	AB
+SloanR	r	Red	626	96	AB
+SloanI	i	Far red	767	106	AB
+SloanZ	z	Near infrared	910	125	AB
+U	U	Ultraviolet	360	75	Vega
+B	B	Blue	440	90	Vega
+V	V	Visual	550	85	Vega
+Uc	UC	UCAC	610	63	Vega
+R	R	Red	670	100	Vega
+I	I	Infrared	870	100	Vega
+Y	Y	Y	1020	120	Vega
+J	J	J	1250	240	Vega
+H	H	H	1650	300	Vega
+K	K	K	2200	410	Vega
+L	L	L	3760	700	Vega
+M	M	M	4770	240	Vega
+N	N	N	10470	5230	Vega
+Q	Q	Q	20130	1650	Vega
+Ap	AP	Apparent	550	85	Vega
+\.

--- a/modules/sql/src/main/resources/db/migration/V034__Replace_Floating.sql
+++ b/modules/sql/src/main/resources/db/migration/V034__Replace_Floating.sql
@@ -1,0 +1,17 @@
+--
+-- Replace double and real by numeric(m,n)
+--
+
+ALTER TABLE e_site
+      ALTER COLUMN longitude TYPE numeric(10,7),
+      ALTER COLUMN latitude  TYPE numeric(10,7);
+
+-- Some precision is lost during conversion
+UPDATE e_site SET longitude = -155.469055, latitude =  19.8238068 WHERE id = 'GN';
+UPDATE e_site SET longitude = -70.7366867, latitude = -30.2407494 WHERE id = 'GS';
+
+ALTER TABLE e_f2_lyot_wheel
+      ALTER COLUMN plate_scale TYPE numeric(4,3),
+      ALTER COLUMN pixel_scale TYPE numeric(3,2);
+
+ALTER TABLE e_f2_read_mode ALTER COLUMN read_noise TYPE numeric(3,1);

--- a/modules/sql/src/main/resources/db/migration/V035__Target_Update.sql
+++ b/modules/sql/src/main/resources/db/migration/V035__Target_Update.sql
@@ -1,0 +1,15 @@
+
+--
+-- Updates target table proper velocity and parallax from (unsigned) bigint
+-- microarcseconds to (signed) numeric milliarcseconds.
+--
+
+ALTER TABLE target
+  ALTER COLUMN pv_ra  SET DATA TYPE numeric(9,3),
+  ALTER COLUMN pv_dec SET DATA TYPE numeric(9,3),
+  ALTER COLUMN px     SET DATA TYPE numeric(9,3);
+
+COMMENT ON COLUMN target.pv_ra  IS '(sidereal) proper velocity in right ascension, in milliarcseconds per year';
+COMMENT ON COLUMN target.pv_dec IS '(sidereal) proper velocity in declination, in milliarcseconds per year';
+COMMENT ON COLUMN target.px     IS '(sidereal) parallax in milliarcseconds';
+

--- a/modules/sql/src/main/resources/db/migration/V036__Varchar_To_Text.sql
+++ b/modules/sql/src/main/resources/db/migration/V036__Varchar_To_Text.sql
@@ -1,0 +1,206 @@
+ALTER TABLE dataset
+  ALTER COLUMN dataset_label TYPE TEXT,
+  ALTER COLUMN observation_id TYPE TEXT,
+  ALTER COLUMN filename TYPE TEXT;
+
+ALTER TABLE e_f2_disperser
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_f2_filter
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_f2_fpu
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_f2_lyot_wheel
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_f2_read_mode
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT,
+  ALTER COLUMN description TYPE TEXT;
+
+ALTER TABLE e_f2_window_cover
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gcal_arc
+  ALTER COLUMN id TYPE identifier,
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gcal_continuum
+  ALTER COLUMN id TYPE identifier,
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gcal_diffuser
+  ALTER COLUMN id TYPE identifier,
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gcal_filter
+  ALTER COLUMN id TYPE identifier,
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gcal_shutter
+  ALTER COLUMN id TYPE identifier,
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_adc
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_amp_count
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_amp_gain
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_amp_read_mode
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_binning
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_custom_slit_width
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_detector
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_disperser_order
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_dtax
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_e_offsetting
+  ALTER COLUMN description TYPE TEXT;
+
+ALTER TABLE e_gmos_north_disperser
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_north_filter
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_north_fpu
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_north_stage_mode
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_roi
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_south_disperser
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_south_filter
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_south_fpu
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_gmos_south_stage_mode
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_instrument
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_magnitude_band
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_mos_preimaging
+  ALTER COLUMN description TYPE TEXT;
+
+ALTER TABLE e_program_role
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_program_type
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE e_site
+  ALTER COLUMN long_name TYPE TEXT,
+  ALTER COLUMN mountain TYPE TEXT,
+  ALTER COLUMN timezone TYPE TEXT,
+  ALTER COLUMN short_name TYPE TEXT;
+
+ALTER TABLE e_template
+  ALTER COLUMN short_name TYPE TEXT,
+  ALTER COLUMN long_name TYPE TEXT;
+
+ALTER TABLE ephemeris
+  ALTER COLUMN ra_str TYPE TEXT,
+  ALTER COLUMN dec_str TYPE TEXT;
+
+ALTER TABLE gem_user
+  ALTER COLUMN id TYPE TEXT,
+  ALTER COLUMN first TYPE TEXT,
+  ALTER COLUMN last TYPE TEXT,
+  ALTER COLUMN email TYPE TEXT;
+
+ALTER TABLE gem_user_program
+  ALTER COLUMN user_id TYPE TEXT,
+  ALTER COLUMN program_id TYPE TEXT;
+
+ALTER TABLE log
+  ALTER COLUMN program TYPE TEXT,
+  ALTER COLUMN message TYPE TEXT,
+  ALTER COLUMN user_id TYPE TEXT;
+
+
+ALTER TABLE observation
+  ALTER COLUMN program_id TYPE TEXT,
+  ALTER COLUMN title TYPE TEXT,
+  ALTER COLUMN observation_id TYPE TEXT;
+
+ALTER TABLE program
+  ALTER COLUMN program_id TYPE TEXT,
+  ALTER COLUMN semester_id TYPE TEXT,
+  ALTER COLUMN title TYPE TEXT;
+
+ALTER TABLE semester
+  ALTER COLUMN semester_id TYPE TEXT;
+
+ALTER TABLE step
+  ALTER COLUMN observation_id TYPE TEXT;
+
+ALTER TABLE step_gmos_north
+  ALTER COLUMN mdf_file_name TYPE TEXT;
+
+ALTER TABLE step_gmos_south
+  ALTER COLUMN mdf_file_name TYPE TEXT;
+
+ALTER TABLE target
+  ALTER COLUMN name TYPE TEXT,
+  ALTER COLUMN ra_str TYPE TEXT,
+  ALTER COLUMN dec_str TYPE TEXT,
+  ALTER COLUMN epoch TYPE TEXT;

--- a/modules/sql/src/main/resources/db/migration/V037__User_Targets.sql
+++ b/modules/sql/src/main/resources/db/migration/V037__User_Targets.sql
@@ -1,0 +1,38 @@
+--
+-- Adds user targets to the model.
+--
+
+
+-- User Target Type
+--
+-- An enumeration of the various uses of target positions associated with an
+-- observation apart from the main science targets.
+
+CREATE TABLE e_user_target_type (
+  id         identifier PRIMARY KEY,
+  short_name TEXT       NOT NULL,
+  long_name  TEXT       NOT NULL,
+  obsolete   boolean    NOT NULL
+);
+
+ALTER TABLE e_user_target_type OWNER TO postgres;
+
+COPY e_user_target_type (id, short_name, long_name, obsolete) FROM stdin;
+BlindOffset	Blind Offset	Blind Offset	f
+OffAxis	Off Axis	Off Axis	f
+TuningStar	Tuning Star	Tuning Star	f
+Other	Other	Other	f
+\.
+
+
+-- User Target Table
+-- Associates a target, user target type, and an observation.
+
+CREATE TABLE user_target (
+  id               SERIAL     PRIMARY KEY,
+  target_id        integer    NOT NULL REFERENCES target(id),
+  user_target_type identifier NOT NULL REFERENCES e_user_target_type(id),
+  observation_id   TEXT       NOT NULL REFERENCES observation ON DELETE CASCADE
+);
+
+ALTER TABLE user_target OWNER TO postgres;

--- a/modules/sql/src/main/resources/db/migration/V038__Add_Gpi.sql
+++ b/modules/sql/src/main/resources/db/migration/V038__Add_Gpi.sql
@@ -1,0 +1,386 @@
+--
+-- Name: e_gpi_adc; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_adc (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  value       boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_adc OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_adc; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_adc(id, short_name, long_name, value) FROM stdin;
+In	In	In	true
+Out	Out	Out	false
+\.
+--
+-- Name: e_gpi_filter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_filter (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  band        identifier  NOT NULL REFERENCES e_magnitude_band,
+  obsolete    boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_filter OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_filter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_filter(id, short_name, long_name, band, obsolete) FROM stdin;
+Y	Y	Y	Y	f
+J	J	J	J	f
+H	H	H	H	f
+K1	K1	K1	K	f
+K2	K2	K2	K	f
+\.
+
+--
+-- Name: e_gpi_disperser; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_disperser (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL
+);
+
+ALTER TABLE e_gpi_disperser OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_disperser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_disperser(id, short_name, long_name) FROM stdin;
+PRISM	Prism	Prism
+WOLLASTON	Wollaston	Prism
+\.
+
+--
+-- Name: e_gpi_apodizer; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_apodizer (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  obsolete    boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_apodizer OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_apodizer; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_apodizer(id, short_name, long_name, obsolete) FROM stdin;
+CLEAR	Clear	Clear	f
+CLEARGP	CLEAR GP	CLEAR GP	f
+APOD_Y	APOD_Y_56	APOD_Y_56	f
+APOD_J	APOD_J_56	APOD_J_56	f
+APOD_H	APOD_H_56	APOD_H_56	f
+APOD_K1	APOD_K1_56	APOD_K1_56	f
+APOD_K2	APOD_K2_56	APOD_K2_56	f
+NRM	NRM	NRM	f
+APOD_HL	APOD_HL	APOD_HL	f
+APOD_STAR	APOD_star	APOD_star	t
+ND3	ND3	ND3	f
+\.
+
+--
+-- Name: e_gpi_lyot; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_lyot (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  obsolete    boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_lyot OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_lyot; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_lyot(id, short_name, long_name, obsolete) FROM stdin;
+BLANK	Blank	Blank	f
+LYOT_080m12_03	080m12_03	080m12_03	f
+LYOT_080m12_04	080m12_04	080m12_04	f
+LYOT_080_04	080_04	080_04	f
+LYOT_080m12_06	080m12_06	080m12_06	f
+LYOT_080m12_04_c	080m12_04_c	080m12_04_c	f
+LYOT_080m12_06_03	080m12_06_03	080m12_06_03	f
+LYOT_080m12_07	080m12_07	080m12_07	f
+LYOT_080m12_10	080m12_10	080m12_10	f
+OPEN	Open	Open	f
+\.
+
+--
+-- Name: e_gpi_artificial_source_unit; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_artificial_source_unit (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  value       boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_artificial_source_unit OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_artificial_source_unit; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_artificial_source_unit(id, short_name, long_name, value) FROM stdin;
+On	On	On	true
+Off	Off	Off	false
+\.
+
+--
+-- Name: e_gpi_entrance_shutter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_entrance_shutter (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  value       boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_entrance_shutter OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_entrance_shutter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_entrance_shutter(id, short_name, long_name, value) FROM stdin;
+Open	Open	Open	true
+Close	Close	Close	false
+\.
+
+--
+-- Name: e_gpi_sience_arm_shutter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_sience_arm_shutter (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  value       boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_sience_arm_shutter OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_sience_arm_shutter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_sience_arm_shutter(id, short_name, long_name, value) FROM stdin;
+Open	Open	Open	true
+Close	Close	Close	false
+\.
+
+--
+-- Name: e_gpi_cal_entrance_shutter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_cal_entrance_shutter (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  value       boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_cal_entrance_shutter OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_cal_entrance_shutter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_cal_entrance_shutter(id, short_name, long_name, value) FROM stdin;
+Open	Open	Open	true
+Close	Close	Close	false
+\.
+
+--
+-- Name: e_gpi_reference_arm_shutter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_reference_arm_shutter (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  value       boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_reference_arm_shutter OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_reference_arm_shutter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_reference_arm_shutter(id, short_name, long_name, value) FROM stdin;
+Open	Open	Open	true
+Close	Close	Close	false
+\.
+
+--
+-- Name: e_gpi_pupil_camera; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_pupil_camera (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  value       boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_pupil_camera OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_pupil_camera; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_pupil_camera(id, short_name, long_name, value) FROM stdin;
+In	In	In	true
+Out	Out	Out	false
+\.
+
+--
+-- Name: e_gpi_fpm; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_fpm (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
+  obsolete    boolean     NOT NULL
+);
+
+ALTER TABLE e_gpi_fpm OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_fpm; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_fpm(id, short_name, long_name, obsolete) FROM stdin;
+OPEN	Open	Open	f
+F50umPIN	50umPIN	50umPIN	f
+WITH_DOT	WITH_DOT	WITH_DOT	f
+SCIENCE	SCIENCE	SCIENCE	f
+FPM_K1	FPM_K1	FPM_K1	f
+FPM_H	FPM_H	FPM_H	f
+FPM_J	FPM_J	FPM_J	f
+FPM_Y	FPM_Y	FPM_Y	f
+\.
+
+--
+-- Name: e_gpi_sampling_mode; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_sampling_mode (
+  id          identifier PRIMARY KEY,
+  short_name  text       NOT NULL,
+  long_name   text       NOT NULL,
+  obsolete    boolean    NOT NULL
+);
+
+ALTER TABLE e_gpi_sampling_mode OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_sampling_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_sampling_mode(id, short_name, long_name, obsolete) FROM stdin;
+FAST	Fast	Fast	f
+SINGLE_CDS	Single CDS	Single CDS	f
+MULTIPLE_CDS	Multiple CDS	Multiple CDS	f
+UTR	UTR	UTR	f
+\.
+
+--
+-- Name: e_gpi_cassegrain; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_cassegrain (
+  id          identifier PRIMARY KEY,
+  short_name  text       NOT NULL,
+  long_name   text       NOT NULL,
+  value       integer    NOT NULL
+);
+
+ALTER TABLE e_gpi_cassegrain OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_cassegrain; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_cassegrain(id, short_name, long_name, value) FROM stdin;
+A0	0	0	0
+A180	180	180	180
+\.
+
+--
+-- Name: e_gpi_observing_mode; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_observing_mode (
+  id                      identifier    PRIMARY KEY,
+  short_name              text          NOT NULL,
+  long_name               text          NOT NULL,
+  filter                  identifier    REFERENCES e_gpi_filter,
+  filter_iterable         boolean       NOT NULL,
+  apodizer                identifier    REFERENCES e_gpi_apodizer,
+  fpm                     identifier    REFERENCES e_gpi_fpm,
+  lyot                    identifier    REFERENCES e_gpi_lyot,
+  bright_limit_prism      numeric(4,3)  NULL,
+  bright_limit_wollaston  numeric(4,3)  NULL,
+  corresponding_h_mode    identifier    NOT NULL REFERENCES e_gpi_observing_mode,
+  obsolete                boolean       NOT NULL
+);
+
+ALTER TABLE e_gpi_observing_mode OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_observing_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_observing_mode(id, short_name, long_name, filter, filter_iterable, apodizer, fpm, lyot, bright_limit_prism, bright_limit_wollaston, corresponding_h_mode, obsolete) FROM stdin;
+CORON_Y_BAND	Coronograph Y-band	Coronograph Y-band	Y	false	APOD_Y	FPM_Y	LYOT_080m12_03	0.5	3.0	CORON_H_BAND	f
+CORON_J_BAND	Coronograph J-band	Coronograph J-band	J	false	APOD_J	FPM_J	LYOT_080m12_04	0.5	3.0	CORON_H_BAND	f
+CORON_H_BAND	Coronograph H-band	Coronograph H-band	H	false	APOD_H	FPM_H	LYOT_080m12_04	0.5	3.0	CORON_H_BAND	f
+CORON_K1_BAND	Coronograph K1-band	Coronograph K1-band	K1	false	APOD_K1	FPM_K1	LYOT_080m12_06_03	0.5	3.0	CORON_H_BAND	f
+CORON_K2_BAND	Coronograph K2-band	Coronograph K2-band	K2	false	APOD_K2	FPM_K1	LYOT_080m12_07	0.5	3.0	CORON_H_BAND	f
+H_STAR	H_STAR	H_STAR	H	false	APOD_STAR	FPM_H	LYOT_080m12_03	\N	\N	H_STAR	t
+H_LIWA	H_LIWA	H_LIWA	H	false	APOD_HL	FPM_K1	LYOT_080m12_04	\N	\N	H_LIWA	f
+DIRECT_Y_BAND	Y direct	Y direct	Y	true	CLEAR	SCIENCE	OPEN	5.5	7.5	DIRECT_H_BAND	f
+DIRECT_J_BAND	J direct	J direct	J	true	CLEAR	SCIENCE	OPEN	5.5	7.5	DIRECT_H_BAND	f
+DIRECT_H_BAND	H direct	H direct	H	true	CLEAR	SCIENCE	OPEN	5.5	7.5	DIRECT_H_BAND	f
+DIRECT_K1_BAND	K1 direct	K1 direct	K1	true	CLEAR	SCIENCE	OPEN	5.5	7.5	DIRECT_H_BAND	f
+DIRECT_K2_BAND	K2 direct	K2 direct	K2	true	CLEAR	SCIENCE	OPEN	5.5	7.5	DIRECT_H_BAND	f
+NRM_Y	Non Redundant Mask Y	Non Redundant Mask Y	Y	true	NRM	SCIENCE	OPEN	\N	\N	NRM_H	f
+NRM_J	Non Redundant Mask J	Non Redundant Mask J	J	true	NRM	SCIENCE	OPEN	\N	\N	NRM_H	f
+NRM_H	Non Redundant Mask H	Non Redundant Mask H	H	true	NRM	SCIENCE	OPEN	\N	\N	NRM_H	f
+NRM_K1	Non Redundant Mask K1	Non Redundant Mask K1	K1	true	NRM	SCIENCE	OPEN	\N	\N	NRM_H	f
+NRM_K2	Non Redundant Mask K2	Non Redundant Mask K2	K2	true	NRM	SCIENCE	OPEN	\N	\N	NRM_H	f
+DARK	Dark	Dark	H	false	APOD_H	FPM_H	BLANK	0.5	3.0	DARK	f
+UNBLOCKED_Y	Y Unblocked	Y Unblocked	Y	false	APOD_Y	SCIENCE	LYOT_080m12_03	4.0	6.5	UNBLOCKED_Y	f
+UNBLOCKED_J	J Unblocked	J Unblocked	J	false	APOD_J	SCIENCE	LYOT_080m12_04	4.0	6.5	UNBLOCKED_J	f
+UNBLOCKED_H	H Unblocked	H Unblocked	H	false	APOD_H	SCIENCE	LYOT_080m12_04	4.0	6.5	UNBLOCKED_H	f
+UNBLOCKED_K1	K1 Unblocked	K1 Unblocked	K1	false	APOD_K1	SCIENCE	LYOT_080m12_06_03	4.0	6.5	UNBLOCKED_K1	f
+UNBLOCKED_K2	K2 Unblocked	K2 Unblocked	K2	false	APOD_K2	SCIENCE	LYOT_080m12_07	4.0	6.5	UNBLOCKED_K2	f
+NONSTANDARD	Nonstandard	Nonstandard	\N	false	\N	\N	\N	\N	\N	NONSTANDARD	f
+\.

--- a/modules/sql/src/main/resources/db/migration/V039__Gpi_MagnitudeLimits.sql
+++ b/modules/sql/src/main/resources/db/migration/V039__Gpi_MagnitudeLimits.sql
@@ -1,0 +1,8 @@
+--
+-- Make the bright limit constraints in gpi_observing_mode have 2 digits
+-- Add checks to forbid negati
+--
+
+ALTER TABLE e_gpi_observing_mode
+      ALTER COLUMN bright_limit_prism     TYPE numeric(4,2),
+      ALTER COLUMN bright_limit_wollaston TYPE numeric(4,2);

--- a/modules/sql/src/main/resources/db/migration/V040__Add_Gnirs.sql
+++ b/modules/sql/src/main/resources/db/migration/V040__Add_Gnirs.sql
@@ -1,0 +1,350 @@
+--
+-- Name: e_gnirs_cross_dispersed; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_prism (
+    id              identifier   PRIMARY KEY,
+    short_name      TEXT         NOT NULL,
+    long_name       TEXT         NOT NULL
+);
+
+ALTER TABLE e_gnirs_prism OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_prism; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_prism (id, short_name, long_name) FROM stdin;
+Mirror	Mirror	Mirror
+Sxd	Short XD	Short cross dispersion
+Lxd	Long XD	Long cross dispersion
+\.
+
+
+--
+-- Name: e_gnirs_fpu_slit; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_fpu_slit(
+    id             identifier   PRIMARY KEY,
+    short_name     TEXT         NOT NULL,
+    long_name      TEXT         NOT NULL,
+    slit_width     numeric(4,3) NOT NULL,
+    obsolete       boolean      NOT NULL
+);
+
+ALTER TABLE e_gnirs_fpu_slit OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_fpu_slit; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_fpu_slit (id, short_name, long_name, slit_width, obsolete) FROM stdin;
+LongSlit1	0.10 arcsec	0.10 arcsec	0.10	f
+LongSlit2	0.15 arcsec	0.15 arcsec	0.15	f
+LongSlit3	0.20 arcsec	0.20 arcsec	0.20	f
+LongSlit4	0.30 arcsec	0.30 arcsec	0.30	f
+LongSlit5	0.45 arcsec	0.45 arcsec	0.45	f
+LongSlit6	0.675 arcsec	0.675 arcsec	0.675	f
+LongSlit7	1.0 arcsec	1.0 arcsec	1.0	f
+LongSlit8	3.0 arcsec	3.0 arcsec	3.0	t
+\.
+
+COMMENT ON COLUMN e_gnirs_fpu_slit.slit_width IS 'arcsec';
+
+
+--
+-- Name: e_gnirs_fpu_other; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_fpu_other(
+    id             identifier PRIMARY KEY,
+    short_name     TEXT       NOT NULL,
+    long_name      TEXT       NOT NULL,
+    obsolete       boolean    NOT NULL
+);
+
+ALTER TABLE e_gnirs_fpu_other OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_fpu_other; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_fpu_other (id, short_name, long_name, obsolete) FROM stdin;
+Ifu	IFU	Integral Field Unit	t
+Acquisition	Acquisition	Acquisition	f
+PupilViewer	Pupil	Pupil viewer	f
+Pinhole1	Small pin	pinhole 0.1	f
+Pinhole2	Large pin	pinhole 0.3	f
+\.
+
+
+--
+-- Name: e_gnirs_disperser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+CREATE TABLE e_gnirs_disperser (
+    id             identifier PRIMARY KEY,
+    short_name     TEXT       NOT NULL,
+    long_name      TEXT       NOT NULL,
+    ruling_density smallint   NOT NULL
+);
+
+ALTER TABLE e_gnirs_disperser OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_disperser; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_disperser (id, short_name, long_name, ruling_density) FROM stdin;
+D10	10	10 l/mm grating	10
+D32	32	32 l/mm grating	32
+D111	111	111 l/mm grating	111
+\.
+
+COMMENT ON COLUMN e_gnirs_disperser.ruling_density IS 'lines/mm';
+
+
+--
+-- Name: e_gnirs_disperser_order; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+CREATE TABLE e_gnirs_disperser_order (
+    id                 identifier   PRIMARY KEY,
+    short_name         TEXT         NOT NULL,
+    long_name          TEXT         NOT NULL,
+    count              smallint     NOT NULL,
+    default_wavelength numeric(4,3) NOT NULL,
+    min_wavelength     numeric(3,2) NOT NULL,
+    max_wavelength     numeric(3,2) NOT NULL,
+    delta_wavelength   numeric(7,6) NOT NULL,
+    band               identifier   REFERENCES e_magnitude_band,
+    cross_dispersed    boolean      NOT NULL
+);
+
+ALTER TABLE e_gnirs_disperser_order OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_disperser_order; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_disperser_order (id, short_name, long_name, count, default_wavelength, min_wavelength, max_wavelength, delta_wavelength, band, cross_dispersed) FROM stdin;
+One	1	One	1	4.850	4.30	6.00	0.000000	M	f
+Two	2	Two	2	3.400	2.70	4.30	0.000000	L	f
+Three	3	Three	3	2.220	1.86	2.70	0.000647	K	t
+FourXD	4XD	FourXD	4	1.650	1.42	1.86	0.000482	H	t
+Four	4	Four	4	1.630	1.42	1.86	0.000485	H	t
+Five	5	Five	5	1.250	1.17	1.42	0.000388	J	t
+Six	6	Six	6	1.100	1.03	1.17	0.000323	\N	t
+Seven	7	Seven	7	0.951	0.88	1.03	0.000276	\N	t
+Eight	8	Eight	8	0.832	0.78	0.88	0.000241	\N	t
+\.
+
+COMMENT ON COLUMN e_gnirs_disperser_order.count              IS
+  'Corresponding numeric value.  E.g., 0, 1, 2';
+COMMENT ON COLUMN e_gnirs_disperser_order.default_wavelength IS
+  'µm';
+COMMENT ON COLUMN e_gnirs_disperser_order.min_wavelength     IS
+  'µm';
+COMMENT ON COLUMN e_gnirs_disperser_order.max_wavelength     IS
+  'µm';
+COMMENT ON COLUMN e_gnirs_disperser_order.delta_wavelength   IS
+  'µm';
+COMMENT ON COLUMN e_gnirs_disperser_order.cross_dispersed    IS
+  'Availability in cross disperesed mode';
+
+
+--
+-- Name: e_gnirs_read_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_read_mode (
+    id                    identifier   PRIMARY KEY,
+    short_name            TEXT         NOT NULL,
+    long_name             TEXT         NOT NULL,
+    count                 smallint     NOT NULL UNIQUE,
+    minimum_exposure_time milliseconds NOT NULL,
+    read_noise            smallint     NOT NULL,
+    read_noise_low        smallint     NOT NULL
+);
+
+ALTER TABLE e_gnirs_read_mode OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_read_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_read_mode (id, short_name, long_name, count, minimum_exposure_time, read_noise, read_noise_low) FROM stdin;
+VeryBright	Very bright	Very Bright Acquisition or High Background	1	200	155	1
+Bright	Bright	Bright objects	2	600	30	1
+Faint	Faint	Faint objects	9000	3	10	16
+VeryFaint	Very faint	Very faint objects	4	18000	7	32
+\.
+
+COMMENT ON COLUMN e_gnirs_disperser_order.count           IS
+  'Numeric value for ordering.';
+COMMENT ON COLUMN e_gnirs_read_mode.minimum_exposure_time IS
+  'ms';
+COMMENT ON COLUMN e_gnirs_read_mode.read_noise            IS
+  'e-';
+COMMENT ON COLUMN e_gnirs_read_mode.read_noise_low        IS
+  'e-';
+
+
+--
+-- Name: e_gmos_north_filter; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_filter (
+    id         identifier   PRIMARY KEY,
+    short_name TEXT         NOT NULL,
+    long_name  TEXT         NOT NULL,
+    wavelength numeric(3,2)
+);
+
+ALTER TABLE e_gnirs_filter OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_filter; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_filter(id, short_name, long_name, wavelength) FROM stdin;
+CrossDispersed	XD	Cross dispersed	\N
+Order6	X	Order 6 (X)	1.10
+Order5	J	Order 5 (J)	1.25
+Order4	H	Order 4 (H: 1.65µm)	1.65
+Order3	K	Order 3 (K)	2.20
+Order2	L	Order 2 (L)	3.50
+Order1	M	Order 1 (M)	4.80
+H2	H2	H2: 2.12µm	2.12
+HNd100x	H+ND100X	H + ND100X	1.65
+H2Nd100x	H2+ND100X	H2 + ND100X	2.12
+PAH	PAH	PAH: 3.3µm	3.30
+Y	Y	Y: 1.03µm	1.03
+J	J	J: 1.25µm	1.25
+K	K	K: 2.20µm	2.20
+\.
+
+COMMENT ON COLUMN e_gnirs_filter.wavelength IS 'µm';
+
+
+--
+-- Name: e_gnirs_camera; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_camera (
+    id          identifier   PRIMARY KEY,
+    short_name  TEXT         NOT NULL,
+    long_name   TEXT         NOT NULL,
+    pixel_scale numeric(3,2) NOT NULL
+);
+
+ALTER TABLE e_gnirs_camera OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_camera; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_camera(id, short_name, long_name, pixel_scale) FROM stdin;
+ShortBlue	Short blue	Short blue camera	0.15
+LongBlue	Long blue	Long blue camera	0.05
+ShortRed	Short red	Short red camera	0.15
+LongRed	Long red	Long red camera	0.05
+\.
+
+COMMENT ON COLUMN e_gnirs_camera.pixel_scale IS 'arcsec/pixels';
+
+
+--
+-- Name: e_gnirs_decker; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_decker (
+    id         identifier PRIMARY KEY,
+    short_name TEXT       NOT NULL,
+    long_name  TEXT       NOT NULL,
+    obsolete   boolean    NOT NULL
+);
+
+ALTER TABLE e_gnirs_decker OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_decker; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_decker(id, short_name, long_name, obsolete) FROM stdin;
+Acquisition	Acquisition	Acquisition	f
+PupilViewer	Pupil	Pupil viewer	f
+ShortCamLongSlit	Shot camera slit	Short camera long slit	f
+ShortCamCrossDispersed	Short camera XD	Short camera cross dispersed	f
+Ifu	IFU	Integral field unit	t
+LongCamLongSlit	Long camera slit	Long camera long slit	f
+Wollaston	Wollaston	Wollaston	t
+\.
+
+
+--
+-- Name: acquisition_mirror; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE acquisition_mirror AS ENUM (
+    'In',
+    'Out'
+);
+
+ALTER TYPE acquisition_mirror OWNER TO postgres;
+
+
+--
+-- Name: e_gnirs_well_depth; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_well_depth (
+    id         identifier PRIMARY KEY,
+    short_name TEXT       NOT NULL,
+    long_name  TEXT       NOT NULL,
+    bias_level smallint   NOT NULL
+);
+
+ALTER TABLE e_gnirs_well_depth OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_well_depth; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_well_depth(id, short_name, long_name, bias_level) FROM stdin;
+Shallow	Shallow	Shallow	300
+Deep	Deep	Deep	600
+\.
+
+COMMENT ON COLUMN e_gnirs_well_depth.bias_level IS 'mV';
+
+
+--
+-- Name: e_gnirs_wavelength_suggestion; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_wavelength_suggestion (
+    id         identifier PRIMARY KEY,
+    short_name TEXT       NOT NULL,
+    long_name  TEXT       NOT NULL,
+    wavelength numeric(3,2)   NOT NULL
+);
+
+ALTER TABLE e_gnirs_wavelength_suggestion OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_wavelength_suggestion; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_wavelength_suggestion(id, short_name, long_name, wavelength) FROM stdin;
+One	4.85	4.85	4.85
+Two	3.40	3.40	3.40
+Three	2.22	2.22	2.22
+Four	1.65	1.65	1.65
+Five	1.63	1.63	1.63
+Six	1.25	1.25	1.25
+Seven	1.10	1.10	1.10
+\.
+
+COMMENT ON COLUMN e_gnirs_wavelength_suggestion.short_name IS 'µm';
+COMMENT ON COLUMN e_gnirs_wavelength_suggestion.long_name  IS 'µm';
+COMMENT ON COLUMN e_gnirs_wavelength_suggestion.wavelength IS 'µm';

--- a/modules/sql/src/main/resources/db/migration/V041__UserTarget_Trigger.sql
+++ b/modules/sql/src/main/resources/db/migration/V041__UserTarget_Trigger.sql
@@ -1,0 +1,19 @@
+--
+-- This migration adds a trigger to cleanup the corresponding target when a
+-- user target is deleted.
+--
+
+-- User targets are automatically deleted when the observation in which they
+-- are contained is deleted.  There is no reference from target back to
+-- user target though, so a deleted user target would leave garbage in the
+-- target table were it not for this trigger.
+
+CREATE FUNCTION delete_user_target_reference() RETURNS trigger AS $delete_user_target_reference$
+  BEGIN
+    DELETE FROM target where id = OLD.target_id;
+    RETURN OLD;
+  END;
+$delete_user_target_reference$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delete_user_target_reference AFTER DELETE ON user_target
+  FOR EACH ROW EXECUTE PROCEDURE delete_user_target_reference();

--- a/modules/sql/src/main/resources/db/migration/V042__UserTarget_ProgId.sql
+++ b/modules/sql/src/main/resources/db/migration/V042__UserTarget_ProgId.sql
@@ -1,0 +1,11 @@
+--
+-- Adds program_id to user_target to facilitate bulk loading for program.
+--
+
+ALTER TABLE user_target
+  ADD COLUMN program_id        text     NOT NULL REFERENCES program ON DELETE CASCADE,
+  ADD COLUMN observation_index id_index NOT NULL,
+  ADD CONSTRAINT observation_id_check CHECK (((observation_id)::text = (((program_id)::text || '-'::text) || observation_index)));
+
+CREATE INDEX user_target_observation_index ON user_target (program_id, observation_index)
+

--- a/modules/sql/src/main/resources/db/migration/V043__Observation_Keys.sql
+++ b/modules/sql/src/main/resources/db/migration/V043__Observation_Keys.sql
@@ -1,0 +1,95 @@
+
+-------------------------------------------------------------------------------
+-- Observation Updates
+--
+-- * Establish (program_id, observation_index, instrument) as primary key.
+--   This (a) provides an index that will work for bulk queries on program_id,
+--   and (b) serves as a foreign key referent from various other tables
+--   guaranteeing that they use the same instrument as the observation.
+--
+-- * Keep observation_id column and constraint as before:
+--     program_id + "-" + observation_index
+--
+-- * Keep a unique constraint on observation_id to prevent two different
+--   instruments for the same observation and gain an index on observation_id.
+--
+-- * Drop the static_ic column, since we are dropping the static_config table
+--   and replacing the static_id with the observation reference triple
+--   (program_id, observation_index, instrument)
+-------------------------------------------------------------------------------
+
+DROP INDEX ix_observation_instrument;
+
+DROP INDEX ix_observation_program_id;
+
+ALTER TABLE observation
+  DROP CONSTRAINT  observation_static_id_fkey,
+  DROP COLUMN      static_id,
+  DROP CONSTRAINT  observation_pkey CASCADE,
+  DROP CONSTRAINT  observation_instrument_observation_id_key,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  unique_observation_id UNIQUE (observation_id);
+
+
+-------------------------------------------------------------------------------
+-- Static Configuration Updates
+--
+-- * Removes the static_config table altogether, flattening the hierarchy.
+--   We are then left with individual instrument static configuration tables
+--   like static_f2, static_gmos_north and their subtables like gmos_custom_roi.
+--   These will refer directly to their corresponding observation.
+--
+-- * Uses the triple (program_id, observation_index, instrument) as a FK into
+--   observation.  This gurantees that he instrument matches and facilitates
+--   bulk load queries for the program as a whole.
+-------------------------------------------------------------------------------
+
+ALTER TABLE gmos_custom_roi
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+
+ALTER TABLE gmos_nod_and_shuffle
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+
+ALTER TABLE static_f2
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+
+ALTER TABLE static_gmos_north
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+
+ALTER TABLE static_gmos_south
+  DROP COLUMN      static_id,
+  ADD  COLUMN      program_id        text     NOT NULL,
+  ADD  COLUMN      observation_index id_index NOT NULL,
+  ADD  PRIMARY KEY (program_id, observation_index, instrument),
+  ADD  CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE;
+
+DROP TABLE static_config;
+
+
+-------------------------------------------------------------------------------
+-- Dynamic Configuration Updates
+--
+-- Here we just switch from observation_id to (program_id, observation_index).
+-------------------------------------------------------------------------------
+
+ALTER TABLE step
+  ADD  COLUMN     program_id        text     NOT NULL,
+  ADD  COLUMN     observation_index id_index NOT NULL,
+  ADD  CONSTRAINT observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE,
+  DROP COLUMN     observation_id,
+  ADD  CONSTRAINT unique_location UNIQUE (program_id, observation_index, location);

--- a/modules/sql/src/main/resources/db/migration/V044__Gnirs_Static_Config.sql
+++ b/modules/sql/src/main/resources/db/migration/V044__Gnirs_Static_Config.sql
@@ -1,0 +1,15 @@
+--
+-- Name: static_gnirs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE static_gnirs (
+    program_id        text       NOT NULL,
+    instrument        identifier NOT NULL,
+    observation_index id_index   NOT NULL,
+    well_depth        identifier NOT NULL REFERENCES e_gnirs_well_depth,
+    PRIMARY KEY (program_id, observation_index, instrument),
+    CONSTRAINT  observation_ref FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE,
+    CONSTRAINT is_gnirs CHECK (instrument = 'Gnirs')
+);
+
+ALTER TABLE static_gnirs OWNER TO postgres;

--- a/modules/sql/src/main/resources/db/migration/V045__Asterism.sql
+++ b/modules/sql/src/main/resources/db/migration/V045__Asterism.sql
@@ -1,0 +1,66 @@
+--
+-- Introduces asterism table and updates to observation to reference it.
+--
+
+-- Add Ghost to e_instrument enum.
+INSERT INTO e_instrument
+         (id,      short_name, long_name, obsolete)
+  VALUES ('Ghost', 'GHOST',    'GHOST',   false   );
+
+-- Asterism discriminator
+
+CREATE TYPE asterism_type AS ENUM (
+  'GhostDualTarget',
+  'SingleTarget'
+);
+
+ALTER TYPE asterism_type OWNER TO postgres;
+
+
+-- Add asterism_type to observation.
+
+ALTER TABLE observation
+  ADD asterism_type asterism_type;
+
+-- Add an admittedly redundant unique constraint so that it asterism type can
+-- serve as a foreign key referential integrity constraint in the asterism
+-- tables.
+
+ALTER TABLE observation
+  ADD UNIQUE (program_id, observation_index, asterism_type);
+
+
+-- Single target asterism can have any instrument except GHOST but it should
+-- match the observation.
+
+CREATE TABLE single_target_asterism (
+  program_id        text          NOT NULL,
+  observation_index id_index      NOT NULL,
+  instrument        identifier    NOT NULL,
+  asterism_type     asterism_type NOT NULL,
+  target_id         integer       NOT NULL  REFERENCES target,
+  PRIMARY KEY (program_id, observation_index, instrument),
+  FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE,
+  FOREIGN KEY (program_id, observation_index, asterism_type) REFERENCES observation (program_id, observation_index, asterism_type) ON DELETE CASCADE,
+  CONSTRAINT is_single CHECK (asterism_type = 'SingleTarget'),
+  CONSTRAINT is_not_ghost CHECK (instrument != 'Ghost')
+);
+
+ALTER TABLE single_target_asterism OWNER TO postgres;
+
+
+-- Placeholder Ghost Asterism
+
+CREATE TABLE ghost_dual_target_asterism (
+  program_id        text          NOT NULL,
+  observation_index id_index      NOT NULL,
+  instrument        identifier    NOT NULL,
+  asterism_type     asterism_type NOT NULL,
+  target1_id        integer       NOT NULL  REFERENCES target,
+  target2_id        integer       NOT NULL  REFERENCES target,
+  PRIMARY KEY (program_id, observation_index, instrument),
+  FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE,
+  FOREIGN KEY (program_id, observation_index, asterism_type) REFERENCES observation (program_id, observation_index, asterism_type) ON DELETE CASCADE,
+  CONSTRAINT is_ghost_dual_target CHECK (asterism_type = 'GhostDualTarget'),
+  CONSTRAINT is_ghost CHECK (instrument = 'Ghost')
+);

--- a/modules/sql/src/main/resources/db/migration/V046__Drop_Wavelength_suggestion.sql
+++ b/modules/sql/src/main/resources/db/migration/V046__Drop_Wavelength_suggestion.sql
@@ -1,0 +1,1 @@
+DROP TABLE e_gnirs_wavelength_suggestion;

--- a/modules/sql/src/main/resources/db/migration/V047__Slit_renaming.sql
+++ b/modules/sql/src/main/resources/db/migration/V047__Slit_renaming.sql
@@ -1,0 +1,93 @@
+-- GNIRS
+
+UPDATE e_gnirs_fpu_slit
+  SET   id = 'LongSlit_0_10'
+  WHERE id = 'LongSlit1';
+
+UPDATE e_gnirs_fpu_slit
+  SET   id = 'LongSlit_0_15'
+  WHERE id = 'LongSlit2';
+
+UPDATE e_gnirs_fpu_slit
+  SET   id = 'LongSlit_0_20'
+  WHERE id = 'LongSlit3';
+
+UPDATE e_gnirs_fpu_slit
+  SET   id = 'LongSlit_0_30'
+  WHERE id = 'LongSlit4';
+
+UPDATE e_gnirs_fpu_slit
+  SET   id = 'LongSlit_0_45'
+  WHERE id = 'LongSlit5';
+
+UPDATE e_gnirs_fpu_slit
+  SET   id = 'LongSlit_0_675'
+  WHERE id = 'LongSlit6';
+
+UPDATE e_gnirs_fpu_slit
+  SET   id = 'LongSlit_1_00'
+  WHERE id = 'LongSlit7';
+
+UPDATE e_gnirs_fpu_slit
+  SET   id = 'LongSlit_3_00'
+  WHERE id = 'LongSlit8';
+
+-- GMOS North
+
+UPDATE e_gmos_north_fpu
+  SET   id = 'LongSlit_0_25'
+  WHERE id = 'Longslit1';
+
+UPDATE e_gmos_north_fpu
+  SET   id = 'LongSlit_0_50'
+  WHERE id = 'Longslit2';
+
+UPDATE e_gmos_north_fpu
+  SET   id = 'LongSlit_0_75'
+  WHERE id = 'Longslit3';
+
+UPDATE e_gmos_north_fpu
+  SET   id = 'LongSlit_1_00'
+  WHERE id = 'Longslit4';
+
+UPDATE e_gmos_north_fpu
+  SET   id = 'LongSlit_1_50'
+  WHERE id = 'Longslit5';
+
+UPDATE e_gmos_north_fpu
+  SET   id = 'LongSlit_2_00'
+  WHERE id = 'Longslit6';
+
+UPDATE e_gmos_north_fpu
+  SET   id = 'LongSlit_5_00'
+  WHERE id = 'Longslit7';
+
+-- GMOS South
+
+UPDATE e_gmos_south_fpu
+  SET   id = 'LongSlit_0_25'
+  WHERE id = 'Longslit1';
+
+UPDATE e_gmos_south_fpu
+  SET   id = 'LongSlit_0_50'
+  WHERE id = 'Longslit2';
+
+UPDATE e_gmos_south_fpu
+  SET   id = 'LongSlit_0_75'
+  WHERE id = 'Longslit3';
+
+UPDATE e_gmos_south_fpu
+  SET   id = 'LongSlit_1_00'
+  WHERE id = 'Longslit4';
+
+UPDATE e_gmos_south_fpu
+  SET   id = 'LongSlit_1_50'
+  WHERE id = 'Longslit5';
+
+UPDATE e_gmos_south_fpu
+  SET   id = 'LongSlit_2_00'
+  WHERE id = 'Longslit6';
+
+UPDATE e_gmos_south_fpu
+  SET   id = 'LongSlit_5_00'
+  WHERE id = 'Longslit7';

--- a/modules/sql/src/main/resources/db/migration/V048__Gnirs_Dynamic.sql
+++ b/modules/sql/src/main/resources/db/migration/V048__Gnirs_Dynamic.sql
@@ -1,0 +1,22 @@
+--
+-- Name: step_gnirs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE step_gnirs (
+    step_gnirs_id         integer      PRIMARY KEY REFERENCES step,
+    camera                identifier   NOT NULL    REFERENCES e_gnirs_camera,
+    decker                identifier   NOT NULL    REFERENCES e_gnirs_decker,
+    disperser             identifier   NOT NULL    REFERENCES e_gnirs_disperser,
+    disperser_order       identifier   NOT NULL    REFERENCES e_gnirs_disperser_order,
+    exposure_time         milliseconds NOT NULL,
+    filter                identifier   NOT NULL    REFERENCES e_gnirs_filter,
+    fpu_slit              identifier               REFERENCES e_gnirs_fpu_slit,
+    fpu_other             identifier               REFERENCES e_gnirs_fpu_other,
+    prism                 identifier   NOT NULL    REFERENCES e_gnirs_prism,
+    read_mode             identifier   NOT NULL    REFERENCES e_gnirs_read_mode
+    CONSTRAINT fpu_slit_or_other
+      CHECK ((fpu_slit IS     NULL AND fpu_other IS NOT NULL) OR
+             (fpu_slit IS NOT NULL AND fpu_other IS     NULL))
+);
+
+ALTER TABLE step_gnirs OWNER TO postgres;

--- a/modules/sql/src/main/resources/db/migration/V049__Gnirs_exposure_time_bigint.sql
+++ b/modules/sql/src/main/resources/db/migration/V049__Gnirs_exposure_time_bigint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE step_gnirs ALTER COLUMN exposure_time TYPE bigint;

--- a/modules/sql/src/main/resources/db/migration/V050__Drop_Static_Config_Trigger.sql
+++ b/modules/sql/src/main/resources/db/migration/V050__Drop_Static_Config_Trigger.sql
@@ -1,0 +1,5 @@
+--
+-- Delete trigger for static_config cleanup, since static_config no longer exists.
+--
+
+DROP TRIGGER delete_static_config ON observation;

--- a/modules/sql/src/main/resources/db/migration/V051__Gnirs_fixes.sql
+++ b/modules/sql/src/main/resources/db/migration/V051__Gnirs_fixes.sql
@@ -1,0 +1,8 @@
+UPDATE e_gnirs_fpu_other SET id = 'Pinhole3' WHERE id = 'Pinhole2';
+
+-- Typo
+UPDATE e_gnirs_decker SET short_name = 'Short camera slit' WHERE id = 'ShortCamLongSlit';
+
+INSERT INTO e_gnirs_decker
+         (id,                      short_name,       long_name,                     obsolete)
+  VALUES ('LongCamCrossDispersed', 'Long camera XD', 'Long camera cross dispersed', false   );

--- a/modules/sql/src/main/resources/db/migration/V052__Gnirs_central_wavelength.sql
+++ b/modules/sql/src/main/resources/db/migration/V052__Gnirs_central_wavelength.sql
@@ -1,0 +1,9 @@
+--
+-- The disperser order can be calculated from the central wavelength
+--
+
+ALTER TABLE step_gnirs
+  DROP  COLUMN  disperser_order,
+  ADD   COLUMN	wavelength	integer	NOT NULL;
+
+COMMENT ON COLUMN step_gnirs.wavelength IS 'µm';

--- a/modules/sql/src/main/resources/db/migration/V053__Gnirs_Gcal_enums.sql
+++ b/modules/sql/src/main/resources/db/migration/V053__Gnirs_Gcal_enums.sql
@@ -1,0 +1,62 @@
+DROP TYPE acquisition_mirror;
+
+--
+-- Name: e_gnirs_acquisition_mirror; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_acquisition_mirror (
+    id         identifier PRIMARY KEY,
+    short_name TEXT       NOT NULL,
+    long_name  TEXT       NOT NULL
+);
+
+ALTER TABLE e_gnirs_acquisition_mirror OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_acquisition_mirror; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_acquisition_mirror(id, short_name, long_name) FROM stdin;
+In	In	In
+Out	Out	Out
+\.
+
+
+ALTER TABLE step_gnirs
+    ADD COLUMN acquisition_mirror identifier NOT NULL REFERENCES e_gnirs_acquisition_mirror;
+
+--
+-- Name: e_gnirs_acquisition_mirror; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gnirs_pixel_scale (
+    id         identifier   PRIMARY KEY,
+    short_name TEXT         NOT NULL,
+    long_name  TEXT         NOT NULL,
+    value      numeric(3,2) NOT NULL
+);
+
+ALTER TABLE e_gnirs_pixel_scale OWNER TO postgres;
+
+--
+-- Data for Name: e_gnirs_pixel_scale; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gnirs_pixel_scale(id, short_name, long_name, value) FROM stdin;
+PixelScale_0_05	0.05 as/pix	Pixel scale for short cameras	0.05
+PixelScale_0_15	0.15 as/pix	Pixel scale for long cameras	0.15
+\.
+
+COMMENT ON COLUMN e_gnirs_pixel_scale.value IS 'arcsec/pixels';
+
+ALTER TABLE e_gnirs_camera
+    DROP COLUMN pixel_scale,
+    ADD COLUMN pixel_scale identifier REFERENCES e_gnirs_pixel_scale;
+
+UPDATE e_gnirs_camera
+    SET pixel_scale = 'PixelScale_0_05' WHERE id = 'LongBlue' OR id = 'LongRed';
+
+UPDATE e_gnirs_camera
+    SET pixel_scale = 'PixelScale_0_15' WHERE id = 'ShortBlue' OR id = 'ShortRed';
+
+ALTER TABLE e_gnirs_camera ALTER COLUMN pixel_scale SET NOT NULL;

--- a/modules/sql/src/main/resources/db/migration/V054__Add_Gnirs_SmartGcal.sql
+++ b/modules/sql/src/main/resources/db/migration/V054__Add_Gnirs_SmartGcal.sql
@@ -1,0 +1,33 @@
+--
+-- Name: smart_gnirs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE smart_gnirs (
+    lamp               gcal_lamp_type     NOT NULL,
+    baseline           gcal_baseline_type NOT NULL,
+    acquisition_mirror identifier         NOT NULL  REFERENCES e_gnirs_acquisition_mirror ON DELETE CASCADE,
+    pixel_scale        identifier         NOT NULL  REFERENCES e_gnirs_pixel_scale        ON DELETE CASCADE,
+    disperser          identifier         NOT NULL  REFERENCES e_gnirs_disperser          ON DELETE CASCADE,
+    fpu_slit           identifier                   REFERENCES e_gnirs_fpu_slit           ON DELETE CASCADE,
+    fpu_other          identifier                   REFERENCES e_gnirs_fpu_other          ON DELETE CASCADE,
+    prism              identifier         NOT NULL  REFERENCES e_gnirs_prism              ON DELETE CASCADE,
+    well_depth         identifier         NOT NULL  REFERENCES e_gnirs_well_depth         ON DELETE CASCADE,
+    min_wavelength     int                NOT NULL  CHECK (min_wavelength >= 0),
+    max_wavelength     int                NOT NULL  CHECK (max_wavelength >= 0),
+    gcal_id            integer            NOT NULL  REFERENCES gcal                       ON DELETE CASCADE
+    CHECK (min_wavelength <= max_wavelength)
+    CONSTRAINT fpu_slit_or_other
+      CHECK ((fpu_slit IS     NULL AND fpu_other IS NOT NULL) OR
+             (fpu_slit IS NOT NULL AND fpu_other IS     NULL))
+);
+
+ALTER TABLE smart_gnirs OWNER TO postgres;
+
+COMMENT ON COLUMN smart_gnirs.min_wavelength IS 'Å';
+COMMENT ON COLUMN smart_gnirs.max_wavelength IS 'Å';
+
+-- While working on GNIRS we found out GMOS used angstroms too
+COMMENT ON COLUMN smart_gmos_south.min_wavelength IS 'Å';
+COMMENT ON COLUMN smart_gmos_south.max_wavelength IS 'Å';
+COMMENT ON COLUMN smart_gmos_north.min_wavelength IS 'Å';
+COMMENT ON COLUMN smart_gmos_north.max_wavelength IS 'Å';

--- a/modules/sql/src/main/resources/db/migration/V055__Gnirs_Coadds.sql
+++ b/modules/sql/src/main/resources/db/migration/V055__Gnirs_Coadds.sql
@@ -1,0 +1,1 @@
+ALTER TABLE step_gnirs ADD COLUMN coadds coadds NOT NULL;

--- a/modules/sql/src/main/scala/Angle.scala
+++ b/modules/sql/src/main/scala/Angle.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+/** Minimal Angle classes to support reading from the enum tables without depending on core. */
+object Angle {
+
+  final case class Arcseconds(toArcsecs: BigDecimal)
+  object Arcseconds {
+    def fromArcsecs(d: BigDecimal): Arcseconds =
+      Arcseconds(d)
+  }
+
+  final case class Degrees(toDegrees: BigDecimal)
+  object Degrees {
+    def fromDegrees(d: BigDecimal): Degrees =
+      Degrees(d)
+  }
+
+}

--- a/modules/sql/src/main/scala/EnumDef.scala
+++ b/modules/sql/src/main/scala/EnumDef.scala
@@ -1,0 +1,212 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+import doobie._
+import java.time.{ Duration, ZoneId }
+import cats.data.NonEmptyList, cats.implicits._
+import shapeless._
+import shapeless.ops.hlist._
+import shapeless.ops.record._
+import shapeless.record._
+
+/** Scala source for an enumeated type, with a suggested filename. */
+final case class EnumDef(fileName: String, text: String)
+
+object EnumDef {
+  import Angle._
+  import EnumRefs._
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.ExplicitImplicitTypes"))
+  protected[sql] object ToImport extends Poly1 {
+    // scalastyle:off method.type
+    implicit def caseString[S] = at[(S, String)] { _ => Option.empty[String] }
+    implicit def caseInt[S] = at[(S, Int)] { _ => Option.empty[String] }
+    implicit def caseBoolean[S] = at[(S, Boolean)] { _ => Option.empty[String] }
+    implicit def caseDouble[S] = at[(S, Double)] { _ => Option.empty[String] }
+    implicit def caseBigDecimal[S] = at[(S, BigDecimal)] { _ => Option.empty[String] }
+    implicit def caseDuration[S] = at[(S, Duration)] { _ =>  Some("java.time.Duration") }
+    implicit def caseArcseconds[S] = at[(S, Arcseconds)] { _ =>  Some("gem.math.Angle") }
+    implicit def caseDegrees[S] = at[(S, Degrees)] { _ =>  Some("gem.math.Angle") }
+    implicit def caseZoneId[S] = at[(S, ZoneId)] { _ =>  Some("java.time.ZoneId") }
+    implicit def caseWavelengthNm[S] = at[(S, Wavelength.Nm )] { _ =>  Some("gem.math.Wavelength") }
+    implicit def caseWavelengthUm[S] = at[(S, Wavelength.Um )] { _ =>  Some("gem.math.Wavelength") }
+    implicit def caseOptionArcseconds[S] = at[(S, Option[Arcseconds])] { _ =>  Some("gem.math.Angle") }
+    implicit def caseOptionDegrees[S] = at[(S, Option[Degrees])] { _ =>  Some("gem.math.Angle") }
+    implicit def caseOptionDouble[S] = at[(S, Option[Double])] { _ =>  Option.empty[String] }
+    implicit def caseOptionWavelengthNm[S] = at[(S, Option[Wavelength.Nm])] { _ => Some("gem.math.Wavelength") }
+    implicit def caseOptionWavelengthUm[S] = at[(S, Option[Wavelength.Um])] { _ => Some("gem.math.Wavelength") }
+    implicit def caseMagnitudeSystem[S] = at[(S, MagnitudeSystem)] { _ => Option.empty[String] }
+    implicit def caseMagnitudeBand[S] = at[(S, MagnitudeBand)] { _ => Option.empty[String] }
+    implicit def caseOptionMagnitudeBand[S] = at[(S, Option[MagnitudeBand])] { _ => Option.empty[String] }
+    implicit def caseMagnitudeValue[S] = at[(S, MagnitudeValue)] { _ => Some("gem.math.MagnitudeValue") }
+    implicit def caseOptionMagnitudeValue[S] = at[(S, Option[MagnitudeValue])] { _ => Some("gem.math.MagnitudeValue") }
+    implicit def caseGnirsPixelScale[S] = at[(S, GnirsPixelScale)] { _ => Option.empty[String] }
+    implicit def caseEnumRef[T <: Symbol, S] = at[(S, EnumRef[T])] { _ => Option.empty[String] }
+    implicit def caseLazyEnumRef[T <: Symbol, S] = at[(S, LazyEnumRef[T])] { _ => Option("cats.Eval") }
+    implicit def caseOptionEnumRef[T <: Symbol, S] = at[(S, Option[EnumRef[T]])] { _ => Option.empty[String] }
+    // scalastyle:on method.type
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.ExplicitImplicitTypes"))
+  protected[sql] object ToDeclaration extends Poly1 {
+    // scalastyle:off method.type
+    implicit def caseString  [S <: Symbol] = at[(S, String)  ] { case (s, _) => "  val " + s.name + ": String" }
+    implicit def caseInt     [S <: Symbol] = at[(S, Int)     ] { case (s, _) => "  val " + s.name + ": Int" }
+    implicit def caseBoolean [S <: Symbol] = at[(S, Boolean) ] { case (s, _) => "  val " + s.name + ": Boolean" }
+    implicit def caseDouble  [S <: Symbol] = at[(S, Double)  ] { case (s, _) => "  val " + s.name + ": Double" }
+    implicit def caseBigDecimal  [S <: Symbol] = at[(S, BigDecimal)  ] { case (s, _) => "  val " + s.name + ": BigDecimal" }
+    implicit def caseDuration[S <: Symbol] = at[(S, Duration)] { case (s, _) => "  val " + s.name + ": Duration" }
+    implicit def caseArcseconds [S <: Symbol] = at[(S, Arcseconds) ] { case (s, _) => "  val " + s.name + ": Angle"}
+    implicit def caseDegrees [S <: Symbol] = at[(S, Degrees) ] { case (s, _) => "  val " + s.name + ": Angle"}
+    implicit def caseZoneId  [S <: Symbol] = at[(S, ZoneId)  ] { case (s, _) => "  val " + s.name + ": ZoneId"}
+
+    implicit def caseWavelengthNm[S <: Symbol] = at[(S, Wavelength.Nm ) ] { case (s, _) => "  val " + s.name + ": Wavelength"}
+    implicit def caseWavelengthUm[S <: Symbol] = at[(S, Wavelength.Um ) ] { case (s, _) => "  val " + s.name + ": Wavelength"}
+
+    implicit def caseOptionArcseconds [S <: Symbol] = at[(S, Option[Arcseconds]) ] { case (s, _) => "  val " + s.name + ": Option[Angle]" }
+    implicit def caseOptionDegrees [S <: Symbol] = at[(S, Option[Degrees]) ] { case (s, _) => "  val " + s.name + ": Option[Angle]" }
+    implicit def caseOptionDouble[S <: Symbol] = at[(S, Option[Double]) ] { case (s, _) => "  val " + s.name + ": Option[Double]" }
+
+    implicit def caseOptionWavelengthNm[S <: Symbol] = at[(S, Option[Wavelength.Nm])] { case (s, _) => s"  val ${s.name}: Option[Wavelength]" }
+    implicit def caseOptionWavelengthUm[S <: Symbol] = at[(S, Option[Wavelength.Um])] { case (s, _) => s"  val ${s.name}: Option[Wavelength]" }
+
+    implicit def caseMagnitudeSystem    [S <: Symbol] = at[(S, MagnitudeSystem)      ] { case (s, _) => s"  val ${s.name}: MagnitudeSystem" }
+    implicit def caseMagnitudeBand      [S <: Symbol] = at[(S, MagnitudeBand)        ] { case (s, _) => s"  val ${s.name}: MagnitudeBand" }
+    implicit def caseOptionMagnitudeBand[S <: Symbol] = at[(S, Option[MagnitudeBand])] { case (s, _) => s"  val ${s.name}: Option[MagnitudeBand]" }
+
+    implicit def caseMagnitudeValue      [S <: Symbol] = at[(S, MagnitudeValue)        ] { case (s, _) => s"  val ${s.name}: MagnitudeValue" }
+    implicit def caseOptionMagnitudeValue[S <: Symbol] = at[(S, Option[MagnitudeValue])] { case (s, _) => s"  val ${s.name}: Option[MagnitudeValue]" }
+    implicit def caseGnirsPixelScale[S <: Symbol] = at[(S, GnirsPixelScale)] { case (s, _) => s"  val ${s.name}: GnirsPixelScale" }
+
+    implicit def caseEnumRef[T <: Symbol, S <: Symbol](implicit w: Witness.Aux[T])       = at[(S, EnumRef[T])        ] { case (s, _) => s"  val ${s.name}: ${w.value.name}" }
+    implicit def caseLazyEnumRef[T <: Symbol, S <: Symbol](implicit w: Witness.Aux[T])   = at[(S, LazyEnumRef[T])    ] { case (s, _) => s"  val ${s.name}: Eval[${w.value.name}]" }
+    implicit def caseOptionEnumRef[T <: Symbol, S <: Symbol](implicit w: Witness.Aux[T]) = at[(S, Option[EnumRef[T]])] { case (s, _) => s"  val ${s.name}: Option[${w.value.name}]" }
+    // scalastyle:on method.type
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.ExplicitImplicitTypes"))
+  protected[sql] object ToLiteral extends Poly1 {
+    implicit val caseString       = at[String     ](a => "\"" + a + "\"")
+    implicit val caseInt          = at[Int        ](a => a.toString)
+    implicit val caseBoolean      = at[Boolean    ](a => a.toString)
+    implicit val caseDouble       = at[Double     ](a => a.toString)
+    implicit val caseBigDecimal   = at[BigDecimal ](a => a.toString)
+    implicit val caseDuration     = at[Duration   ](a => s"Duration.ofMillis(${a.toMillis})")
+    implicit val caseArcseconds   = at[Arcseconds ](a => s"Angle.fromDoubleArcseconds(${a.toArcsecs})")
+    implicit val caseDegrees      = at[Degrees    ](a => s"Angle.fromDoubleDegrees(${a.toDegrees})")
+    implicit val caseZoneId       = at[ZoneId     ](a => s"""ZoneId.of("${a.toString}")""")
+
+    implicit val caseWavelengthNm    = at[Wavelength.Nm  ](a => s"""Wavelength.fromAngstroms.unsafeGet(${a.toAngstrom})""")
+    implicit val caseWavelengthUm    = at[Wavelength.Um  ](a => s"""Wavelength.fromAngstroms.unsafeGet(${a.toAngstrom})""")
+    implicit val caseMagnitudeSystem = at[MagnitudeSystem](a => s"MagnitudeSystem.${a.id}")
+
+    implicit val caseOptionArcseconds = at[Option[Arcseconds]](a => a.fold("Option.empty[Angle]")(aʹ => s"Some(Angle.fromDoubleArcseconds(${aʹ.toArcsecs}))"))
+    implicit val caseOptionDegrees    = at[Option[Degrees]   ](a => a.fold("Option.empty[Angle]")(aʹ => s"Some(Angle.fromDoubleDegrees(${aʹ.toDegrees}))"))
+    implicit val caseOptionDouble     = at[Option[Double]    ](a => a.fold("None")(aʹ => s"Some($aʹ)"))
+
+    implicit val caseMagnitudeBand       = at[MagnitudeBand        ](a => s"MagnitudeBand.${a.id}")
+    implicit val caseOptionMagnitudeBand = at[Option[MagnitudeBand]](a => a.fold("None")(aʹ => s"Some(MagnitudeBand.${aʹ.id})"))
+
+    implicit val caseMagnitudeValue       = at[MagnitudeValue        ](a => s"MagnitudeValue(${a.toScaledInt})")
+    implicit val caseOptionMagnitudeValue = at[Option[MagnitudeValue]](a => a.fold("Option.empty[MagnitudeValue]")(aʹ => s"Some(MagnitudeValue(${aʹ.toScaledInt}))"))
+
+    implicit val caseOptionWavelengthNm = at[Option[Wavelength.Nm]](a => a.fold("Option.empty[Wavelength]")(aʹ => s"""Some(Wavelength.fromAngstroms.unsafeGet(${aʹ.toAngstrom}))"""))
+    implicit val caseOptionWavelengthUm = at[Option[Wavelength.Um]](a => a.fold("Option.empty[Wavelength]")(aʹ => s"""Some(Wavelength.fromAngstroms.unsafeGet(${aʹ.toAngstrom}))"""))
+    implicit val caseGnirsPixelScale = at[GnirsPixelScale](a => s"GnirsPixelScale.${a.id}")
+
+    // scalastyle:off method.type
+    implicit def caseEnumRef[T <: Symbol](implicit w: Witness.Aux[T])       = at[EnumRef[T]        ](a => s"${w.value.name}.${a.tag}")
+    implicit def caseLazyEnumRef[T <: Symbol](implicit w: Witness.Aux[T])   = at[LazyEnumRef[T]        ](a => s"""cats.Eval.later(${w.value.name}.unsafeFromTag("${a.tag}"))""")
+    implicit def caseOptionEnumRef[T <: Symbol](implicit w: Witness.Aux[T]) = at[Option[EnumRef[T]]](a => a.fold(s"Option.empty[${w.value.name}]")(aʹ => s"Some(${w.value.name}.${aʹ.tag})"))
+    // scalastyle:on method.type
+  }
+
+  private def constructor[H <: HList, O <: HList, L](name: String, id: String, h: H)(
+    implicit ma: Mapper.Aux[ToLiteral.type, H, O],
+             ta: ToTraversable.Aux[O, List, L]
+  ): String =
+    h.map(ToLiteral).toList.mkString(s"  /** @group Constructors */ case object $id extends $name(", ", ", ")")
+
+  private def declaration[H <: HList, O <: HList, L](name: String, h: H)(
+    implicit ma: Mapper.Aux[ToDeclaration.type, H, O],
+             ta: ToTraversable.Aux[O, List, L]
+  ): String =
+    h.map(ToDeclaration).toList.mkString(s"sealed abstract class $name(\n", ",\n", "\n) extends Product with Serializable")
+
+   def imports[H <: HList, O <: HList, L](h: H)(
+    implicit ma: Mapper.Aux[ToImport.type, H, O],
+             ta: ToTraversable.Aux[O, List, Option[String]]
+  ): String = {
+    val is: List[String] =
+      List("cats.syntax.eq._", "cats.instances.string._", "gem.util.Enumerated") ++
+      h.map(ToImport).toList.collect { case Some(s) => s }
+    is.distinct.sorted.map(s => s"import $s").mkString("\n")
+  }
+
+  // scalastyle:off method.length
+  def fromRecords[R <: HList, F <: HList, D <: HList, I <: HList, V <: HList, Lub1, Lub2, L <: HList](name: String, desc: String, records: NonEmptyList[(String, R)])(
+    implicit  f: Fields.Aux[R, F],
+              d: Mapper.Aux[ToDeclaration.type, F, D],
+             d2: Mapper.Aux[ToImport.type, F, I],
+             t1: ToTraversable.Aux[D, List, Lub1],
+              v: Values.Aux[R, V],
+             ma: Mapper.Aux[ToLiteral.type, V, L],
+             t2: ToTraversable.Aux[L, List, Lub2],
+             t3: ToTraversable.Aux[I, List, Option[String]]
+  ): EnumDef =
+    EnumDef(s"$name.scala", s"""
+      |package gem
+      |package enum
+      |
+      |${imports(records.head._2.fields)}
+      |
+      |/**
+      | * Enumerated type for $desc.
+      | * @group Enumerations (Generated)
+      | */
+      |${declaration(name, records.head._2.fields)}
+      |
+      |object $name {
+      |
+      |${records.map { case (id, r) => constructor(name, id, r.values) }.intercalate("\n") }
+      |
+      |  /** All members of $name, in canonical order. */
+      |  val all: List[$name] =
+      |    List(${records.map(_._1).intercalate(", ")})
+      |
+      |  /** Select the member of $name with the given tag, if any. */
+      |  def fromTag(s: String): Option[$name] =
+      |    all.find(_.tag === s)
+      |
+      |  /** Select the member of $name with the given tag, throwing if absent. */
+      |  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+      |  def unsafeFromTag(s: String): $name =
+      |    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+      |
+      |  /** @group Typeclass Instances */
+      |  implicit val ${name}Enumerated: Enumerated[$name] =
+      |    new Enumerated[$name] {
+      |      def all = $name.all
+      |      def tag(a: $name) = a.tag
+      |    }
+      |
+      |}
+      |""".stripMargin.trim
+    )
+  // scalastyle:on method.length
+
+  def fromQuery[R <: HList, F <: HList, D <: HList, I <: HList, V <: HList, Lub1, Lub2, L <: HList](name: String, desc: String)(records: Query0[(String, R)])(
+    implicit  f: Fields.Aux[R, F],
+              d: Mapper.Aux[ToDeclaration.type, F, D],
+             d2: Mapper.Aux[ToImport.type, F, I],
+             t1: ToTraversable.Aux[D, List, Lub1],
+              v: Values.Aux[R, V],
+             ma: Mapper.Aux[ToLiteral.type, V, L],
+             t2: ToTraversable.Aux[L, List, Lub2],
+             t3: ToTraversable.Aux[I, List, Option[String]]
+  ): ConnectionIO[EnumDef] =
+    records.nel.map(fromRecords(name, desc, _))
+
+}

--- a/modules/sql/src/main/scala/EnumRefs.scala
+++ b/modules/sql/src/main/scala/EnumRefs.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+/** Minimal classes to refer to other enums by id. This is required to construct
+ *  enums refering to others like Gpi Observing Mode. */
+object EnumRefs {
+  final case class EnumRef[T <: Symbol](tag: String)
+  final case class LazyEnumRef[T <: Symbol](tag: String)
+}

--- a/modules/sql/src/main/scala/GnirsPixelScale.scala
+++ b/modules/sql/src/main/scala/GnirsPixelScale.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+/** Minimal PixelScale classes to support reading from the enum
+  * tables.
+  */
+
+final case class GnirsPixelScale(id: String)

--- a/modules/sql/src/main/scala/MagnitudeBand.scala
+++ b/modules/sql/src/main/scala/MagnitudeBand.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+/** Minimal MagnitudeBand classes to support reading from the enum
+  * tables.
+  */
+
+final case class MagnitudeBand(id: String)
+
+final case class MagnitudeSystem(id: String)

--- a/modules/sql/src/main/scala/MagnitudeValue.scala
+++ b/modules/sql/src/main/scala/MagnitudeValue.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+import java.math.RoundingMode.HALF_UP
+
+/** Minimal MagnitudeValue class to support reading from the enum
+  * tables.
+  */
+final case class MagnitudeValue(value: BigDecimal) extends Product with Serializable {
+  def toScaledInt: Int = value.underlying.scaleByPowerOfTen(2).setScale(0, HALF_UP).intValue
+}

--- a/modules/sql/src/main/scala/Main.scala
+++ b/modules/sql/src/main/scala/Main.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+import doobie._, doobie.implicits._
+import gem.sql.enum._
+import java.nio.file._
+import cats.implicits._, cats.effect.IO
+
+object Main {
+
+  val xa: Transactor[IO] =
+    Transactor.fromDriverManager[IO](
+      "org.postgresql.Driver",
+      "jdbc:postgresql:gem",
+      "postgres",
+      ""
+    )
+
+  val enums: ConnectionIO[List[EnumDef]] = {
+    List(
+      F2Enums    .enums,
+      GcalEnums  .enums,
+      GmosEnums  .enums,
+      GnirsEnums .enums,
+      GpiEnums   .enums,
+      MiscEnums  .enums,
+      TargetEnums.enums
+    ).flatten.sequence
+  }
+
+  def write(dir: Path, d: EnumDef): IO[Unit] = {
+    val out = dir.resolve(d.fileName)
+    IO(Files.write(out, d.text.getBytes("UTF-8"))) *>
+    IO(Console.println(s"Wrote $out")) // scalastyle:ignore console.io
+  }
+
+  def writeAll(dir: Path): IO[Unit] =
+    for {
+      eds <- enums.transact(xa)
+      _   <- IO(Files.createDirectories(dir))
+      _   <- eds.traverse_(write(dir, _))
+    } yield ()
+
+  def runl(args: List[String]): IO[Unit] =
+    args match {
+      case List(dirName) => IO(Paths.get(dirName).toAbsolutePath).flatMap(writeAll)
+      case _             => IO(Console.println("usage: <main> path/to/output/dir")) // scalastyle:ignore console.io
+    }
+
+  def main(args: Array[String]): Unit =
+    runl(args.toList).unsafeRunSync
+
+}

--- a/modules/sql/src/main/scala/Wavelength.scala
+++ b/modules/sql/src/main/scala/Wavelength.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+import java.math.RoundingMode.HALF_UP
+
+/** Minimal Wavelength classes to support reading from the enum
+  * tables.
+  */
+sealed trait Wavelength extends Product with Serializable {
+  def toBigDecimal: BigDecimal
+
+  def toAngstrom: Int = {
+    val n = this match {
+      case Wavelength.Nm(_) => 1
+      case Wavelength.Um(_) => 4
+    }
+    toBigDecimal.underlying.scaleByPowerOfTen(n).setScale(0, HALF_UP).intValue
+  }
+}
+
+object Wavelength {
+  final case class Nm(toBigDecimal: BigDecimal) extends Wavelength
+  final case class Um(toBigDecimal: BigDecimal) extends Wavelength
+
+  def fromNm(bd: BigDecimal): Wavelength.Nm =
+    Nm(bd)
+
+  def fromUm(bd: BigDecimal): Wavelength.Um =
+    Um(bd)
+}

--- a/modules/sql/src/main/scala/enum/F2Enums.scala
+++ b/modules/sql/src/main/scala/enum/F2Enums.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+package enum
+
+import doobie._, doobie.implicits._
+import java.time.Duration
+import shapeless.record._
+
+object F2Enums {
+
+  val enums: List[ConnectionIO[EnumDef]] =
+    List(
+
+      EnumDef.fromQuery("F2Disperser", "Flamingos2 dispersers") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Wavelength.Um`.T
+        sql"SELECT id, id tag, short_name, long_name, wavelength FROM e_f2_disperser".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("F2Filter", "Flamingos2 filters") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Option[Wavelength.Um], 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, wavelength, obsolete FROM e_f2_filter".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("F2Fpu", "Flamingos2 focal plane units") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'slitWidth -> Int, 'decker -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, slit_width, decker, obsolete FROM e_f2_fpu".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("F2LyotWheel", "Flamingos2 Lyot wheel") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'plateScale -> Double, 'pixelScale -> Double, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, plate_scale, pixel_scale, obsolete FROM e_f2_lyot_wheel".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("F2ReadMode", "Flamingos2 read modes") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'description -> String, 'minimumExposureTime -> Duration, 'recommendedExposureTime -> Duration, 'readoutTime -> Duration, 'readCount -> Int, 'readNoise -> Double`.T
+        sql"SELECT id, id tag, short_name, long_name, description, minimum_exposure_time, recommended_exposure_time, readout_time, read_count, read_noise FROM e_f2_read_mode".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("F2WindowCover", "Flamingos2 window cover state") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"SELECT id, id tag, short_name, long_name FROM e_f2_window_cover".query[(String, R)]
+      }
+
+    )
+
+}

--- a/modules/sql/src/main/scala/enum/GcalEnums.scala
+++ b/modules/sql/src/main/scala/enum/GcalEnums.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+package enum
+
+import doobie._, doobie.implicits._
+import shapeless.record._
+
+object GcalEnums {
+
+  val enums: List[ConnectionIO[EnumDef]] =
+    List(
+
+      EnumDef.fromQuery("GcalFilter", "calibration unit filter") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_filter".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GcalContinuum", "calibration unit continuum lamps") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_continuum".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GcalArc", "calibration unit arc lamps") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_arc".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GcalDiffuser", "calibration unit diffusers") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_diffuser".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GcalShutter", "calibration unit shutter states") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_shutter".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GcalBaselineType", "calibration baseline type") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'gcal_baseline_type'
+        """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GcalLampType", "calibration lamp type") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'gcal_lamp_type'
+        """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("SmartGcalType", "\"smart\" calibration sequence tpes") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'smart_gcal_type'
+        """.query[(String, R)]
+      }
+
+    )
+
+}

--- a/modules/sql/src/main/scala/enum/GmosEnums.scala
+++ b/modules/sql/src/main/scala/enum/GmosEnums.scala
@@ -1,0 +1,118 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+package enum
+
+import doobie._, doobie.implicits._
+import shapeless.record._
+
+object GmosEnums {
+  import Angle.Arcseconds
+
+  val enums: List[ConnectionIO[EnumDef]] =
+    List(
+
+      EnumDef.fromQuery("GmosAdc", "GMOS ADC") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"""SELECT id, id tag, short_name, long_name FROM e_gmos_adc""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosAmpCount", "GMOS amp count") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"""SELECT id, id tag, short_name, long_name FROM e_gmos_amp_count""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosAmpGain", "GMOS amp gain") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"""SELECT id, id tag, short_name, long_name FROM e_gmos_amp_gain""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosAmpReadMode", "GMOS amp read mode") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"""SELECT id, id tag, short_name, long_name FROM e_gmos_amp_read_mode""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosCustomSlitWidth", "GMOS custom slit width") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'width -> Arcseconds`.T
+        sql"""SELECT id, id tag, short_name, long_name, width FROM e_gmos_custom_slit_width""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosDetector", "GMOS detector") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'northPixelSize -> Arcseconds, 'southPixelSize -> Arcseconds, 'shuffleOffset -> Int, 'xSize -> Int, 'ySize -> Int, 'maxRois -> Int`.T
+        sql"""SELECT id, id tag, short_name, long_name, north_pixel_size, south_pixel_size, shuffle_offset, x_size, y_size, max_rois FROM e_gmos_detector""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosDisperserOrder", "GMOS disperser order") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'count -> Int`.T
+        sql"""SELECT id, id tag, short_name, long_name, count FROM e_gmos_disperser_order""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosDtax", "GMOS detector translation X offset") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'dtax -> Int`.T
+        sql"""SELECT id, id tag, short_name, long_name, dtax FROM e_gmos_dtax""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosEOffsetting", "GMOS Electric Offsetting") {
+        type R = Record.`'tag -> String, 'description -> String, 'toBoolean -> Boolean`.T
+        sql"select id, id tag, description, to_boolean FROM e_gmos_e_offsetting".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosNorthDisperser", "GMOS North dispersers") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'rulingDensity -> Int, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, ruling_density, obsolete FROM e_gmos_north_disperser""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosNorthFilter", "GMOS North filters") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Wavelength.Um, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, wavelength, obsolete FROM e_gmos_north_filter""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosNorthFpu", "GMOS North focal plane units") {
+        type GmosNorthFpuRec = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'slitWidth -> Option[Arcseconds]`.T
+        sql"""SELECT id, id tag, short_name, long_name, slit_width FROM e_gmos_north_fpu""".query[(String, GmosNorthFpuRec)]
+      },
+
+      EnumDef.fromQuery("GmosNorthStageMode", "GMOS North stage modes") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gmos_north_stage_mode""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosRoi", "GMOS ROI (region of interest)") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gmos_roi""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosSouthDisperser", "GMOS South dispersers") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'rulingDensity -> Int, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, ruling_density, obsolete FROM e_gmos_south_disperser""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosSouthFilter", "GMOS South filters") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Wavelength.Um, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, wavelength, obsolete FROM e_gmos_south_filter""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosSouthFpu", "GMOS South focal plane units") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'slitWidth -> Option[Arcseconds]`.T
+        sql"""SELECT id, id tag, short_name, long_name, slit_width FROM e_gmos_south_fpu""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosSouthStageMode", "GMOS South stage mode") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gmos_south_stage_mode""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosXBinning", "GMOS X-binning") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'count -> Int`.T
+        sql"""SELECT id, id tag, short_name, long_name, count FROM e_gmos_binning""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GmosYBinning", "GMOS Y-binning") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'count -> Int`.T
+        sql"""SELECT id, id tag, short_name, long_name, count FROM e_gmos_binning""".query[(String, R)]
+      }
+
+    )
+
+}

--- a/modules/sql/src/main/scala/enum/GnirsEnums.scala
+++ b/modules/sql/src/main/scala/enum/GnirsEnums.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+package enum
+
+import doobie._, doobie.implicits._
+import shapeless.record._
+
+object GnirsEnums {
+  import Angle.Arcseconds
+
+  val enums: List[ConnectionIO[EnumDef]] =
+    List(
+
+      EnumDef.fromQuery("GnirsAcquisitionMirror", "GNIRS Acquisition Mirror") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"""SELECT id, id tag, short_name, long_name FROM e_gnirs_acquisition_mirror""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GnirsCamera", "GNIRS Camera") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'pixelScale -> GnirsPixelScale`.T
+        sql"""SELECT id, id tag, short_name, long_name, pixel_scale FROM e_gnirs_camera""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GnirsDecker", "GNRIS Decker") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gnirs_decker""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GnirsDisperser", "GNIRS Disperser") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'rulingDensity -> Int`.T
+        sql"""SELECT id, id tag, short_name, long_name, ruling_density FROM e_gnirs_disperser""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GnirsDisperserOrder", "GNIRS Disperser Order") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'count -> Int, 'defaultWavelength -> Wavelength.Um, 'minWavelength -> Wavelength.Um, 'maxWavelength -> Wavelength.Um, 'deltaWavelength -> Wavelength.Um, 'band -> Option[MagnitudeBand], 'cross_dispersed -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, count, default_wavelength, min_wavelength, max_wavelength, delta_wavelength, band, cross_dispersed FROM e_gnirs_disperser_order""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GnirsFilter", "GNIRS Filter") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'waveLength -> Option[Wavelength.Um]`.T
+        sql"""SELECT id, id tag, short_name, long_name, wavelength FROM e_gnirs_filter""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GnirsFpuSlit", "GNIRS FPU Slit") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'slitWidth -> Arcseconds, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, slit_width, obsolete FROM e_gnirs_fpu_slit""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GnirsFpuOther", "GNIRS FPU Other") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gnirs_fpu_other""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GnirsPixelScale", "GNIRS Pixel Scale") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> BigDecimal`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gnirs_pixel_scale""".query[(String, R)]
+      },
+
+
+      EnumDef.fromQuery("GnirsWellDepth", "GNRIS Well Depth") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'bias_level -> Int`.T
+        sql"""SELECT id, id tag, short_name, long_name, bias_level FROM e_gnirs_well_depth""".query[(String, R)]
+      }
+
+    )
+
+}

--- a/modules/sql/src/main/scala/enum/GpiEnums.scala
+++ b/modules/sql/src/main/scala/enum/GpiEnums.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+package enum
+
+import doobie._, doobie.implicits._
+import shapeless.record._
+import shapeless.Witness
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object GpiEnums {
+  import EnumRefs._
+
+  val enums: List[ConnectionIO[EnumDef]] =
+    List(
+
+      EnumDef.fromQuery("GpiAdc", "GPI ADC") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_adc""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiFilter", "GPI Filter") {
+        val  m = Witness('MagnitudeBand)
+        type M = m.T
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'band -> EnumRef[M], 'obsolete -> Boolean`.T
+        val ret = sql"""SELECT id, id tag, short_name, long_name, band, obsolete FROM e_gpi_filter""".query[(String, E)]
+        (ret, m.value: M)._1 // convince scalac that we really do use M
+      },
+
+      EnumDef.fromQuery("GpiDisperser", "GPI Disperser") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"""SELECT id, id tag, short_name, long_name FROM e_gpi_disperser""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiApodizer", "GPI Apodizer") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gpi_apodizer""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiLyot", "GPI Lyot") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gpi_lyot""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiASU", "GPI Artificial Source Unit") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_artificial_source_unit""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiEntranceShutter", "GPI Entrance Shutter") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_entrance_shutter""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiScienceArmShutter", "GPI Science Arm Shutter") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_sience_arm_shutter""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiCalEntranceShutter", "GPI Cal Entrance Shutter") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_cal_entrance_shutter""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiReferenceArmShutter", "GPI Reference Arm Shutter") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_reference_arm_shutter""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiPupilCamera", "GPI Pupil Camera") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_pupil_camera""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiFPM", "GPI FPM") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gpi_fpm""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiSamplingMode", "GPI Sampling Mode") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gpi_sampling_mode""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiCassegrain", "GPI Cassegrain") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Int`.T
+        sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_cassegrain""".query[(String, E)]
+      },
+
+      EnumDef.fromQuery("GpiObservingMode", "GPI ObservingMode") {
+        val (a, b, c, d, e) = (Witness('GpiFilter), Witness('GpiApodizer), Witness('GpiFPM), Witness('GpiLyot), Witness('GpiObservingMode))
+        type A = a.T
+        type B = b.T
+        type C = c.T
+        type D = d.T
+        type E = e.T
+        type F = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'filter -> Option[EnumRef[A]], 'filterIterable -> Boolean, 'apodizer -> Option[EnumRef[B]], 'fpm -> Option[EnumRef[C]], 'lyot -> Option[EnumRef[D]], 'brightLimitPrism -> Option[MagnitudeValue], 'brightLimitWollaston -> Option[MagnitudeValue], 'correspondingHMode -> LazyEnumRef[E], 'obsolete  -> Boolean`.T
+        val ret = sql"""SELECT id, id tag, short_name, long_name, filter, filter_iterable, apodizer, fpm, lyot, bright_limit_prism, bright_limit_wollaston, corresponding_h_mode, obsolete FROM e_gpi_observing_mode""".query[(String, F)]
+        (ret, a.value: A, b.value: B, c.value: C, d.value: D, e.value: E)._1 // suppress unused warnigs
+      }
+
+    )
+
+}

--- a/modules/sql/src/main/scala/enum/MiscEnums.scala
+++ b/modules/sql/src/main/scala/enum/MiscEnums.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+package enum
+
+import doobie._, doobie.implicits._
+import java.time.ZoneId
+import shapeless.record._
+
+object MiscEnums {
+  import Angle._
+
+  val enums: List[ConnectionIO[EnumDef]] =
+    List(
+
+      EnumDef.fromQuery("MosPreImaging", "MOS pre-imaging category") {
+        type R = Record.`'tag -> String, 'description -> String, 'toBoolean -> Boolean`.T
+        sql"SELECT id, id tag, description, to_boolean FROM e_mos_preimaging".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("StepType", "step types") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'step_type'
+         """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("EventType", "observe [[gem.Event Event]]) types") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel a, enumlabel b
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'evt_type'
+        """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("Instrument", "instruments") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_instrument".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("ProgramType", "program types (see [[gem.ProgramId ProgramId]])") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_program_type".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("Site", "Gemini observing sites") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'mountain -> String, 'latitude -> Degrees, 'longitude -> Degrees, 'altitude -> Int, 'timezone -> ZoneId`.T
+        sql"""SELECT id, id tag, short_name, long_name, mountain, latitude, longitude, altitude,
+                timezone
+              FROM e_site""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("ProgramRole", "user roles with respect to a given program") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"SELECT id, id tag, short_name, long_name FROM e_program_role".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("Half", "semester half") {
+        type R = Record.`'tag -> String, 'toInt -> Int`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y, enumsortorder - 1
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'half'
+         """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("EphemerisKeyType", "Non-sidereal target lookup type") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        sql"SELECT id, id tag, short_name, long_name FROM e_ephemeris_type".query[(String, R)]
+      }
+
+    )
+
+}

--- a/modules/sql/src/main/scala/enum/TargetEnums.scala
+++ b/modules/sql/src/main/scala/enum/TargetEnums.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+package enum
+
+import doobie._, doobie.implicits._
+import shapeless.record._
+
+object TargetEnums {
+
+  val enums: List[ConnectionIO[EnumDef]] =
+    List(
+
+      EnumDef.fromQuery("AsterismType", "asterism types") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'asterism_type'
+         """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("TrackType", "track types") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'e_track_type'
+         """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("MagnitudeSystem", "magnitude system") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'magnitude_system'
+         """.query[(String, R)]
+      },
+
+      EnumDef.fromQuery("MagnitudeBand", "magnitude band") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'center -> Wavelength.Nm, 'width -> Int, 'magnitudeSystem -> MagnitudeSystem`.T
+        sql"""SELECT id, id tag, short_name, long_name, center, width, default_system FROM e_magnitude_band""".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("UserTargetType", "user target type") {
+        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_user_target_type".query[(String, R)]
+      }
+
+    )
+
+}

--- a/modules/sql/src/main/scala/package.scala
+++ b/modules/sql/src/main/scala/package.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import doobie._
+import java.time.{ Duration, ZoneId }
+
+package object sql {
+  implicit val DurationMeta: Meta[Duration] =
+    Meta[Long].xmap(Duration.ofMillis, _.toMillis)
+
+  implicit val ZoneIdMeta: Meta[ZoneId] =
+    Meta[String].xmap(ZoneId.of, _.toString)
+}

--- a/modules/telnetd/src/main/scala/TelnetServer.scala
+++ b/modules/telnetd/src/main/scala/TelnetServer.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.telnetd
+
+import gem.Log
+import cats.effect.{ IO }
+import gem.dao.DatabaseConfiguration
+import fs2.Stream
+import tuco._, Tuco._
+
+object TelnetServer {
+
+  // Single-element stream starting a server, yielding unit, automatically cleaned up.
+  private def server(db: DatabaseConfiguration, telnet: TelnetdConfiguration, log: Log[SessionIO]): Stream[IO, Unit] = {
+    Stream.bracket(
+      Config(Interaction.main(
+        db.transactor[SessionIO], log
+      ), telnet.port).start
+    )(_ => Stream(()), identity)
+  }
+
+  /** Single-element stream starting a server, yielding unit, automatically cleaned up. */
+  def stream(db: DatabaseConfiguration, telnet: TelnetdConfiguration): Stream[IO, Unit] =
+    Stream.eval(Log.newLogIn[SessionIO, IO]("telnetd", db.transactor[IO])).flatMap { log =>
+      server(db, telnet, log)
+    }
+
+}

--- a/modules/telnetd/src/main/scala/TelnetdConfiguration.scala
+++ b/modules/telnetd/src/main/scala/TelnetdConfiguration.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.telnetd
+
+final case class TelnetdConfiguration(port: Int)
+
+object TelnetdConfiguration {
+
+  val forTesting: TelnetdConfiguration =
+    apply(9091)
+
+}

--- a/modules/telnetd/src/main/scala/command/SiteOpt.scala
+++ b/modules/telnetd/src/main/scala/command/SiteOpt.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+package command
+
+import gem.enum.Site
+
+import atto._
+import Atto._
+
+import cats.data.{ NonEmptyList, ValidatedNel }
+import cats.implicits._
+
+import com.monovore.decline.Opts
+
+
+/** Site options shared across various commands.
+  */
+trait SiteOpt {
+
+  /** Validates a gemini-site String. */
+  def validateSite(s: String): ValidatedNel[String, Site] =
+    gem.EnumParsers.site.parseOnly(s)
+      .either
+      .leftMap(_ => s"'$s' is not a Gemini site")
+      .toValidatedNel
+
+  /** Required site option, "--site" or "-s". */
+  val site: Opts[Site] =
+    Opts.option[String]("site", help = "GN | GS", short = "s")
+      .mapValidated(validateSite)
+
+  /** Multiple site options, defaulting to GS and GN. */
+  val sites: Opts[Set[Site]] =
+    Opts.options[String]("site", help = "GN | GS", short = "s")
+      .mapValidated { _.map(validateSite).sequence }
+      .withDefault(NonEmptyList.of(Site.GN, Site.GS))
+      .map { nel => Set(nel.toList: _*) }
+
+}

--- a/modules/telnetd/src/main/scala/command/eph.scala
+++ b/modules/telnetd/src/main/scala/command/eph.scala
@@ -1,0 +1,153 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+package command
+
+import gem.enum.Site
+import gem.horizons.EphemerisContext
+import gem.math.ObservingNight
+import gem.util.Timestamp
+
+import cats.data.NonEmptyList
+import cats.implicits._
+import com.monovore.decline.{ Command => _, _ }
+import tuco._
+import Tuco._
+import tuco.shell._
+
+import java.nio.file.Path
+import java.time.Instant
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeFormatter
+
+/** Commands for working with ephemerides.
+  *
+  * exportCommand - exports ephemerides to files for the TCS
+  * reportCommand - display ephemerides status information
+  * updateCommand - updates ephemerides from horizons if necessary
+  */
+object eph extends SiteOpt {
+
+  /** Export directory option. */
+  val dir: Opts[Path] =
+    Opts.option[Path]("dir", help = "export to directory", short = "d")
+      .validate("Directory must be writeable") { _.toFile.canWrite }
+
+  /** Ephemeris key argument parsing.
+    *
+    * @param name     name of the ephemeris key type (e.g., "horizons-key", or
+    *                 generic "ephemeris-key"
+    * @param failMsg  text to display if a key cannot be parsed
+    * @param collectf function that selects a subset of valid ephemeris keys
+    *                 (e.g., only those that are also horizons keys)
+    */
+  private def keys[K <: EphemerisKey](
+    name:    String,
+    failMsg: String => String
+  )(
+    collectf: PartialFunction[EphemerisKey, K]
+  ): Opts[NonEmptyList[K]] =
+
+    Opts.arguments[String](name)
+      .orEmpty
+      .mapValidated {
+        _.foldMap { keyStr =>
+          EphemerisKey.fromString
+            .getOption(keyStr)
+            .collect(collectf)
+            .fold(failMsg(keyStr).invalidNel[List[K]]) { k =>
+              List(k).validNel[String]
+            }
+        }.withEither(_.flatMap {
+          case Nil    => Left(NonEmptyList.one("Must supply at least one valid key"))
+          case h :: t => Right(NonEmptyList.of(h, t: _*))
+        })
+      }
+
+  /** Argument for one or more ephemeris keys of any type. */
+  val anyKeys: Opts[NonEmptyList[EphemerisKey]] =
+    keys("ephemeris-key", keyStr => s"'$keyStr' is not a valid ephemeris key") {
+      case k => k
+    }
+
+  /** Argument for one or more horizons keys. */
+  val horizonsKeys: Opts[NonEmptyList[EphemerisKey.Horizons]] =
+    keys("horizons-key", keyStr => s"'$keyStr' is not a valid horizons key") {
+      case k: EphemerisKey.Horizons => k
+    }
+
+  /** Command that exports ephemeris files in TCS format to a directory on the
+    * server.
+    */
+  val exportCommand: GemCommand = {
+    def range(now: Instant, s: Site): (Timestamp, Timestamp) = {
+      val n = ObservingNight.fromSiteAndInstant(s, now)
+      (Timestamp.unsafeFromInstant(n.start), Timestamp.unsafeFromInstant(n.end))
+    }
+
+    Command(
+      "eph-export", "Export ephemerides for the current night for use by the TCS",
+      (site, dir, anyKeys).mapN { (s: Site, p: Path, ks: NonEmptyList[EphemerisKey]) =>
+        (d: GemState) => {
+
+          ks.traverse { k =>
+            for {
+              r <- SessionIO.delay(Instant.now).map(range(_, s))
+              _ <- write(s"Exporting $k @ $s ... ")
+              f <- d.ephemeris.export(k, s, r._1, r._2, p)
+              _ <- writeLn(s"$f")
+            } yield ()
+          }.as(d)
+        }
+      }
+    ).zoom(Session.data[GemState])
+
+  }
+
+  private def horizonsCommand(name: String, help: String, msg: String)
+                             (f: (GemState, EphemerisKey.Horizons, Site) => SessionIO[EphemerisContext]): GemCommand =
+    Command(
+      name, help,
+      (site, horizonsKeys).mapN { (s: Site, ks: NonEmptyList[EphemerisKey.Horizons]) => (d: GemState) =>
+        ks.traverse { k =>
+          for {
+            _ <- writeLn(s"$msg $k @ $s ...")
+            c <- f(d, k, s)
+            _ <- writeLn(report.format(c))
+          } yield ()
+        }.as(d)
+      }
+    ).zoom(Session.data[GemState])
+
+  val reportCommand: GemCommand =
+    horizonsCommand("eph-report", "Display ephemeris report", "Looking up") { (d, k, s) =>
+      d.ephemeris.report(k, s)
+    }
+
+  val updateCommand: GemCommand =
+    horizonsCommand("eph-update", "Update ephemeris from horizons, if necessary", "Updating") { (d, k, s) =>
+      d.ephemeris.update(k, s)
+    }
+
+  /** EphemerisContext report formatting. */
+  private object report {
+    val timeFormatter: DateTimeFormatter =
+      DateTimeFormatter.RFC_1123_DATE_TIME.withZone(UTC)
+
+    def formatTime(ot: Option[Timestamp]): String =
+      ot.map(t => timeFormatter.format(t.toInstant)).orEmpty
+
+    /** Formats an EphemerisContext for display to the user. */
+    def format(ctx: EphemerisContext): String =
+      s"""
+         |${ctx.key} @ ${ctx.site}
+         |  Last Update.......: ${formatTime(ctx.meta.map(_.lastUpdate))}
+         |  Last Update Check.: ${formatTime(ctx.meta.map(_.lastUpdateCheck))}
+         |  Solution Reference: ${ctx.meta.flatMap(_.solnRef).map(_.stringValue).orEmpty}
+         |  Available Range...: ${formatTime(ctx.rnge.map(_._1))}${ctx.rnge.as(" - ").orEmpty}${formatTime(ctx.rnge.map(_._2))}
+       """.stripMargin
+  }
+
+}

--- a/modules/telnetd/src/main/scala/command/fetch.scala
+++ b/modules/telnetd/src/main/scala/command/fetch.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+package command
+
+import cats.implicits._
+import com.monovore.decline.{ Command => _, _ }
+import tuco._
+import Tuco._
+import tuco.shell._
+
+/** Command to fetch an observation or program from an OCS2 ODB.
+  */
+object fetch {
+
+  val host: Opts[String] =
+    Opts.option[String](
+      help    = s"ODB hostname (default localhost)",
+      metavar = "host",
+      short   = "h",
+      long    = "host"
+    ).withDefault("localhost")
+
+  val oid: Opts[Observation.Id] =
+    Opts.argument[String](
+      metavar = "obs-id"
+    ).mapValidated { s =>
+      Observation.Id.fromString(s).toValidNel(s"Could not parse '$s' as an observation id")
+    }
+
+  val pid: Opts[Program.Id] =
+    Opts.argument[String](
+      metavar = "prog-id"
+    ).mapValidated { s =>
+      ProgramId.fromString.getOption(s).toValidNel(s"Could not parse '$s' as a program id")
+    }
+
+  val obsCommand: GemCommand =
+    Command(
+      "fetch-obs", "Fetch an observation from an OCS2 ODB and store it.",
+      (host, oid).mapN { (h: String, id: Observation.Id) => (d: GemState) => {
+        for {
+          r <- d.ocs2.importObservation(h, id)
+          _ <- writeLn(r.fold(m => s"Failed to import ${id.format}: $m", _ => s"Imported ${id.format}"))
+        } yield d
+      }}
+    ).zoom(Session.data[GemState])
+
+  val progCommand: GemCommand =
+    Command(
+      "fetch-prog", "Fetch a program from an OCS2 ODB and store it.",
+      (host, pid).mapN { (h: String, id: Program.Id) => (d: GemState) => {
+        for {
+          r <- d.ocs2.importProgram(h, id)
+          _ <- writeLn(r.fold(
+                 m => s"Failed to import ${Program.Id.fromString.reverseGet(id)}: $m",
+                 _ => s"Imported ${Program.Id.fromString.reverseGet(id)}"
+               ))
+        } yield d
+      }}
+    ).zoom(Session.data[GemState])
+}

--- a/modules/telnetd/src/main/scala/command/ls.scala
+++ b/modules/telnetd/src/main/scala/command/ls.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+package command
+
+import cats.implicits._
+import com.monovore.decline.{ Command => _, _ }
+import tuco._, Tuco._, tuco.shell._
+
+/** A command that lists programs with matching program id and/or title. */
+object ls {
+
+  val defaultMax: Int = 100
+
+  val num: Opts[Int] =
+    Opts.option[Int](
+      help    = s"Maximum number of programs to display (default $defaultMax).",
+      metavar = "int",
+      short   = "n",
+      long    = "number"
+    ).withDefault(defaultMax)
+
+  val pat: Opts[String] =
+    Opts.argument[String](
+      metavar = "pattern"
+    ).withDefault("*")
+     .map(_.replaceAll("\\*", "%")
+           .replaceAll("\\.", "?"))
+
+  val command: GemCommand =
+    Command(
+      "ls", "List all visible with ids or titles matching the given pattern.",
+      (num, pat).mapN { (n: Int, p: String) => (d: GemState) =>
+         for {
+           progs  <- d.queryProgramsByName(p, n + 1)
+           (h, t)  = progs.splitAt(n)
+           cols   <- getColumns
+           _      <- formatProgs(h, cols).traverse(writeLn(_))
+           _      <- writeLn(s"--Limit reached. ($n)--").whenA(t.nonEmpty)
+         } yield d
+      }
+    ).zoom(Session.data[GemState])
+
+  // scala.text and kiama are both on the classpath but neither has any doc so I'm just going
+  // to do this by hand for now. We're going to truncate output for now.
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def formatProgs(ps: List[(Program.Id, String)], width: Int): List[String] = {
+    val w1 = ps.map(_._1.toString.length).foldRight(0)(_ max _) + 2
+    val w2 = width - w1
+    ps.map { p =>
+      p._1.toString.padTo(w1, ' ') + p._2.take(w2)
+    }
+  }
+
+}

--- a/modules/telnetd/src/main/scala/command/package.scala
+++ b/modules/telnetd/src/main/scala/command/package.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+
+import cats.implicits._
+import com.monovore.decline.{ Command => _, _ }
+import tuco._, Tuco._, tuco.shell._
+
+package object command {
+
+  /** Our state is a Service with effect type SessionIO. */
+  type GemState = Service[SessionIO]
+
+  val All: Commands[GemState] =
+    Commands[GemState](
+      eph.exportCommand,
+      eph.reportCommand,
+      eph.updateCommand,
+      fetch.obsCommand,
+      fetch.progCommand,
+      ls.command,
+      whoami.command,
+      passwd.command
+    )
+
+  /** Our commands are in SessionIO, and pass a Session[GemState] around. */
+  type GemCommand = Command[SessionIO, Session[GemState]]
+
+  // Our commnds are always in SessionIO.
+  def shellCommand[A](
+    name: String,
+    desc: String,
+    parser: Opts[A => SessionIO[A]]
+  ): Command[SessionIO, A] =
+    shellCommandWithCompleter(name, desc, parser, (_, _) => List.empty[String].pure[SessionIO])
+
+  def shellCommandWithCompleter[A](
+    name: String,
+    desc: String,
+    parser: Opts[A => SessionIO[A]],
+    complete: (A, String) => SessionIO[List[String]]
+  ): Command[SessionIO, A] =
+    Command(name, desc, parser, complete)
+
+}

--- a/modules/telnetd/src/main/scala/command/passwd.scala
+++ b/modules/telnetd/src/main/scala/command/passwd.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+package command
+
+import cats.Applicative
+import com.monovore.decline.{ Command => _, _ }
+import tuco._, Tuco._, tuco.shell._
+
+/** A command for changing passwords. */
+object passwd {
+
+  val command: GemCommand =
+    shellCommand[GemState](
+      "passwd", "Change password.",
+      Applicative[Opts].pure { s =>
+        for {
+          o <- readLn("Old password: ", mask = Some('*'))
+          n <- readLn("New password: ", mask = Some('*'))
+          b <- s.changePassword(o, n)
+          _ <- if (b) writeLn("Password changed.")
+               else   writeLn("Incorrect old password and/or invalid new password.")
+        } yield s
+      }
+    ).zoom(Session.data[GemState])
+
+}

--- a/modules/telnetd/src/main/scala/command/whoami.scala
+++ b/modules/telnetd/src/main/scala/command/whoami.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+package command
+
+import cats.Applicative
+import gem.enum.ProgramRole
+import com.monovore.decline.{ Command => _, _ }
+import tuco._, Tuco._, tuco.shell._
+
+/** A command to show information about the current user. */
+object whoami {
+
+  val command: GemCommand =
+    shellCommand[User[ProgramRole]](
+      "whoami", "Show information about the current user.",
+      Applicative[Opts].pure { u =>
+        for {
+          _ <- writeLn(s"username: ${u.id}")
+          _ <- writeLn(s"   first: ${u.firstName}")
+          _ <- writeLn(s"    last: ${u.lastName}")
+          _ <- writeLn(s"   email: ${u.email}")
+          _ <- writeLn(s"   flags: ${if (u.isStaff) "staff" else "<none>"}")
+        } yield u
+      }
+    ).zoom(Session.data[GemState] ^|-> Service.user[SessionIO])
+
+}

--- a/modules/telnetd/src/main/scala/interact.scala
+++ b/modules/telnetd/src/main/scala/interact.scala
@@ -1,0 +1,74 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+
+import cats.implicits._
+import doobie.imports.Transactor
+import tuco._, Tuco._
+import tuco.shell._
+
+/** Module defining the behavior of our telnet server, parameterized over transactors. */
+object Interaction {
+
+  /**
+   * Initial state for a command shell session has a logged-in Service value, as well as all the
+   * Gem commands and a customized prompt.
+   */
+  def initialState(service: Service[SessionIO]): Session[Service[SessionIO]] =
+    Session.initial(service).copy(
+      commands = Builtins[Service[SessionIO]] |+| command.All,
+      prompt   = s"${service.user.id}@gem> "
+    )
+
+  /**
+   * Login loop. Prompt for a password `remainingTries` times and return a Service on success. The
+   * transactors are needed for the `Service`.
+   */
+  def loginLoop(
+    user:     String,
+    maxTries: Int,
+    xa:       Transactor[SessionIO],
+    log:      Log[SessionIO]
+  ): SessionIO[Option[Service[SessionIO]]] = {
+    def go(remaining: Int): SessionIO[Option[Service[SessionIO]]] =
+      if (remaining < 1) {
+        Option.empty[Service[SessionIO]].pure[SessionIO]
+      } else {
+        for {
+          p <- readLn("Password: ", mask = Some('*'))
+          u <- Service.tryLogin(user, p, xa, log)
+          r <- if (u.isEmpty) writeLn("Incorrect password.") *> go(remaining - 1)
+               else u.pure[SessionIO]
+        } yield r
+      }
+    go(maxTries)
+  }
+
+  /**
+   * Command shell. Greet the user and run the command shell. Clean up on exit.
+   * TODO: per-session log is wasteful and can't be cleaned up reliably
+   */
+  def runSession(service: Service[SessionIO]): SessionIO[Unit] =
+    for {
+      d <- SessionIO.delay(new java.util.Date)
+      _ <- writeLn(s"Welcome, local time is $d." )
+      f <- CommandShell.run(initialState(service))
+      _ <- f.data.log.shutdown(1000L)
+      _ <- writeLn(s"Goodbye.")
+    } yield ()
+
+  /**
+   * Entry point for our telnet behavior. If the user logs in successfully the transactors will be
+   * associated with the Session.
+   */
+  def main(xa: Transactor[SessionIO], log: Log[SessionIO]): SessionIO[Unit] =
+    for {
+      _ <- writeLn("Welcome to Gem")
+      n <- readLn("Username: ")
+      s <- loginLoop(n, 3, xa, log)
+      _ <- s.fold(writeLn(s"Login failed."))(runSession)
+    } yield ()
+
+}

--- a/modules/telnetd/src/main/scala/main.scala
+++ b/modules/telnetd/src/main/scala/main.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package telnetd
+
+import cats.effect.IO
+import gem.dao.DatabaseConfiguration
+import fs2.{ Stream, StreamApp }
+
+object Main extends StreamApp[IO] {
+  import StreamApp.ExitCode
+
+  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] =
+    for {
+      _ <- TelnetServer.stream(DatabaseConfiguration.forTesting, TelnetdConfiguration.forTesting)
+      _ <- Stream.eval(IO(Console.println("Press a key to exit."))) // scalastyle:off
+      _ <- Stream.eval(IO(scala.io.StdIn.readLine()))
+      _ <- Stream.eval(requestShutdown)
+    } yield ExitCode(0)
+
+}

--- a/modules/ui/src/main/scala/gem/ui/Main.scala
+++ b/modules/ui/src/main/scala/gem/ui/Main.scala
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ui
+
+import gem.CoAdds
+import gem.config._
+import gem.enum._
+import gem.math._
+
+import java.time.{ Duration, Year }
+import scala.collection.immutable.{ TreeMap, TreeSet }
+
+object TestProgram {
+  val pid: Program.Id =
+    ProgramId.Science(Site.GS, Semester(Year.of(2018), Half.A), ProgramType.Q, Index.One)
+
+  val vega: Target =
+    Target("Vega",
+      Right(ProperMotion(
+        Coordinates.fromHmsDms.unsafeGet("18:36:56.336 38:47:01.28"),
+        Epoch.J2000,
+        Some(Offset(
+          Offset.P(Angle.fromMicroarcseconds(200940L)),
+          Offset.Q(Angle.fromMicroarcseconds(286230L))
+        )),
+        Some(RadialVelocity(-20686)),
+        Some(Angle.fromMicroarcseconds(130230L)))
+      )
+    )
+
+  val gcal: GcalConfig =
+    GcalConfig(
+      Right(GcalConfig.GcalArcs(GcalArc.ArArc, Nil)),
+      GcalFilter.None,
+      GcalDiffuser.Ir,
+      GcalShutter.Open,
+      Duration.ofSeconds(1L),
+      CoAdds.One
+    )
+
+  val f2: Observation.Flamingos2 =
+    Observation.Flamingos2(
+      "F2 Observation",
+      TargetEnvironment.Flamingos2(None, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
+      StaticConfig.Flamingos2.Default,
+      List(DynamicConfig.Flamingos2.Default.toStep(Step.Base.Gcal(gcal)))
+    )
+
+  val gmosS: Observation.GmosS =
+    Observation.GmosS(
+      "GMOS-S Observation",
+      TargetEnvironment.GmosS(None, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
+      StaticConfig.GmosS.Default,
+      List(DynamicConfig.GmosS.Default.toStep(Step.Base.SmartGcal(SmartGcalType.Arc)))
+    )
+
+  val gmosN: Observation.GmosN =
+    Observation.GmosN(
+      "GMOS-N Observation",
+      TargetEnvironment.GmosN(None, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
+      StaticConfig.GmosN.Default,
+      List(DynamicConfig.GmosN.Default.toStep(Step.Base.Bias))
+    )
+
+  val p: Program =
+    Program(
+      pid,
+      "Test Program",
+      TreeMap[Index, Observation](
+        Index.fromShort.unsafeGet(1) -> f2,
+        Index.fromShort.unsafeGet(2) -> gmosS,
+        Index.fromShort.unsafeGet(3) -> gmosN
+      )
+    )
+
+}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    // scalastyle:off
+    println(TestProgram.p)
+    // scalastyle:on
+  }
+}

--- a/modules/web/src/main/scala/Application.scala
+++ b/modules/web/src/main/scala/Application.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package web
+
+import cats.effect.IO
+import gem.{ Service => GemService }
+import gem.json._
+import io.circe.syntax._
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.dsl.io._
+
+/**
+ * The main application web service, which is "authenticated" in the sense that request carries
+ * along a Service[IO] that provides access to the Gem back-end.
+ */
+object Application {
+
+  // These give us unapplies we can use for matching arguments.
+  private val Query  = QueryParamDecoder[String].optMatcher("query")
+  private val Limit  = QueryParamDecoder[Int].optMatcher("limit")
+
+  /** Turn a glob-style pattern into a SQL pattern. */
+  def globToSql(s: String): String =
+    s.replaceAll("\\*", "%")
+     .replaceAll("\\.", "?")
+
+  /** Gem application endpoints. */
+  def service: AuthedService[GemService[IO], IO] =
+    AuthedService {
+
+      // Select matching program ids and titles.
+      case GET -> Root / "api" / "query" / "program" :? Query(q) +& Limit(n) as gs =>
+        val pattern = globToSql(q.getOrElse("*"))
+        val limit   = n.getOrElse(100)
+        gs.queryProgramsByName(pattern, limit).flatMap(ps => Ok(ps.map(p => (p._1, p._2)).asJson ))
+
+    }
+
+}

--- a/modules/web/src/main/scala/Environment.scala
+++ b/modules/web/src/main/scala/Environment.scala
@@ -1,0 +1,97 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package web
+
+import cats.implicits._
+import cats.effect.IO
+import doobie.Transactor
+import fs2.Stream
+import gem.{ Service => GemService }
+import gem.dao.DatabaseConfiguration
+import io.circe._
+import io.circe.parser.decode
+import io.circe.syntax._
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+import pdi.jwt.Jwt
+import pdi.jwt.algorithms.JwtHmacAlgorithm
+
+/**
+ * The runtime environment for the web server, providing access to required services. You can think
+ * of this as a "realized" configuration. The environment doesn't know anything about http4s, and it
+ * should only appear in the outermost layer of the application. In particular the main application
+ * endpoints don't know about the environment. This has the potential to turn into a God object so
+ * we need to keep an eye on it.
+ */
+abstract class Environment(val config: WebConfiguration) {
+
+  /** A logger that goes to the database, cc:'d to JDK logging. */
+  def log: Log[IO]
+
+  /** A source of database connections. */
+  def transactor: Transactor[IO]
+
+  /**
+   * Encode a JWT claim, which is an arbitrary JSON object with some well-known fields. The result
+   * here is the three-part encoding described at https://jwt.io/
+   */
+  def encodeJwt[A: Encoder](claim: A): String
+
+  /**
+   * Decode and validate a JWT claim, if possible. This must be in IO because validation depends
+   * on clock time.
+   */
+  def decodeJwt[A: Decoder](value: String): IO[Either[String, A]]
+
+  /** Attempt to log in, yielding a Service value tied to this Environment's log and transactor. */
+  def tryLogin(userId: String, password: String): IO[Option[GemService[IO]]] =
+    GemService.tryLogin(userId, password, transactor, log)
+
+  /** Like tryLogin, but for prevoiusly authenticated users. */
+  def service(userId: String): IO[Option[GemService[IO]]] =
+    GemService.service(userId, transactor, log)
+
+  /** Shut down this environment, releasing any held resources. */
+  def shutdown: IO[Unit] =
+    log.shutdown(config.log.shutdownTimeout)
+
+}
+
+object Environment {
+
+  // Right now we'll just create a key on startup, which means sessions can't survive server
+  // re-start. We could also write it to a file and try to read it on startup, or use a shared
+  // keychain to support single sign-on. But for now keep it simple.
+  private def randomSecretKey(algorithm: JwtHmacAlgorithm): IO[SecretKey] =
+    IO {
+      val bytes = new Array[Byte](128)
+      scala.util.Random.nextBytes(bytes)
+      new SecretKeySpec(bytes, algorithm.fullName)
+    }
+
+  /** Realize a "living" server environment from a static configuration. */
+  def quicken(cfg: WebConfiguration, db: DatabaseConfiguration): IO[Environment] = {
+
+    // TODO: hikari
+    val xa = db.transactor[IO]
+
+    (randomSecretKey(cfg.jwt.algorithm), Log.newLog[IO](cfg.log.name, xa)).mapN { (sk, lg) =>
+      new Environment(cfg) {
+        override def log = lg
+        override def transactor = xa
+        override def encodeJwt[A: Encoder](claim: A) =
+          Jwt.encode(claim.asJson.noSpaces, sk, cfg.jwt.algorithm)
+        override def decodeJwt[A: Decoder](value: String) =
+          IO(Jwt.decode(value, sk).toEither.leftMap(_.getMessage).flatMap(decode[A](_).leftMap(_.getMessage)))
+      }
+    }
+
+  }
+
+  /** A single-element stream yielding an Environment, which will be cleaned up. */
+  def stream(cfg: WebConfiguration, db: DatabaseConfiguration): Stream[IO, Environment] =
+    Stream.bracket(quicken(cfg, db))(a => Stream(a), _.shutdown)
+
+}

--- a/modules/web/src/main/scala/Gatekeeper.scala
+++ b/modules/web/src/main/scala/Gatekeeper.scala
@@ -1,0 +1,130 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package web
+
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+import gem.json._
+import gem.{ Service => GemService }
+import io.circe.generic.auto._
+import java.time.Instant
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.dsl.io._
+import org.http4s.server._
+
+/**
+ * A middleware that provides a login endpoint and implements JWT-based authorization, lifting
+ * authenticated services that rely on a GemService[IO] (as our main app service does).
+ */
+object Gatekeeper {
+
+  /**
+   * Our JSON web token (JWT), for now containing only a user id and a span of time when it is
+   * valid. It will be encoded and signed, yielding a token which is sent to the user on login, and
+   * will be returned in subsequent requests. Note that some are used by JWT itself, so the field
+   * names and their meaning is important in some cases. See https://jwt.io/
+   */
+  final case class GemToken(
+    iat: Long,  // JWT spec: issued at,  in Epoch seconds
+    exp: Long,  // JWT spec: expiration, in Epoch seconds
+    uid: String // ours, not part of the spec
+  )
+  object GemToken {
+
+    /** Construct a token, issued now and valid for `expiresIn` seconds. */
+    def create(user: User[_], expiresIn: Long): IO[GemToken] =
+      IO {
+        val now = Instant.now()
+        new GemToken(
+          iat = now.getEpochSecond,
+          exp = now.plusSeconds(expiresIn).getEpochSecond,
+          uid = user.id
+        )
+      }
+
+    /**
+     * Construct a token using the TTL defined in the envronment, and encode/sign it using the
+     * algorithm and secret key also defined in the environment.
+     */
+    @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+    def encode(env: Environment, user: User[_]): IO[String] =
+      create(user, env.config.jwt.ttlSeconds).map(env.encodeJwt(_))
+
+    /**
+     * Like `encode`, but embeds the encoded JWT in a cooke with environment-specified
+     * name.
+     */
+    def cookie(env: Environment, user: User[_]): IO[Cookie] =
+      encode(env, user).map(Cookie(env.config.jwt.cookieName, _))
+
+    /**
+     * Decode an encoded GemToken if possible, otherwise return an error string to be included
+     * in the Forbidden() body.
+     */
+    @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+    def decode(env: Environment, encoded: String): IO[Either[String, GemToken]] =
+      env.decodeJwt[GemToken](encoded)
+
+    /** Like `decode`, but pulls the encoded value from the envronment-defined cookie. */
+    def decodeFromCookie(env: Environment, req: Request[IO]): IO[Either[String, GemToken]] =
+      req.findCookie(env.config.jwt.cookieName) match {
+        case Some(c) => GemToken.decode(env, c.content)
+        case None    => IO.pure(Left(s"Cookie ${env.config.jwt.cookieName} not present."))
+      }
+
+  }
+
+  // A data type for login requests.
+  final case class LoginRequest(uid: String, pass: String)
+
+  /** A service that listens to /login and issues new cookies. */
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference")) // false positive on decodeJson
+  def login(env: Environment): HttpService[IO] =
+    HttpService[IO] {
+      // curl -i -d '{ "uid": "bobdole", "pass": "banana" }' localhost:8080/login
+      case req @ POST -> Root / "login" =>
+        req.decodeJson[LoginRequest].flatMap { case LoginRequest(u, p) =>
+          env.tryLogin(u, p).flatMap {
+            case None      => Forbidden("Login failed.")
+            case Some(svc) => GemToken.cookie(env, svc.user).flatMap(c => Ok("Logged in.").map(_.addCookie(c)))
+          }
+        }
+    }
+
+  /**
+   * Given an AuthedService and an Environment that knows how to authenticate user cookies, yield a
+   * Normal HttpService that verifies the cookie on the way in and updates it on the way out. This
+   * is a bit more complex than normal services because we must work in OptionT to handle the case
+   * where `delegate` doesn't respond.
+   */
+  def authenticate(env: Environment, delegate: AuthedService[GemService[IO], IO]): HttpService[IO] =
+    Kleisli[OptionT[IO, ?], Request[IO], Response[IO]] {
+      // curl -i -b gem.jwt=... localhost:8080/something/else
+      case req =>
+        OptionT.liftF(GemToken.decodeFromCookie(env, req)).flatMap {
+          case Left(msg)  => OptionT.liftF(Forbidden(msg))
+          case Right(jwt) =>
+            OptionT.liftF(env.service(jwt.uid)).flatMap {
+              case None      => OptionT.liftF(Forbidden(s"JWT is valid but user ${jwt.uid} was not found."))
+              case Some(svc) =>
+                // Delegate and refresh our cookie as the response comes back.
+                delegate.run(AuthedRequest(svc, req)).flatMap { res =>
+                  OptionT.liftF(GemToken.cookie(env, svc.user).map(res.addCookie))
+                }
+            }
+        }
+    }
+
+  /**
+   * Construct the gatekeeper middleware. We need a server environment to figure out how to do
+   * do this because we need a way to encode/decode tokens, as well as way to log users in.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  def apply(env: Environment): AuthMiddleware[IO, GemService[IO]] = delegate =>
+    login(env) <+> authenticate(env, delegate)
+
+}

--- a/modules/web/src/main/scala/Main.scala
+++ b/modules/web/src/main/scala/Main.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package web
+
+import cats.effect.IO
+import gem.dao.DatabaseConfiguration
+import fs2.{ Stream, StreamApp }
+
+object Main extends StreamApp[IO] {
+  import StreamApp.ExitCode
+
+  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] =
+    for {
+      _ <- WebServer.stream(WebConfiguration.forTesting, DatabaseConfiguration.forTesting)
+      _ <- Stream.eval(IO(Console.println("Press a key to exit."))) // scalastyle:off
+      _ <- Stream.eval(IO(scala.io.StdIn.readLine()))
+      _ <- Stream.eval(requestShutdown)
+    } yield ExitCode(0)
+
+}

--- a/modules/web/src/main/scala/WebConfiguration.scala
+++ b/modules/web/src/main/scala/WebConfiguration.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package web
+
+import pdi.jwt.JwtAlgorithm
+import pdi.jwt.algorithms.JwtHmacAlgorithm
+
+/**
+ * Static configuration for the server. This is used to construct an Environment. It's not yet
+ * clear what should be passed in and what should be hard-coded.
+ */
+final case class WebConfiguration(
+  jwt:       WebConfiguration.Jwt,
+  webServer: WebConfiguration.WebServer,
+  log:       WebConfiguration.Log
+)
+
+object WebConfiguration {
+
+  /** A reasonable configuration for testing with a local database. */
+  val forTesting: WebConfiguration =
+    WebConfiguration(
+      jwt = Jwt(
+        algorithm  = JwtAlgorithm.HS256,
+        cookieName = "gem.jwt",
+        ttlSeconds = 60 * 5
+      ),
+      webServer = WebServer(
+        port = 9090,
+        host = "0.0.0.0"
+      ),
+      log = Log(
+        name            = "web",
+        shutdownTimeout = 1000L
+      )
+    )
+
+  /** Logger configuration. */
+  final case class Log(name: String, shutdownTimeout: Long)
+
+  /** JWT configuration. */
+  final case class Jwt(algorithm: JwtHmacAlgorithm, cookieName: String, ttlSeconds: Long)
+
+  /** Web server configuration. */
+  final case class WebServer(port: Int, host: String)
+
+}

--- a/modules/web/src/main/scala/WebServer.scala
+++ b/modules/web/src/main/scala/WebServer.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package web
+
+import cats.effect.IO
+import gem.dao.DatabaseConfiguration
+import fs2.Stream
+import org.http4s.HttpService
+import org.http4s.server.Server
+import org.http4s.server.blaze.BlazeBuilder
+
+object WebServer {
+
+  // Single-element stream that creates and yields a web server, guaranteeing cleanup.
+  private def server(cfg: WebConfiguration.WebServer, root: HttpService[IO]): Stream[IO, Server[IO]] =
+    Stream.bracket(
+      BlazeBuilder[IO]
+        .bindHttp(cfg.port, cfg.host)
+        .mountService(root, "/")
+        .start)(
+      s => Stream(s),
+      _.shutdown
+    )
+
+  /** A single-element stream that creates and yields a web server, guaranteeing cleanup. */
+  def stream(web: WebConfiguration, db: DatabaseConfiguration): Stream[IO, Server[IO]] =
+    Environment.stream(web, db).flatMap { env =>
+      server(env.config.webServer, Gatekeeper(env)(Application.service))
+    }
+
+}

--- a/modules/web/src/main/scala/package.scala
+++ b/modules/web/src/main/scala/package.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.implicits._
+import org.http4s._
+import org.http4s.dsl.io._
+
+package object web {
+
+  implicit class QueryParamDecoderOps[A](fa: QueryParamDecoder[A]) {
+    def matcher(key: String): QueryParamDecoderMatcher[A] =
+      new QueryParamDecoderMatcher[A](key)(fa) {}
+    def optMatcher(key: String): OptionalQueryParamDecoderMatcher[A] =
+      new OptionalQueryParamDecoderMatcher[A](key)(fa) {}
+  }
+
+  implicit class RequestOps[F[_]](val req: Request[F]) extends AnyVal {
+    def findCookie(name: String): Option[Cookie] =
+      headers.Cookie.from(req.headers).flatMap(cs => cs.values.toList.find(_.name === name))
+  }
+
+}

--- a/pg-image.txt
+++ b/pg-image.txt
@@ -1,0 +1,6 @@
+# This file must contain a single non-blank, non-comment line specifying the name of
+# the Postgres container to use for deployment. We need to do this so that database version
+# upgrades are part of the evolution of the app; if we want to deploy an old version we
+# need to know the old Postgres image name at the specified commit.
+
+postgres:9.6.0

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -5,6 +5,7 @@ import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import wartremover.WartRemover.autoImport._
 import net.virtualvoid.sbt.graph.DependencyGraphPlugin.autoImport._
 import com.timushev.sbt.updates.UpdatesPlugin.autoImport._
+import org.flywaydb.sbt.FlywayPlugin.autoImport._
 
 /**
   * Define tasks and settings used by module definitions
@@ -23,14 +24,24 @@ object Common {
     )
 
   lazy val commonSettings = Seq(
+    // Workaround for https://github.com/sbt/sbt/issues/4109
+    initialCommands += "jline.TerminalFactory.get.init\n",
+
     scalaVersion                            := Settings.LibraryVersions.scalaVersion,
     scalacOptions                          ++= Settings.Definitions.scalacOptions,
     scalacOptions in (Compile, console)     ~= (_.filterNot(Set(
       "-Xfatal-warnings",
       "-Ywarn-unused:imports"
     ))),
+    scalacOptions in (Compile, doc) ++= Seq(
+      "-groups",
+      "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath,
+      "-skip-packages", "scalaz",
+      "-doc-title", "Gem",
+      "-doc-version", version.value
+    ),
     // These sbt-header settings can't be set in ThisBuild for some reason
-    headerMappings                          := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.CppStyleLineComment),
+    headerMappings                          := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
     headerLicense                           := Some(HeaderLicense.Custom(
       """|Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
          |For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
@@ -41,17 +52,22 @@ object Common {
     // Wartremover in compile and test (not in Console)
     wartremoverErrors in (Compile, compile) := gemWarts,
     wartremoverErrors in (Test,    compile) := gemWarts,
+    // Don't build javadoc when we're packaging the docker image.
+    mappings in (Compile, packageDoc)       := Seq(),
     sources in (Compile,doc)                := Seq.empty,
+    // Temporary, needed for decline 0.4.0-M1
+    resolvers += Resolver.jcenterRepo,
+
     // We don't care to see updates about the scala language itself
     dependencyUpdatesFilter -= moduleFilter(name = "scala-library"),
     dependencyUpdatesFilter -= moduleFilter(name = "scala-reflect"),
     // Don't worry about stale deps pulled in by scala-js
     dependencyUpdatesFilter -= moduleFilter(organization = "org.eclipse.jetty"),
-
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork"), // by default, ignore network tests
     // Don't worry about monocle versions that start with the same prefix.
     dependencyUpdatesFilter -= moduleFilter(
       organization = "com.github.julien-truffaut",
-      revision = sbt.io.GlobFilter(Settings.LibraryVersions.monocle.replace("-cats", "*"))
+      revision = sbt.io.GlobFilter(Settings.LibraryVersions.monocleVersion.replace("-cats", "*"))
     )
   )
 
@@ -63,4 +79,13 @@ object Common {
     // activate the ScalaJS defined annotation by default
     scalacOptions       += "-P:scalajs:sjsDefinedByDefault"
   )
+
+  lazy val flywaySettings = Seq(
+    flywayUrl  := "jdbc:postgresql:gem",
+    flywayUser := "postgres",
+    flywayLocations := Seq(
+      s"filesystem:${baseDirectory.value}/src/main/resources/db/migration"
+    )
+  )
+
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -48,7 +48,7 @@ object Common {
          |""".stripMargin
     )),
     // Common libraries
-    libraryDependencies                    ++= Seq(Cats.value, Mouse.value) ++ TestLibs.value,
+    libraryDependencies                    ++= TestLibs.value,
     // Wartremover in compile and test (not in Console)
     wartremoverErrors in (Compile, compile) := gemWarts,
     wartremoverErrors in (Test,    compile) := gemWarts,

--- a/project/ImageManifest.scala
+++ b/project/ImageManifest.scala
@@ -1,0 +1,104 @@
+// Copyright (c) 2016-2017 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.implicits._
+import java.time._
+import scala.math.floor
+import scala.sys.process._
+
+case class ImageManifest(history: NonEmptyList[String], timestamp: Instant, unstable: Boolean, postgresImage: String) {
+  import ImageManifest.Keys
+
+  /** Commit hash for this version. */
+  def commit: String =
+    history.head
+
+  /** Timestamp as LocalDateTime. */
+  def localDateTime: LocalDateTime =
+    LocalDateTime.ofInstant(timestamp, ZoneOffset.UTC)
+
+  /** Timestamp as fractional Julian day. */
+  def julianDay: Double = {
+    val d = localDateTime
+    val a = floor((14.0 - d.getMonthValue) / 12.0)
+    val y = d.getYear + 4800.0 - a
+    val m = d.getMonthValue + 12 * a - 3.0
+    d.getDayOfMonth +
+    floor((153.0 * m + 2.0) / 5.0) +
+    365 * y +
+    floor(y / 4.0) -
+    floor(y / 100.0) +
+    floor(y / 400.0) -
+    32045.0
+  }
+
+  /** Timestamp as a J2000 fractional epoch year. */
+  def j2000: Double = {
+    val jd = julianDay
+    val yearBasis:    Double = 2000.0
+    val julianBasis:  Double = 2451545.0
+    val lengthOfYear: Double = 365.25
+    yearBasis + (jd - julianBasis) / lengthOfYear
+  }
+
+  /** Format a plausibly human-consumable "version" string for artifact naming. */
+  def formatVersion: String =
+    if (unstable) f"$j2000%8.4f-$commit-UNSTABLE"
+    else          f"$j2000%8.4f-$commit"
+
+  /** Docker labels for this ImageManifest, in a format sbt-native-packager likes. */
+  def labels: Map[String, String] =
+    Map(
+      Keys.Commit   -> commit,
+      Keys.History  -> history.intercalate(","),
+      Keys.Unstable -> unstable.toString,
+      Keys.Version  -> formatVersion,
+      Keys.Postgres -> postgresImage
+    )
+
+  /**
+   * True if this version is compatible with the given commit; that is, true if and only if the
+   * given commit is in this version's history. If true then there is an upgrade path. No version
+   * is ever compatible with an unstable version so we do not consider this case.
+   */
+  def isCompatibleWith(commit: String): Boolean =
+    history.exists(_ === commit)
+
+}
+
+object ImageManifest {
+
+  /** Module of docker label keys. */
+  object Keys {
+    val Commit   = "gem.commit"
+    val History  = "gem.history"
+    val Unstable = "gem.unstable"
+    val Version  = "gem.version"
+    val Postgres = "gem.postgres"
+  }
+
+  /**
+   * Calculate the full commit history (a list of hashes) for determinig whether an olderversion's
+   * data can be read. The head of this list is the release hash.
+   */
+  def history: IO[NonEmptyList[String]] =
+    IO("git rev-list HEAD".!!)
+      .map(_.split("\n").toList)
+      .map(NonEmptyList.fromList)
+      .map(_.getOrElse(sys.error("git history is empty")))
+
+  /** Determine whether there are local changes past the current commit. */
+  def unstable: IO[Boolean] =
+    IO("git diff-index --quiet HEAD --".!).map(_ =!= 0)
+
+  /** Compute the Unix epoch time in SECONDS for the last commit. */
+  def instant: IO[Instant] =
+    IO(s"git show -s --pretty=format:%ct HEAD".!!).map(_.trim.toLong).map(Instant.ofEpochSecond)
+
+  /** Compute a manifest based on the local Git situation and the provided postgres image name. */
+  def current(postgresImage: String): IO[ImageManifest] =
+    (history, instant, unstable).mapN(apply(_, _, _, postgresImage))
+
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -87,20 +87,28 @@ object Settings {
     val mouseVersion        = "0.17"
     val fs2Version          = "0.10.4"
     val shapelessVersion    = "2.3.3"
+    val attoVersion         = "0.6.2"
+    val scalaParsersVersion  = "1.1.1"
+    val scalaXmlVerson       = "1.1.0"
 
-    val http4s       = "0.18.11"
+    val http4sVersion        = "0.18.12"
     val squants      = "1.3.0"
     val argonaut     = "6.2.1"
     val commonsHttp  = "2.0.2"
     val unboundId    = "3.2.1"
-    val jwt          = "0.14.1"
+    val jwt          = "0.16.0"
     val slf4j        = "1.7.25"
     val log4s        = "1.6.1"
     val logback      = "1.2.3"
     val janino       = "3.0.8"
     val logstash     = "5.1"
     val knobs        = "6.0.33"
-    val monocle      = "1.5.1-cats"
+    val monocleVersion      = "1.5.1-cats"
+    val circeVersion         = "0.9.3"
+    val doobieVersion        = "0.5.3"
+    val flywayVersion        = "5.0.7"
+    val tucoVersion          = "0.3.1"
+    val declineVersion       = "0.4.1"
 
     // test libraries
     val scalaTest             = "3.0.5"
@@ -137,75 +145,92 @@ object Settings {
     */
   object Libraries {
     // Test Libraries
-    val TestLibs = Def.setting(Seq(
+    val TestLibs               = Def.setting(Seq(
       "org.typelevel"              %%% "cats-testkit"              % LibraryVersions.catsVersion         % "test",
       "com.github.alexarchambault" %%% "scalacheck-shapeless_1.13" % LibraryVersions.scalaCheckShapeless % "test"
     ))
-    val XmlUnit = "xmlunit" % "xmlunit" % LibraryVersions.xmlUnit % "test"
-    val JUnitInterface = "com.novocode" % "junit-interface" % LibraryVersions.jUnitInterface % "test"
+    val XmlUnit                = "xmlunit" % "xmlunit" % LibraryVersions.xmlUnit % "test"
+    val JUnitInterface         = "com.novocode" % "junit-interface" % LibraryVersions.jUnitInterface % "test"
 
-    val Argonaut    = "io.argonaut"        %% "argonaut"                          % LibraryVersions.argonaut
-    val CommonsHttp = "commons-httpclient" %  "commons-httpclient"                % LibraryVersions.commonsHttp
-    val UnboundId   = "com.unboundid"      %  "unboundid-ldapsdk-minimal-edition" % LibraryVersions.unboundId
-    val JwtCore     = "com.pauldijou"      %% "jwt-core"                          % LibraryVersions.jwt
-    val Slf4j       = "org.slf4j"          %  "slf4j-api"                         % LibraryVersions.slf4j
-    val JuliSlf4j   = "org.slf4j"          %  "jul-to-slf4j"                      % LibraryVersions.slf4j
-    val Logback     = Seq(
+    // Server side libraries
+    val Cats                   = Def.setting("org.typelevel" %%% "cats-core"                         % LibraryVersions.catsVersion)
+    val CatsEffect             = Def.setting("org.typelevel" %%% "cats-effect"                       % LibraryVersions.catsEffectVersion)
+    val CatsFree               = Def.setting("org.typelevel" %%% "cats-free"                         % LibraryVersions.catsVersion)
+    val Fs2                    = "co.fs2"                    %%  "fs2-core"                          % LibraryVersions.fs2Version
+    val Fs2IO                  = "co.fs2"                    %%  "fs2-io"                            % LibraryVersions.fs2Version % "test"
+    val Mouse                  = Def.setting("org.typelevel" %%% "mouse"                             % LibraryVersions.mouseVersion)
+    val Shapeless              = Def.setting("com.chuusai"   %%% "shapeless"                         % LibraryVersions.shapelessVersion)
+    val Decline                = "com.monovore"              %%  "decline"                           % LibraryVersions.declineVersion
+    val Argonaut               = "io.argonaut"               %%  "argonaut"                          % LibraryVersions.argonaut
+    val CommonsHttp            = "commons-httpclient"        %   "commons-httpclient"                % LibraryVersions.commonsHttp
+    val UnboundId              = "com.unboundid"             %   "unboundid-ldapsdk-minimal-edition" % LibraryVersions.unboundId
+    val JwtCore                = "com.pauldijou"             %%  "jwt-core"                          % LibraryVersions.jwt
+    val Slf4j                  = "org.slf4j"                 %   "slf4j-api"                         % LibraryVersions.slf4j
+    val JuliSlf4j              = "org.slf4j"                 %   "jul-to-slf4j"                      % LibraryVersions.slf4j
+    val Logback                = Seq(
       "ch.qos.logback"       % "logback-core"             % LibraryVersions.logback,
       "ch.qos.logback"       % "logback-classic"          % LibraryVersions.logback,
       "org.codehaus.janino"  % "janino"                   % LibraryVersions.janino,
       "net.logstash.logback" % "logstash-logback-encoder" % LibraryVersions.logstash
     )
-    val Log4s       = "org.log4s"          %% "log4s"                             % LibraryVersions.log4s
-    val Logging     = Seq(JuliSlf4j, Log4s) ++ Logback
-    val Knobs       = "io.verizon.knobs"   %% "core"                              % LibraryVersions.knobs
-    val OpenCSV     = "net.sf.opencsv"     %  "opencsv"                           % LibraryVersions.opencsv
-
-    val Squants     = Def.setting("org.typelevel"     %%% "squants"              % LibraryVersions.squants)
-    val BooPickle   = Def.setting("io.suzaku"         %%% "boopickle"            % LibraryVersions.booPickle)
-    val JavaTimeJS  = Def.setting("io.github.cquiroz" %%% "scala-java-time"      % LibraryVersions.javaTimeJS)
-    val JavaLogJS   = Def.setting("org.scala-js"      %%% "scalajs-java-logging" % LibraryVersions.javaLogJS)
-
-    // FP
-    val Cats             = Def.setting("org.typelevel" %%% "cats-core"           % LibraryVersions.catsVersion)
-    val CatsEffect       = Def.setting("org.typelevel" %%% "cats-effect"         % LibraryVersions.catsEffectVersion)
-    val Fs2              = "co.fs2"                    %%  "fs2-core"            % LibraryVersions.fs2Version
-    val Mouse            = Def.setting("org.typelevel" %%% "mouse"               % LibraryVersions.mouseVersion)
-    val Shapeless        = Def.setting("com.chuusai"   %%% "shapeless"           % LibraryVersions.shapelessVersion)
-
-    // Server side libraries
-    val Http4s  = Seq(
-      "org.http4s" %% "http4s-dsl"          % LibraryVersions.http4s,
-      "org.http4s" %% "http4s-blaze-server" % LibraryVersions.http4s)
-    val Http4sBoopickle  = "org.http4s" %% "http4s-boopickle" % LibraryVersions.http4s
-
-    val Monocle  = Def.setting(Seq(
-      "com.github.julien-truffaut" %%% "monocle-core"   % LibraryVersions.monocle,
-      "com.github.julien-truffaut" %%% "monocle-macro"  % LibraryVersions.monocle,
-      "com.github.julien-truffaut" %%% "monocle-unsafe" % LibraryVersions.monocle,
-      "com.github.julien-truffaut" %%% "monocle-law"    % LibraryVersions.monocle % "test"))
+    val Log4s                  = "org.log4s"                          %%  "log4s"                    % LibraryVersions.log4s
+    val Logging                = Seq(JuliSlf4j, Log4s) ++ Logback
+    val Knobs                  = "io.verizon.knobs"                   %%  "core"                     % LibraryVersions.knobs
+    val OpenCSV                = "net.sf.opencsv"                     %   "opencsv"                  % LibraryVersions.opencsv
+    val Squants                = Def.setting("org.typelevel"          %%% "squants"                  % LibraryVersions.squants)
+    val ScalaXml               = Def.setting("org.scala-lang.modules" %%% "scala-xml"                % LibraryVersions.scalaXmlVerson)
+    val ScalaParserCombinators = Def.setting("org.scala-lang.modules" %%  "scala-parser-combinators" % LibraryVersions.scalaParsersVersion)
+    val Http4s                 = Seq(
+      "org.http4s" %% "http4s-dsl"          % LibraryVersions.http4sVersion,
+      "org.http4s" %% "http4s-blaze-server" % LibraryVersions.http4sVersion)
+    val Http4sClient           = "org.http4s"                         %%  "http4s-blaze-client"      % LibraryVersions.http4sVersion
+    val Http4sBoopickle        = "org.http4s"                         %%  "http4s-boopickle"         % LibraryVersions.http4sVersion
+    val Http4sCirce            = "org.http4s"                         %%  "http4s-circe"             % LibraryVersions.http4sVersion
+    val Http4sXml              = "org.http4s"                         %%  "http4s-scala-xml"         % LibraryVersions.http4sVersion
+    val Flyway                 = "org.flywaydb"                       %   "flyway-core"              % LibraryVersions.flywayVersion
+    val Atto                   = Def.setting("org.tpolecat"           %%% "atto-core"                % LibraryVersions.attoVersion)
+    val Monocle                = Def.setting(Seq(
+      "com.github.julien-truffaut" %%% "monocle-core"   % LibraryVersions.monocleVersion,
+      "com.github.julien-truffaut" %%% "monocle-macro"  % LibraryVersions.monocleVersion,
+      "com.github.julien-truffaut" %%% "monocle-unsafe" % LibraryVersions.monocleVersion,
+      "com.github.julien-truffaut" %%% "monocle-law"    % LibraryVersions.monocleVersion % "test"))
+    val Tuco                   = Seq(
+      "org.tpolecat" %% "tuco-core"  % LibraryVersions.tucoVersion,
+      "org.tpolecat" %% "tuco-shell" % LibraryVersions.tucoVersion
+    )
+    val Circe                  = Def.setting(Seq(
+      "io.circe" %%% "circe-core"    % LibraryVersions.circeVersion,
+      "io.circe" %%% "circe-generic" % LibraryVersions.circeVersion,
+      "io.circe" %%% "circe-parser"  % LibraryVersions.circeVersion))
+    val Doobie                 = Seq(
+      "org.tpolecat" %% "doobie-core"      % LibraryVersions.doobieVersion,
+      "org.tpolecat" %% "doobie-postgres"  % LibraryVersions.doobieVersion,
+      "org.tpolecat" %% "doobie-scalatest" % LibraryVersions.doobieVersion % "test")
 
     // Client Side JS libraries
-    val ReactScalaJS = Def.setting(Seq(
+    val ReactScalaJS            = Def.setting(Seq(
       "com.github.japgolly.scalajs-react" %%% "core"         % LibraryVersions.scalajsReact,
       "com.github.japgolly.scalajs-react" %%% "extra"        % LibraryVersions.scalajsReact,
       "com.github.japgolly.scalajs-react" %%% "ext-scalaz72" % LibraryVersions.scalajsReact
     ))
-    val Diode = Def.setting(Seq(
+    val Diode                   = Def.setting(Seq(
       "io.suzaku" %%% "diode"       % LibraryVersions.diode,
       "io.suzaku" %%% "diode-react" % LibraryVersions.diodeReact
     ))
-    val ScalaJSDom              = Def.setting("org.scala-js"                 %%% "scalajs-dom"               % LibraryVersions.scalaDom)
-    val ScalaJSReactVirtualized = Def.setting("io.github.cquiroz"            %%% "scalajs-react-virtualized" % LibraryVersions.scalaJSReactVirtualized)
-    val ScalaJSReactDraggable   = Def.setting("io.github.cquiroz"            %%% "scalajs-react-draggable"   % LibraryVersions.scalaJSReactDraggable)
-    val ScalaJSReactClipboard   = Def.setting("io.github.cquiroz"            %%% "scalajs-react-clipboard"   % LibraryVersions.scalaJSReactClipboard)
-    val JQuery                  = Def.setting("org.querki"                   %%% "jquery-facade"             % LibraryVersions.scalaJQuery)
+    val ScalaJSDom              = Def.setting("org.scala-js"      %%% "scalajs-dom"               % LibraryVersions.scalaDom)
+    val ScalaJSReactVirtualized = Def.setting("io.github.cquiroz" %%% "scalajs-react-virtualized" % LibraryVersions.scalaJSReactVirtualized)
+    val ScalaJSReactDraggable   = Def.setting("io.github.cquiroz" %%% "scalajs-react-draggable"   % LibraryVersions.scalaJSReactDraggable)
+    val ScalaJSReactClipboard   = Def.setting("io.github.cquiroz" %%% "scalajs-react-clipboard"   % LibraryVersions.scalaJSReactClipboard)
+    val JQuery                  = Def.setting("org.querki"        %%% "jquery-facade"             % LibraryVersions.scalaJQuery)
+    val BooPickle               = Def.setting("io.suzaku"         %%% "boopickle"                 % LibraryVersions.booPickle)
+    val JavaTimeJS              = Def.setting("io.github.cquiroz" %%% "scala-java-time"           % LibraryVersions.javaTimeJS)
+    val JavaLogJS               = Def.setting("org.scala-js"      %%% "scalajs-java-logging"      % LibraryVersions.javaLogJS)
 
     // OCS Libraries, these should become modules in the future
     val SpModelCore = "edu.gemini.ocs"    %% "edu-gemini-spmodel-core"        % LibraryVersions.ocsVersion
     val SeqexecOdb  = Seq(
                       "edu.gemini.ocs"    %% "edu-gemini-seqexec-odb"         % LibraryVersions.ocsVersion,
-                      "dom4j"            %  "dom4j"                          % "1.5.1"
+                      "dom4j"             %  "dom4j"                          % "1.5.1"
                         exclude("jaxen", "jaxen")
                         exclude("jaxme", "jaxme-api")
                         exclude("msv", "xsdlib")
@@ -218,17 +243,17 @@ object Settings {
     val TRPC        = "edu.gemini.ocs"    %% "edu-gemini-util-trpc"           % LibraryVersions.ocsVersion
     val WDBAClient  = Seq(
                       "edu.gemini.ocs"    %% "edu-gemini-wdba-session-client" % LibraryVersions.ocsVersion,
-                      "org.apache.xmlrpc" %  "xmlrpc-client"                  % LibraryVersions.apacheXMLRPC
-    )
+                      "org.apache.xmlrpc" %  "xmlrpc-client"                  % LibraryVersions.apacheXMLRPC)
 
-    val EpicsService = "edu.gemini.epics" % "epics-service" % LibraryVersions.epicsService
-    val GmpCommandsRecords = "edu.gemini.gmp" % "gmp-commands-records" % LibraryVersions.gmpCommandRecords
-    val GiapiJmsUtil = "edu.gemini.aspen" % "giapi-jms-util" % LibraryVersions.giapiJmsUtil
-    val GiapiJmsProvider = "edu.gemini.jms" % "jms-activemq-provider" % LibraryVersions.giapiJmsProvider
-    val Giapi = "edu.gemini.aspen" % "giapi" % LibraryVersions.giapi
+    // GIAPI Libraries
+    val EpicsService        = "edu.gemini.epics"     % "epics-service"           % LibraryVersions.epicsService
+    val GmpCommandsRecords  = "edu.gemini.gmp"       % "gmp-commands-records"    % LibraryVersions.gmpCommandRecords
+    val GiapiJmsUtil        = "edu.gemini.aspen"     % "giapi-jms-util"          % LibraryVersions.giapiJmsUtil
+    val GiapiJmsProvider    = "edu.gemini.jms"       % "jms-activemq-provider"   % LibraryVersions.giapiJmsProvider
+    val Giapi               = "edu.gemini.aspen"     % "giapi"                   % LibraryVersions.giapi
     val GiapiCommandsClient = "edu.gemini.aspen.gmp" % "gmp-commands-jms-client" % LibraryVersions.giapiCommandsClient
-    val GiapiStatusService = "edu.gemini.aspen" % "giapi-status-service" % LibraryVersions.giapiStatusService
-    val Guava = "com.google.guava" % "guava" % LibraryVersions.guava
+    val GiapiStatusService  = "edu.gemini.aspen"     % "giapi-status-service"    % LibraryVersions.giapiStatusService
+    val Guava               = "com.google.guava"     % "guava"                   % LibraryVersions.guava
   }
 
   object PluginVersions {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,51 +12,41 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core"   % "1.0.1",
   "org.typelevel" %% "cats-effect" % "0.8"
 )
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % scalaJSVersion)
 
 addSbtPlugin("org.flywaydb"       % "flyway-sbt"               % "4.2.0")
-addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin"    % "1.0.0")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager"      % "1.3.3")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-git"                  % "0.9.3")
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"               % "4.1.0")
-addSbtPlugin("org.wartremover"    % "sbt-wartremover"          % "2.2.1")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.23")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
-addSbtPlugin("net.virtual-void"   % "sbt-dependency-graph"     % "0.9.0")
-addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.3.4")
-addSbtPlugin("io.github.cquiroz"  % "sbt-tzdb"                 % "0.1.2")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.4.0")
 
 // sbt revolver lets launching applications from the sbt console
-addSbtPlugin("io.spray"          % "sbt-revolver"           % "0.9.1")
+addSbtPlugin("io.spray"           % "sbt-revolver"             % "0.9.1")
 
 // Extract metadata from sbt and make it available to the code
-addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"          % "0.7.0")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.7.0")
 
 // Support making distributions
-addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"    % "1.3.2")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager"      % "1.3.3")
 
 // Check the style with scalastyle
-addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin"    % "1.0.0")
 
 // add and check headers
-addSbtPlugin("de.heikoseeberger" % "sbt-header"             % "3.0.1")
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"               % "4.1.0")
 
 // Built the version out of git
-addSbtPlugin("com.typesafe.sbt"  % "sbt-git"                % "0.9.3")
-addSbtPlugin("com.dwijnand"      % "sbt-dynver"             % "3.0.0")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-git"                  % "0.9.3")
+addSbtPlugin("com.dwijnand"       % "sbt-dynver"               % "3.0.0")
 
-addSbtPlugin("org.wartremover"   % "sbt-wartremover"        % "2.2.1")
+addSbtPlugin("org.wartremover"    % "sbt-wartremover"          % "2.2.1")
 
 // Use NPM modules rather than webjars
-addSbtPlugin("ch.epfl.scala"     % "sbt-scalajs-bundler"    % "0.13.0")
+addSbtPlugin("ch.epfl.scala"      % "sbt-scalajs-bundler"      % "0.13.0")
 
 // Used to find dependencies
-addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph"  % "0.9.0")
-addSbtPlugin("com.timushev.sbt"  % "sbt-updates"           % "0.3.4")
+addSbtPlugin("net.virtual-void"   % "sbt-dependency-graph"     % "0.9.0")
+addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.3.4")
 
 // Generate a custom tzdb
-addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.1.2")
+addSbtPlugin("io.github.cquiroz"  % "sbt-tzdb"                 % "0.1.2")
 
 // Avoids a warning message when starting sbt-git
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,30 @@
+resolvers  ++= Seq(
+  "Flyway" at "https://davidmweber.github.io/flyway-sbt.repo",
+  Resolver.bintrayIvyRepo("rtimush", "sbt-plugin-snapshots")
+)
 // Gives support for Scala.js compilation
 val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.23")
 
+libraryDependencies ++= Seq(
+  "org.postgresql" % "postgresql"  % "42.2.1", // needed by flyway
+  "org.slf4j"      % "slf4j-nop"   % "1.7.25", // to silence some log messages
+  "org.typelevel" %% "cats-core"   % "1.0.1",
+  "org.typelevel" %% "cats-effect" % "0.8"
+)
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
+addSbtPlugin("org.flywaydb"       % "flyway-sbt"               % "4.2.0")
+addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin"    % "1.0.0")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager"      % "1.3.3")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-git"                  % "0.9.3")
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"               % "4.1.0")
+addSbtPlugin("org.wartremover"    % "sbt-wartremover"          % "2.2.1")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.23")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
+addSbtPlugin("net.virtual-void"   % "sbt-dependency-graph"     % "0.9.0")
+addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.3.4")
+addSbtPlugin("io.github.cquiroz"  % "sbt-tzdb"                 % "0.1.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.4.0")
 
 // sbt revolver lets launching applications from the sbt console
@@ -39,3 +60,5 @@ addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.1.2")
 
 // Avoids a warning message when starting sbt-git
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"
+
+onLoad in Global := { s => "dependencyUpdates" :: s }

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,2 @@
+// So the build build will use it
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates" % "0.3.4")

--- a/queries.sql
+++ b/queries.sql
@@ -1,0 +1,57 @@
+-- Program.Id => Program[Observation[Step[_]]
+
+  SELECT p.program_id,
+         p.title,
+         o.observation_id,
+         o.title,
+         s.index,
+         s.instrument,
+         s.step_type,
+         sg.gcal_lamp,
+         sg.shutter,
+         sc.offset_p,
+         sc.offset_q
+    FROM program p
+         LEFT OUTER JOIN observation o ON o.program_id = p.program_id
+         LEFT OUTER JOIN step s ON s.observation_id = o.observation_id
+         LEFT OUTER JOIN step_gcal sg
+            ON sg.observation_id = s.observation_id AND sg.index = s.index
+         LEFT OUTER JOIN step_science sc
+            ON sc.observation_id = s.observation_id AND sc.index = s.index
+   WHERE p.program_id = 'Benoit'
+ORDER BY observation_id, index;
+
+-- Program.Id => Program[Observation[Nothing]] or Program[Observation.Id]
+
+  SELECT p.program_id,
+         p.title,
+         o.observation_id,
+         o.title
+    FROM program p LEFT OUTER JOIN observation o ON o.program_id = p.program_id
+   WHERE p.program_id = 'Benoit'
+ORDER BY observation_id, index;
+
+-- Observation.Id => Observation[Step[_]]
+
+  SELECT o.observation_id,
+         o.title,
+         s.index,
+         s.instrument,
+         s.step_type,
+         sg.gcal_lamp,
+         sg.shutter,
+         sc.offset_p,
+         sc.offset_q
+    FROM observation o
+         LEFT OUTER JOIN step s ON s.observation_id = o.observation_id
+         LEFT OUTER JOIN step_gcal sg
+            ON sg.observation_id = s.observation_id AND sg.index = s.index
+         LEFT OUTER JOIN step_science sc
+            ON sc.observation_id = s.observation_id AND sc.index = s.index
+   WHERE o.program_id = 'Benoit' AND o.observation_index = 12
+ORDER BY observation_id, index
+
+;
+
+
+

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -26,16 +26,17 @@
  <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
  <!-- <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check> -->
  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+ <check customId="console.io" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <customMessage>Avoid console i/o É disable with // scalastyle:off console.io</customMessage>
   <parameters>
    <parameter name="regex"><![CDATA[println]]></parameter>
   </parameters>
  </check>
- <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+ <!-- <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
    <parameter name="maxTypes"><![CDATA[30]]></parameter>
   </parameters>
- </check>
+ </check> -->
  <!-- <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
   <parameters>
    <parameter name="maximum"><![CDATA[10]]></parameter>
@@ -43,14 +44,14 @@
  </check> -->
  <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+ <check customId="method.length" level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxLength"><![CDATA[50]]></parameter>
   </parameters>
  </check>
  <!-- <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check> -->
  <!-- <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check> -->
- <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+ <check customId="method.type" level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
   <parameters>
    <parameter name="ignoreOverride">true</parameter>
   </parameters>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -27,7 +27,7 @@
  <!-- <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check> -->
  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
  <check customId="console.io" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-  <customMessage>Avoid console i/o É disable with // scalastyle:off console.io</customMessage>
+  <customMessage>Avoid console i/o disable with // scalastyle:off console.io</customMessage>
   <parameters>
    <parameter name="regex"><![CDATA[println]]></parameter>
   </parameters>

--- a/travis-jvmopts
+++ b/travis-jvmopts
@@ -1,0 +1,6 @@
+-Dfile.encoding=UTF8
+-Xms3G
+-Xmx3G
+-Xss6M
+-XX:ReservedCodeCacheSize=256M
+-XX:-UseGCOverheadLimit


### PR DESCRIPTION
This is the big merge of gem and ocs3.  gem's history should have been preserved and there are very few code changes:

* Some adjustments for the scala upgrade in gem
* Fix for a flaky test in ocs3

I kept gem's README as ocs3 is largely obsolete

The main change is on the build. the logic was to start with ocs3 build which is more complex and add gem's bits. I think for the most part it is fine though there are some details:

* gem used a custom name format at https://github.com/gemini-hlsw/gem/blob/master/build.sbt#L181. I dont think that properly applies to the seqexec so i took it away but could be restored somehow
* The version is set using ocs3 style. That may break the docker versioning as I removed this: https://github.com/gemini-hlsw/gem/blob/master/build.sbt#L30. @tpolecat may need to further refine this
* The way to define libraries was different and I went with ocs3 style of defining variables pointing to the libraries

/cc @tpolecat @jdnavarro @swalker2m @sraaphorst @jluhrs 

