### PR TITLE
SEQNG-631: Support navigating steps from the configuration table

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -1,3 +1,5 @@
+@import "~semantic-ui-less/themes/default/globals/site.variables";
+
 @color_2: #573a08;
 @color_3: black;
 @text_color: rgba(0, 0, 0, 0.95);
@@ -692,6 +694,14 @@ body {
 
 .ReactVirtualized__Table__headerTruncatedText {
   flex: auto;
+}
+
+// Get the same background color as a button
+.SeqexecStyles-labelAsButton {
+  @import "~semantic-ui-less/themes/default/elements/button.variables";
+  background: @background !important;
+  padding-top: @verticalPadding !important;
+  padding-bottom: @verticalPadding !important;
 }
 
 //===========================

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -10,6 +10,7 @@ import seqexec.model.events._
 import seqexec.web.client.semanticui.elements.checkbox.Checkbox
 import seqexec.web.client.semanticui.elements.icon.Icon.{IconCopy, IconAngleDoubleDown, IconAngleDoubleUp}
 import seqexec.web.client.semanticui.elements.button.Button
+import seqexec.web.client.semanticui.elements.button.Button.LeftLabeled
 import seqexec.web.client.semanticui.{Size => SSize}
 import seqexec.web.client.model.{GlobalLog, SectionOpen}
 import seqexec.web.client.actions.ToggleLogArea
@@ -181,7 +182,7 @@ object LogArea {
               SeqexecStyles.logControlRow,
               <.div(
                 ^.cls := "ui six wide column",
-                Button(Button.Props(icon = Option(toggleIcon), labeled = true, compact = true, size = SSize.Small, onClick = p.log.dispatchCB(ToggleLogArea)), toggleText)
+                Button(Button.Props(icon = Option(toggleIcon), labeled = LeftLabeled, compact = true, size = SSize.Small, onClick = p.log.dispatchCB(ToggleLogArea)), toggleText)
               ),
               <.div(
                 ^.cls := "ui ten wide column",

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -202,4 +202,6 @@ object SeqexecStyles {
   val controlCellRow: GStyle = GStyle.fromString("SeqexecStyles-controlCellRow")
 
   val settingsCellRow: GStyle = GStyle.fromString("SeqexecStyles-settingsCellRow")
+
+  val labelAsButton: GStyle = GStyle.fromString("SeqexecStyles-labelAsButton")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -11,8 +11,8 @@ import seqexec.web.client.model.Pages.{InstrumentPage, SequencePage, SeqexecPage
 import seqexec.web.client.circuit.{SeqexecCircuit, InstrumentStatusFocus}
 import seqexec.web.client.semanticui._
 import seqexec.web.client.semanticui.elements.icon.Icon._
-import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.semanticui.elements.label.Label
+import seqexec.web.client.components.SeqexecStyles
 import web.client.style._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.component.Scala.Unmounted

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -35,13 +35,15 @@ object SequenceStepsTableContainer {
   def updateStepToRun(step: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.set(State(step)).liftCB
 
-  def toolbar(p: Props): VdomElement =
-    p.p().stepConfigDisplayed.fold{
+  def toolbar(p: Props): VdomElement = {
+    val statusAndStep = p.p()
+    statusAndStep.stepConfigDisplayed.fold{
       <.div(
-        SequenceDefaultToolbar(p).when(p.p().isLogged),
-        SequenceAnonymousToolbar(p.site, p.p().instrument).unless(p.p().isLogged)
+        SequenceDefaultToolbar(p).when(statusAndStep.isLogged),
+        SequenceAnonymousToolbar(p.site, statusAndStep.instrument).unless(statusAndStep.isLogged)
       ): VdomElement
-    }(s => p.p().id.fold(ReactFragment())(id => StepConfigToolbar(StepConfigToolbar.Props(p.router, p.site, p.p().instrument, id, s))))
+    }(s => statusAndStep.id.fold(ReactFragment())(id => StepConfigToolbar(StepConfigToolbar.Props(p.router, p.site, statusAndStep.instrument, id, s, statusAndStep.totalSteps))))
+  }
 
   private val component = ScalaComponent.builder[Props]("SequenceStepsTableContainer")
     .initialState(State(0))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -17,6 +17,7 @@ import seqexec.web.client.actions.{RequestCancelPause, RequestPause, RequestSync
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.components.sequence.SequenceStepsTableContainer
 import seqexec.web.client.semanticui.elements.button.Button
+import seqexec.web.client.semanticui.elements.button.Button.LeftLabeled
 import seqexec.web.client.semanticui.elements.popup.Popup
 import seqexec.web.client.semanticui.elements.icon.Icon
 import seqexec.web.client.semanticui.elements.icon.Icon.{IconRefresh, IconPlay, IconPause, IconBan}
@@ -62,7 +63,7 @@ object SequenceControl {
       Button(
         Button.Props(
           icon = Some(icon),
-          labeled = true,
+          labeled = LeftLabeled,
           onClick = onClick,
           color = Some(color),
           disabled = disabled),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -75,7 +75,7 @@ object StepConfigToolbar {
                 (p.router.link(SequenceConfigPage(p.instrument, p.id, p.step))
                   (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = previousStep(p)), "Prev"))): VdomElement,
                 ReactFragment()),
-              Label(Label.Props(RunningStep(p.step, p.total).show, size = Size.Large)),
+              Label(Label.Props(RunningStep(p.step, p.total).show, size = Size.Large, extraStyles = List(SeqexecStyles.labelAsButton))),
               (p.step < p.total - 1).fold(
                 (p.router.link(SequenceConfigPage(p.instrument, p.id, p.step + 2))
                   (Button(Button.Props(icon = Some(IconChevronRight), labeled = RightLabeled, onClick = nextStep(p)), "Next"))): VdomElement,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -3,30 +3,43 @@
 
 package seqexec.web.client.components.sequence.toolbars
 
+import cats.implicits._
 import gem.Observation
-import seqexec.model.Model.{Instrument, SeqexecSite, StepId}
-import seqexec.web.client.model.Pages._
-import seqexec.web.client.circuit.SeqexecCircuit
-import seqexec.web.client.components.SeqexecStyles
-import seqexec.web.client.actions.NavigateSilentTo
-import seqexec.web.client.semanticui.elements.button.Button
-import seqexec.web.client.semanticui.elements.icon.Icon.IconChevronLeft
-import web.client.style._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
+import seqexec.model.Model.{Instrument, SeqexecSite}
+import seqexec.web.client.model.Pages._
+import seqexec.web.client.ModelOps._
+import seqexec.web.client.circuit.SeqexecCircuit
+import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.actions.NavigateSilentTo
+import seqexec.web.client.semanticui.elements.button.ButtonGroup
+import seqexec.web.client.semanticui.elements.button.Button
+import seqexec.web.client.semanticui.elements.button.Button._
+import seqexec.web.client.semanticui.elements.icon.Icon.{IconChevronLeft, IconChevronRight}
+import seqexec.web.client.semanticui.elements.label.Label
+import seqexec.web.client.semanticui.Size
+import web.client.style._
+import mouse.boolean._
 
 /**
   * Toolbar when displaying a step configuration
   */
 object StepConfigToolbar {
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite, instrument: Instrument, id: Observation.Id, step: StepId) {
+  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite, instrument: Instrument, id: Observation.Id, step: Int, total: Int) {
     protected[sequence] val sequenceInfoConnects = site.instruments.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i)))).toMap
   }
 
   def backToSequence(p: Props): Callback =
     SeqexecCircuit.dispatchCB(NavigateSilentTo(SequencePage(p.instrument, p.id, p.step)))
+
+  def previousStep(p: Props): Callback =
+    SeqexecCircuit.dispatchCB(NavigateSilentTo(SequenceConfigPage(p.instrument, p.id, p.step)))
+
+  def nextStep(p: Props): Callback =
+    SeqexecCircuit.dispatchCB(NavigateSilentTo(SequenceConfigPage(p.instrument, p.id, p.step + 1)))
 
   private val component = ScalaComponent.builder[Props]("StepConfigToolbar")
     .stateless
@@ -50,17 +63,23 @@ object StepConfigToolbar {
             SeqexecStyles.shorterFields,
             <.div(
               p.router.link(SequencePage(p.instrument, p.id, p.step))
-                (Button(Button.Props(icon = Some(IconChevronLeft), labeled = true, onClick = backToSequence(p)), "Back"))
+                (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = backToSequence(p)), "Back"))
             )
           ),
           <.div(
             ^.cls := "ui right floated eight wide column",
-            <.div(
-              SeqexecStyles.configLabel,
-              <.h5(
-                ^.cls := "ui header",
-                s" Configuration for step ${p.step + 1}"
-              )
+            SeqexecStyles.shorterFields,
+            ButtonGroup(
+              ButtonGroup.Props(List(GStyle.fromString("right floated"))),
+              (p.step > 0).fold(
+                (p.router.link(SequenceConfigPage(p.instrument, p.id, p.step))
+                  (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = previousStep(p)), "Prev"))): VdomElement,
+                ReactFragment()),
+              Label(Label.Props(RunningStep(p.step, p.total).show, size = Size.Large)),
+              (p.step < p.total - 1).fold(
+                (p.router.link(SequenceConfigPage(p.instrument, p.id, p.step + 2))
+                  (Button(Button.Props(icon = Some(IconChevronRight), labeled = RightLabeled, onClick = nextStep(p)), "Next"))): VdomElement,
+                ReactFragment())
             )
           )
         )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
@@ -50,7 +50,7 @@ object circuit {
   final case class InstrumentStatusFocus(instrument: Instrument, active: Boolean, idState: Option[(Observation.Id, SequenceState)], runningStep: Option[RunningStep]) extends UseValueEq
   final case class InstrumentTabContentFocus(instrument: Instrument, active: Boolean, sequenceSelected: Boolean, logDisplayed: SectionVisibilityState) extends UseValueEq
   final case class StatusAndObserverFocus(isLogged: Boolean, name: Option[String], instrument: Instrument, id: Option[Observation.Id], observer: Option[Observer], status: Option[SequenceState], targetName: Option[TargetName]) extends UseValueEq
-  final case class StatusAndStepFocus(isLogged: Boolean, instrument: Instrument, id: Option[Observation.Id], stepConfigDisplayed: Option[Int]) extends UseValueEq
+  final case class StatusAndStepFocus(isLogged: Boolean, instrument: Instrument, id: Option[Observation.Id], stepConfigDisplayed: Option[Int], totalSteps: Int) extends UseValueEq
   final case class StepsTableFocus(id: Observation.Id, instrument: Instrument, state: SequenceState, steps: List[Step], stepConfigDisplayed: Option[Int], nextStepToRun: Option[Int]) extends UseValueEq
   final case class StepsTableAndStatusFocus(status: ClientStatus, stepsTable: Option[StepsTableFocus]) extends UseValueEq
   final case class ControlModel(id: Observation.Id, isPartiallyExecuted: Boolean, nextStepToRun: Option[Int], status: SequenceState, inConflict: Boolean) extends UseValueEq
@@ -168,7 +168,8 @@ object circuit {
 
     def statusAndStepReader(i: Instrument): ModelR[SeqexecAppRootModel, StatusAndStepFocus] =
       statusReader.zip(instrumentTab(i)).zoom {
-        case (status, InstrumentTabActive(tab, _)) => StatusAndStepFocus(status.isLogged, i, tab.sequence.map(_.id), tab.stepConfigDisplayed)
+        case (status, InstrumentTabActive(tab, _)) =>
+        StatusAndStepFocus(status.isLogged, i, tab.sequence.map(_.id), tab.stepConfigDisplayed, tab.sequence.foldMap(_.steps.length))
       }
 
     def stepsTableReaderF(i: Instrument): ModelR[SeqexecAppRootModel, Option[StepsTableFocus]] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/button/Button.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/button/Button.scala
@@ -16,7 +16,7 @@ import cats.implicits._
 
 object Button {
   sealed trait ButtonState
-  case object Active extends ButtonState
+  case object Active   extends ButtonState
   case object Inactive extends ButtonState
 
   object ButtonState {
@@ -25,18 +25,18 @@ object Button {
 
   sealed trait Emphasis
   case object NoEmphasis extends Emphasis
-  case object Primary extends Emphasis
-  case object Secondary extends Emphasis
+  case object Primary    extends Emphasis
+  case object Secondary  extends Emphasis
 
   object Emphasis {
     implicit val equal: Eq[Emphasis] = Eq.fromUniversalEquals
   }
 
   sealed trait Animated
-  case object NotAnimated extends Animated
+  case object NotAnimated    extends Animated
   case object AnimatedButton extends Animated
-  case object Vertical extends Animated
-  case object Fade extends Animated
+  case object Vertical       extends Animated
+  case object Fade           extends Animated
 
   object Animated {
     implicit val equal: Eq[Animated] = Eq.fromUniversalEquals
@@ -44,91 +44,106 @@ object Button {
 
   sealed trait Type
   case object ButtonType extends Type
-  case object ResetType extends Type
+  case object ResetType  extends Type
   case object SubmitType extends Type
+
+  sealed trait Labeled
+  case object NotLabeled   extends Labeled
+  case object LeftLabeled  extends Labeled
+  case object RightLabeled extends Labeled
+
+  object Labeled {
+    implicit val equal: Eq[Labeled] = Eq.fromUniversalEquals
+  }
 
   object Type {
     implicit val equal: Eq[Type] = Eq.fromUniversalEquals
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  final case class Props(state: ButtonState                    = Inactive,
-                   emphasis   : Emphasis                       = NoEmphasis,
-                   animated   : Animated                       = NotAnimated,
-                   icon       : Option[Icon]                   = None,
-                   size       : Size                           = Size.NotSized,
-                   buttonType : Type                           = ButtonType,
-                   form       : Option[String]                 = None,
-                   basic      : Boolean                        = false,
-                   inverted   : Boolean                        = false,
-                   circular   : Boolean                        = false,
-                   labeled    : Boolean                        = false,
-                   compact    : Boolean                        = false,
-                   disabled   : Boolean                        = false,
-                   tabIndex   : Option[Int]                    = None,
-                   color      : Option[String]                 = None,
-                   onClick    : Callback                       = Callback.empty,
-                   dataTooltip: Option[String]                 = None,
-                   extraStyles: List[GStyle]                   = Nil)
+  final case class Props(state: ButtonState = Inactive,
+                         emphasis: Emphasis = NoEmphasis,
+                         animated: Animated = NotAnimated,
+                         icon: Option[Icon] = None,
+                         size: Size = Size.NotSized,
+                         buttonType: Type = ButtonType,
+                         form: Option[String] = None,
+                         basic: Boolean = false,
+                         inverted: Boolean = false,
+                         circular: Boolean = false,
+                         labeled: Labeled = NotLabeled,
+                         compact: Boolean = false,
+                         disabled: Boolean = false,
+                         tabIndex: Option[Int] = None,
+                         color: Option[String] = None,
+                         onClick: Callback = Callback.empty,
+                         dataTooltip: Option[String] = None,
+                         extraStyles: List[GStyle] = Nil)
 
   private def classSet(p: Props): TagMod =
     ^.classSet(
-      "active"    -> (p.state === Active),
-      "primary"   -> (p.emphasis === Primary),
-      "secondary" -> (p.emphasis === Secondary),
-      "animated"  -> (p.animated =!= NotAnimated),
-      "vertical"  -> (p.animated === Vertical),
-      "fade"      -> (p.animated === Fade),
-      "icon"      -> p.icon.isDefined,
-      "basic"     -> p.basic,
-      "inverted"  -> p.inverted,
-      "circular"  -> p.circular,
-      "labeled"   -> p.labeled,
-      "disabled"  -> p.disabled,
-      "compact"   -> p.compact,
-      "tiny"      -> (p.size === Size.Tiny),
-      "mini"      -> (p.size === Size.Mini),
-      "small"     -> (p.size === Size.Small),
-      "large"     -> (p.size === Size.Large),
-      "big"       -> (p.size === Size.Big),
-      "huge"      -> (p.size === Size.Huge),
-      "massive"   -> (p.size === Size.Massive)
+      "active"        -> (p.state === Active),
+      "primary"       -> (p.emphasis === Primary),
+      "secondary"     -> (p.emphasis === Secondary),
+      "animated"      -> (p.animated =!= NotAnimated),
+      "vertical"      -> (p.animated === Vertical),
+      "fade"          -> (p.animated === Fade),
+      "icon"          -> p.icon.isDefined,
+      "basic"         -> p.basic,
+      "inverted"      -> p.inverted,
+      "circular"      -> p.circular,
+      "labeled"       -> (p.labeled === LeftLabeled),
+      "right labeled" -> (p.labeled === RightLabeled),
+      "disabled"      -> p.disabled,
+      "compact"       -> p.compact,
+      "tiny"          -> (p.size === Size.Tiny),
+      "mini"          -> (p.size === Size.Mini),
+      "small"         -> (p.size === Size.Small),
+      "large"         -> (p.size === Size.Large),
+      "big"           -> (p.size === Size.Big),
+      "huge"          -> (p.size === Size.Huge),
+      "massive"       -> (p.size === Size.Massive)
     )
 
-  private def component = ScalaComponent.builder[Props]("Button")
-    .renderPC((_, p, c) =>
-      if (p.animated === NotAnimated)
-        <.button(
-          ^.cls := "ui button",
-          p.extraStyles.map(geminiStyleToTagMod).toTagMod,
-          ^.`type` := (p.buttonType match {
-            case ButtonType => "button"
-            case SubmitType => "submit"
-            case ResetType  => "reset"
-          }),
-          p.form.map(f => formId := f).whenDefined,
-          p.color.map(u => ^.cls := u).whenDefined,
-          p.dataTooltip.map(t => dataTooltip := t).whenDefined,
-          classSet(p),
-          ^.onClick --> p.onClick,
-          p.icon.whenDefined,
-          c
-        )
-      else {
-        <.div(
-          ^.cls := "ui button",
-          ^.tabIndex :=? p.tabIndex,
-          classSet(p),
-          ^.onClick --> p.onClick,
-          p.icon.whenDefined,
-          c
-        )
-      }
-    ).build
+  private def component =
+    ScalaComponent
+      .builder[Props]("Button")
+      .renderPC(
+        (_, p, c) =>
+          if (p.animated === NotAnimated)
+            <.button(
+              ^.cls := "ui button",
+              p.extraStyles.map(geminiStyleToTagMod).toTagMod,
+              ^.`type` := (p.buttonType match {
+                case ButtonType => "button"
+                case SubmitType => "submit"
+                case ResetType  => "reset"
+              }),
+              p.form.map(f => formId := f).whenDefined,
+              p.color.map(u => ^.cls := u).whenDefined,
+              p.dataTooltip.map(t => dataTooltip := t).whenDefined,
+              classSet(p),
+              ^.onClick --> p.onClick,
+              p.icon.whenDefined,
+              c
+            )
+          else {
+            <.div(
+              ^.cls := "ui button",
+              ^.tabIndex :=? p.tabIndex,
+              classSet(p),
+              ^.onClick --> p.onClick,
+              p.icon.whenDefined,
+              c
+            )
+        })
+      .build
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  def apply(p: Props, children: VdomNode*): Unmounted[Props, Unit, Unit] = component(p)(children: _*)
+  def apply(p: Props, children: VdomNode*): Unmounted[Props, Unit, Unit] =
+    component(p)(children: _*)
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  def apply(text: String): Unmounted[Props, Unit, Unit] = component(Props())(text)
+  def apply(text: String): Unmounted[Props, Unit, Unit] =
+    component(Props())(text)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/button/ButtonGroup.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/button/ButtonGroup.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.semanticui.elements.button
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import web.client.style._
+
+object ButtonGroup {
+
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  final case class Props(extraStyles: List[GStyle] = Nil)
+
+  private def component =
+    ScalaComponent
+      .builder[Props]("ButtonGroup")
+      .renderPC(
+        (_, p, c) =>
+          <.div(
+            p.extraStyles.map(geminiStyleToTagMod).toTagMod,
+            ^.cls := "ui buttons",
+            c
+        ))
+      .build
+
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  def apply(p: Props, children: VdomNode*): Unmounted[Props, Unit, Unit] =
+    component(p)(children: _*)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  def apply(children: VdomNode*): Unmounted[Props, Unit, Unit] =
+    component(Props())(children: _*)
+}


### PR DESCRIPTION
This is an idea I got from using GPI. often I'd like to check the config of step N and then check step N+1 but this meant navigating back to the steps table.

In this PR I'm adding buttons to navigate directly on the config page. I hope it is useful.

I'm also using this PR to check if I can reuse semantic ui less variables. This will be very helpful on theming.

![screencast 2018-07-06 12-19-21](https://user-images.githubusercontent.com/3615303/42389886-1b9ed632-8118-11e8-8991-b5cb73e88308.gif)
