### PR TITLE
SEQNG-627: Web server does not honor site configuration

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/Model.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Model.scala
@@ -15,7 +15,7 @@ import java.time.ZoneId
 // scalastyle:off
 object Model {
   // We use this to avoid a dependency on spModel, should be replaced by gem
-  sealed trait SeqexecSite {
+  sealed trait SeqexecSite extends Product with Serializable {
     def instruments: NonEmptyList[Instrument]
     def timeZone: ZoneId
   }

--- a/modules/seqexec/web/client/src/main/resources/dev.js
+++ b/modules/seqexec/web/client/src/main/resources/dev.js
@@ -15,5 +15,5 @@ $.fn.popup = require("semantic-ui-popup");
 
 if (module.hot) {
   module.hot.accept();
-  App.seqexec.SeqexecApp.start("GS");
+  App.seqexec.SeqexecApp.start();
 }

--- a/modules/seqexec/web/client/src/main/resources/prod.js
+++ b/modules/seqexec/web/client/src/main/resources/prod.js
@@ -13,4 +13,4 @@ $.fn.transition = require("semantic-ui-transition");
 $.fn.modal = require("semantic-ui-modal");
 $.fn.popup = require("semantic-ui-popup");
 
-App.seqexec.SeqexecApp.start("GS");
+App.seqexec.SeqexecApp.start();

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -257,4 +257,12 @@ object SeqexecWebClient extends ModelBooPicklers {
       url = s"$baseUrl/start"
     ).map(_.responseText)
 
+  /**
+    * Read the site of the server
+    */
+  def site(): Future[String] =
+    Ajax.get(
+      url = s"$baseUrl/site"
+    ).map(_.responseText)
+
 }

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -32,7 +32,7 @@ import scala.math._
 /**
   * Rest Endpoints under the /api route
   */
-class SeqexecUIApiRoutes(devMode: Boolean, auth: AuthenticationService, engineOutput: Topic[IO, SeqexecEvent]) extends BooEncoders with ModelLenses {
+class SeqexecUIApiRoutes(site: String, devMode: Boolean, auth: AuthenticationService, engineOutput: Topic[IO, SeqexecEvent]) extends BooEncoders with ModelLenses {
 
   // Logger for client messages
   private val clientLog = getLogger
@@ -96,6 +96,10 @@ class SeqexecUIApiRoutes(devMode: Boolean, auth: AuthenticationService, engineOu
         val userName = user.fold(_ => "Anonymous", _.displayName)
         // Always return ok
         IO(clientLog.info(s"$userName connected from ${auth.req.remoteHost.getOrElse("Unknown")}")) *> Ok("")
+
+      case GET -> Root / "seqexec" / "site" as _ =>
+        // Return the site of the current server
+        Ok(site)
 
       case GET -> Root / "seqexec" / "events" as user        =>
         // Stream seqexec events to clients and a ping

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -108,7 +108,7 @@ object WebServerLauncher extends StreamApp[IO] with LogInitialization {
       .withWebSockets(true)
       .mountService(new StaticRoutes(conf.devMode, OcsBuildInfo.builtAtMillis).service, "/")
       .mountService(new SeqexecCommandRoutes(as, inputs, se).service, "/api/seqexec/commands")
-      .mountService(new SeqexecUIApiRoutes(conf.devMode, as, outputs).service, "/api")
+      .mountService(new SeqexecUIApiRoutes(conf.site, conf.devMode, as, outputs).service, "/api")
     conf.sslConfig.fold(builder) { ssl =>
       val storeInfo = StoreInfo(ssl.keyStore, ssl.keyStorePwd)
       builder.withSSL(storeInfo, ssl.certPwd, "TLS")

--- a/modules/seqexec/web/server/src/test/scala/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
+++ b/modules/seqexec/web/server/src/test/scala/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
@@ -24,7 +24,7 @@ class SeqexecUIApiRoutesSpec extends FlatSpec with Matchers with UriFunctions wi
   private val service =
     for {
       o <- out
-    } yield new SeqexecUIApiRoutes(true, authService, o).service
+    } yield new SeqexecUIApiRoutes("GS", true, authService, o).service
 
   "SeqexecUIApiRoutes login" should
     "reject requests without body" in {


### PR DESCRIPTION
This is a bug leftover from the ui build revamp. it used to be that the client will be custom built for each site with the site name embedded on the html. However now that is generated by webpack and for testing it was left at GS.

This fix changes how the client starts. It will query the site before launching and will configure itself for that site. This is slightly inefficient and could be improved by changing the build but that will be an involved task

This has been tested changing the site locally and also verified building the distributions for GN and GS