### PR TITLE
Horizons paging bugfix

### DIFF
--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQueryPagingPropSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQueryPagingPropSpec.scala
@@ -54,12 +54,24 @@ class HorizonsEphemerisQueryPagingPropSpec extends PropSpec with PropertyChecks 
     }
   }
 
-  property("last element should be less than one step size away from end") {
+  property("last element should be less than two step sizes away from end") {
     forAll { (t: TestCase) =>
       t.paging.lastOption match {
         case None    => fail
-        case Some(q) => q.endTime should (be >= t.end and be <= (t.end + t.step))
+        case Some(q) => q.endTime should (be >= t.end and be < (t.end + t.step * 2))
       }
+    }
+  }
+
+  property("explicitly handle case where last page would have one element using MaxElement-sized pages") {
+    // This was a failing randomly generated test case, so we'll leave it as a test.
+    val s = Instant.parse("2003-10-24T03:53:56.396546622Z")
+    val e = Instant.parse("2003-11-28T00:22:17.151546622Z")
+    val d = Duration.parse("PT6.69S")
+    val t = TestCase(s, e, d)
+    t.paging.lastOption match {
+      case None    => fail
+      case Some(q) => q.endTime should (be >= t.end and be < (t.end + t.step * 2))
     }
   }
 

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
@@ -117,10 +117,11 @@ final class HorizonsEphemerisQuerySpec extends CatsSuite with EphemerisTestSuppo
     checkPaging(
       start,
       end,
-      // Here the first query is shortened so that the last query will have at
-      // least two elements.  There's no way to query for just one element.
-      HorizonsEphemerisQuery(titan, GS, start,           end - OneMinute * 2L, Max - 1),
-      HorizonsEphemerisQuery(titan, GS, end - OneMinute, end,                  2      )
+      // Here the first query has Max elements.  The second query would have
+      // just one element but since that won't work with horizons it is extended
+      // to include an additional element.
+      HorizonsEphemerisQuery(titan, GS, start, end - OneMinute, Max),
+      HorizonsEphemerisQuery(titan, GS, end,   end + OneMinute,   2)
     )
   }
 


### PR DESCRIPTION
This PR fixes the [Random ephemeris test failure](https://github.com/gemini-hlsw/gem/issues/278) issue.  The problem was in the code that pages a long request into smaller queries that are palatable for horizons.  One of the complications is that a query for just a single element doesn't work.  The previous version of this code would try to shrink the next-to-last query by one element and thereby make the last query request two elements in this case.  I tried to simplify the logic somewhat and just request an extra element instead.   It's still a bit convoluted unfortunately.