### PR TITLE
SEQNG-612: Refactor the Seqexec to support DHS and GDS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -386,7 +386,7 @@ lazy val seqexec_web_server = project.in(file("modules/seqexec/web/server"))
   .settings(commonSettings: _*)
   .settings(
     addCompilerPlugin(Plugins.kindProjectorPlugin),
-    libraryDependencies ++= Seq(UnboundId, JwtCore, Knobs) ++ Http4s ++ Logging,
+    libraryDependencies ++= Seq(UnboundId, JwtCore, Knobs, Http4sClient) ++ Http4s ++ Logging,
     // Supports launching the server in the background
     mainClass in reStart := Some("seqexec.web.server.http4s.WebServerLauncher"),
   )
@@ -511,6 +511,8 @@ lazy val seqexec_server = project
           Knobs,
           OpenCSV,
           Log4s,
+          Http4sClient,
+          Http4sXml,
           Http4sBoopickle
       ) ++ SeqexecOdb ++ Monocle.value ++ WDBAClient ++ TestLibs.value
   )

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -326,7 +326,7 @@ class Engine[D: ActionMetadataGenerator, U](implicit ev: ActionMetadataGenerator
         modifyS(id)(_.setBreakpoint(step, v))
       case SkipMark(id, _, step, v)   => Logger.debug(s"Engine: skip mark changed for step $step to $v") *>
         modifyS(id)(_.setSkipMark(step, v))
-      case SetObserver(id, _, name)   => Logger.debug(s"Engine: Setting Observer for observation $id to '$name' by ${ue.username}") *> setObserver(id)(name)
+      case SetObserver(id, _, name)   => Logger.debug(s"Engine: Setting Observer for observation ${id.format} to '${name.value}' by ${ue.username}") *> setObserver(id)(name)
       case Poll(_)                    => Logger.debug("Engine: Polling current state")
       case GetState(f)                => getState(f)
       case ModifyState(f, _)          => modify(f)
@@ -345,7 +345,7 @@ class Engine[D: ActionMetadataGenerator, U](implicit ev: ActionMetadataGenerator
       case PartialResult(id, i, r) => Logger.debug("Engine: Partial result") *> partialResult(id, i, r)
       case Paused(id, i, r)        => Logger.debug("Engine: Action paused") *> actionPause(id, i, r)
       case Failed(id, i, e)        => logError(e) *> fail(id)(i, e)
-      case Busy(id, _)             => Logger.warning(s"Cannot run sequence $id because required systems are in use.")
+      case Busy(id, _)             => Logger.warning(s"Cannot run sequence ${id.format} because required systems are in use.")
       case BreakpointReached(_)    => Logger.debug("Engine: Breakpoint reached")
       case Executed(id)            => Logger.debug("Engine: Execution completed") *> next(id)
       case Executing(id)           => Logger.debug("Engine: Executing") *> execute(id)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Header.scala
@@ -4,11 +4,16 @@
 package seqexec.server
 
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.keywords.DhsClient
-import seqexec.server.keywords.DhsClient._
+import seqexec.server.keywords._
 
+/**
+ * Typeclass for types that can send keywords
+ */
 trait HeaderProvider[A] {
+  // Name of the instrument to be sent to the DHS
   def name(a: A): String
+  // Client to send keywords to an appropriate server
+  def keywordsClient(a: A): KeywordsClient
 }
 
 object HeaderProvider {
@@ -16,14 +21,18 @@ object HeaderProvider {
 
   final class HeaderProviderOps[A: HeaderProvider](val a: A) {
     def name: String = HeaderProvider[A].name(a)
+    def keywordsClient: KeywordsClient = HeaderProvider[A].keywordsClient(a)
   }
 
   implicit def ToHeaderProviderOps[A: HeaderProvider](a: A): HeaderProviderOps[A] = new HeaderProviderOps(a)
 }
 
+/**
+ * Header implementations know what headers sent before and after an observation
+ */
 trait Header {
-  def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit]
-  def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit]
+  def sendBefore(id: ImageFileId): SeqAction[Unit]
+  def sendAfter(id: ImageFileId): SeqAction[Unit]
 }
 
 object Header {
@@ -35,7 +44,7 @@ object Header {
   val StrDefault: String = "No Value"
   val BooleanDefault: Boolean = false
 
-  def buildKeyword[A](get: SeqAction[A], name: String, f: (String, A) => DhsClient.Keyword[A]): KeywordBag => SeqAction[KeywordBag] =
+  def buildKeyword[A](get: SeqAction[A], name: String, f: (String, A) => Keyword[A]): KeywordBag => SeqAction[KeywordBag] =
     k => get.map(x => k.add(f(name, x)))
   def buildInt8(get: SeqAction[Byte], name: String ): KeywordBag => SeqAction[KeywordBag]       = buildKeyword(get, name, Int8Keyword)
   def buildInt16(get: SeqAction[Short], name: String ): KeywordBag => SeqAction[KeywordBag]     = buildKeyword(get, name, Int16Keyword)
@@ -50,9 +59,9 @@ object Header {
     ks.foldLeft(z) { case (a,b) => a.flatMap(b) }
   }
 
-  def sendKeywords[A: HeaderProvider](id: ImageFileId, inst: A, hs: DhsClient, b: Seq[KeywordBag => SeqAction[KeywordBag]]): SeqAction[Unit] = for {
+  def sendKeywords[A: HeaderProvider](id: ImageFileId, inst: A, b: Seq[KeywordBag => SeqAction[KeywordBag]]): SeqAction[Unit] = for {
     bag <- bundleKeywords(inst, b)
-    _   <- hs.setKeywords(id, bag, finalFlag = false)
+    _   <- inst.keywordsClient.setKeywords(id, bag, finalFlag = false)
   } yield ()
 
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Header.scala
@@ -4,7 +4,8 @@
 package seqexec.server
 
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.DhsClient._
+import seqexec.server.keywords.DhsClient
+import seqexec.server.keywords.DhsClient._
 
 trait Header {
   def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -4,6 +4,7 @@
 package seqexec.server
 
 import seqexec.model.dhs.ImageFileId
+import seqexec.server.keywords.{DhsInstrument, KeywordsClient}
 import edu.gemini.spModel.config2.Config
 import squants.Time
 
@@ -11,7 +12,6 @@ trait InstrumentSystem extends System {
   // The name used for this instrument in the science fold configuration
   val sfName: String
   val contributorName: String
-  val dhsInstrumentName: String
   val observeControl: InstrumentSystem.ObserveControl
   def observe(config: Config): SeqObserve[ImageFileId, ObserveCommand.Result]
   //Expected total observe lapse, used to calculate timeout
@@ -24,12 +24,12 @@ object InstrumentSystem {
 
   implicit val HeaderProvider: HeaderProvider[InstrumentSystem] = new HeaderProvider[InstrumentSystem] {
     def name(a: InstrumentSystem): String = a match {
-      case i: flamingos2.Flamingos2 => i.dhsInstrumentName
-      case i: gmos.GmosNorth        => i.dhsInstrumentName
-      case i: gmos.GmosSouth        => i.dhsInstrumentName
-      case i: gnirs.Gnirs           => i.dhsInstrumentName
-      case i: gpi.GPI[_]            => i.dhsInstrumentName
-      case _                        => sys.error("Missing instrument")
+      case i: DhsInstrument => i.dhsInstrumentName
+      case _                => sys.error("Missing instrument")
+    }
+    def keywordsClient(a: InstrumentSystem): KeywordsClient = a match {
+      case u: DhsInstrument => u
+      case _                => sys.error("Missing instrument")
     }
   }
   sealed trait ObserveControl

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -21,6 +21,17 @@ trait InstrumentSystem extends System {
 }
 
 object InstrumentSystem {
+
+  implicit val HeaderProvider: HeaderProvider[InstrumentSystem] = new HeaderProvider[InstrumentSystem] {
+    def name(a: InstrumentSystem): String = a match {
+      case i: flamingos2.Flamingos2 => i.dhsInstrumentName
+      case i: gmos.GmosNorth        => i.dhsInstrumentName
+      case i: gmos.GmosSouth        => i.dhsInstrumentName
+      case i: gnirs.Gnirs           => i.dhsInstrumentName
+      case i: gpi.GPI[_]            => i.dhsInstrumentName
+      case _                        => sys.error("Missing instrument")
+    }
+  }
   sealed trait ObserveControl
   object Uncontrollable extends ObserveControl
   final case class StopObserveCmd(self: SeqAction[Unit]) extends AnyVal

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -10,7 +10,8 @@ import seqexec.model.Model.{Instrument, Resource, SequenceMetadata, StepState}
 import seqexec.model.{ActionType, Model}
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.DhsClient.{KeywordBag, StringKeyword}
+import seqexec.server.keywords.DhsClient
+import seqexec.server.keywords.DhsClient.{KeywordBag, StringKeyword}
 import seqexec.server.SeqTranslate.{Settings, Systems}
 import seqexec.server.SeqexecFailure.{Unexpected, UnrecognizedInstrument}
 import seqexec.server.InstrumentSystem._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -3,6 +3,11 @@
 
 package seqexec.server
 
+import cats._
+import cats.data.{EitherT, Kleisli, NonEmptyList, Reader}
+import cats.effect.IO
+import cats.implicits._
+import edu.gemini.seqexec.odb.{ExecutedDataset, SeqexecSequence}
 import edu.gemini.spModel.core.Site
 import seqexec.engine.Result.{Configured, FileIdAllocated, Observed}
 import seqexec.engine.{Action, ActionMetadata, Event, Result, Sequence, Step, fromIO}
@@ -10,12 +15,13 @@ import seqexec.model.Model.{Instrument, Resource, SequenceMetadata, StepState}
 import seqexec.model.{ActionType, Model}
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.keywords.DhsClient
-import seqexec.server.keywords.DhsClient.{KeywordBag, StringKeyword}
+import seqexec.server.HeaderProvider._
 import seqexec.server.SeqTranslate.{Settings, Systems}
 import seqexec.server.SeqexecFailure.{Unexpected, UnrecognizedInstrument}
 import seqexec.server.InstrumentSystem._
 import seqexec.server.flamingos2.{Flamingos2, Flamingos2Controller, Flamingos2Header}
+import seqexec.server.keywords.{DhsClient, DhsInstrument}
+import seqexec.server.keywords.{KeywordBag, StringKeyword}
 import seqexec.server.gpi.{GPI, GPIController, GPIHeader}
 import seqexec.server.gcal._
 import seqexec.server.gmos.{GmosController, GmosHeader, GmosNorth, GmosSouth}
@@ -29,11 +35,6 @@ import edu.gemini.spModel.gemini.altair.AltairConstants
 import edu.gemini.spModel.obscomp.InstConstants._
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import org.log4s._
-import cats._
-import cats.data.{EitherT, Kleisli, NonEmptyList, Reader}
-import cats.effect.IO
-import cats.implicits._
-import edu.gemini.seqexec.odb.{ExecutedDataset, SeqexecSequence}
 import squants.Time
 import fs2.Stream
 // import org.http4s.client.Client
@@ -47,6 +48,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   import SeqTranslate._
 
+  // All instruments ask the DHS for an ImageFileId
   private def dhsFileId(inst: InstrumentSystem): SeqAction[ImageFileId] =
     systems.dhs.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List(inst.contributorName, "dhs-http")))
 
@@ -70,7 +72,8 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   private def info(msg: => String): SeqAction[Unit] = EitherT.right(IO.apply(Log.info(msg)))
 
-  private def observe[A <: InstrumentSystem: Show: HeaderProvider](config: Config, obsId: Observation.Id, inst: A,
+  //scalastyle:off
+  private def observe[A <: InstrumentSystem: HeaderProvider](config: Config, obsId: Observation.Id, inst: A,
                       otherSys: List[System], headers: Reader[ActionMetadata, List[Header]])
                      (ctx: ActionMetadata): SeqAction[Result.Partial[FileIdAllocated]] = {
     val dataId: SeqAction[String] = EitherT(IO.apply(
@@ -82,28 +85,34 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     // endObserve must be sent to the instrument too.
     def notifyObserveEnd: SeqAction[Unit] = (inst +: otherSys).map(_.notifyObserveEnd).sequence.map(_ => ())
 
-    def closeImage(id: ImageFileId, client: DhsClient): SeqAction[Unit] =
-      client.setKeywords(id, KeywordBag(StringKeyword("instrument", inst.dhsInstrumentName)), finalFlag = true)
+    def closeImage(id: ImageFileId): SeqAction[Unit] =
+      inst match {
+        case i: DhsInstrument =>
+          i.dhsClient.setKeywords(id, KeywordBag(StringKeyword("instrument", i.dhsInstrumentName)), finalFlag = true)
+        case _ =>
+          SeqAction.void
+      }
 
     def doObserve(fileId: ImageFileId): SeqAction[Result] =
       for {
         d   <- dataId
         _   <- sendDataStart(obsId, fileId, d)
         _   <- notifyObserveStart
-        _   <- headers(ctx).map(_.sendBefore(fileId, inst)).sequence
-        _   <- info(s"Start ${inst.show} observation $obsId with label $fileId")
+        _   <- headers(ctx).map(_.sendBefore(fileId)).sequence
+        _   <- info(s"Start ${inst.name} observation ${obsId.format} with label $fileId")
         r   <- inst.observe(config)(fileId)
-        _   <- info(s"Completed ${inst.show} observation $obsId with label $fileId")
+        _   <- info(s"Completed ${inst.name} observation ${obsId.format} with label $fileId")
         ret <- observeTail(fileId, d)(r)
       } yield ret
 
     def observeTail(id: ImageFileId, dataId: String)(r: ObserveCommand.Result): SeqAction[Result] = {
       val successTail: SeqAction[Result] = for {
         _ <- notifyObserveEnd
-        _ <- headers(ctx).reverseMap(_.sendAfter(id, inst)).sequence
-        _ <- closeImage(id, systems.dhs)
+        _ <- headers(ctx).reverseMap(_.sendAfter(id)).sequence
+        _ <- closeImage(id)
         _ <- sendDataEnd(obsId, id, dataId)
       } yield Result.OK(Observed(id))
+
       val stopTail: SeqAction[Result] = successTail
       val abortTail: SeqAction[Result] = sendObservationAborted(obsId, id) *>
         SeqAction.fail(SeqexecFailure.Execution(s"Observation $id aborted by user."))
@@ -112,7 +121,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
         case ObserveCommand.Success => successTail
         case ObserveCommand.Stopped => stopTail
         case ObserveCommand.Aborted => abortTail
-        case ObserveCommand.Paused => SeqAction(Result.Paused(ObserveContext(observeTail(id, dataId), inst.calcObserveTime(config))))
+        case ObserveCommand.Paused  => SeqAction(Result.Paused(ObserveContext(observeTail(id, dataId), inst.calcObserveTime(config))))
       }
     }
 
@@ -121,9 +130,8 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     } yield Result.Partial(FileIdAllocated(id), Kleisli(_ => doObserve(id).value.map(_.toResult)))
   }
 
-  //scalastyle:off
   private def step(obsId: Observation.Id, i: Int, config: Config, nextToRun: Int, datasets: Map[Int, ExecutedDataset]): TrySeq[Step] = {
-    def buildStep(inst: InstrumentSystem, sys: List[System], headers: Reader[ActionMetadata,List[Header]], resources: Set[Resource]): Step = {
+    def buildStep[A <: InstrumentSystem: HeaderProvider](inst: A, sys: List[System], headers: Reader[ActionMetadata,List[Header]], resources: Set[Resource]): Step = {
       val initialStepExecutions: List[List[Action]] =
         if (i === 0) List(List(systems.odb.sequenceStart(obsId, "").map(_ => Result.Ignored).toAction(ActionType.Undefined)))
         else Nil
@@ -317,10 +325,10 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
   }
 
   private def toInstrumentSys(inst: Model.Instrument): TrySeq[InstrumentSystem] = inst match {
-    case Model.Instrument.F2    => TrySeq(Flamingos2(systems.flamingos2))
-    case Model.Instrument.GmosS => TrySeq(GmosSouth(systems.gmosSouth))
-    case Model.Instrument.GmosN => TrySeq(GmosNorth(systems.gmosNorth))
-    case Model.Instrument.GNIRS => TrySeq(Gnirs(systems.gnirs))
+    case Model.Instrument.F2    => TrySeq(Flamingos2(systems.flamingos2, systems.dhs))
+    case Model.Instrument.GmosS => TrySeq(GmosSouth(systems.gmosSouth, systems.dhs))
+    case Model.Instrument.GmosN => TrySeq(GmosNorth(systems.gmosNorth, systems.dhs))
+    case Model.Instrument.GNIRS => TrySeq(Gnirs(systems.gnirs, systems.dhs))
     case Model.Instrument.GPI   => TrySeq(GPI(systems.gpi))
     case _                      => TrySeq.fail(Unexpected(s"Instrument $inst not supported."))
   }
@@ -354,56 +362,62 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
   // I cannot use a sealed trait as base, because I cannot have all systems in one source file (too big),
   // so either I use an unchecked notation, or add a default case that throws an exception.
   private def resourceFromSystem(s: System): Resource = (s: @unchecked) match {
-    case Tcs(_, _, _)  => Resource.TCS
-    case Gcal(_, _)    => Resource.Gcal
-    case GmosNorth(_)  => Instrument.GmosN
-    case GmosSouth(_)  => Instrument.GmosS
-    case Flamingos2(_) => Instrument.F2
-    case Gnirs(_)      => Instrument.GNIRS
-    case GPI(_)        => Instrument.GPI
+    case Tcs(_, _, _)     => Resource.TCS
+    case Gcal(_, _)       => Resource.Gcal
+    case GmosNorth(_, _)  => Instrument.GmosN
+    case GmosSouth(_, _)  => Instrument.GmosS
+    case Flamingos2(_, _) => Instrument.F2
+    case Gnirs(_, _)      => Instrument.GNIRS
+    case GPI(_)           => Instrument.GPI
 
   }
 
   private def calcInstHeader(config: Config, inst: Model.Instrument): TrySeq[Header] = {
     val tcsKReader = if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader
     inst match {
-      case Model.Instrument.F2     => TrySeq(Flamingos2Header.header(systems.dhs, new Flamingos2Header.ObsKeywordsReaderImpl(config),
-        tcsKReader))
+      case Model.Instrument.F2     =>
+        toInstrumentSys(inst).map(Flamingos2Header.header(_, new Flamingos2Header.ObsKeywordsReaderImpl(config), tcsKReader))
       case Model.Instrument.GmosS |
            Model.Instrument.GmosN  =>
         val gmosInstReader = if (settings.gmosKeywords) GmosHeader.InstKeywordReaderImpl else GmosHeader.DummyInstKeywordReader
-        TrySeq(GmosHeader.header(systems.dhs, GmosHeader.ObsKeywordsReaderImpl(config), gmosInstReader, tcsKReader))
+        toInstrumentSys(inst).map(GmosHeader.header(_, GmosHeader.ObsKeywordsReaderImpl(config), gmosInstReader, tcsKReader))
       case Model.Instrument.GNIRS  =>
         val gnirsReader = if(settings.gnirsKeywords) GnirsKeywordReaderImpl else GnirsKeywordReaderDummy
-        TrySeq(GnirsHeader.header(systems.dhs, gnirsReader, tcsKReader))
-      case Model.Instrument.GPI    => TrySeq(GPIHeader.header(systems.gpi.gdsClient, tcsKReader))
-      case _                       => TrySeq.fail(Unexpected(s"Instrument $inst not supported."))
+        toInstrumentSys(inst).map(GnirsHeader.header(_, gnirsReader, tcsKReader))
+      case Model.Instrument.GPI    =>
+        TrySeq(GPIHeader.header())
+      case _                       =>
+        TrySeq.fail(Unexpected(s"Instrument $inst not supported."))
     }
   }
 
-  private def commonHeaders(config: Config, tcsSubsystems: List[TcsController.Subsystem])(ctx: ActionMetadata): Header = new StandardHeader(
-    systems.dhs,
-    ObsKeywordReaderImpl(config, site.displayName.replace(' ', '-')),
-    if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader,
-    StateKeywordsReader(ctx.conditions, ctx.operator, ctx.observer),
-    tcsSubsystems
-  )
+  private def commonHeaders(config: Config, tcsSubsystems: List[TcsController.Subsystem], inst: InstrumentSystem)(ctx: ActionMetadata): Header =
+    new StandardHeader(
+      inst,
+      ObsKeywordReaderImpl(config, site.displayName.replace(' ', '-')),
+      if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader,
+      StateKeywordsReader(ctx.conditions, ctx.operator, ctx.observer),
+      tcsSubsystems
+    )
 
-  private val gwsHeaders: Header = GwsHeader.header(systems.dhs,
-    if (settings.gwsKeywords) GwsKeywordsReaderImpl else DummyGwsKeywordsReader
-  )
+  private val gwsHeaders: Header = GwsHeader.header(GwsHeader,
+      if (settings.gwsKeywords) GwsKeywordsReaderImpl else DummyGwsKeywordsReader
+    )(GwsHeader.headerProvider(systems.dhs))
 
-  private val gcalHeader: Header = GcalHeader.header(systems.dhs,
-    if (settings.gcalKeywords) GcalKeywordsReaderImpl else DummyGcalKeywordsReader
-  )
+  private val gcalHeader: Header = GcalHeader.header(systems.gcal,
+      if (settings.gcalKeywords) GcalKeywordsReaderImpl else DummyGcalKeywordsReader
+    )
 
   private def calcHeaders(config: Config, stepType: StepType): TrySeq[Reader[ActionMetadata, List[Header]]] = stepType match {
-    case CelestialObject(inst) => calcInstHeader(config, inst).map(h => Reader(ctx =>
-      List(commonHeaders(config, all.toList)(ctx), gwsHeaders, h)))
-    case FlatOrArc(inst)       => calcInstHeader(config, inst).map(h => Reader(ctx =>
-      List(commonHeaders(config, flatOrArcTcsSubsystems(inst).toList)(ctx), gcalHeader, gwsHeaders, h)))
-    case DarkOrBias(inst)      => calcInstHeader(config, inst).map(h => Reader(ctx =>
-      List(commonHeaders(config, Nil)(ctx), gwsHeaders, h)))
+    case CelestialObject(inst) => toInstrumentSys(inst) >>= {i =>
+        calcInstHeader(config, inst).map(h => Reader(ctx => List(commonHeaders(config, all.toList, i)(ctx), gwsHeaders, h)))
+      }
+    case FlatOrArc(inst)       => toInstrumentSys(inst) >>= { i =>
+        calcInstHeader(config, inst).map(h => Reader(ctx => List(commonHeaders(config, flatOrArcTcsSubsystems(inst).toList, i)(ctx), gcalHeader, gwsHeaders, h)))
+      }
+    case DarkOrBias(inst)      => toInstrumentSys(inst) >>= { i =>
+        calcInstHeader(config, inst).map(h => Reader(ctx => List(commonHeaders(config, Nil, i)(ctx), gwsHeaders, h)))
+      }
     case st                    => TrySeq.fail(Unexpected(s"Unsupported step type $st"))
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -22,6 +22,7 @@ import seqexec.model.Model._
 import seqexec.model.events._
 import seqexec.model.{ActionType, UserDetails}
 import seqexec.server.ConfigUtilOps._
+import seqexec.server.keywords._
 import seqexec.server.flamingos2.{Flamingos2ControllerEpics, Flamingos2ControllerSim, Flamingos2ControllerSimBad, Flamingos2Epics}
 import seqexec.server.gcal.{GcalControllerEpics, GcalControllerSim, GcalEpics}
 import seqexec.server.gmos.{GmosControllerSim, GmosEpics, GmosNorthControllerEpics, GmosSouthControllerEpics}
@@ -34,14 +35,16 @@ import edu.gemini.spModel.core.{Peer, SPProgramID, Site}
 import edu.gemini.spModel.obscomp.InstConstants
 import edu.gemini.spModel.seqcomp.SeqConfigNames.OCS_KEY
 import fs2.{Scheduler, Stream}
+import org.http4s.client.Client
 import knobs.Config
 import mouse.all._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-class SeqexecEngine(settings: SeqexecEngine.Settings) {
+class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings) {
   import SeqexecEngine._
+  println(httpClient)
 
   val odbProxy: ODBProxy = new ODBProxy(new Peer(settings.odbHost, 8443, null),
     if (settings.odbNotifications) ODBProxy.OdbCommandsImpl(new Peer(settings.odbHost, 8442, null))
@@ -354,7 +357,7 @@ object SeqexecEngine {
                       failAt: Int,
                       odbQueuePollingInterval: Duration,
                       giapi: Giapi[IO])
-  def apply(settings: Settings): SeqexecEngine = new SeqexecEngine(settings)
+  def apply(httpClient: Client[IO], settings: Settings): SeqexecEngine = new SeqexecEngine(httpClient, settings)
 
   // Couldn't find this on Scalaz
   def splitWhere[A](l: List[A])(p: (A => Boolean)): (List[A], List[A]) =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -44,7 +44,6 @@ import scala.concurrent.duration._
 
 class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings) {
   import SeqexecEngine._
-  println(httpClient)
 
   val odbProxy: ODBProxy = new ODBProxy(new Peer(settings.odbHost, 8443, null),
     if (settings.odbNotifications) ODBProxy.OdbCommandsImpl(new Peer(settings.odbHost, 8442, null))
@@ -56,7 +55,7 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings) {
     odbProxy,
     if (settings.dhsSim) DhsClientSim(settings.date) else DhsClientHttp(settings.dhsURI),
     if (settings.tcsSim) TcsControllerSim else TcsControllerEpics,
-    if (settings.gcalSim) GcalControllerSim else GcalControllerEpics,
+    if (settings.gcalSim) GcalControllerSim(DhsClientSim(settings.date)) else GcalControllerEpics(DhsClientHttp(settings.dhsURI)),
     if (settings.instSim) {
       if (settings.instForceError) Flamingos2ControllerSimBad(settings.failAt)
       else Flamingos2ControllerSim

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StandardHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StandardHeader.scala
@@ -356,7 +356,7 @@ class StandardHeader(
     buildInt32(obsReader.getSciBand.orDefault, "SCIBAND")
   )
 
-  def timinigWindows(id: ImageFileId, inst: String): SeqAction[Unit] = {
+  def timinigWindows[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
     val timingWindows = obsReader.getTimingWindows
     val windows = timingWindows.flatMap {
       case (i, tw) =>
@@ -370,7 +370,7 @@ class StandardHeader(
     sendKeywords(id, inst, hs, windowsCount :: windows)
   }
 
-  def requestedConditions(id: ImageFileId, inst: String): SeqAction[Unit] = {
+  def requestedConditions[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
     import ObsKeywordsReader._
     val keys = List(
       "REQIQ" -> IQ,
@@ -383,7 +383,7 @@ class StandardHeader(
     sendKeywords(id, inst, hs, requested)
   }
 
-  def requestedAirMassAngle(id: ImageFileId, inst: String): SeqAction[Unit] = {
+  def requestedAirMassAngle[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
     import ObsKeywordsReader._
     val keys = List(
       "REQMAXAM" -> MAX_AIRMASS,
@@ -398,7 +398,7 @@ class StandardHeader(
   }
 
   // scalastyle:of
-  override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] = {
+  override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
     def guiderKeywords(guideWith: SeqAction[StandardGuideOptions.Value], baseName: String, target: TargetKeywordsReader,
                        extras: List[KeywordBag => SeqAction[KeywordBag]]): SeqAction[Unit] = guideWith.flatMap { g =>
       if (g === StandardGuideOptions.Value.guide) sendKeywords(id, inst, hs, List(
@@ -445,7 +445,7 @@ class StandardHeader(
   }
   // scalastyle:on
 
-  override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] = sendKeywords(id, inst, hs,
+  override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = sendKeywords(id, inst, hs,
     List(
       buildDouble(tcsReader.getAirMass.orDefault, "AIRMASS"),
       buildDouble(tcsReader.getStartAirMass.orDefault, "AMSTART"),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StandardHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StandardHeader.scala
@@ -11,7 +11,8 @@ import cats.implicits._
 import seqexec.model.Model.{Conditions, Observer, Operator}
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.DhsClient.KeywordBag
+import seqexec.server.keywords.DhsClient
+import seqexec.server.keywords.DhsClient.KeywordBag
 import seqexec.server.tcs.{TargetKeywordsReader, Tcs, TcsController, TcsKeywordsReader}
 import edu.gemini.spModel.config2.{Config, ItemKey}
 import edu.gemini.spModel.dataflow.GsaAspect.Visibility

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StandardHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StandardHeader.scala
@@ -11,8 +11,7 @@ import cats.implicits._
 import seqexec.model.Model.{Conditions, Observer, Operator}
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.keywords.DhsClient
-import seqexec.server.keywords.DhsClient.KeywordBag
+import seqexec.server.keywords.KeywordBag
 import seqexec.server.tcs.{TargetKeywordsReader, Tcs, TcsController, TcsKeywordsReader}
 import edu.gemini.spModel.config2.{Config, ItemKey}
 import edu.gemini.spModel.dataflow.GsaAspect.Visibility
@@ -25,10 +24,6 @@ import edu.gemini.spModel.target.obsComp.TargetObsCompConstants._
 import mouse.all._
 
 import scala.collection.breakOut
-
-/**
-  * Created by jluhrs on 1/31/17.
-  */
 
 trait ObsKeywordsReader {
   def getObsType: SeqAction[String]
@@ -214,8 +209,8 @@ final case class StateKeywordsReader(conditions: Conditions, operator: Option[Op
   def getRawBackgroundLight: SeqAction[String] = SeqAction(encodeCondition(conditions.sb.toInt))
 }
 
-class StandardHeader(
-  hs: DhsClient,
+class StandardHeader[A: HeaderProvider](
+  inst: A,
   obsReader: ObsKeywordsReader,
   tcsReader: TcsKeywordsReader,
   stateReader: StateKeywordsReader,
@@ -278,15 +273,15 @@ class StandardHeader(
     case StandardGuideOptions.Value.freeze => "frozen"
   }
 
-  private def optTcsKeyword[A](s: TcsController.Subsystem)(v: SeqAction[A])(implicit d:DefaultValue[A]) : SeqAction[A] =
+  private def optTcsKeyword[B](s: TcsController.Subsystem)(v: SeqAction[B])(implicit d:DefaultValue[B]) : SeqAction[B] =
     if(tcsSubsystems.contains(s)) v
     else SeqAction(d.default)
 
-  private def mountTcsKeyword[A](v: SeqAction[A])(implicit d:DefaultValue[A]) = optTcsKeyword[A](TcsController.Subsystem.Mount)(v)(d)
+  private def mountTcsKeyword[B](v: SeqAction[B])(implicit d:DefaultValue[B]) = optTcsKeyword[B](TcsController.Subsystem.Mount)(v)(d)
 
-  private def m2TcsKeyword[A](v: SeqAction[A])(implicit d:DefaultValue[A]) = optTcsKeyword[A](TcsController.Subsystem.M2)(v)(d)
+  private def m2TcsKeyword[B](v: SeqAction[B])(implicit d:DefaultValue[B]) = optTcsKeyword[B](TcsController.Subsystem.M2)(v)(d)
 
-  private def sfTcsKeyword[A](v: SeqAction[A])(implicit d:DefaultValue[A]) = optTcsKeyword[A](TcsController.Subsystem.ScienceFold)(v)(d)
+  private def sfTcsKeyword[B](v: SeqAction[B])(implicit d:DefaultValue[B]) = optTcsKeyword[B](TcsController.Subsystem.ScienceFold)(v)(d)
 
   private val baseKeywords = List(
     buildString(SeqAction(OcsBuildInfo.version), "SEQEXVER"),
@@ -356,7 +351,7 @@ class StandardHeader(
     buildInt32(obsReader.getSciBand.orDefault, "SCIBAND")
   )
 
-  def timinigWindows[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
+  def timinigWindows(id: ImageFileId): SeqAction[Unit] = {
     val timingWindows = obsReader.getTimingWindows
     val windows = timingWindows.flatMap {
       case (i, tw) =>
@@ -367,10 +362,10 @@ class StandardHeader(
           buildDouble(tw.period,   f"REQTWP${i + 1}%02d"))
     }
     val windowsCount = buildInt32(SeqAction(timingWindows.length), "NUMREQTW")
-    sendKeywords(id, inst, hs, windowsCount :: windows)
+    sendKeywords(id, inst, windowsCount :: windows)
   }
 
-  def requestedConditions[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
+  def requestedConditions(id: ImageFileId): SeqAction[Unit] = {
     import ObsKeywordsReader._
     val keys = List(
       "REQIQ" -> IQ,
@@ -380,10 +375,10 @@ class StandardHeader(
     val requested = keys.flatMap {
       case (keyword, value) => obsReader.getRequestedConditions.get(value).toList.map(buildString(_, keyword))
     }
-    sendKeywords(id, inst, hs, requested)
+    sendKeywords(id, inst, requested)
   }
 
-  def requestedAirMassAngle[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
+  def requestedAirMassAngle(id: ImageFileId): SeqAction[Unit] = {
     import ObsKeywordsReader._
     val keys = List(
       "REQMAXAM" -> MAX_AIRMASS,
@@ -393,15 +388,15 @@ class StandardHeader(
     val requested = keys.flatMap {
       case (keyword, value) => obsReader.getRequestedAirMassAngle.get(value).toList.map(buildDouble(_, keyword))
     }
-    if (!requested.isEmpty) sendKeywords(id, inst, hs, requested)
+    if (!requested.isEmpty) sendKeywords(id, inst, requested)
     else SeqAction.void
   }
 
   // scalastyle:of
-  override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
+  override def sendBefore(id: ImageFileId): SeqAction[Unit] = {
     def guiderKeywords(guideWith: SeqAction[StandardGuideOptions.Value], baseName: String, target: TargetKeywordsReader,
                        extras: List[KeywordBag => SeqAction[KeywordBag]]): SeqAction[Unit] = guideWith.flatMap { g =>
-      if (g === StandardGuideOptions.Value.guide) sendKeywords(id, inst, hs, List(
+      if (g === StandardGuideOptions.Value.guide) sendKeywords(id, inst, List(
         buildDouble(target.getRA.orDefault, baseName + "ARA"),
         buildDouble(target.getDec.orDefault, baseName + "ADEC"),
         buildDouble(target.getRadialVelocity.orDefault, baseName + "ARV"), {
@@ -434,10 +429,10 @@ class StandardHeader(
 
     val aowfsKeywords = standardGuiderKeywords(obsReader.getAowfsGuide, "AO", tcsReader.getAowfsTarget, List())
 
-    sendKeywords(id, inst, hs, baseKeywords) *>
-    requestedConditions(id, inst) *>
-    requestedAirMassAngle(id, inst) *>
-    timinigWindows(id, inst) *>
+    sendKeywords(id, inst, baseKeywords) *>
+    requestedConditions(id) *>
+    requestedAirMassAngle(id) *>
+    timinigWindows(id) *>
     pwfs1Keywords *>
     pwfs2Keywords *>
     oiwfsKeywords *>
@@ -445,7 +440,7 @@ class StandardHeader(
   }
   // scalastyle:on
 
-  override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = sendKeywords(id, inst, hs,
+  override def sendAfter(id: ImageFileId): SeqAction[Unit] = sendKeywords(id, inst,
     List(
       buildDouble(tcsReader.getAirMass.orDefault, "AIRMASS"),
       buildDouble(tcsReader.getStartAirMass.orDefault, "AMSTART"),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -8,6 +8,7 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.flamingos2.Flamingos2Controller._
 import seqexec.server._
+import seqexec.server.keywords.{DhsInstrument, DhsClient}
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2._
 import edu.gemini.spModel.obscomp.InstConstants.{DARK_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
@@ -19,7 +20,7 @@ import cats.data.{EitherT, Reader}
 import cats.effect.IO
 import cats.implicits._
 
-final case class Flamingos2(f2Controller: Flamingos2Controller) extends InstrumentSystem {
+final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsClient) extends InstrumentSystem with DhsInstrument {
 
   import Flamingos2._
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -11,16 +11,13 @@ import cats.effect.IO
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.tcs.TcsKeywordsReader
-import seqexec.server.{ConfigUtilOps, DhsClient, Header, SeqAction, SeqexecFailure}
+import seqexec.server.{ConfigUtilOps, Header, SeqAction, SeqexecFailure}
+import seqexec.server.keywords.DhsClient
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.data.YesNoType
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.{MOS_PREIMAGING_PROP, READMODE_PROP, ReadMode}
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import cats.implicits._
-
-/**
-  * Created by jluhrs on 2/10/17.
-  */
 
 class Flamingos2Header(hs: DhsClient, f2ObsReader: Flamingos2Header.ObsKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) extends Header {
   import Header.Implicits._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -9,6 +9,7 @@ import java.time.format.DateTimeFormatter
 import cats.data.EitherT
 import cats.effect.IO
 import seqexec.model.dhs.ImageFileId
+import seqexec.server.HeaderProvider
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.tcs.TcsKeywordsReader
 import seqexec.server.{ConfigUtilOps, Header, SeqAction, SeqexecFailure}
@@ -19,35 +20,33 @@ import edu.gemini.spModel.gemini.flamingos2.Flamingos2.{MOS_PREIMAGING_PROP, REA
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import cats.implicits._
 
-class Flamingos2Header(hs: DhsClient, f2ObsReader: Flamingos2Header.ObsKeywordsReader, tcsKeywordsReader: TcsKeywordsReader) extends Header {
-  import Header.Implicits._
-  import Header._
-  override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] =  {
-    sendKeywords(id, inst, hs, List(
-      buildBoolean(f2ObsReader.getPreimage.map(_.toBoolean), "PREIMAGE"),
-      buildString(SeqAction(LocalDate.now.format(DateTimeFormatter.ISO_LOCAL_DATE)), "DATE-OBS"),
-      buildString(tcsKeywordsReader.getUT.orDefault, "TIME-OBS"),
-      buildString(f2ObsReader.getReadMode.map{
-        case ReadMode.BRIGHT_OBJECT_SPEC => "Bright"
-        case ReadMode.MEDIUM_OBJECT_SPEC => "Medium"
-        case ReadMode.FAINT_OBJECT_SPEC  => "Dark"
-      }, "READMODE"),
-      buildInt32(f2ObsReader.getReadMode.map{
-        case ReadMode.BRIGHT_OBJECT_SPEC => 1
-        case ReadMode.MEDIUM_OBJECT_SPEC => 4
-        case ReadMode.FAINT_OBJECT_SPEC  => 8
-      }, "NREADS"))
-    )
-  }
-
-  override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] = SeqAction(())
-}
-
 object Flamingos2Header {
-  import Header.Implicits._
+  def header(hs: DhsClient, f2ObsReader: Flamingos2Header.ObsKeywordsReader, tcsKeywordsReader: TcsKeywordsReader): Header =
+    new Header {
+      import Header.Implicits._
+      import Header._
+      override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =  {
+        sendKeywords(id, inst, hs, List(
+          buildBoolean(f2ObsReader.getPreimage.map(_.toBoolean), "PREIMAGE"),
+          buildString(SeqAction(LocalDate.now.format(DateTimeFormatter.ISO_LOCAL_DATE)), "DATE-OBS"),
+          buildString(tcsKeywordsReader.getUT.orDefault, "TIME-OBS"),
+          buildString(f2ObsReader.getReadMode.map{
+            case ReadMode.BRIGHT_OBJECT_SPEC => "Bright"
+            case ReadMode.MEDIUM_OBJECT_SPEC => "Medium"
+            case ReadMode.FAINT_OBJECT_SPEC  => "Dark"
+          }, "READMODE"),
+          buildInt32(f2ObsReader.getReadMode.map{
+            case ReadMode.BRIGHT_OBJECT_SPEC => 1
+            case ReadMode.MEDIUM_OBJECT_SPEC => 4
+            case ReadMode.FAINT_OBJECT_SPEC  => 8
+          }, "NREADS"))
+        )
+      }
 
-  def apply(hs: DhsClient, f2ObsReader: ObsKeywordsReader, tcsKeywordsReader: TcsKeywordsReader): Flamingos2Header =
-    new Flamingos2Header(hs, f2ObsReader, tcsKeywordsReader)
+      override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = SeqAction(())
+    }
+
+  import Header.Implicits._
 
   trait ObsKeywordsReader {
     def getPreimage: SeqAction[YesNoType]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/Gcal.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/Gcal.scala
@@ -38,9 +38,6 @@ final case class Gcal(controller: GcalController, isCP: Boolean) extends System 
 }
 
 object Gcal {
-  implicit val GcalHeaderProvider: HeaderProvider[Gcal] = new HeaderProvider[Gcal] {
-    def name(a: Gcal): String = ???
-  }
   def explainExtractError(e: ExtractFailure): SeqexecFailure =
     SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/Gcal.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/Gcal.scala
@@ -38,6 +38,9 @@ final case class Gcal(controller: GcalController, isCP: Boolean) extends System 
 }
 
 object Gcal {
+  implicit val GcalHeaderProvider: HeaderProvider[Gcal] = new HeaderProvider[Gcal] {
+    def name(a: Gcal): String = ???
+  }
   def explainExtractError(e: ExtractFailure): SeqexecFailure =
     SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalController.scala
@@ -4,6 +4,8 @@
 package seqexec.server.gcal
 
 import seqexec.server.SeqAction
+import seqexec.server.HeaderProvider
+import seqexec.server.keywords.{DhsClient, KeywordsClient, StandaloneDhsClient}
 import edu.gemini.spModel.gemini.calunit.CalUnitParams.Shutter
 
 import cats.Eq
@@ -13,6 +15,8 @@ trait GcalController {
 
   import GcalController._
 
+  val dhsClient: DhsClient
+
   def getConfig: SeqAction[GcalConfig]
 
   def applyConfig(config: GcalConfig): SeqAction[Unit]
@@ -20,6 +24,10 @@ trait GcalController {
 }
 
 object GcalController {
+  implicit val headerProvider: HeaderProvider[GcalController] = new HeaderProvider[GcalController] {
+    def name(a: GcalController): String = "gcal"
+    def keywordsClient(a: GcalController): KeywordsClient = StandaloneDhsClient(a.dhsClient)
+  }
 
   sealed trait LampState extends Product with Serializable
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerEpics.scala
@@ -3,12 +3,13 @@
 
 package seqexec.server.gcal
 
-import seqexec.server.{EpicsCodex, SeqAction}
-import edu.gemini.spModel.gemini.calunit.CalUnitParams.{Diffuser, Filter, Shutter}
 import cats.implicits._
+import edu.gemini.spModel.gemini.calunit.CalUnitParams.{Diffuser, Filter, Shutter}
 import edu.gemini.seqexec.server.gcal.BinaryOnOff
+import seqexec.server.{EpicsCodex, SeqAction}
+import seqexec.server.keywords.DhsClient
 
-object GcalControllerEpics extends GcalController {
+final case class GcalControllerEpics(dhsClient: DhsClient) extends GcalController {
   import EpicsCodex._
   import GcalController._
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerSim.scala
@@ -5,12 +5,10 @@ package seqexec.server.gcal
 
 import seqexec.server.gcal.GcalController.GcalConfig
 import seqexec.server.{SeqAction, TrySeq}
+import seqexec.server.keywords.DhsClient
 import org.log4s.getLogger
 
-/**
-  * Created by jluhrs on 3/15/17.
-  */
-object GcalControllerSim extends GcalController {
+final case class GcalControllerSim(dhsClient: DhsClient) extends GcalController {
   private val Log = getLogger
 
   override def getConfig: SeqAction[GcalConfig] = SeqAction(GcalController.GcalConfig.allOff)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
@@ -4,21 +4,25 @@
 package seqexec.server.gcal
 
 import seqexec.model.dhs.ImageFileId
+import seqexec.server.HeaderProvider
 import seqexec.server.Header._
 import seqexec.server.Header.Implicits._
 import seqexec.server.{Header, SeqAction}
 import seqexec.server.keywords.DhsClient
 
-class GcalHeader(hs: DhsClient, gcalReader: GcalKeywordReader) extends Header {
-  private val gcalKeywords = List(
-    buildString(gcalReader.getLamp.orDefault, "GCALLAMP"),
-    buildString(gcalReader.getFilter.orDefault, "GCALFILT"),
-    buildString(gcalReader.getDiffuser.orDefault, "GCALDIFF"),
-    buildString(gcalReader.getShutter.orDefault, "GCALSHUT")
-  )
+object GcalHeader {
+  implicit def header(hs: DhsClient, gcalReader: GcalKeywordReader): Header =
+    new Header {
+      private val gcalKeywords = List(
+        buildString(gcalReader.getLamp.orDefault, "GCALLAMP"),
+        buildString(gcalReader.getFilter.orDefault, "GCALFILT"),
+        buildString(gcalReader.getDiffuser.orDefault, "GCALDIFF"),
+        buildString(gcalReader.getShutter.orDefault, "GCALSHUT")
+      )
 
-  override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] =
-    sendKeywords(id, inst, hs, gcalKeywords)
+      override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
+        sendKeywords(id, inst, hs, gcalKeywords)
 
-  override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] = SeqAction(())
+      override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = SeqAction(())
+    }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
@@ -8,10 +8,9 @@ import seqexec.server.HeaderProvider
 import seqexec.server.Header._
 import seqexec.server.Header.Implicits._
 import seqexec.server.{Header, SeqAction}
-import seqexec.server.keywords.DhsClient
 
 object GcalHeader {
-  implicit def header(hs: DhsClient, gcalReader: GcalKeywordReader): Header =
+  implicit def header[A: HeaderProvider](inst: A, gcalReader: GcalKeywordReader): Header =
     new Header {
       private val gcalKeywords = List(
         buildString(gcalReader.getLamp.orDefault, "GCALLAMP"),
@@ -20,9 +19,9 @@ object GcalHeader {
         buildString(gcalReader.getShutter.orDefault, "GCALSHUT")
       )
 
-      override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
-        sendKeywords(id, inst, hs, gcalKeywords)
+      override def sendBefore(id: ImageFileId): SeqAction[Unit] =
+        sendKeywords(id, inst, gcalKeywords)
 
-      override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = SeqAction(())
+      override def sendAfter(id: ImageFileId): SeqAction[Unit] = SeqAction(())
     }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
@@ -6,7 +6,8 @@ package seqexec.server.gcal
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.Header._
 import seqexec.server.Header.Implicits._
-import seqexec.server.{DhsClient, Header, SeqAction}
+import seqexec.server.{Header, SeqAction}
+import seqexec.server.keywords.DhsClient
 
 class GcalHeader(hs: DhsClient, gcalReader: GcalKeywordReader) extends Header {
   private val gcalKeywords = List(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -8,6 +8,7 @@ import seqexec.server.ConfigUtilOps.{ContentError, ConversionError, _}
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.Config._
 import seqexec.server.gmos.GmosController.SiteDependentTypes
+import seqexec.server.keywords.DhsInstrument
 import seqexec.server._
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.GmosCommonType._
@@ -23,7 +24,7 @@ import cats.effect.IO
 import mouse.all._
 import scala.concurrent.duration._
 
-abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosController[T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends InstrumentSystem {
+abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosController[T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends InstrumentSystem with DhsInstrument {
   import Gmos._
   import InstrumentSystem._
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
@@ -7,10 +7,9 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.Header.Implicits._
 import seqexec.server.Header._
-import seqexec.server.HeaderProvider
+import seqexec.server.InstrumentSystem
 import seqexec.server.tcs.TcsKeywordsReader
 import seqexec.server.{ConfigUtilOps, Header, SeqAction, SeqexecFailure}
-import seqexec.server.keywords.DhsClient
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.data.YesNoType
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.IS_MOS_PREIMAGING_PROP
@@ -20,247 +19,249 @@ import cats.effect.IO
 import cats.implicits._
 
 object GmosHeader {
-  def header(hs: DhsClient, gmosObsReader: GmosHeader.ObsKeywordsReader, gmosReader: GmosHeader.InstKeywordsReader, tcsKeywordsReader: TcsKeywordsReader): Header =
+  // scalastyle:off
+  def header(inst: InstrumentSystem, gmosObsReader: GmosHeader.ObsKeywordsReader, gmosReader: GmosHeader.InstKeywordsReader, tcsKeywordsReader: TcsKeywordsReader): Header =
     new Header {
-    override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] ={
-      sendKeywords(id, inst, hs, List(
-        buildInt32(tcsKeywordsReader.getGmosInstPort.orDefault, "INPORT"),
-        buildString(gmosReader.ccName, "GMOSCC"),
-        buildString(tcsKeywordsReader.getUT.orDefault, "TIME-OBS"),
-        buildBoolean(gmosObsReader.preimage.map(_.toBoolean), "PREIMAGE"))
-        // TODO NOD*
-      )
+      override def sendBefore(id: ImageFileId): SeqAction[Unit] = {
+        sendKeywords(id, inst, List(
+          buildInt32(tcsKeywordsReader.getGmosInstPort.orDefault, "INPORT"),
+          buildString(gmosReader.ccName, "GMOSCC"),
+          buildString(tcsKeywordsReader.getUT.orDefault, "TIME-OBS"),
+          buildBoolean(gmosObsReader.preimage.map(_.toBoolean), "PREIMAGE"))
+          // TODO NOD*
+        )
+      }
+
+      private def adcKeywords =
+        if (gmosReader.isADCInUse) {
+          List(
+            buildDouble(gmosReader.adcPrismEntSt, "ADCENPST"),
+            buildDouble(gmosReader.adcPrismEntEnd, "ADCENPEN"),
+            buildDouble(gmosReader.adcPrismEntMe, "ADCENPME"),
+            buildDouble(gmosReader.adcPrismExtSt, "ADCEXPST"),
+            buildDouble(gmosReader.adcPrismExtEnd, "ADCEXPEN"),
+            buildDouble(gmosReader.adcPrismExtMe, "ADCEXPME"),
+            buildDouble(gmosReader.adcWavelength1, "ADCWLEN1"),
+            buildDouble(gmosReader.adcWavelength2, "ADCWLEN2")
+          )
+        } else Nil
+
+      private def roiKeywords = gmosReader.roiValues.map {
+        case (i, rv) =>
+          List(
+            buildInt32(rv.xStart, s"DETRO${i}X"),
+            buildInt32(rv.xSize, s"DETRO${i}XS"),
+            buildInt32(rv.yStart, s"DETRO${i}Y"),
+            buildInt32(rv.ySize, s"DETRO${i}YS")
+          )
+      }.toList
+
+      private val InBeam: Int = 0
+      private def readMaskName: SeqAction[String] = gmosReader.maskLoc.flatMap{v => if(v === InBeam) gmosReader.maskName else SeqAction("None")}
+
+      override def sendAfter(id: ImageFileId): SeqAction[Unit] = {
+        sendKeywords(id, inst, List(
+          buildInt32(gmosReader.maskId, "MASKID"),
+          buildString(readMaskName, "MASKNAME"),
+          buildInt32(gmosReader.maskType, "MASKTYP"),
+          buildInt32(gmosReader.maskLoc, "MASKLOC"),
+          buildString(gmosReader.filter1, "FILTER1"),
+          buildInt32(gmosReader.filter1Id, "FILTID1"),
+          buildString(gmosReader.filter2, "FILTER2"),
+          buildInt32(gmosReader.filter2Id, "FILTID2"),
+          buildString(gmosReader.grating, "GRATING"),
+          buildInt32(gmosReader.gratingId, "GRATID"),
+          buildDouble(gmosReader.gratingWavelength, "GRWLEN"),
+          buildDouble(gmosReader.gratingAdjustedWavelength, "CENTWAVE"),
+          buildInt32(gmosReader.gratingOrder, "GRORDER"),
+          buildDouble(gmosReader.gratingTilt, "GRTILT"),
+          buildDouble(gmosReader.gratingStep, "GRSTEP"),
+          buildDouble(gmosReader.dtaX, "DTAX"),
+          buildDouble(gmosReader.dtaY, "DTAY"),
+          buildDouble(gmosReader.dtaZ, "DTAZ"),
+          buildDouble(gmosReader.dtaZst, "DTAZST"),
+          buildDouble(gmosReader.dtaZen, "DTAZEN"),
+          buildDouble(gmosReader.dtaZme, "DTAZME"),
+          buildString(gmosReader.stageMode, "DTMODE"),
+          buildString(gmosReader.adcMode, "ADCMODE"),
+          buildString(gmosReader.dcName, "GMOSDC"),
+          buildString(gmosReader.detectorType, "DETTYPE"),
+          buildString(gmosReader.detectorId, "DETID"),
+          buildDouble(gmosReader.exposureTime, "EXPOSURE"),
+          buildInt32(gmosReader.adcUsed, "ADCUSED"),
+          buildInt32(gmosReader.detNRoi, "DETNROI")
+          // TODO These are enabled on N&S only
+          /*buildInt32(gmosReader.aExpCount, "ANODCNT"),
+          buildInt32(gmosReader.bExpCount, "BNODCNT"),
+          buildInt32(gmosReader.exposureTime, "SUBINT")*/
+        ) ::: adcKeywords ::: roiKeywords.flatten)
+      }
+    }
+    // scalastyle:on
+
+    final case class RoiValues(xStart: SeqAction[Int], xSize: SeqAction[Int], yStart: SeqAction[Int], ySize: SeqAction[Int])
+    trait ObsKeywordsReader {
+      def preimage: SeqAction[YesNoType]
     }
 
-    private def adcKeywords =
-      if (gmosReader.isADCInUse) {
-        List(
-          buildDouble(gmosReader.adcPrismEntSt, "ADCENPST"),
-          buildDouble(gmosReader.adcPrismEntEnd, "ADCENPEN"),
-          buildDouble(gmosReader.adcPrismEntMe, "ADCENPME"),
-          buildDouble(gmosReader.adcPrismExtSt, "ADCEXPST"),
-          buildDouble(gmosReader.adcPrismExtEnd, "ADCEXPEN"),
-          buildDouble(gmosReader.adcPrismExtMe, "ADCEXPME"),
-          buildDouble(gmosReader.adcWavelength1, "ADCWLEN1"),
-          buildDouble(gmosReader.adcWavelength2, "ADCWLEN2")
-        )
-      } else Nil
-
-    private def roiKeywords = gmosReader.roiValues.map {
-      case (i, rv) =>
-        List(
-          buildInt32(rv.xStart, s"DETRO${i}X"),
-          buildInt32(rv.xSize, s"DETRO${i}XS"),
-          buildInt32(rv.yStart, s"DETRO${i}Y"),
-          buildInt32(rv.ySize, s"DETRO${i}YS")
-        )
-    }.toList
-
-    private val InBeam: Int = 0
-    private def readMaskName: SeqAction[String] = gmosReader.maskLoc.flatMap{v => if(v === InBeam) gmosReader.maskName else SeqAction("None")}
-
-    override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
-      sendKeywords(id, inst, hs, List(
-        buildInt32(gmosReader.maskId, "MASKID"),
-        buildString(readMaskName, "MASKNAME"),
-        buildInt32(gmosReader.maskType, "MASKTYP"),
-        buildInt32(gmosReader.maskLoc, "MASKLOC"),
-        buildString(gmosReader.filter1, "FILTER1"),
-        buildInt32(gmosReader.filter1Id, "FILTID1"),
-        buildString(gmosReader.filter2, "FILTER2"),
-        buildInt32(gmosReader.filter2Id, "FILTID2"),
-        buildString(gmosReader.grating, "GRATING"),
-        buildInt32(gmosReader.gratingId, "GRATID"),
-        buildDouble(gmosReader.gratingWavelength, "GRWLEN"),
-        buildDouble(gmosReader.gratingAdjustedWavelength, "CENTWAVE"),
-        buildInt32(gmosReader.gratingOrder, "GRORDER"),
-        buildDouble(gmosReader.gratingTilt, "GRTILT"),
-        buildDouble(gmosReader.gratingStep, "GRSTEP"),
-        buildDouble(gmosReader.dtaX, "DTAX"),
-        buildDouble(gmosReader.dtaY, "DTAY"),
-        buildDouble(gmosReader.dtaZ, "DTAZ"),
-        buildDouble(gmosReader.dtaZst, "DTAZST"),
-        buildDouble(gmosReader.dtaZen, "DTAZEN"),
-        buildDouble(gmosReader.dtaZme, "DTAZME"),
-        buildString(gmosReader.stageMode, "DTMODE"),
-        buildString(gmosReader.adcMode, "ADCMODE"),
-        buildString(gmosReader.dcName, "GMOSDC"),
-        buildString(gmosReader.detectorType, "DETTYPE"),
-        buildString(gmosReader.detectorId, "DETID"),
-        buildDouble(gmosReader.exposureTime, "EXPOSURE"),
-        buildInt32(gmosReader.adcUsed, "ADCUSED"),
-        buildInt32(gmosReader.detNRoi, "DETNROI")
-        // TODO These are enabled on N&S only
-        /*buildInt32(gmosReader.aExpCount, "ANODCNT"),
-        buildInt32(gmosReader.bExpCount, "BNODCNT"),
-        buildInt32(gmosReader.exposureTime, "SUBINT")*/
-      ) ::: adcKeywords ::: roiKeywords.flatten)
+    final case class ObsKeywordsReaderImpl(config: Config) extends ObsKeywordsReader {
+      override def preimage: SeqAction[YesNoType] = EitherT(IO.pure(config.extract(INSTRUMENT_KEY / IS_MOS_PREIMAGING_PROP)
+        .as[YesNoType].leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
     }
-  }
 
-  final case class RoiValues(xStart: SeqAction[Int], xSize: SeqAction[Int], yStart: SeqAction[Int], ySize: SeqAction[Int])
-  trait ObsKeywordsReader {
-    def preimage: SeqAction[YesNoType]
-  }
+    trait InstKeywordsReader {
+      def ccName: SeqAction[String]
+      // TODO Add NOD*
+      /*def nodMode: SeqAction[String]
+      def nodPix: SeqAction[Int]
+      def nodCount: SeqAction[Int]
+      def nodAxOff: SeqAction[Int]
+      def nodAyOff: SeqAction[Int]
+      def nodBxOff: SeqAction[Int]
+      def nodByOff: SeqAction[Int]*/
+      def maskId: SeqAction[Int]
+      def maskName: SeqAction[String]
+      def maskType: SeqAction[Int]
+      def maskLoc: SeqAction[Int]
+      def filter1: SeqAction[String]
+      def filter2: SeqAction[String]
+      def filter1Id: SeqAction[Int]
+      def filter2Id: SeqAction[Int]
+      def grating: SeqAction[String]
+      def gratingId: SeqAction[Int]
+      def gratingWavelength: SeqAction[Double]
+      def gratingAdjustedWavelength: SeqAction[Double]
+      def gratingOrder: SeqAction[Int]
+      def gratingTilt: SeqAction[Double]
+      def gratingStep: SeqAction[Double]
+      def dtaX: SeqAction[Double]
+      def dtaY: SeqAction[Double]
+      def dtaZ: SeqAction[Double]
+      def dtaZst: SeqAction[Double]
+      def dtaZen: SeqAction[Double]
+      def dtaZme: SeqAction[Double]
+      def stageMode: SeqAction[String]
+      def adcMode: SeqAction[String]
+      def dcName: SeqAction[String]
+      def detectorType: SeqAction[String]
+      def detectorId: SeqAction[String]
+      def exposureTime: SeqAction[Double]
+      def adcUsed: SeqAction[Int]
+      def adcPrismEntSt: SeqAction[Double]
+      def adcPrismEntEnd: SeqAction[Double]
+      def adcPrismEntMe: SeqAction[Double]
+      def adcPrismExtSt: SeqAction[Double]
+      def adcPrismExtEnd: SeqAction[Double]
+      def adcPrismExtMe: SeqAction[Double]
+      def adcWavelength1: SeqAction[Double]
+      def adcWavelength2: SeqAction[Double]
+      def detNRoi: SeqAction[Int]
+      def roiValues: Map[Int, RoiValues]
+      def aExpCount: SeqAction[Int]
+      def bExpCount: SeqAction[Int]
+      def isADCInUse: Boolean
+    }
 
-  final case class ObsKeywordsReaderImpl(config: Config) extends ObsKeywordsReader {
-    override def preimage: SeqAction[YesNoType] = EitherT(IO.pure(config.extract(INSTRUMENT_KEY / IS_MOS_PREIMAGING_PROP)
-      .as[YesNoType].leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
-  }
+    object DummyInstKeywordReader extends InstKeywordsReader {
+      override def ccName: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def maskId: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def maskName: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def maskType: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def maskLoc: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def filter1: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def filter2: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def filter1Id: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def filter2Id: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def grating: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def gratingId: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def gratingWavelength: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def gratingAdjustedWavelength: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def gratingOrder: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def gratingTilt: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def gratingStep: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def dtaX: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def dtaY: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def dtaZ: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def dtaZst: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def dtaZen: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def dtaZme: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def stageMode: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def adcMode: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def dcName: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def detectorType: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def detectorId: SeqAction[String] = SeqAction(Header.StrDefault)
+      override def exposureTime: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def adcUsed: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def adcPrismEntSt: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def adcPrismEntEnd: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def adcPrismEntMe: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def adcPrismExtSt: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def adcPrismExtEnd: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def adcPrismExtMe: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def adcWavelength1: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def adcWavelength2: SeqAction[Double] = SeqAction(Header.DoubleDefault)
+      override def detNRoi: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def roiValues: Map[Int, RoiValues] = Map.empty
+      override def aExpCount: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def bExpCount: SeqAction[Int] = SeqAction(Header.IntDefault)
+      override def isADCInUse: Boolean = false
+    }
 
-  trait InstKeywordsReader {
-    def ccName: SeqAction[String]
-    // TODO Add NOD*
-    /*def nodMode: SeqAction[String]
-    def nodPix: SeqAction[Int]
-    def nodCount: SeqAction[Int]
-    def nodAxOff: SeqAction[Int]
-    def nodAyOff: SeqAction[Int]
-    def nodBxOff: SeqAction[Int]
-    def nodByOff: SeqAction[Int]*/
-    def maskId: SeqAction[Int]
-    def maskName: SeqAction[String]
-    def maskType: SeqAction[Int]
-    def maskLoc: SeqAction[Int]
-    def filter1: SeqAction[String]
-    def filter2: SeqAction[String]
-    def filter1Id: SeqAction[Int]
-    def filter2Id: SeqAction[Int]
-    def grating: SeqAction[String]
-    def gratingId: SeqAction[Int]
-    def gratingWavelength: SeqAction[Double]
-    def gratingAdjustedWavelength: SeqAction[Double]
-    def gratingOrder: SeqAction[Int]
-    def gratingTilt: SeqAction[Double]
-    def gratingStep: SeqAction[Double]
-    def dtaX: SeqAction[Double]
-    def dtaY: SeqAction[Double]
-    def dtaZ: SeqAction[Double]
-    def dtaZst: SeqAction[Double]
-    def dtaZen: SeqAction[Double]
-    def dtaZme: SeqAction[Double]
-    def stageMode: SeqAction[String]
-    def adcMode: SeqAction[String]
-    def dcName: SeqAction[String]
-    def detectorType: SeqAction[String]
-    def detectorId: SeqAction[String]
-    def exposureTime: SeqAction[Double]
-    def adcUsed: SeqAction[Int]
-    def adcPrismEntSt: SeqAction[Double]
-    def adcPrismEntEnd: SeqAction[Double]
-    def adcPrismEntMe: SeqAction[Double]
-    def adcPrismExtSt: SeqAction[Double]
-    def adcPrismExtEnd: SeqAction[Double]
-    def adcPrismExtMe: SeqAction[Double]
-    def adcWavelength1: SeqAction[Double]
-    def adcWavelength2: SeqAction[Double]
-    def detNRoi: SeqAction[Int]
-    def roiValues: Map[Int, RoiValues]
-    def aExpCount: SeqAction[Int]
-    def bExpCount: SeqAction[Int]
-    def isADCInUse: Boolean
-  }
+    object InstKeywordReaderImpl extends InstKeywordsReader {
 
-  object DummyInstKeywordReader extends InstKeywordsReader {
-    override def ccName: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def maskId: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def maskName: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def maskType: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def maskLoc: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def filter1: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def filter2: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def filter1Id: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def filter2Id: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def grating: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def gratingId: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def gratingWavelength: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def gratingAdjustedWavelength: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def gratingOrder: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def gratingTilt: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def gratingStep: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def dtaX: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def dtaY: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def dtaZ: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def dtaZst: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def dtaZen: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def dtaZme: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def stageMode: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def adcMode: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def dcName: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def detectorType: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def detectorId: SeqAction[String] = SeqAction(Header.StrDefault)
-    override def exposureTime: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def adcUsed: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def adcPrismEntSt: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def adcPrismEntEnd: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def adcPrismEntMe: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def adcPrismExtSt: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def adcPrismExtEnd: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def adcPrismExtMe: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def adcWavelength1: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def adcWavelength2: SeqAction[Double] = SeqAction(Header.DoubleDefault)
-    override def detNRoi: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def roiValues: Map[Int, RoiValues] = Map.empty
-    override def aExpCount: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def bExpCount: SeqAction[Int] = SeqAction(Header.IntDefault)
-    override def isADCInUse: Boolean = false
-  }
-
-  object InstKeywordReaderImpl extends InstKeywordsReader {
-
-    override def ccName: SeqAction[String] = GmosEpics.instance.ccName.toSeqAction
-    override def maskId: SeqAction[Int] = GmosEpics.instance.maskId.toSeqAction
-    override def maskName: SeqAction[String] = GmosEpics.instance.fpu.toSeqAction
-    override def maskType: SeqAction[Int] = GmosEpics.instance.maskType.toSeqAction
-    override def maskLoc: SeqAction[Int] = GmosEpics.instance.inBeam.toSeqAction
-    override def filter1: SeqAction[String] = GmosEpics.instance.filter1.toSeqAction
-    override def filter2: SeqAction[String] = GmosEpics.instance.filter2.toSeqAction
-    override def filter1Id: SeqAction[Int] = GmosEpics.instance.filter1Id.toSeqAction
-    override def filter2Id: SeqAction[Int] = GmosEpics.instance.filter2Id.toSeqAction
-    override def grating: SeqAction[String] = GmosEpics.instance.disperser.toSeqAction
-    override def gratingId: SeqAction[Int] = GmosEpics.instance.disperserId.toSeqAction
-    override def gratingWavelength: SeqAction[Double] = GmosEpics.instance.gratingWavel.toSeqAction
-    override def gratingAdjustedWavelength: SeqAction[Double] = GmosEpics.instance.disperserWavel.toSeqAction
-    override def gratingOrder: SeqAction[Int] = GmosEpics.instance.disperserOrder.toSeqAction
-    override def gratingTilt: SeqAction[Double] = GmosEpics.instance.gratingTilt.toSeqAction
-    override def gratingStep: SeqAction[Double] =
-      // Set the value to the epics channel if inBeam is    1
-      GmosEpics.instance.reqGratingMotorSteps.filter(_ => GmosEpics.instance.disperserInBeam === Some(1)).toSeqAction
-    override def dtaX: SeqAction[Double] = GmosEpics.instance.dtaX.toSeqAction
-    override def dtaY: SeqAction[Double] = GmosEpics.instance.dtaY.toSeqAction
-    override def dtaZ: SeqAction[Double] = GmosEpics.instance.dtaZ.toSeqAction
-    override def dtaZst: SeqAction[Double] = GmosEpics.instance.dtaZStart.toSeqAction
-    override def dtaZen: SeqAction[Double] = GmosEpics.instance.dtaZEnd.toSeqAction
-    override def dtaZme: SeqAction[Double] = GmosEpics.instance.dtaZMean.toSeqAction
-    override def stageMode: SeqAction[String] = GmosEpics.instance.stageMode.toSeqAction
-    override def adcMode: SeqAction[String] = GmosEpics.instance.adcMode.toSeqAction
-    override def dcName: SeqAction[String] = GmosEpics.instance.dcName.toSeqAction
-    override def detectorType: SeqAction[String] = GmosEpics.instance.detectorType.toSeqAction
-    override def detectorId: SeqAction[String] = GmosEpics.instance.detectorId.toSeqAction
-    // TODO Exposure changes with N&S
-    override def exposureTime: SeqAction[Double] = GmosEpics.instance.reqExposureTime.map(_.toDouble).toSeqAction
-    override def adcUsed: SeqAction[Int] = GmosEpics.instance.adcUsed.toSeqAction
-    override def adcPrismEntSt: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleStart.toSeqAction
-    override def adcPrismEntEnd: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleEnd.toSeqAction
-    override def adcPrismEntMe: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleMean.toSeqAction
-    override def adcPrismExtSt: SeqAction[Double] = GmosEpics.instance.adcPrismExitAngleStart.toSeqAction
-    override def adcPrismExtEnd: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleEnd.toSeqAction
-    override def adcPrismExtMe: SeqAction[Double] = GmosEpics.instance.adcPrismExitAngleEnd.toSeqAction
-    override def adcWavelength1: SeqAction[Double] = GmosEpics.instance.adcExitLowerWavel.toSeqAction
-    override def adcWavelength2: SeqAction[Double] = GmosEpics.instance.adcExitUpperWavel.toSeqAction
-    // The TCL code does some verifications to ensure the value is not negative
-    override def detNRoi: SeqAction[Int] = SeqAction(GmosEpics.instance.roiNumUsed.filter(_ > 0).getOrElse(0))
-    override def roiValues: Map[Int, RoiValues] =
-      (for {
-        i <- 1 to GmosEpics.instance.roiNumUsed.getOrElse(0)
-        roi = GmosEpics.instance.rois.get(i)
-      } yield roi.map { r =>
-          i ->
-            RoiValues(r.ccdXstart.toSeqAction, r.ccdXsize.toSeqAction, r.ccdYstart.toSeqAction, r.ccdYsize.toSeqAction)
-        }).toList.collect { case Some(x) => x }.toMap
-    override def aExpCount: SeqAction[Int] = GmosEpics.instance.aExpCount.toSeqAction
-    override def bExpCount: SeqAction[Int] = GmosEpics.instance.aExpCount.toSeqAction
-    override def isADCInUse: Boolean =
-      GmosEpics.instance.adcUsed.forall(_ === 1)
-  }
+      override def ccName: SeqAction[String] = GmosEpics.instance.ccName.toSeqAction
+      override def maskId: SeqAction[Int] = GmosEpics.instance.maskId.toSeqAction
+      override def maskName: SeqAction[String] = GmosEpics.instance.fpu.toSeqAction
+      override def maskType: SeqAction[Int] = GmosEpics.instance.maskType.toSeqAction
+      override def maskLoc: SeqAction[Int] = GmosEpics.instance.inBeam.toSeqAction
+      override def filter1: SeqAction[String] = GmosEpics.instance.filter1.toSeqAction
+      override def filter2: SeqAction[String] = GmosEpics.instance.filter2.toSeqAction
+      override def filter1Id: SeqAction[Int] = GmosEpics.instance.filter1Id.toSeqAction
+      override def filter2Id: SeqAction[Int] = GmosEpics.instance.filter2Id.toSeqAction
+      override def grating: SeqAction[String] = GmosEpics.instance.disperser.toSeqAction
+      override def gratingId: SeqAction[Int] = GmosEpics.instance.disperserId.toSeqAction
+      override def gratingWavelength: SeqAction[Double] = GmosEpics.instance.gratingWavel.toSeqAction
+      override def gratingAdjustedWavelength: SeqAction[Double] = GmosEpics.instance.disperserWavel.toSeqAction
+      override def gratingOrder: SeqAction[Int] = GmosEpics.instance.disperserOrder.toSeqAction
+      override def gratingTilt: SeqAction[Double] = GmosEpics.instance.gratingTilt.toSeqAction
+      override def gratingStep: SeqAction[Double] =
+        // Set the value to the epics channel if inBeam is    1
+        GmosEpics.instance.reqGratingMotorSteps.filter(_ => GmosEpics.instance.disperserInBeam === Some(1)).toSeqAction
+      override def dtaX: SeqAction[Double] = GmosEpics.instance.dtaX.toSeqAction
+      override def dtaY: SeqAction[Double] = GmosEpics.instance.dtaY.toSeqAction
+      override def dtaZ: SeqAction[Double] = GmosEpics.instance.dtaZ.toSeqAction
+      override def dtaZst: SeqAction[Double] = GmosEpics.instance.dtaZStart.toSeqAction
+      override def dtaZen: SeqAction[Double] = GmosEpics.instance.dtaZEnd.toSeqAction
+      override def dtaZme: SeqAction[Double] = GmosEpics.instance.dtaZMean.toSeqAction
+      override def stageMode: SeqAction[String] = GmosEpics.instance.stageMode.toSeqAction
+      override def adcMode: SeqAction[String] = GmosEpics.instance.adcMode.toSeqAction
+      override def dcName: SeqAction[String] = GmosEpics.instance.dcName.toSeqAction
+      override def detectorType: SeqAction[String] = GmosEpics.instance.detectorType.toSeqAction
+      override def detectorId: SeqAction[String] = GmosEpics.instance.detectorId.toSeqAction
+      // TODO Exposure changes with N&S
+      override def exposureTime: SeqAction[Double] = GmosEpics.instance.reqExposureTime.map(_.toDouble).toSeqAction
+      override def adcUsed: SeqAction[Int] = GmosEpics.instance.adcUsed.toSeqAction
+      override def adcPrismEntSt: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleStart.toSeqAction
+      override def adcPrismEntEnd: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleEnd.toSeqAction
+      override def adcPrismEntMe: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleMean.toSeqAction
+      override def adcPrismExtSt: SeqAction[Double] = GmosEpics.instance.adcPrismExitAngleStart.toSeqAction
+      override def adcPrismExtEnd: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleEnd.toSeqAction
+      override def adcPrismExtMe: SeqAction[Double] = GmosEpics.instance.adcPrismExitAngleEnd.toSeqAction
+      override def adcWavelength1: SeqAction[Double] = GmosEpics.instance.adcExitLowerWavel.toSeqAction
+      override def adcWavelength2: SeqAction[Double] = GmosEpics.instance.adcExitUpperWavel.toSeqAction
+      // The TCL code does some verifications to ensure the value is not negative
+      override def detNRoi: SeqAction[Int] = SeqAction(GmosEpics.instance.roiNumUsed.filter(_ > 0).getOrElse(0))
+      override def roiValues: Map[Int, RoiValues] =
+        (for {
+          i <- 1 to GmosEpics.instance.roiNumUsed.getOrElse(0)
+          roi = GmosEpics.instance.rois.get(i)
+        } yield roi.map { r =>
+            i ->
+              RoiValues(r.ccdXstart.toSeqAction, r.ccdXsize.toSeqAction, r.ccdYstart.toSeqAction, r.ccdYsize.toSeqAction)
+          }).toList.collect { case Some(x) => x }.toMap
+      override def aExpCount: SeqAction[Int] = GmosEpics.instance.aExpCount.toSeqAction
+      override def bExpCount: SeqAction[Int] = GmosEpics.instance.aExpCount.toSeqAction
+      override def isADCInUse: Boolean =
+        GmosEpics.instance.adcUsed.forall(_ === 1)
+    }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
@@ -8,7 +8,8 @@ import seqexec.server.ConfigUtilOps._
 import seqexec.server.Header.Implicits._
 import seqexec.server.Header._
 import seqexec.server.tcs.TcsKeywordsReader
-import seqexec.server.{ConfigUtilOps, DhsClient, Header, SeqAction, SeqexecFailure}
+import seqexec.server.{ConfigUtilOps, Header, SeqAction, SeqexecFailure}
+import seqexec.server.keywords.DhsClient
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.data.YesNoType
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.IS_MOS_PREIMAGING_PROP

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -8,6 +8,7 @@ import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.{GmosNorthController, NorthTypes, northConfigTypes}
+import seqexec.server.keywords.DhsClient
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.GmosNorthType
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
@@ -15,7 +16,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 
-final case class GmosNorth(c: GmosNorthController) extends Gmos[NorthTypes](c,
+final case class GmosNorth(c: GmosNorthController, dhsClient: DhsClient) extends Gmos[NorthTypes](c,
   new SiteSpecifics[NorthTypes] {
     override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
     override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] = config.extract(INSTRUMENT_KEY / FILTER_PROP).as[NorthTypes#Filter]
@@ -30,5 +31,5 @@ final case class GmosNorth(c: GmosNorthController) extends Gmos[NorthTypes](c,
 object GmosNorth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply(c: GmosController[NorthTypes]): GmosNorth = new GmosNorth(c)
+  def apply(c: GmosController[NorthTypes], dhsClient: DhsClient): GmosNorth = new GmosNorth(c, dhsClient)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -9,6 +9,7 @@ import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.{GmosSouthController, SouthTypes, southConfigTypes}
+import seqexec.server.keywords.DhsClient
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.GmosSouthType
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
@@ -16,7 +17,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 
-final case class GmosSouth(c: GmosSouthController) extends Gmos[SouthTypes](c,
+final case class GmosSouth(c: GmosSouthController, dhsClient: DhsClient) extends Gmos[SouthTypes](c,
   new SiteSpecifics[SouthTypes] {
     override val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
     override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] = config.extract(INSTRUMENT_KEY / FILTER_PROP).as[SouthTypes#Filter]
@@ -31,5 +32,5 @@ final case class GmosSouth(c: GmosSouthController) extends Gmos[SouthTypes](c,
 object GmosSouth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply(c: GmosController[SouthTypes]): GmosSouth = new GmosSouth(c)
+  def apply(c: GmosController[SouthTypes], dhsClient: DhsClient): GmosSouth = new GmosSouth(c, dhsClient)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -11,6 +11,7 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gnirs.GnirsController.{CCConfig, DCConfig, Other, ReadMode}
 import seqexec.server._
+import seqexec.server.keywords.{DhsInstrument, DhsClient}
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gnirs.GNIRSConstants.{INSTRUMENT_NAME_PROP, WOLLASTON_PRISM_PROP}
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams._
@@ -21,7 +22,7 @@ import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
-final case class Gnirs(controller: GnirsController) extends InstrumentSystem {
+final case class Gnirs(controller: GnirsController, dhsClient: DhsClient) extends InstrumentSystem with DhsInstrument {
   override val sfName: String = "gnirs"
   override val contributorName: String = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
@@ -7,7 +7,8 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.server.Header._
 import seqexec.server.Header.Implicits._
 import seqexec.server.tcs.TcsKeywordsReader
-import seqexec.server.{DhsClient, Header, SeqAction}
+import seqexec.server.{Header, SeqAction}
+import seqexec.server.keywords.DhsClient
 
 class GnirsHeader(hs: DhsClient, gnirsReader: GnirsKeywordReader, tcsReader: TcsKeywordsReader) extends Header {
   override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
@@ -5,17 +5,15 @@ package seqexec.server.gnirs
 
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.Header._
-import seqexec.server.HeaderProvider
+import seqexec.server.InstrumentSystem
 import seqexec.server.Header.Implicits._
 import seqexec.server.tcs.TcsKeywordsReader
 import seqexec.server.{Header, SeqAction}
-import seqexec.server.keywords.DhsClient
-
 
 object GnirsHeader {
-  def header(hs: DhsClient, gnirsReader: GnirsKeywordReader, tcsReader: TcsKeywordsReader): Header = new Header {
-    override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
-      sendKeywords(id, inst, hs, List(
+  def header(inst: InstrumentSystem, gnirsReader: GnirsKeywordReader, tcsReader: TcsKeywordsReader): Header = new Header {
+    override def sendBefore(id: ImageFileId): SeqAction[Unit] =
+      sendKeywords(id, inst, List(
         buildInt32(tcsReader.getGnirsInstPort.orDefault, "INPORT"),
         buildString(gnirsReader.getArrayId, "ARRAYID"),
         buildString(gnirsReader.getArrayType, "ARRAYTYP"),
@@ -46,8 +44,8 @@ object GnirsHeader {
         buildDouble(gnirsReader.getDetectorBias, "DETBIAS")
       ) )
 
-    override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
-      sendKeywords(id, inst, hs, List(
+    override def sendAfter(id: ImageFileId): SeqAction[Unit] =
+      sendKeywords(id, inst, List(
         buildString(tcsReader.getUT.orDefault, "UTEND"),
         buildDouble(gnirsReader.getObsEpoch, "OBSEPOCH")
       ) )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
@@ -5,52 +5,51 @@ package seqexec.server.gnirs
 
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.Header._
+import seqexec.server.HeaderProvider
 import seqexec.server.Header.Implicits._
 import seqexec.server.tcs.TcsKeywordsReader
 import seqexec.server.{Header, SeqAction}
 import seqexec.server.keywords.DhsClient
 
-class GnirsHeader(hs: DhsClient, gnirsReader: GnirsKeywordReader, tcsReader: TcsKeywordsReader) extends Header {
-  override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] =
-    sendKeywords(id, inst, hs, List(
-      buildInt32(tcsReader.getGnirsInstPort.orDefault, "INPORT"),
-      buildString(gnirsReader.getArrayId, "ARRAYID"),
-      buildString(gnirsReader.getArrayType, "ARRAYTYP"),
-      buildString(tcsReader.getDate.orDefault, "DATE-OBS"),
-      buildString(tcsReader.getUT.orDefault, "TIME-OBS"),
-      buildString(tcsReader.getUT.orDefault, "UTSTART"),
-      buildString(gnirsReader.getFilter1, "FILTER1"),
-      buildInt32(gnirsReader.getFilterWheel1Pos, "FW1_ENG"),
-      buildString(gnirsReader.getFilter2, "FILTER2"),
-      buildInt32(gnirsReader.getFilterWheel2Pos, "FW2_ENG"),
-      buildString(gnirsReader.getCamera, "CAMERA"),
-      buildInt32(gnirsReader.getCameraPos, "CAM_ENG"),
-      buildString(gnirsReader.getSlit, "SLIT"),
-      buildInt32(gnirsReader.getSlitPos, "SLIT_ENG"),
-      buildString(gnirsReader.getDecker, "DECKER"),
-      buildInt32(gnirsReader.getDeckerPos, "DKR_ENG"),
-      buildString(gnirsReader.getGrating, "GRATING"),
-      buildInt32(gnirsReader.getGratingPos, "GR_ENG"),
-      buildDouble(gnirsReader.getGratingWavelength, "GRATWAVE"),
-      buildInt32(gnirsReader.getGratingOrder, "GRATORD"),
-      buildDouble(gnirsReader.getGratingTilt, "GRATTILT"),
-      buildString(gnirsReader.getPrism, "PRISM"),
-      buildInt32(gnirsReader.getPrismPos, "PRSM_ENG"),
-      buildString(gnirsReader.getAcquisitionMirror, "ACQMIR"),
-      buildString(gnirsReader.getWindowCover, "COVER"),
-      buildString(gnirsReader.getFocus, "FOCUS"),
-      buildInt32(gnirsReader.getFocusPos, "FCS_ENG"),
-      buildDouble(gnirsReader.getDetectorBias, "DETBIAS")
-    ) )
-
-  override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] =
-    sendKeywords(id, inst, hs, List(
-      buildString(tcsReader.getUT.orDefault, "UTEND"),
-      buildDouble(gnirsReader.getObsEpoch, "OBSEPOCH")
-    ) )
-}
 
 object GnirsHeader {
-  def apply(hs: DhsClient, gnirsReader: GnirsKeywordReader, tcsReader: TcsKeywordsReader): GnirsHeader =
-    new GnirsHeader(hs, gnirsReader, tcsReader)
+  def header(hs: DhsClient, gnirsReader: GnirsKeywordReader, tcsReader: TcsKeywordsReader): Header = new Header {
+    override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
+      sendKeywords(id, inst, hs, List(
+        buildInt32(tcsReader.getGnirsInstPort.orDefault, "INPORT"),
+        buildString(gnirsReader.getArrayId, "ARRAYID"),
+        buildString(gnirsReader.getArrayType, "ARRAYTYP"),
+        buildString(tcsReader.getDate.orDefault, "DATE-OBS"),
+        buildString(tcsReader.getUT.orDefault, "TIME-OBS"),
+        buildString(tcsReader.getUT.orDefault, "UTSTART"),
+        buildString(gnirsReader.getFilter1, "FILTER1"),
+        buildInt32(gnirsReader.getFilterWheel1Pos, "FW1_ENG"),
+        buildString(gnirsReader.getFilter2, "FILTER2"),
+        buildInt32(gnirsReader.getFilterWheel2Pos, "FW2_ENG"),
+        buildString(gnirsReader.getCamera, "CAMERA"),
+        buildInt32(gnirsReader.getCameraPos, "CAM_ENG"),
+        buildString(gnirsReader.getSlit, "SLIT"),
+        buildInt32(gnirsReader.getSlitPos, "SLIT_ENG"),
+        buildString(gnirsReader.getDecker, "DECKER"),
+        buildInt32(gnirsReader.getDeckerPos, "DKR_ENG"),
+        buildString(gnirsReader.getGrating, "GRATING"),
+        buildInt32(gnirsReader.getGratingPos, "GR_ENG"),
+        buildDouble(gnirsReader.getGratingWavelength, "GRATWAVE"),
+        buildInt32(gnirsReader.getGratingOrder, "GRATORD"),
+        buildDouble(gnirsReader.getGratingTilt, "GRATTILT"),
+        buildString(gnirsReader.getPrism, "PRISM"),
+        buildInt32(gnirsReader.getPrismPos, "PRSM_ENG"),
+        buildString(gnirsReader.getAcquisitionMirror, "ACQMIR"),
+        buildString(gnirsReader.getWindowCover, "COVER"),
+        buildString(gnirsReader.getFocus, "FOCUS"),
+        buildInt32(gnirsReader.getFocusPos, "FCS_ENG"),
+        buildDouble(gnirsReader.getDetectorBias, "DETBIAS")
+      ) )
+
+    override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
+      sendKeywords(id, inst, hs, List(
+        buildString(tcsReader.getUT.orDefault, "UTEND"),
+        buildDouble(gnirsReader.getObsEpoch, "OBSEPOCH")
+      ) )
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPI.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPI.scala
@@ -25,8 +25,6 @@ final case class GPI[F[_]](controller: GPIController) extends InstrumentSystem {
 
   override val contributorName: String = "gpi"
 
-  override val dhsInstrumentName: String = "GPI"
-
   override val observeControl: InstrumentSystem.ObserveControl =
     InstrumentSystem.Uncontrollable
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
@@ -25,6 +25,7 @@ import mouse.boolean._
 import org.log4s.getLogger
 import scala.concurrent.duration.Duration
 import seqexec.model.dhs.ImageFileId
+import seqexec.server.keywords.GDSClient
 import seqexec.server.SeqAction
 
 object GPILookupTables {
@@ -94,7 +95,7 @@ object GPILookupTables {
   )
 }
 
-final case class GPIController(gpiClient: GPIClient[IO]) {
+final case class GPIController(gpiClient: GPIClient[IO], gdsClient: GDSClient[IO]) {
   import GPIController._
   import GPILookupTables._
   private val Log             = getLogger

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIHeader.scala
@@ -5,12 +5,17 @@ package seqexec.server.gpi
 
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.tcs.TcsKeywordsReader
-import seqexec.server.{Header, SeqAction}
+import seqexec.server.{Header, HeaderProvider, SeqAction}
+import seqexec.server.keywords.GDSClient
 
-final case class GPIHeader(tcsReader: TcsKeywordsReader) extends Header {
-  override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] =
-    SeqAction.void
+object GPIHeader {
+  def header[F[_]](client: GDSClient[F], tcsReader: TcsKeywordsReader): Header = new Header {
+    println(client)
+    println(tcsReader)
+    override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
+      SeqAction.void
 
-  override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] =
-    SeqAction.void
+    override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
+      SeqAction.void
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIHeader.scala
@@ -4,18 +4,17 @@
 package seqexec.server.gpi
 
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.tcs.TcsKeywordsReader
-import seqexec.server.{Header, HeaderProvider, SeqAction}
-import seqexec.server.keywords.GDSClient
+// import seqexec.server.tcs.TcsKeywordsReader
+import seqexec.server.{Header, SeqAction}
+// import seqexec.server.keywords.GDSClient
 
 object GPIHeader {
-  def header[F[_]](client: GDSClient[F], tcsReader: TcsKeywordsReader): Header = new Header {
-    println(client)
-    println(tcsReader)
-    override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
+  //def header[F[_]](client: GDSClient[F], tcsReader: TcsKeywordsReader): Header = new Header {
+  def header[F[_]](): Header = new Header {
+    override def sendBefore(id: ImageFileId): SeqAction[Unit] =
       SeqAction.void
 
-    override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] =
+    override def sendAfter(id: ImageFileId): SeqAction[Unit] =
       SeqAction.void
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsHeader.scala
@@ -6,7 +6,8 @@ package seqexec.server.gws
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.Header.Implicits._
 import seqexec.server.Header._
-import seqexec.server.{DhsClient, EpicsHealth, Header, SeqAction}
+import seqexec.server.{EpicsHealth, Header, SeqAction}
+import seqexec.server.keywords.DhsClient
 
 /**
   * Created by jluhrs on 7/17/17.

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsHeader.scala
@@ -6,57 +6,56 @@ package seqexec.server.gws
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.Header.Implicits._
 import seqexec.server.Header._
-import seqexec.server.{EpicsHealth, Header, SeqAction}
+import seqexec.server.{EpicsHealth, Header, HeaderProvider, SeqAction}
 import seqexec.server.keywords.DhsClient
 
-/**
-  * Created by jluhrs on 7/17/17.
-  */
-class GwsHeader(hs: DhsClient, gwsReader: GwsKeywordReader) extends Header {
-  override def sendBefore(id: ImageFileId, inst: String): SeqAction[Unit] = {
-    gwsReader.getHealth.flatMap{
-      case Some(EpicsHealth.Good) => sendKeywords(id, inst, hs, List(
-        buildDouble(gwsReader.getHumidity.orDefault, "HUMIDITY"),
-        {
-          val x = gwsReader.getTemperature.map(_.map(_.toCelsiusScale))
-          buildDouble(x.orDefault, "TAMBIENT")
-        },
-        {
-          val x = gwsReader.getTemperature.map(_.map(_.toFahrenheitScale))
-          buildDouble(x.orDefault, "TAMBIEN2")
-        },
-        {
-          val x = gwsReader.getAirPressure.map(_.map(_.toMillimetersOfMercury))
-          buildDouble(x.orDefault, "PRESSURE")
-        },
-        {
-          val x = gwsReader.getAirPressure.map(_.map(_.toPascals))
-          buildDouble(x.orDefault, "PRESSUR2")
-        },
-        {
-          val x = gwsReader.getDewPoint.map(_.map(_.toCelsiusScale))
-          buildDouble(x.orDefault, "DEWPOINT")
-        },
-        {
-          val x = gwsReader.getDewPoint.map(_.map(_.toFahrenheitScale))
-          buildDouble(x.orDefault, "DEWPOIN2")
-        },
-        {
-          val x = gwsReader.getWindVelocity.map(_.map(_.toMetersPerSecond))
-          buildDouble(x.orDefault, "WINDSPEE")
-        },
-        {
-          val x = gwsReader.getWindVelocity.map(_.map(_.toInternationalMilesPerHour))
-          buildDouble(x.orDefault, "WINDSPE2")
-        },
-        {
-          val x = gwsReader.getWindDirection.map(_.map(_.toDegrees))
-          buildDouble(x.orDefault, "WINDDIRE")
-        }
-      ))
-      case _       => SeqAction(())
+object GwsHeader {
+  def header(hs: DhsClient, gwsReader: GwsKeywordReader): Header = new Header {
+    override def sendBefore[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = {
+      gwsReader.getHealth.flatMap{
+        case Some(EpicsHealth.Good) => sendKeywords(id, inst, hs, List(
+          buildDouble(gwsReader.getHumidity.orDefault, "HUMIDITY"),
+          {
+            val x = gwsReader.getTemperature.map(_.map(_.toCelsiusScale))
+            buildDouble(x.orDefault, "TAMBIENT")
+          },
+          {
+            val x = gwsReader.getTemperature.map(_.map(_.toFahrenheitScale))
+            buildDouble(x.orDefault, "TAMBIEN2")
+          },
+          {
+            val x = gwsReader.getAirPressure.map(_.map(_.toMillimetersOfMercury))
+            buildDouble(x.orDefault, "PRESSURE")
+          },
+          {
+            val x = gwsReader.getAirPressure.map(_.map(_.toPascals))
+            buildDouble(x.orDefault, "PRESSUR2")
+          },
+          {
+            val x = gwsReader.getDewPoint.map(_.map(_.toCelsiusScale))
+            buildDouble(x.orDefault, "DEWPOINT")
+          },
+          {
+            val x = gwsReader.getDewPoint.map(_.map(_.toFahrenheitScale))
+            buildDouble(x.orDefault, "DEWPOIN2")
+          },
+          {
+            val x = gwsReader.getWindVelocity.map(_.map(_.toMetersPerSecond))
+            buildDouble(x.orDefault, "WINDSPEE")
+          },
+          {
+            val x = gwsReader.getWindVelocity.map(_.map(_.toInternationalMilesPerHour))
+            buildDouble(x.orDefault, "WINDSPE2")
+          },
+          {
+            val x = gwsReader.getWindDirection.map(_.map(_.toDegrees))
+            buildDouble(x.orDefault, "WINDDIRE")
+          }
+        ))
+        case _       => SeqAction(())
+      }
     }
-  }
 
-  override def sendAfter(id: ImageFileId, inst: String): SeqAction[Unit] = SeqAction(())
+    override def sendAfter[A: HeaderProvider](id: ImageFileId, inst: A): SeqAction[Unit] = SeqAction(())
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsKeywordReader.scala
@@ -10,9 +10,6 @@ import squants.space.Degrees
 import squants.thermal.Celsius
 import squants.{Angle, Temperature, Velocity}
 
-/**
-  * Created by jluhrs on 3/13/17.
-  */
 trait GwsKeywordReader {
   def getHealth: SeqAction[Option[EpicsHealth]]
   def getTemperature: SeqAction[Option[Temperature]]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClient.scala
@@ -1,9 +1,10 @@
 // Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package seqexec.server
+package seqexec.server.keywords
 
 import seqexec.model.dhs.ImageFileId
+import seqexec.server.SeqAction
 
 /**
   * Defines the interface for dhs client, with methods, e.g. to request image creation

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClient.scala
@@ -18,7 +18,7 @@ trait DhsClient {
   /**
     * Set the keywords for an image
     */
-  def setKeywords(id: ImageFileId, keywords: DhsClient.KeywordBag, finalFlag: Boolean): SeqAction[Unit]
+  def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): SeqAction[Unit]
 
 }
 
@@ -32,59 +32,5 @@ object DhsClient {
   object Transient extends Lifetime("TRANSIENT")
 
   final case class ImageParameters(lifetime: Lifetime, contributors: List[Contributor])
-
-  // TODO: Implement the unsigned types, if needed.
-  sealed case class KeywordType protected (str: String)
-  object TypeInt8 extends KeywordType("INT8")
-  object TypeInt16 extends KeywordType("INT16")
-  object TypeInt32 extends KeywordType("INT32")
-  object TypeFloat extends KeywordType("FLOAT")
-  object TypeDouble extends KeywordType("DOUBLE")
-  object TypeBoolean extends KeywordType("BOOLEAN")
-  object TypeString extends KeywordType("STRING")
-
-
-  // The developer uses these classes to define all the typed keywords
-  sealed class Keyword[T] protected (val n: String, val t: KeywordType, val v: T)
-  final case class Int8Keyword(name: String, value: Byte) extends Keyword[Byte](name, TypeInt8, value)
-  final case class Int16Keyword(name: String, value: Short) extends Keyword[Short](name, TypeInt16, value)
-  final case class Int32Keyword(name: String, value: Int) extends Keyword[Int](name, TypeInt32, value)
-  final case class FloatKeyword(name: String, value: Float) extends Keyword[Float](name, TypeFloat, value)
-  final case class DoubleKeyword(name: String, value: Double) extends Keyword[Double](name, TypeDouble, value)
-  final case class BooleanKeyword(name: String, value: Boolean) extends Keyword[Boolean](name, TypeBoolean, value)
-  final case class StringKeyword(name: String, value: String) extends Keyword[String](name, TypeString, value)
-
-  // At the end, I want to just pass a list of keywords to be sent to the DHS. I cannot do this with Keyword[T],
-  // because I cannot mix different types in a List. But at the end I only care about the value as a String, so I
-  // use an internal representation, and offer a class to the developer (KeywordBag) to create the list from typed
-  // keywords.
-
-  final case class InternalKeyword(name: String, keywordType: KeywordType, value: String)
-
-  protected implicit def internalKeywordConvert[T](k: Keyword[T]): InternalKeyword = InternalKeyword(k.n, k.t, s"${k.v}")
-
-  final case class KeywordBag(keywords: List[InternalKeyword]) {
-    def add[T](k: Keyword[T]): KeywordBag = KeywordBag(keywords :+ internalKeywordConvert(k))
-    def append(other: KeywordBag): KeywordBag =  KeywordBag(keywords ::: other.keywords)
-  }
-
-  //TODO: Add more apply methods if necessary
-  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object KeywordBag {
-    def empty: KeywordBag = KeywordBag(List())
-    def apply[A](k1: Keyword[A]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1)))
-    def apply[A, B](k1: Keyword[A], k2: Keyword[B]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2)))
-    def apply[A, B, C](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C]): KeywordBag =
-      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3)))
-    def apply[A, B, C, D](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D]): KeywordBag =
-      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
-        internalKeywordConvert(k4)))
-    def apply[A, B, C, D, E](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E]): KeywordBag =
-      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
-        internalKeywordConvert(k4), internalKeywordConvert(k5)))
-    def apply[A, B, C, D, E, F](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E], k6: Keyword[F]): KeywordBag =
-      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
-        internalKeywordConvert(k4), internalKeywordConvert(k5), internalKeywordConvert(k6)))
-  }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClientHttp.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClientHttp.scala
@@ -14,7 +14,7 @@ import cats.data.EitherT
 import cats.effect.IO
 import seqexec.model.dhs.ImageFileId
 import seqexec.server._
-import seqexec.server.keywords.DhsClient.{ImageParameters, KeywordBag}
+import seqexec.server.keywords.DhsClient.ImageParameters
 import seqexec.server.SeqexecFailure.SeqexecExceptionWhile
 import org.apache.commons.httpclient.HttpClient
 import org.apache.commons.httpclient.methods.{EntityEnclosingMethod, PostMethod, PutMethod}
@@ -69,7 +69,7 @@ class DhsClientHttp(val baseURI: String) extends DhsClient {
   implicit def imageParametersEncode: EncodeJson[DhsClient.ImageParameters] = EncodeJson[DhsClient.ImageParameters]( p =>
     ("lifetime" := p.lifetime.str) ->: ("contributors" := p.contributors) ->: Json.jEmptyObject )
 
-  implicit def keywordEncode: EncodeJson[DhsClient.InternalKeyword] = EncodeJson[DhsClient.InternalKeyword]( k =>
+  implicit def keywordEncode: EncodeJson[InternalKeyword] = EncodeJson[InternalKeyword]( k =>
     ("name" := k.name) ->: ("type" := k.keywordType.str) ->: ("value" := k.value) ->: Json.jEmptyObject )
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClientHttp.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClientHttp.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package seqexec.server
+package seqexec.server.keywords
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -13,7 +13,8 @@ import Argonaut._
 import cats.data.EitherT
 import cats.effect.IO
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.DhsClient.{ImageParameters, KeywordBag}
+import seqexec.server._
+import seqexec.server.keywords.DhsClient.{ImageParameters, KeywordBag}
 import seqexec.server.SeqexecFailure.SeqexecExceptionWhile
 import org.apache.commons.httpclient.HttpClient
 import org.apache.commons.httpclient.methods.{EntityEnclosingMethod, PostMethod, PutMethod}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GDSClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GDSClient.scala
@@ -10,15 +10,11 @@ import org.http4s.client.Client
 /**
   * Gemini Data service client
   */
-final case class GDSClient[F[_]](client: Client[F]) {
+final case class GDSClient[F[_]](client: Client[F]) extends KeywordsClient {
   /**
     * Set the keywords for an image
     */
-  def setKeywords(id: ImageFileId, keywords: DhsClient.KeywordBag, finalFlag: Boolean): SeqAction[Unit] = {
-    println("DHS")
-    println(id)
-    println(keywords)
-    println(finalFlag)
+  def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): SeqAction[Unit] = {
     SeqAction.void
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GDSClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GDSClient.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.keywords
+
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.SeqAction
+import org.http4s.client.Client
+
+/**
+  * Gemini Data service client
+  */
+final case class GDSClient[F[_]](client: Client[F]) {
+  /**
+    * Set the keywords for an image
+    */
+  def setKeywords(id: ImageFileId, keywords: DhsClient.KeywordBag, finalFlag: Boolean): SeqAction[Unit] = {
+    println("DHS")
+    println(id)
+    println(keywords)
+    println(finalFlag)
+    SeqAction.void
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import seqexec.model.dhs.ImageFileId
+
+package keywords {
+  /**
+   * Clients that can send keywords to a server that could e.g. write them to a file
+   */
+  trait KeywordsClient {
+    def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): SeqAction[Unit]
+  }
+
+  trait DhsInstrument extends KeywordsClient {
+    val dhsClient: DhsClient
+
+    val dhsInstrumentName: String
+
+    def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): SeqAction[Unit] =
+      dhsClient.setKeywords(id, keywords, finalFlag)
+  }
+
+  final case class StandaloneDhsClient(dhsClient: DhsClient) extends KeywordsClient {
+    override def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): SeqAction[Unit] =
+      dhsClient.setKeywords(id, keywords, finalFlag)
+  }
+
+  // TODO: Implement the unsigned types, if needed.
+  sealed case class KeywordType protected (str: String)
+  object TypeInt8 extends KeywordType("INT8")
+  object TypeInt16 extends KeywordType("INT16")
+  object TypeInt32 extends KeywordType("INT32")
+  object TypeFloat extends KeywordType("FLOAT")
+  object TypeDouble extends KeywordType("DOUBLE")
+  object TypeBoolean extends KeywordType("BOOLEAN")
+  object TypeString extends KeywordType("STRING")
+
+
+  // The developer uses these classes to define all the typed keywords
+  sealed class Keyword[T] protected (val n: String, val t: KeywordType, val v: T)
+  final case class Int8Keyword(name: String, value: Byte) extends Keyword[Byte](name, TypeInt8, value)
+  final case class Int16Keyword(name: String, value: Short) extends Keyword[Short](name, TypeInt16, value)
+  final case class Int32Keyword(name: String, value: Int) extends Keyword[Int](name, TypeInt32, value)
+  final case class FloatKeyword(name: String, value: Float) extends Keyword[Float](name, TypeFloat, value)
+  final case class DoubleKeyword(name: String, value: Double) extends Keyword[Double](name, TypeDouble, value)
+  final case class BooleanKeyword(name: String, value: Boolean) extends Keyword[Boolean](name, TypeBoolean, value)
+  final case class StringKeyword(name: String, value: String) extends Keyword[String](name, TypeString, value)
+
+  // At the end, I want to just pass a list of keywords to be sent to the DHS. I cannot do this with Keyword[T],
+  // because I cannot mix different types in a List. But at the end I only care about the value as a String, so I
+  // use an internal representation, and offer a class to the developer (KeywordBag) to create the list from typed
+  // keywords.
+
+  private[keywords] final case class InternalKeyword(name: String, keywordType: KeywordType, value: String)
+
+  final case class KeywordBag(keywords: List[InternalKeyword]) {
+    def add[T](k: Keyword[T]): KeywordBag = KeywordBag(keywords :+ internalKeywordConvert(k))
+    def append(other: KeywordBag): KeywordBag =  KeywordBag(keywords ::: other.keywords)
+  }
+
+  //TODO: Add more apply methods if necessary
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  object KeywordBag {
+    def empty: KeywordBag = KeywordBag(List())
+    def apply[A](k1: Keyword[A]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1)))
+    def apply[A, B](k1: Keyword[A], k2: Keyword[B]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2)))
+    def apply[A, B, C](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3)))
+    def apply[A, B, C, D](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4)))
+    def apply[A, B, C, D, E](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4), internalKeywordConvert(k5)))
+    def apply[A, B, C, D, E, F](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E], k6: Keyword[F]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4), internalKeywordConvert(k5), internalKeywordConvert(k6)))
+  }
+}
+
+package object keywords {
+
+  def internalKeywordConvert[T](k: Keyword[T]): InternalKeyword = InternalKeyword(k.n, k.t, s"${k.v}")
+}

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -16,6 +16,7 @@ import seqexec.model.Model.Instrument.GmosS
 import seqexec.model.Model.{SequenceMetadata, SequenceState, StepConfig}
 import seqexec.server.SeqTranslate.ObserveContext
 import seqexec.server.keywords.DhsClientSim
+import seqexec.server.keywords.GDSClient
 import seqexec.server.flamingos2.Flamingos2ControllerSim
 import seqexec.server.gcal.GcalControllerEpics
 import seqexec.server.gmos.GmosControllerSim
@@ -64,12 +65,12 @@ class SeqTranslateSpec extends FlatSpec {
     new ODBProxy(new Peer("localhost", 8443, null), ODBProxy.DummyOdbCommands),
     DhsClientSim(LocalDate.of(2016, 4, 15)),
     TcsControllerEpics,
-    GcalControllerEpics,
+    GcalControllerEpics(DhsClientSim(LocalDate.of(2016, 4, 15))),
     Flamingos2ControllerSim,
     GmosControllerSim.south,
     GmosControllerSim.north,
     GnirsControllerSim,
-    GPIController(new GPIClient(Giapi.giapiConnectionIO.connect.unsafeRunSync, scala.concurrent.ExecutionContext.Implicits.global))
+    GPIController(new GPIClient(Giapi.giapiConnectionIO.connect.unsafeRunSync, scala.concurrent.ExecutionContext.Implicits.global), new GDSClient[IO](null))
   )
 
   private val translatorSettings = SeqTranslate.Settings(tcsKeywords = false, f2Keywords = false, gwsKeywords = false,

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -15,6 +15,7 @@ import seqexec.model.ActionType
 import seqexec.model.Model.Instrument.GmosS
 import seqexec.model.Model.{SequenceMetadata, SequenceState, StepConfig}
 import seqexec.server.SeqTranslate.ObserveContext
+import seqexec.server.keywords.DhsClientSim
 import seqexec.server.flamingos2.Flamingos2ControllerSim
 import seqexec.server.gcal.GcalControllerEpics
 import seqexec.server.gmos.GmosControllerSim

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -159,7 +159,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
       SeqexecEngine.observeStatus(executions) shouldBe ActionStatus.Paused
     }
 
-  private val seqexecEngine = SeqexecEngine(defaultSettings)
+  private val seqexecEngine = SeqexecEngine(null, defaultSettings)
   private def advanceOne(q: EventQueue, s0: executeEngine.StateType, put: IO[Either[SeqexecFailure, Unit]]): Stream[Pure, Option[executeEngine.StateType]] =
     Stream.emit((put *> executeEngine.process(q.dequeue)(s0).take(1).compile.last).unsafeRunSync.map(_._2))
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -24,9 +24,9 @@ import seqexec.model.{ActionType, UserDetails}
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class SeqexecEngineSpec extends FlatSpec with Matchers {
   private val defaultSettings = Settings(Site.GS,
-    "localhost",
-    LocalDate.of(2017, 1, 1),
-    "http://localhost/",
+    odbHost = "localhost",
+    date = LocalDate.of(2017, 1, 1),
+    dhsURI = "http://localhost/",
     dhsSim = true,
     tcsSim = true,
     instSim = true,
@@ -38,6 +38,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
     gwsKeywords = false,
     gcalKeywords = false,
     gnirsKeywords = false,
+    gpiKeywords = SeqexecEngine.GPIKeywords.GPIKeywordsSimulated,
     instForceError = false,
     failAt = 0,
     10.seconds,

--- a/modules/seqexec/server/src/test/scala/seqexec/server/keywords/DhsClientSimSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/keywords/DhsClientSimSpec.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package seqexec.server
+package seqexec.server.keywords
 
 import java.time.LocalDate
 
-import seqexec.server.DhsClient.{Int32Keyword, KeywordBag, Permanent}
+import seqexec.server.keywords.DhsClient.{Int32Keyword, KeywordBag, Permanent}
 import org.scalatest.{FlatSpec, Matchers}
 
 class DhsClientSimSpec extends FlatSpec with Matchers {

--- a/modules/seqexec/server/src/test/scala/seqexec/server/keywords/DhsClientSimSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/keywords/DhsClientSimSpec.scala
@@ -5,7 +5,7 @@ package seqexec.server.keywords
 
 import java.time.LocalDate
 
-import seqexec.server.keywords.DhsClient.{Int32Keyword, KeywordBag, Permanent}
+import seqexec.server.keywords.DhsClient.Permanent
 import org.scalatest.{FlatSpec, Matchers}
 
 class DhsClientSimSpec extends FlatSpec with Matchers {

--- a/modules/seqexec/web/server/src/main/resources/app.conf
+++ b/modules/seqexec/web/server/src/main/resources/app.conf
@@ -66,4 +66,5 @@ seqexec-engine {
     # Tmp file for development
     smartGCalDir = "/tmp/smartgcal"
     gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
+    gpiKeywords = true
 }


### PR DESCRIPTION
On the process to support GDS I realized that the base code on the seqexec server needs a refactoring to make it less dhs specific. Most of the keyword related logic assumes the DHS is used with no room for the GDS which behaves differently.

Another aspect is there is an assumption of a single DHS while there are multiple GDS. This is now abstracted away on a `KeywordsClient` that is a property of `InstrumentSystem`

At the end there is still no logic to actually send commands to the GDS but this refactor will let us work with both DHS and GDS

Further changes will be needed in the near future but I wanted to send this PR to make it easier to review