### PR TITLE
Support new asteroid formats

### DIFF
--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
@@ -204,7 +204,7 @@ object HorizonsNameQuery {
         }.toRight("Could not match '1I/'Oumuamua (A/2017 U1)' header pattern.")
 
       // Single result with form: JPL/HORIZONS     A/2017 U7     2015-Dec-31 11:40:21
-      def case6 =
+      def case6: ParsedAsteroids =
         """  +(A/\d+ [^(]+?)  """.r.findFirstMatchIn(header).map { m =>
           List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
         }.toRight("Could not match 'A/2017 U7' header pattern.")

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
@@ -197,12 +197,26 @@ object HorizonsNameQuery {
           List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
         }.toRight("Could not match '418993 (2009 MS9)' header pattern.")
 
+      // Single result with form: JPL/HORIZONS              1I/'Oumuamua (A/2017 U1)         2018-Apr-16 18:28:59
+      def case5: ParsedAsteroids =
+        """  +\S+\s+\((A/.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match '1I/'Oumuamua (A/2017 U1)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS     A/2017 U7     2015-Dec-31 11:40:21
+      def case6 =
+        """  +(A/\d+ [^(]+?)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match 'A/2017 U7' header pattern.")
+
       // First one that works!
       case0 orElse
       case1 orElse
       case2 orElse
       case3 orElse
-      case4 orElse "Could not parse the header line as an asteroid".asLeft
+      case4 orElse
+      case5 orElse
+      case6 orElse "Could not parse the header line as an asteroid".asLeft
     }
     // scalastyle:on method.length
 

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsNameQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsNameQuerySpec.scala
@@ -83,6 +83,12 @@ final class HorizonsNameQuerySpec extends CatsSuite with RespectIncludeTags {
     ).asRight
   }
 
+  test("asteroid search should handle single result (Format 5) 1I/'Oumuamua (A/2017 U1)", RequiresNetwork) {
+    runSearch(Search.Asteroid("A/2017 U1")) shouldEqual List(
+      Resolution(EK.AsteroidNew("A/2017 U1"), "A/2017 U1")
+    ).asRight
+  }
+
   test("major body search should handle empty results", RequiresNetwork) {
     runSearch(Search.MajorBody("covfefe")) shouldEqual Nil.asRight
   }


### PR DESCRIPTION
This PR brings the Horizons [asteroid format updates](https://github.com/gemini-hlsw/ocs/pull/1472) over from the `ocs` project.  Unfortunately I cannot add a test case for one of the formats because there don't seem to be any examples that produce it.  The objects were all reclassified as comets.