### PR TITLE
SEQNG-612: Enable autoprefixing on production

### DIFF
--- a/app/seqexec-server/src/main/resources/app.conf
+++ b/app/seqexec-server/src/main/resources/app.conf
@@ -62,4 +62,5 @@ seqexec-engine {
     smartGCalDir = "/tmp/smartgcal"
     failAt = 2
     ioTimeout = "5 seconds"
+    gpiUrl = "failover:(tcp://127.0.0.1:61616)?timeout=4000"
 }

--- a/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
@@ -14,10 +14,14 @@ const Web = Merge(
   parts.resourceModules,
   parts.extractCSS({
     devMode: false,
-    use: ["css-loader", "less-loader"] // parts.autoprefix()] // autoprefix needs a fix on scalajs-bundler
+    use: ["css-loader", parts.autoprefix(), "less-loader"] // Order is very important: css, post-css, less
   }),
   parts.minifyJavaScript(),
-  parts.minifyCSS({}),
+  parts.minifyCSS({
+    safe: true,
+    discardComments: { removeAll: true },
+    autoprefixer: { disable: true } // Otherwise this conflicts with post-css autoprefixer
+  }),
   parts.extraAssets,
   parts.fontAssets,
   {
@@ -27,7 +31,7 @@ const Web = Merge(
     },
     output: {
       filename: "[name].[chunkhash].js",
-      publicPath: "/" // Required to make the url navigation work
+      publicPath: "/" // Required to make url navigation work
     },
     plugins: [
       // Useful to further minify react and make it faster in production

--- a/modules/seqexec/web/client/src/webpack/webpack.parts.js
+++ b/modules/seqexec/web/client/src/webpack/webpack.parts.js
@@ -18,6 +18,17 @@ module.exports.rootDir = rootDir;
 const resourcesDir = path.resolve(rootDir, "src/main/resources");
 module.exports.resourcesDir = resourcesDir;
 
+// Set of browser to support on the css. Taken from Semantic-UI-React
+module.exports.browsers = {
+  browsers: [
+    ">1%",
+    "last 4 versions",
+    "Firefox ESR",
+    "not ie < 9" // React doesn't support IE8 anyway
+  ],
+  flexbox: "no-2009"
+};
+
 // Setup webpack-dev-server. Use only in development
 module.exports.devServer = ({ host, port } = {}) => ({
   devServer: {
@@ -70,6 +81,17 @@ module.exports.extractCSS = ({ devMode, include, exclude, use = [] }) => {
   };
 };
 
+// Enable autoprefixing with postcss
+exports.autoprefix = () => {
+  return {
+    loader: "postcss-loader",
+    options: {
+      autoprefixer: module.exports.browsers,
+      plugins: () => [require("autoprefixer")()]
+    }
+  };
+};
+
 // This is needed for scala.js projects
 module.exports.resourceModules = {
   resolve: {
@@ -100,14 +122,6 @@ module.exports.resolveSemanticUI = {
     }
   }
 };
-
-// Enable autoprefixing with postcss
-exports.autoprefix = () => ({
-  loader: "postcss-loader",
-  options: {
-    plugins: () => [require("autoprefixer")()]
-  }
-});
 
 // Support css minifications
 exports.minifyCSS = ({ options }) => ({


### PR DESCRIPTION
During the last ui build update we lost [css autoprefixing](https://css-tricks.com/autoprefixing-css-variables/). We used to do that with scalacss but we removed that. Now we can re enable it with `webpack` and `postcss/nano`.

Note the process is fairly slow so it is only enabled for the final production