### PR TITLE
Lib updates

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -17,7 +17,7 @@ import seqexec.web.common.FixedLengthBuffer
 import web.client.style._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.virtualized._
 import react.clipboard._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -16,10 +16,10 @@ import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.model.Model.SeqexecSite
 import web.client.style._
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{CallbackTo, ScalaComponent, ScalazReact}
+import japgolly.scalajs.react.{CallbackTo, ScalaComponent, CatsReact}
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.router.RouterCtl
-import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.CatsReact._
 import cats.implicits._
 
 object SequenceStepsTableContainer {
@@ -32,7 +32,7 @@ object SequenceStepsTableContainer {
 
   private val ST = ReactS.Fix[State]
 
-  def updateStepToRun(step: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def updateStepToRun(step: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.set(State(step)).liftCB
 
   def toolbar(p: Props): VdomElement =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -4,10 +4,10 @@
 package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
-import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{Callback, CallbackTo, ScalaComponent, ScalazReact}
+import japgolly.scalajs.react.{Callback, CallbackTo, ScalaComponent, CatsReact}
 import gem.Observation
 import mouse.all._
 import seqexec.model.Model._
@@ -87,16 +87,16 @@ object StepsControlButtons {
   def requestObsResume(id: Observation.Id, stepId: Int): Callback =
     Callback(SeqexecCircuit.dispatch(RequestObsResume(id, stepId)))
 
-  def handleStop(id: Observation.Id, stepId: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def handleStop(id: Observation.Id, stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestStop(id, stepId)) >> ST.set(StopRequested).liftCB
 
-  def handleAbort(id: Observation.Id, stepId: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def handleAbort(id: Observation.Id, stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestAbort(id, stepId)) >> ST.set(AbortRequested).liftCB
 
-  def handleObsPause(id: Observation.Id, stepId: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def handleObsPause(id: Observation.Id, stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestObsPause(id, stepId)) >> ST.set(PauseRequested).liftCB
 
-  def handleObsResume(id: Observation.Id, stepId: Int): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def handleObsResume(id: Observation.Id, stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestObsResume(id, stepId)) >> ST.set(ResumeRequested).liftCB
 
   private val component = ScalaComponent.builder[Props]("StepsControlButtons")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -6,8 +6,8 @@ package seqexec.web.client.components.sequence.toolbars
 import diode.react.ModelProxy
 import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{Callback, CallbackTo, ScalaComponent, ScalazReact}
-import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.{Callback, CallbackTo, ScalaComponent, CatsReact}
+import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import gem.Observation
 import mouse.all._
@@ -45,16 +45,16 @@ object SequenceControl {
 
   private val ST = ReactS.Fix[State]
 
-  def requestRun(s: Observation.Id): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def requestRun(s: Observation.Id): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(Callback(SeqexecCircuit.dispatch(RequestRun(s)))) >> ST.mod(_.requestRun).liftCB
 
-  def requestSync(s: Observation.Id): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def requestSync(s: Observation.Id): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(Callback(SeqexecCircuit.dispatch(RequestSync(s)))) >> ST.mod(_.requestSync).liftCB
 
-  def requestPause(s: Observation.Id): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def requestPause(s: Observation.Id): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(Callback(SeqexecCircuit.dispatch(RequestPause(s)))) >> ST.mod(_.requestPause).liftCB
 
-  def requestCancelPause(s: Observation.Id): ScalazReact.ReactST[CallbackTo, State, Unit] =
+  def requestCancelPause(s: Observation.Id): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(Callback(SeqexecCircuit.dispatch(RequestCancelPause(s)))) >> ST.mod(_.requestCancelPause).liftCB
 
   private def controlButton(icon: Icon, color: String, onClick: Callback, disabled: Boolean, tooltip: String, text: String) =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/checkbox/Checkbox.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/checkbox/Checkbox.scala
@@ -6,7 +6,7 @@ package seqexec.web.client.semanticui.elements.checkbox
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.CatsReact._
 import web.client.style._
 
 /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/input/InputEV.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/input/InputEV.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client.semanticui.elements.input
 
 import japgolly.scalajs.react.{Callback, CallbackTo, ReactEventFromInput, ScalaComponent}
-import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.StateSnapshot

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/slider/Slider.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/slider/Slider.scala
@@ -6,7 +6,7 @@ package seqexec.web.client.semanticui.elements.slider
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react.CatsReact._
 import web.client.style._
 
 /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/WebpackResources.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/WebpackResources.scala
@@ -5,9 +5,8 @@ package seqexec.web.client.services
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
-
-import scalaz.Show
-import scalaz.syntax.show._
+import cats.Show
+import cats.implicits._
 
 object WebpackResources {
 
@@ -15,11 +14,11 @@ object WebpackResources {
   trait WebpackResource extends js.Object
 
   object WebpackResource {
-    implicit val show: Show[WebpackResource] = Show.showFromToString
+    implicit val show: Show[WebpackResource] = Show.fromToString
   }
 
   implicit class WebpackResourceOps(val r: WebpackResource) extends AnyVal {
-    def resource: String = r.shows
+    def resource: String = r.show
   }
 
   @JSImport("semantic-ui-less/semantic.less", JSImport.Default)

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -62,6 +62,10 @@ object Common {
     dependencyUpdatesFilter -= moduleFilter(name = "scala-reflect"),
     // Don't worry about stale deps pulled in by scala-js
     dependencyUpdatesFilter -= moduleFilter(organization = "org.eclipse.jetty"),
+    // Don't worry about old ocs related dependencies
+    dependencyUpdatesFilter -= moduleFilter(organization = "dom4j"),
+    dependencyUpdatesFilter -= moduleFilter(organization = "net.sf.opencsv"),
+    dependencyUpdatesFilter -= moduleFilter(organization = "commons-httpclient"),
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork"), // by default, ignore network tests
     // Don't worry about monocle versions that start with the same prefix.
     dependencyUpdatesFilter -= moduleFilter(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -210,7 +210,7 @@ object Settings {
       "com.github.japgolly.scalajs-react" %%% "core"             % LibraryVersions.scalajsReact,
       "com.github.japgolly.scalajs-react" %%% "extra"            % LibraryVersions.scalajsReact,
       "com.github.japgolly.scalajs-react" %%% "ext-monocle-cats" % LibraryVersions.scalajsReact,
-      "com.github.japgolly.scalajs-react" %%% "ext-scalaz72"     % LibraryVersions.scalajsReact
+      "com.github.japgolly.scalajs-react" %%% "ext-cats"         % LibraryVersions.scalajsReact
     ))
     val Diode                   = Def.setting(Seq(
       "io.suzaku" %%% "diode"       % LibraryVersions.diode,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -67,14 +67,14 @@ object Settings {
 
     // ScalaJS libraries
     val scalaDom                = "0.9.6"
-    val scalajsReact            = "1.2.0"
+    val scalajsReact            = "1.2.1"
     val booPickle               = "1.3.0"
     val diode                   = "1.1.3"
     val diodeReact              = "1.1.3.120"
     val javaTimeJS              = "2.0.0-M13"
-    val javaLogJS               = "0.1.4"
+    val javaLogJS               = "0.1.5"
     val scalaJQuery             = "1.2"
-    val scalaJSReactVirtualized = "0.3.0"
+    val scalaJSReactVirtualized = "0.3.1"
     val scalaJSReactClipboard   = "0.3.0"
     val scalaJSReactDraggable   = "0.1.0"
 
@@ -88,7 +88,7 @@ object Settings {
     val scalaParsersVersion     = "1.1.1"
     val scalaXmlVerson          = "1.1.0"
 
-    val http4sVersion           = "0.18.13"
+    val http4sVersion           = "0.18.14"
     val squants                 = "1.3.0"
     val argonaut                = "6.2.2"
     val commonsHttp             = "2.0.2"
@@ -121,7 +121,7 @@ object Settings {
     val semanticUI              = "2.2.10"
     val ocsVersion              = "2018101.1.1"
     val uglifyJs                = "1.2.4"
-    val reactVirtualized        = "9.18.5"
+    val reactVirtualized        = "9.20.0"
     val reactDraggable          = "3.0.5"
     val reactClipboard          = "5.0.0"
 


### PR DESCRIPTION
This brings several libraries up to date including:

* http4s
* scalajs-react
* react-virtualized

I also noted we still had a bit of scalaz usage on the client, this PR removes that as well

I'm also skipping checking some legacy dependencies for updates. 

@tpolecat There are a few updates on the db side libs but I didn't want to update those