### PR TITLE
SEQNG-655 Fix UI alignment issues on the running steps

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -253,12 +253,13 @@ body {
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  width: 200px;
+  width: 100%;
+  padding-right: 7px;
 }
 
 .SeqexecStyles-observationProgressBar {
   margin: 0 !important;
-  width: 200px;
+  width: 100%;
 }
 
 .SeqexecStyles-observationBar {
@@ -267,7 +268,7 @@ body {
 
 .SeqexecStyles-observationLabel {
   text-align: center;
-  width: 200px;
+  width: 100%;
 }
 
 .SeqexecStyles-guidingCell {
@@ -303,6 +304,7 @@ body {
 
 .SeqexecStyles-subsystems {
   margin-left: auto;
+  padding-right: 7px;
 }
 
 .SeqexecStyles-componentLabel {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -47,16 +47,16 @@ object SequenceControl {
   private val ST = ReactS.Fix[State]
 
   def requestRun(s: Observation.Id): CatsReact.ReactST[CallbackTo, State, Unit] =
-    ST.retM(Callback(SeqexecCircuit.dispatch(RequestRun(s)))) >> ST.mod(_.requestRun).liftCB
+    ST.retM(SeqexecCircuit.dispatchCB(RequestRun(s))) >> ST.mod(_.requestRun).liftCB
 
   def requestSync(s: Observation.Id): CatsReact.ReactST[CallbackTo, State, Unit] =
-    ST.retM(Callback(SeqexecCircuit.dispatch(RequestSync(s)))) >> ST.mod(_.requestSync).liftCB
+    ST.retM(SeqexecCircuit.dispatchCB(RequestSync(s))) >> ST.mod(_.requestSync).liftCB
 
   def requestPause(s: Observation.Id): CatsReact.ReactST[CallbackTo, State, Unit] =
-    ST.retM(Callback(SeqexecCircuit.dispatch(RequestPause(s)))) >> ST.mod(_.requestPause).liftCB
+    ST.retM(SeqexecCircuit.dispatchCB(RequestPause(s))) >> ST.mod(_.requestPause).liftCB
 
   def requestCancelPause(s: Observation.Id): CatsReact.ReactST[CallbackTo, State, Unit] =
-    ST.retM(Callback(SeqexecCircuit.dispatch(RequestCancelPause(s)))) >> ST.mod(_.requestCancelPause).liftCB
+    ST.retM(SeqexecCircuit.dispatchCB(RequestCancelPause(s))) >> ST.mod(_.requestCancelPause).liftCB
 
   private def controlButton(icon: Icon, color: String, onClick: Callback, disabled: Boolean, tooltip: String, text: String) =
     Popup(Popup.Props("button", tooltip),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -7,7 +7,7 @@ import cats.Show
 import cats.implicits._
 import cats.data.NonEmptyList
 import gem.enum.Site
-import seqexec.model.Model.{Resource, Instrument, SequenceState, SequenceView, Step, StepState, StandardStep}
+import seqexec.model.Model.{ActionStatus, Resource, Instrument, SequenceState, SequenceView, Step, StepState, StandardStep}
 
 /**
   * Contains useful operations for the seqexec model
@@ -85,6 +85,12 @@ object ModelOps {
       }
 
     def isPartiallyExecuted: Boolean = s.steps.exists(_.isFinished)
+
+    def showAsRunning(i: Int): SequenceView = s.copy(steps = s.steps.collect {
+      case s: StandardStep if s.id === i => s.copy(status = StepState.Running,
+         configStatus = List((Resource.TCS, ActionStatus.Pending), (Resource.Gcal, ActionStatus.Running), (Instrument.GPI, ActionStatus.Completed)))
+      case s                             => s
+    })
   }
 
   implicit class SiteOps(val s: Site) extends AnyVal {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -79,7 +79,6 @@ object actions {
   final case class ConnectionError(s: String) extends Action
   final case class ServerMessage(e: SeqexecEvent) extends Action
 
-  // Temporal actions for UI prototyping
   final case class FlipSkipStep(id: Observation.Id, step: Step) extends Action
   final case class FlipBreakpointStep(id: Observation.Id, step: Step) extends Action
   final case class UpdateObserver(id: Observation.Id, name: String) extends Action
@@ -88,6 +87,9 @@ object actions {
   final case class UpdateCloudCover(cc: CloudCover) extends Action
   final case class UpdateSkyBackground(sb: SkyBackground) extends Action
   final case class UpdateWaterVapor(wv: WaterVapor) extends Action
+
+  // Used for UI debugging
+  final case class MarkStepAsRunning(s: Observation.Id, step: Int) extends Action
 
   // scalastyle:on
   private val standardStep: PartialFunction[Step, (StepId, StepState, List[(Resource, ActionStatus)])] = {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
@@ -120,6 +120,7 @@ object circuit {
     private val syncToAddedHandler       = new SyncToAddedRemovedRun(zoomTo(_.uiModel.navLocation))
     private val remoteRequestsHandler    = new RemoteRequestsHandler(zoomTo(_.clientId))
     private val syncRequestsHandler      = new SyncRequestsHandler(zoomTo(_.uiModel.syncInProgress))
+    private val debuggingHandler         = new DebuggingHandler(zoomTo(_.uiModel.sequences))
 
     override protected def initialModel = SeqexecAppRootModel.initial
 
@@ -217,7 +218,8 @@ object circuit {
       operatorHandler,
       remoteRequestsHandler,
       syncRequestsHandler,
-      navigationHandler)
+      navigationHandler,
+      debuggingHandler)
 
     /**
       * Handles a fatal error most likely during action processing

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
@@ -693,4 +693,17 @@ object handlers {
         modelUpdateMessage,
         defaultMessage).combineAll
   }
+
+  /**
+    * Handle for UI debugging events
+    */
+  class DebuggingHandler[M](modelRW: ModelRW[M, LoadedSequences]) extends ActionHandler(modelRW) with Handlers {
+    override def handle: PartialFunction[Any, ActionResult[M]] = {
+      case MarkStepAsRunning(obsId, step) =>
+        updated(value.copy(queue = value.queue.collect {
+          case v: SequenceView if v.id === obsId => v.showAsRunning(step)
+          case v                                 => v
+        }))
+    }
+  }
 }


### PR DESCRIPTION
Small css fixes for alignments on the steps table. I added a handler to simulate more easily events like running a step without having to actually run a sequence

before:
![seqexec - gs-test-01-33 2018-07-12 15-59-15](https://user-images.githubusercontent.com/3615303/42657064-31af9d18-85ef-11e8-8edc-adce203f523e.png)

after:
![seqexec - gs-test-01-33 2018-07-12 15-58-03](https://user-images.githubusercontent.com/3615303/42657083-3a01dbca-85ef-11e8-88eb-3278f826f722.png)

before:
![seqexec - gs-test-01-33 2018-07-12 15-45-52](https://user-images.githubusercontent.com/3615303/42657151-712640fa-85ef-11e8-842e-e3dcfcad6008.png)

after:
![seqexec - gs-test-01-33 2018-07-12 15-45-29](https://user-images.githubusercontent.com/3615303/42657163-78f715ac-85ef-11e8-8785-a8d2b8cf8317.png)
