### PR TITLE
SEQNG-648: Use Site type from core

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/Model.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Model.scala
@@ -10,30 +10,9 @@ import cats.implicits._
 import cats.data.NonEmptyList
 import gem.Observation
 
-import java.time.ZoneId
-
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.IsInstanceOf"))
 // scalastyle:off
 object Model {
-  // We use this to avoid a dependency on spModel, should be replaced by gem
-  sealed trait SeqexecSite extends Product with Serializable {
-    def instruments: NonEmptyList[Instrument]
-    def timeZone: ZoneId
-  }
-  object SeqexecSite {
-    final case class SeqexecGN(timeZone: ZoneId) extends SeqexecSite {
-      val instruments: NonEmptyList[Instrument] = Instrument.gnInstruments
-    }
-
-    final case class SeqexecGS(timeZone: ZoneId) extends SeqexecSite {
-      val instruments : NonEmptyList[Instrument]= Instrument.gsInstruments
-    }
-
-    implicit val show: Show[SeqexecSite] = Show.show {
-      case SeqexecGN(_) => "GN"
-      case SeqexecGS(_) => "GS"
-    }
-  }
 
   sealed trait ServerLogLevel extends Product with Serializable
   object ServerLogLevel {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/SeqexecApp.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/SeqexecApp.scala
@@ -4,8 +4,8 @@
 package seqexec.web.client
 
 import cats.effect.IO
+import gem.enum.Site
 import java.util.logging.{Level, Logger}
-import java.time.ZoneId
 import org.scalajs.dom.document
 import org.scalajs.dom.raw.Element
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
@@ -14,7 +14,6 @@ import seqexec.web.client.services.log.ConsoleHandler
 import seqexec.web.client.services.SeqexecWebClient
 import seqexec.web.client.actions.Initialize
 import seqexec.web.client.circuit.SeqexecCircuit
-import seqexec.model.Model.SeqexecSite
 
 /**
   * Seqexec WebApp entry point
@@ -38,19 +37,16 @@ object SeqexecApp {
     ()
   }
 
-  def setupSite: IO[SeqexecSite] = IO.fromFuture {
+  def setupSite: IO[Site] = IO.fromFuture {
     IO {
       import scala.concurrent.ExecutionContext.Implicits.global
 
       // Read the site from the webserver
-      SeqexecWebClient.site().map {
-        case "GN" => SeqexecSite.SeqexecGN(ZoneId.of("Pacific/Honolulu"))
-        case _    => SeqexecSite.SeqexecGS(ZoneId.of("America/Santiago"))
-      }
+      SeqexecWebClient.site().map(Site.fromTag(_).getOrElse(Site.GS))
     }
   }
 
-  def initializeDataModel(seqexecSite: SeqexecSite): IO[Unit] = IO {
+  def initializeDataModel(seqexecSite: Site): IO[Unit] = IO {
     // Set the instruments before adding it to the dom
     SeqexecCircuit.dispatch(Initialize(seqexecSite))
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
@@ -3,7 +3,6 @@
 
 package seqexec.web.client.components
 
-import cats.implicits._
 import diode.react.ModelProxy
 import diode.react.ReactPot._
 import gem.enum.Site
@@ -15,7 +14,6 @@ import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.model.WebSocketConnection
 import seqexec.web.client.model.Pages.Root
 import seqexec.web.client.OcsBuildInfo
-import seqexec.web.client.ModelOps._
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.elements.menu.HeaderItem
 import web.client.style._
@@ -40,7 +38,7 @@ object Footer {
         <.a(
           ^.cls := "header item",
           ^.onClick ==> goHome,
-          s"Seqexec - ${p.show}"
+          s"Seqexec - ${p.shortName}"
         ),
         HeaderItem(HeaderItem.Props(OcsBuildInfo.version, sub = true)),
         wsConnect(ConnectionState.apply),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
@@ -3,20 +3,21 @@
 
 package seqexec.web.client.components
 
+import cats.implicits._
 import diode.react.ModelProxy
 import diode.react.ReactPot._
-import seqexec.model.Model.SeqexecSite
+import gem.enum.Site
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.component.Scala.Unmounted
 import seqexec.web.client.actions.NavigateTo
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.model.WebSocketConnection
 import seqexec.web.client.model.Pages.Root
 import seqexec.web.client.OcsBuildInfo
+import seqexec.web.client.ModelOps._
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.elements.menu.HeaderItem
-import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.component.Scala.Unmounted
-import cats.implicits._
 import web.client.style._
 
 /**
@@ -31,7 +32,7 @@ object Footer {
     Callback(SeqexecCircuit.dispatch(NavigateTo(Root)))
   }
 
-  private val component = ScalaComponent.builder[SeqexecSite]("SeqexecAppBar")
+  private val component = ScalaComponent.builder[Site]("SeqexecAppBar")
     .stateless
     .render_P(p =>
       <.div(
@@ -58,7 +59,7 @@ object Footer {
     )
     .build
 
-  def apply(s: SeqexecSite): Unmounted[SeqexecSite, Unit, Unit] = component(s)
+  def apply(s: Site): Unmounted[Site, Unit, Unit] = component(s)
 }
 
 /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
@@ -39,7 +39,7 @@ object AppTitle {
         SeqexecStyles.notInMobile,
         <.h4(
           ^.cls := "ui horizontal divider header",
-          s"Seqexec ${p.site.show}",
+          s"Seqexec ${p.site.shortName}",
           p.ws().ws.renderPending(_ =>
             <.div(
               SeqexecStyles.errorText,
@@ -120,7 +120,7 @@ object SeqexecUI {
     case SequenceConfigPage(_, id, _) => s"Seqexec - ${id.format}"
     case SequencePage(_, id, _)       => s"Seqexec - ${id.format}"
     case InstrumentPage(i)            => s"Seqexec - ${i.show}"
-    case _                            => s"Seqexec - ${site.show}"
+    case _                            => s"Seqexec - ${site.shortName}"
   }
 
   // Prism from url params to config page

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
@@ -15,18 +15,20 @@ import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import gem.Observation
+import gem.enum.Site
 import scala.scalajs.js.timers.SetTimeoutHandle
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.actions.WSConnect
 import seqexec.web.client.model.Pages._
+import seqexec.web.client.ModelOps._
 import seqexec.web.client.actions.{NavigateSilentTo, RequestSoundEcho}
 import seqexec.web.client.components.sequence.{HeadersSideBar, SequenceArea}
-import seqexec.model.Model.{Instrument, SeqexecSite}
+import seqexec.model.Model.Instrument
 import seqexec.web.client.model.WebSocketConnection
 import web.client.style._
 
 object AppTitle {
-  final case class Props(site: SeqexecSite, ws: ModelProxy[WebSocketConnection])
+  final case class Props(site: Site, ws: ModelProxy[WebSocketConnection])
 
   private val component = ScalaComponent.builder[Props]("SeqexecUI")
     .stateless
@@ -49,11 +51,11 @@ object AppTitle {
       )
     ).build
 
-  def apply(site: SeqexecSite, ws: ModelProxy[WebSocketConnection]): Unmounted[Props, Unit, Unit] = component(Props(site, ws))
+  def apply(site: Site, ws: ModelProxy[WebSocketConnection]): Unmounted[Props, Unit, Unit] = component(Props(site, ws))
 }
 
 object SeqexecMain {
-  final case class Props(site: SeqexecSite, ctl: RouterCtl[SeqexecPages])
+  final case class Props(site: Site, ctl: RouterCtl[SeqexecPages])
 
   private val lbConnect = SeqexecCircuit.connect(_.uiModel.loginBox)
   private val logConnect = SeqexecCircuit.connect(_.uiModel.globalLog)
@@ -105,7 +107,7 @@ object SeqexecMain {
       )
     ).build
 
-  def apply(site: SeqexecSite, ctl: RouterCtl[SeqexecPages]): Unmounted[Props, Unit, Unit] = component(Props(site, ctl))
+  def apply(site: Site, ctl: RouterCtl[SeqexecPages]): Unmounted[Props, Unit, Unit] = component(Props(site, ctl))
 }
 
 /**
@@ -114,7 +116,7 @@ object SeqexecMain {
 object SeqexecUI {
   final case class RouterProps(page: InstrumentPage, router: RouterCtl[InstrumentPage])
 
-  def pageTitle(site: SeqexecSite)(p: SeqexecPages): String = p match {
+  def pageTitle(site: Site)(p: SeqexecPages): String = p match {
     case SequenceConfigPage(_, id, _) => s"Seqexec - ${id.format}"
     case SequencePage(_, id, _)       => s"Seqexec - ${id.format}"
     case InstrumentPage(i)            => s"Seqexec - ${i.show}"
@@ -135,7 +137,7 @@ object SeqexecUI {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-  def router(site: SeqexecSite): IO[Router[SeqexecPages]] = {
+  def router(site: Site): IO[Router[SeqexecPages]] = {
     val instrumentNames = site.instruments.map(i => (i.show, i)).toList.toMap
 
     val routerConfig = RouterConfigDsl[SeqexecPages].buildConfig { dsl =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -3,10 +3,16 @@
 
 package seqexec.web.client.components.sequence
 
+import cats.implicits._
 import diode.react.ModelProxy
-import seqexec.model.Model.{SequenceState, SeqexecSite}
+import gem.enum.Site
+import japgolly.scalajs.react.extra.router.RouterCtl
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react._
+import seqexec.model.Model.SequenceState
 import seqexec.web.client.actions.{NavigateTo, SelectIdToDisplay, SelectInstrumentToDisplay}
-import seqexec.web.client.ModelOps.RunningStep
+import seqexec.web.client.ModelOps._
 import seqexec.web.client.model.Pages.{InstrumentPage, SequencePage, SeqexecPages}
 import seqexec.web.client.circuit.{SeqexecCircuit, InstrumentStatusFocus}
 import seqexec.web.client.semanticui._
@@ -14,14 +20,9 @@ import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.elements.label.Label
 import seqexec.web.client.components.SeqexecStyles
 import web.client.style._
-import japgolly.scalajs.react.extra.router.RouterCtl
-import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react._
-import cats.implicits._
 
 object InstrumentTab {
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite, t: ModelProxy[InstrumentStatusFocus])
+  final case class Props(router: RouterCtl[SeqexecPages], site: Site, t: ModelProxy[InstrumentStatusFocus])
 
   private val component = ScalaComponent.builder[Props]("InstrumentMenu")
     .stateless
@@ -102,7 +103,7 @@ object InstrumentTab {
   * Menu with tabs
   */
 object InstrumentsTabs {
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite) {
+  final case class Props(router: RouterCtl[SeqexecPages], site: Site) {
     protected[sequence] val instrumentConnects = site.instruments.toList.map(i => SeqexecCircuit.connect(SeqexecCircuit.instrumentStatusReader(i)))
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -3,27 +3,28 @@
 
 package seqexec.web.client.components.sequence
 
+import cats.implicits._
 import diode.react.ModelProxy
-import seqexec.web.client.components.sequence.toolbars.{SequenceDefaultToolbar, StepConfigToolbar, SequenceAnonymousToolbar}
-import seqexec.web.client.circuit.{SeqexecCircuit, StatusAndStepFocus, InstrumentTabContentFocus}
-import seqexec.web.client.model.Pages.SeqexecPages
-import seqexec.web.client.model.{SectionOpen, SectionClosed}
-import seqexec.web.client.semanticui._
-import seqexec.web.client.semanticui.elements.message.IconMessage
-import seqexec.web.client.semanticui.elements.icon.Icon.IconInbox
-import seqexec.web.client.components.SeqexecStyles
-import seqexec.web.client.components.sequence.steps.StepsTable
-import seqexec.model.Model.SeqexecSite
-import web.client.style._
+import gem.enum.Site
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.{CallbackTo, ScalaComponent, CatsReact}
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.CatsReact._
-import cats.implicits._
+import seqexec.web.client.components.sequence.toolbars.{SequenceDefaultToolbar, StepConfigToolbar, SequenceAnonymousToolbar}
+import seqexec.web.client.circuit.{SeqexecCircuit, StatusAndStepFocus, InstrumentTabContentFocus}
+import seqexec.web.client.model.Pages.SeqexecPages
+import seqexec.web.client.model.{SectionOpen, SectionClosed}
+import seqexec.web.client.ModelOps._
+import seqexec.web.client.semanticui._
+import seqexec.web.client.semanticui.elements.message.IconMessage
+import seqexec.web.client.semanticui.elements.icon.Icon.IconInbox
+import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.components.sequence.steps.StepsTable
+import web.client.style._
 
 object SequenceStepsTableContainer {
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite, p: ModelProxy[StatusAndStepFocus]) {
+  final case class Props(router: RouterCtl[SeqexecPages], site: Site, p: ModelProxy[StatusAndStepFocus]) {
     protected[sequence] val sequenceControlConnects = site.instruments.toList.fproduct(i => SeqexecCircuit.connect(SeqexecCircuit.sequenceControlReader(i))).toMap
     private[sequence] val instrumentConnects = site.instruments.toList.fproduct(i => SeqexecCircuit.connect(SeqexecCircuit.stepsTableReader(i))).toMap
     protected[sequence] val sequenceObserverConnects = site.instruments.toList.fproduct(i => SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i))).toMap
@@ -56,7 +57,7 @@ object SequenceStepsTableContainer {
       )
     }.build
 
-  def apply(router: RouterCtl[SeqexecPages], site: SeqexecSite, p: ModelProxy[StatusAndStepFocus]): Unmounted[Props, State, Unit] =
+  def apply(router: RouterCtl[SeqexecPages], site: Site, p: ModelProxy[StatusAndStepFocus]): Unmounted[Props, State, Unit] =
     component(Props(router, site, p))
 }
 
@@ -65,7 +66,7 @@ object SequenceStepsTableContainer {
 */
 object SequenceTabContent {
 
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite, p: ModelProxy[InstrumentTabContentFocus]) {
+  final case class Props(router: RouterCtl[SeqexecPages], site: Site, p: ModelProxy[InstrumentTabContentFocus]) {
     protected[sequence] val connect = SeqexecCircuit.connect(SeqexecCircuit.statusAndStepReader(p().instrument))
   }
 
@@ -91,7 +92,7 @@ object SequenceTabContent {
     }
     .build
 
-    def apply(router: RouterCtl[SeqexecPages], site: SeqexecSite, p: ModelProxy[InstrumentTabContentFocus]): Unmounted[Props, Unit, Unit] =
+    def apply(router: RouterCtl[SeqexecPages], site: Site, p: ModelProxy[InstrumentTabContentFocus]): Unmounted[Props, Unit, Unit] =
       component(Props(router, site, p))
 }
 
@@ -99,7 +100,7 @@ object SequenceTabContent {
  * Contains the area with tabs and the sequence body
  */
 object SequenceTabsBody {
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite) {
+  final case class Props(router: RouterCtl[SeqexecPages], site: Site) {
     protected[sequence] val instrumentConnects = site.instruments.toList.map(i => SeqexecCircuit.connect(SeqexecCircuit.instrumentTabContentReader(i)))
   }
 
@@ -112,7 +113,7 @@ object SequenceTabsBody {
       )
     ).build
 
-  def apply(router: RouterCtl[SeqexecPages], site: SeqexecSite): Unmounted[Props, Unit, Unit] =
+  def apply(router: RouterCtl[SeqexecPages], site: Site): Unmounted[Props, Unit, Unit] =
     component(Props(router, site))
 }
 
@@ -120,7 +121,7 @@ object SequenceTabsBody {
  * Top level container of the sequence area
  */
 object SequenceArea {
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite)
+  final case class Props(router: RouterCtl[SeqexecPages], site: Site)
 
   private val component = ScalaComponent.builder[Props]("QueueTableSection")
     .stateless
@@ -132,5 +133,5 @@ object SequenceArea {
       )
     ).build
 
-  def apply(router: RouterCtl[SeqexecPages], site: SeqexecSite): Unmounted[Props, Unit, Unit] = component(Props(router, site))
+  def apply(router: RouterCtl[SeqexecPages], site: Site): Unmounted[Props, Unit, Unit] = component(Props(router, site))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceAnonymousToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceAnonymousToolbar.scala
@@ -3,9 +3,11 @@
 
 package seqexec.web.client.components.sequence.toolbars
 
-import seqexec.model.Model.{Instrument, SeqexecSite}
+import gem.enum.Site
+import seqexec.model.Model.Instrument
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.ModelOps._
 import web.client.style._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.ScalaComponent
@@ -15,7 +17,7 @@ import japgolly.scalajs.react.component.Scala.Unmounted
   * Toolbar for anonymous users
   */
 object SequenceAnonymousToolbar {
-  final case class Props(site: SeqexecSite, instrument: Instrument) {
+  final case class Props(site: Site, instrument: Instrument) {
     protected[sequence] val instrumentConnects =
      site.instruments.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i)))).toMap
   }
@@ -36,5 +38,5 @@ object SequenceAnonymousToolbar {
       )
     ).build
 
-  def apply(site: SeqexecSite, i: Instrument): Unmounted[Props, Unit, Unit] = component(Props(site, i))
+  def apply(site: Site, i: Instrument): Unmounted[Props, Unit, Unit] = component(Props(site, i))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -5,11 +5,12 @@ package seqexec.web.client.components.sequence.toolbars
 
 import cats.implicits._
 import gem.Observation
+import gem.enum.Site
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import seqexec.model.Model.{Instrument, SeqexecSite}
+import seqexec.model.Model.Instrument
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.ModelOps._
 import seqexec.web.client.circuit.SeqexecCircuit
@@ -28,7 +29,7 @@ import mouse.boolean._
   * Toolbar when displaying a step configuration
   */
 object StepConfigToolbar {
-  final case class Props(router: RouterCtl[SeqexecPages], site: SeqexecSite, instrument: Instrument, id: Observation.Id, step: Int, total: Int) {
+  final case class Props(router: RouterCtl[SeqexecPages], site: Site, instrument: Instrument, id: Observation.Id, step: Int, total: Int) {
     protected[sequence] val sequenceInfoConnects = site.instruments.toList.map(i => (i, SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(i)))).toMap
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -3,14 +3,21 @@
 
 package seqexec.web.client
 
-import seqexec.model.Model.{Resource, Instrument, SequenceState, SequenceView, Step, StepState, StandardStep}
 import cats.Show
 import cats.implicits._
+import cats.data.NonEmptyList
+import gem.enum.Site
+import seqexec.model.Model.{Resource, Instrument, SequenceState, SequenceView, Step, StepState, StandardStep}
 
 /**
   * Contains useful operations for the seqexec model
   */
 object ModelOps {
+  implicit val siteStateShow: Show[Site] = Show.show[Site] {
+    case Site.GN => "GN"
+    case Site.GS => "GS"
+  }
+
   implicit val sequenceStateShow: Show[SequenceState] = Show.show[SequenceState] {
     case SequenceState.Completed        => "Complete"
     case SequenceState.Running(true, _) => "Pausing..."
@@ -82,6 +89,13 @@ object ModelOps {
       }
 
     def isPartiallyExecuted: Boolean = s.steps.exists(_.isFinished)
+  }
+
+  implicit class SiteOps(val s: Site) extends AnyVal {
+    def instruments: NonEmptyList[Instrument] = s match {
+      case Site.GN => Instrument.gnInstruments
+      case Site.GS => Instrument.gsInstruments
+    }
   }
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -13,10 +13,6 @@ import seqexec.model.Model.{Resource, Instrument, SequenceState, SequenceView, S
   * Contains useful operations for the seqexec model
   */
 object ModelOps {
-  implicit val siteStateShow: Show[Site] = Show.show[Site] {
-    case Site.GN => "GN"
-    case Site.GS => "GS"
-  }
 
   implicit val sequenceStateShow: Show[SequenceState] = Show.show[SequenceState] {
     case SequenceState.Completed        => "Complete"

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -6,6 +6,7 @@ package seqexec.web.client
 import diode.Action
 import cats.Show
 import gem.Observation
+import gem.enum.Site
 import seqexec.model.UserDetails
 import seqexec.model.Model._
 import seqexec.model.events._
@@ -18,7 +19,7 @@ object actions {
   // Actions
   final case class NavigateTo(page: Pages.SeqexecPages) extends Action
   final case class NavigateSilentTo(page: Pages.SeqexecPages) extends Action
-  final case class Initialize(site: SeqexecSite) extends Action
+  final case class Initialize(site: Site) extends Action
 
   // Actions to close and/open the login box
   case object OpenLoginBox extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
@@ -9,6 +9,7 @@ import diode._
 import diode.data._
 import diode.react.ReactConnector
 import gem.Observation
+import gem.enum.Site
 import java.util.logging.Logger
 import japgolly.scalajs.react.Callback
 import seqexec.model.UserDetails
@@ -38,7 +39,7 @@ object circuit {
 
   // All these classes are focused views of the root model. They are used to only update small sections of the
   // UI even if other parts of the root model change
-  final case class WebSocketsFocus(location: Pages.SeqexecPages, sequences: LoadedSequences, user: Option[UserDetails], clientId: Option[ClientID], site: Option[SeqexecSite]) extends UseValueEq
+  final case class WebSocketsFocus(location: Pages.SeqexecPages, sequences: LoadedSequences, user: Option[UserDetails], clientId: Option[ClientID], site: Option[Site]) extends UseValueEq
   final case class InitialSyncFocus(location: Pages.SeqexecPages, sod: SequencesOnDisplay, firstLoad: Boolean) extends UseValueEq
   final case class SequenceInQueue(id: Observation.Id, status: SequenceState, instrument: Instrument, active: Boolean, name: String, targetName: Option[TargetName], runningStep: Option[RunningStep]) extends UseValueEq
   object SequenceInQueue {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
@@ -12,6 +12,7 @@ import diode.data.{Pending, RefTo, Pot, Ready}
 import java.util.logging.{Level, Logger}
 import java.time.Instant
 import gem.Observation
+import gem.enum.Site
 import mouse.all._
 import org.scalajs.dom._
 import seqexec.model.UserDetails
@@ -326,7 +327,7 @@ object handlers {
   /**
     * Handles actions related to the changing the selection of the displayed sequence
     */
-  class SequenceDisplayHandler[M](modelRW: ModelRW[M, (SequencesOnDisplay, Option[SeqexecSite])]) extends ActionHandler(modelRW) with Handlers {
+  class SequenceDisplayHandler[M](modelRW: ModelRW[M, (SequencesOnDisplay, Option[Site])]) extends ActionHandler(modelRW) with Handlers {
     def handleSelectSequenceDisplay: PartialFunction[Any, ActionResult[M]] = {
       case SelectInstrumentToDisplay(i) =>
         updated(value.copy(_1 = value._1.focusOnInstrument(i)))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -8,9 +8,11 @@ import cats.implicits._
 import diode.RootModelR
 import diode.data._
 import gem.Observation
+import gem.enum.Site
 import seqexec.model.UserDetails
 import seqexec.model.Model._
 import seqexec.model.events._
+import seqexec.web.client.ModelOps._
 import seqexec.web.common.{Zipper, FixedLengthBuffer}
 import org.scalajs.dom.WebSocket
 
@@ -93,7 +95,7 @@ object model {
 
   // Model for the tabbed area of sequences
   final case class SequencesOnDisplay(instrumentSequences: Zipper[SequenceTab]) {
-    def withSite(site: SeqexecSite): SequencesOnDisplay =
+    def withSite(site: Site): SequencesOnDisplay =
       SequencesOnDisplay(Zipper.fromNel(site.instruments.map(SequenceTab(_, SequencesOnDisplay.emptySeqRef, None, None))))
 
     // Display a given step on the focused sequence
@@ -196,7 +198,7 @@ object model {
   /**
     * Root of the UI Model of the application
     */
-  final case class SeqexecAppRootModel(ws: WebSocketConnection, site: Option[SeqexecSite], clientId: Option[ClientID], uiModel: SeqexecUIModel)
+  final case class SeqexecAppRootModel(ws: WebSocketConnection, site: Option[Site], clientId: Option[ClientID], uiModel: SeqexecUIModel)
 
   object SeqexecAppRootModel {
     type LoadedSequences = SequencesQueue[SequenceView]


### PR DESCRIPTION
Another removal of a duplicate case from the seqexec mini model and use of the core `Site` class instead