### PR TITLE
Use node 9 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_script:
 
 install:
   - . $HOME/.nvm/nvm.sh
-  - nvm install stable
-  - nvm use stable
+  - nvm install 9.4.0
+  - nvm use 9.4.0
   - npm install jsdom
   - pip install --user awscli
 script:


### PR DESCRIPTION
The build is a bit flaky failing sometimes when building the optimized clients. Scala.js hasn't confirmed support for node 10.x which is now the default in travis

This PR forces to use node 9