### PR TITLE
Update to scala.js 0.6.24

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
@@ -38,7 +38,7 @@ object OffsetFns {
     f"${axis.show}:"
 
   def offsetValueFormat(off: Offset): String =
-    f" ${off.value}%003.2f″"
+    f" ${off.value}%03.2f″"
 
   def offsetText(axis: OffsetAxis)(step: Step): String =
     offsetValueFormat(axis match {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers  ++= Seq(
 )
 // Gives support for Scala.js compilation
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.23")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.24")
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql"  % "42.2.1", // needed by flyway


### PR DESCRIPTION
A minor scala.js update got a lot more complicated due to a bug fix on the floating point formatting algorithim