### PR TITLE
SEQNG-645 Fixes display for rows with breakpoints and completed

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -1,4 +1,5 @@
 @import "~semantic-ui-less/themes/default/globals/site.variables";
+@import "~semantic-ui-less/themes/default/collections/table.variables";
 
 @color_2: #573a08;
 @color_3: black;
@@ -15,7 +16,6 @@
 @background_color_6: #f9fafb;
 @background_color_7: rgba(0, 0, 0, 0.05);
 @background_color_8: #fff6f6;
-@background_color_9: #e0e0e0;
 @background_color_10: #fcfff5;
 @border_color: rgba(34, 36, 38, 0.15);
 @table_row_left_padding: 7px;
@@ -401,7 +401,7 @@ body {
 }
 
 .SeqexecStyles-rowActive {
-  background-color: @background_color_9;
+  background-color: @background;
   color: @color_7;
   box-shadow: 0px 0px 0px rgba(0, 0, 0, 0.87) inset;
   background-clip: padding-box;
@@ -421,7 +421,12 @@ body {
 
 .SeqexecStyles-rowDisabled {
   pointer-events: none;
-  color: @color_6;
+  background: @background;
+  color: @disabledTextColor;
+}
+
+.SeqexecStyles-rowNone {
+  background: @background;
 }
 
 .stepRowWithBreakpoint() {
@@ -429,8 +434,6 @@ body {
   text-overflow: ellipsis;
   word-wrap: break-word;
   white-space: nowrap;
-  background-color: @background_color_1;
-  color: @text_color;
   .borderRight();
   .borderTop();
   background-size: 100% 4px;
@@ -442,6 +445,7 @@ body {
 
 .SeqexecStyles-stepRowWithBreakpoint {
   .stepRowWithBreakpoint();
+  background: @background;
   background-image: linear-gradient(
     to right,
     @breakpoint_line_color 0px,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -124,7 +124,7 @@ object StepsTable {
     case s if s.status === StepState.Paused  => SeqexecStyles.rowNegative
     case s if s.status === StepState.Skipped => SeqexecStyles.rowActive
     case s if s.isFinished                   => SeqexecStyles.rowDisabled
-    case _                                   => SeqexecStyles.rowNone
+    case _                                   => SeqexecStyles.stepRow
   }
 
   def rowClassName(p: Props)(i: Int): String = ((i, p.rowGetter(i), p.loggedIn) match {


### PR DESCRIPTION
Just some css changes to fix SEQNG-645. now it looks correct:

![seqexec - gs-test-01-30 2018-07-09 11-45-08](https://user-images.githubusercontent.com/3615303/42461142-cd463874-836d-11e8-939c-382f63bb9620.png)
