### PR TITLE
Auto-deploy to sbfocstest-lv1 for `develop` merges

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,6 @@ import NativePackagerHelper._
 import sbtcrossproject.{crossProject, CrossType}
 import com.typesafe.sbt.packager.docker._
 
-// our version is determined by the current git state (see project/ImageManifest.scala)
-def imageManifest = ImageManifest.current("postgres:9.6.0").unsafeRunSync
-
 name := Settings.Definitions.name
 
 organization in Global := "edu.gemini.ocs"
@@ -287,9 +284,9 @@ lazy val ctl = project
       CatsFree.value,
       Decline
     ),
-    TaskKey[Unit]("deployTest") := (runMain in Compile).toTask {
-      s" gem.ctl.main --no-ansi --host sbfocstest-lv1.cl.gemini.edu deploy-test ${imageManifest.formatVersion}"
-    } .value,
+    // TaskKey[Unit]("deployTest") := (runMain in Compile).toTask {
+    //   s" gem.ctl.main --no-ansi --host sbfocstest-lv1.cl.gemini.edu deploy-test ${version.value}"
+    // } .value,
     fork in run := true
   )
 
@@ -305,7 +302,7 @@ lazy val main = project
     dockerBaseImage       := "openjdk:8u141",
     dockerExposedPorts    := List(9090, 9091),
     dockerRepository      := Some("sbfocsdev-lv1.cl.gemini.edu"),
-    dockerLabels          := imageManifest.labels,
+    dockerLabels          := ImageManifest.current("postgres:9.6.0", version.value).unsafeRunSync.labels,
 
     // Install nc before changing the user
     dockerCommands       ++= dockerCommands.value.flatMap {

--- a/build.sbt
+++ b/build.sbt
@@ -284,9 +284,11 @@ lazy val ctl = project
       CatsFree.value,
       Decline
     ),
-    // TaskKey[Unit]("deployTest") := (runMain in Compile).toTask {
-    //   s" gem.ctl.main --no-ansi --host sbfocstest-lv1.cl.gemini.edu deploy-test ${version.value}"
-    // } .value,
+    TaskKey[Unit]("deployTest") := Def.taskDyn {
+      (runMain in Compile).toTask {
+        s" gem.ctl.main --no-ansi --host sbfocstest-lv1.cl.gemini.edu deploy-test ${version.value}"
+      }
+    } .value,
     fork in run := true
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -286,7 +286,7 @@ lazy val ctl = project
     ),
     TaskKey[Unit]("deployTest") := Def.taskDyn {
       (runMain in Compile).toTask {
-        s" gem.ctl.main --no-ansi --host sbfocstest-lv1.cl.gemini.edu deploy-test ${version.value}"
+        s" gem.ctl.main --verbose --host sbfocstest-lv1.cl.gemini.edu deploy-test ${version.value}"
       }
     } .value,
     fork in run := true

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -10,7 +10,6 @@ cd `dirname $0`/..
 echo "--- :scala: Compiling main codebase"
 /usr/local/bin/sbt                  \
   -jvm-opts build/buildkite-jvmopts \
-  -no-colors                        \
   -Docs3.skipDependencyUpdates      \
   headerCheck                       \
   test:headerCheck                  \
@@ -25,7 +24,6 @@ echo "--- :scala: Compiling main codebase"
 echo "--- :scala: Compiling tests"
 /usr/local/bin/sbt                                        \
   -jvm-opts build/buildkite-jvmopts                       \
-  -no-colors                                              \
   -Docs3.skipDependencyUpdates                            \
   -Docs3.databaseUrl=jdbc:postgresql://$HOST_AND_PORT/gem \
   test:compile
@@ -44,6 +42,7 @@ function cleanup {
   echo "--- :postgres: Cleaning up Postgres test instance"
   docker stop $CID
   docker rm --volumes --force $CID
+  echo "--- :tada: Done"
 }
 trap cleanup EXIT
 
@@ -61,7 +60,6 @@ done
 echo "--- :scala: Running tests"
 /usr/local/bin/sbt                                        \
   -jvm-opts build/buildkite-jvmopts                       \
-  -no-colors                                              \
   -Docs3.skipDependencyUpdates                            \
   -Docs3.databaseUrl=jdbc:postgresql://$HOST_AND_PORT/gem \
   sql/flywayMigrate                                       \
@@ -74,14 +72,12 @@ echo "--- :scala: Running tests"
 echo "--- :javascript: Linking Javascript"
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
-  -no-colors                            \
   -Docs3.skipDependencyUpdates          \
   ui/fastOptJS
 
 echo "--- :webpack: Webpack"
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
-  -no-colors                            \
   -Docs3.skipDependencyUpdates          \
   seqexec_web_client/fastOptJS::webpack
 
@@ -96,12 +92,8 @@ echo "--- :webpack: Webpack"
   echo "--- :docker: Creating a Docker image"
   /usr/local/bin/sbt                      \
     -jvm-opts build/buildkite-jvmopts     \
-    -no-colors                            \
     -Docs3.skipDependencyUpdates          \
     main/docker:publish                   \
     main/docker:clean
 
 # fi
-
-
-

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -39,10 +39,13 @@ CID=`docker run --detach --publish 5432 postgres:9.6.0`
 
 # Add an exit handler to ensure we always clean up.
 function cleanup {
+  # Unfold the previous (failing) group if we're exiting abnormally
+  if [[ $? -ne 0 ]]; then
+    echo "^^^ +++"
+  fi
   echo "--- :postgres: Cleaning up Postgres test instance"
   docker stop $CID
   docker rm --volumes --force $CID
-  echo "--- :tada: Done"
 }
 trap cleanup EXIT
 
@@ -95,5 +98,11 @@ echo "--- :webpack: Webpack"
     -Docs3.skipDependencyUpdates          \
     main/docker:publish                   \
     main/docker:clean
+
+  echo "--- :docker: Deploying to the test environment "
+  /usr/local/bin/sbt                      \
+    -jvm-opts build/buildkite-jvmopts     \
+    -Docs3.skipDependencyUpdates          \
+    ctl/deployTest
 
 # fi

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -90,7 +90,7 @@ echo "--- :webpack: Webpack"
 
 # If this is a merge into `develop` then this is a shippable version and we will build a docker
 # image for it. We can later deploy it to test or production.
-# if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ];
+if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ];
 
   echo "--- :docker: Creating a Docker image"
   /usr/local/bin/sbt                      \
@@ -99,10 +99,4 @@ echo "--- :webpack: Webpack"
     main/docker:publish                   \
     main/docker:clean
 
-  echo "--- :docker: Deploying to the test environment "
-  /usr/local/bin/sbt                      \
-    -jvm-opts build/buildkite-jvmopts     \
-    -Docs3.skipDependencyUpdates          \
-    ctl/deployTest
-
-# fi
+fi

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -7,7 +7,7 @@ cd `dirname $0`/..
 ### BUILD
 ###
 
-echo "--- :scala: Compiling main codebase ..."
+echo "--- :scala: Compiling main codebase"
 /usr/local/bin/sbt                  \
   -jvm-opts build/buildkite-jvmopts \
   -no-colors                        \
@@ -22,7 +22,7 @@ echo "--- :scala: Compiling main codebase ..."
 ###
 
 # Compile tests
-echo "--- :scala: Compiling tests ..."
+echo "--- :scala: Compiling tests"
 /usr/local/bin/sbt                                        \
   -jvm-opts build/buildkite-jvmopts                       \
   -no-colors                                              \
@@ -36,12 +36,12 @@ echo "--- :scala: Compiling tests ..."
 
 # Start a new Postgres container for this build
 # TODO: read postgres version from the build
-echo "--- :postgres: Starting Postgres test instance ..."
+echo "--- :postgres: Starting Postgres test instance"
 CID=`docker run --detach --publish 5432 postgres:9.6.0`
 
 # Add an exit handler to ensure we always clean up.
 function cleanup {
-  echo "--- :postgres: Cleaning up Postgres test instance ..."
+  echo "--- :postgres: Cleaning up Postgres test instance"
   docker stop $CID
   docker rm --volumes --force $CID
 }
@@ -51,14 +51,14 @@ trap cleanup EXIT
 HOST_AND_PORT=`docker port $CID 5432/tcp`
 
 # The postgres user already exists, so we can go ahead and create the database
-echo "--- :postgres: Creating database ..."
+echo "--- :postgres: Creating database"
 until docker exec $CID psql -U postgres -c 'create database gem'
 do
   sleep 1
 done
 
 # Set up the schema and run tests
-echo "--- :scala: Running tests ..."
+echo "--- :scala: Running tests"
 /usr/local/bin/sbt                                        \
   -jvm-opts build/buildkite-jvmopts                       \
   -no-colors                                              \
@@ -71,14 +71,14 @@ echo "--- :scala: Running tests ..."
 ### JAVASCRIPT PACKAGING
 ###
 
-echo "--- :javascript: Packaging Javascript ..."
+echo "--- :javascript: Linking Javascript"
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
   -no-colors                            \
   -Docs3.skipDependencyUpdates          \
   ui/fastOptJS
 
-echo "--- :webpack: Webpack ..."
+echo "--- :webpack: Webpack"
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
   -no-colors                            \
@@ -91,14 +91,16 @@ echo "--- :webpack: Webpack ..."
 
 # If this is a merge into `develop` then this is a shippable version and we will build a docker
 # image for it. We can later deploy it to test or production.
-# if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ]; then
-  echo "--- :docker: Creating a Docker image ..."
+# if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ];
+
+  echo "--- :docker: Creating a Docker image"
   /usr/local/bin/sbt                      \
     -jvm-opts build/buildkite-jvmopts     \
     -no-colors                            \
     -Docs3.skipDependencyUpdates          \
-    main/docker:publish
+    main/docker:publish                   \
     main/docker:clean
+
 # fi
 
 

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -7,7 +7,7 @@ cd `dirname $0`/..
 ### BUILD
 ###
 
-echo ":scala: Compiling ..."
+echo "--- :scala: Compiling ..."
 /usr/local/bin/sbt                  \
   -jvm-opts build/buildkite-jvmopts \
   -no-colors                        \
@@ -23,12 +23,12 @@ echo ":scala: Compiling ..."
 
 # Start a new Postgres container for this build
 # TODO: read postgres version from the build
-echo ":postgres: Starting Postgres test instance ..."
+echo "--- :postgres: Starting Postgres test instance ..."
 CID=`docker run --detach --publish 5432 postgres:9.6.0`
 
 # Add an exit handler to ensure we always clean up.
 function cleanup {
-  echo ":postgres: Cleaning up Postgres test instance ..."
+  echo "--- :postgres: Cleaning up Postgres test instance ..."
   docker stop $CID
   docker rm --volumes --force $CID
 }
@@ -40,12 +40,12 @@ HOST_AND_PORT=`docker port $CID 5432/tcp`
 # The postgres user already exists, so we can go ahead and create the database
 until docker exec $CID psql -U postgres -c 'create database gem'
 do
-  echo ":postgres: Waiting for Postgres to start up ..."
+  echo "--- :postgres: Waiting for Postgres to start up ..."
   sleep 0.5
 done
 
 # Set up the schema and compile tests
-echo ":scala: Compiling tests ..."
+echo "--- :scala: Compiling tests ..."
 /usr/local/bin/sbt                                        \
   -jvm-opts build/buildkite-jvmopts                       \
   -no-colors                                              \
@@ -55,7 +55,7 @@ echo ":scala: Compiling tests ..."
   test:compile
 
 # Run tests
-echo ":scala: Running tests ..."
+echo "--- :scala: Running tests ..."
 /usr/local/bin/sbt                                        \
   -jvm-opts build/buildkite-jvmopts                       \
   -no-colors                                              \
@@ -67,14 +67,14 @@ echo ":scala: Running tests ..."
 ### JAVASCRIPT PACKAGING
 ###
 
-echo ":javascript: Packaging Javascript ..."
+echo "--- :javascript: Packaging Javascript ..."
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
   -no-colors                            \
   -Docs3.skipDependencyUpdates          \
   ui/fastOptJS
 
-echo ":webpack: Webpack ..."
+echo "--- :webpack: Webpack ..."
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
   -no-colors                            \
@@ -88,7 +88,7 @@ echo ":webpack: Webpack ..."
 # If this is a merge into `develop` then this is a shippable version and we will build a docker
 # image for it. We can later deploy it to test or production.
 if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ]; then
-  echo ":docker: Creating a Docker image ..."
+  echo "--- :docker: Creating a Docker image ..."
   /usr/local/bin/sbt                      \
     -jvm-opts build/buildkite-jvmopts     \
     -no-colors                            \

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -90,7 +90,7 @@ echo "--- :webpack: Webpack"
 
 # If this is a merge into `develop` then this is a shippable version and we will build a docker
 # image for it. We can later deploy it to test or production.
-if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ];
+if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ]; then
 
   echo "--- :docker: Creating a Docker image"
   /usr/local/bin/sbt                      \

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -90,7 +90,7 @@ echo "--- :webpack: Webpack"
 
 # If this is a merge into `develop` then this is a shippable version and we will build a docker
 # image for it. We can later deploy it to test or production.
-if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ];
+# if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ];
 
   echo "--- :docker: Creating a Docker image"
   /usr/local/bin/sbt                      \
@@ -99,4 +99,10 @@ if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" 
     main/docker:publish                   \
     main/docker:clean
 
-fi
+  echo "--- :docker: Deploying to the test environment "
+  /usr/local/bin/sbt                      \
+    -jvm-opts build/buildkite-jvmopts     \
+    -Docs3.skipDependencyUpdates          \
+    ctl/deployTest
+
+# fi

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -90,7 +90,7 @@ echo "--- :webpack: Webpack"
 
 # If this is a merge into `develop` then this is a shippable version and we will build a docker
 # image for it. We can later deploy it to test or production.
-# if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ];
+if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ];
 
   echo "--- :docker: Creating a Docker image"
   /usr/local/bin/sbt                      \
@@ -105,4 +105,4 @@ echo "--- :webpack: Webpack"
     -Docs3.skipDependencyUpdates          \
     ctl/deployTest
 
-# fi
+fi

--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -7,6 +7,7 @@ cd `dirname $0`/..
 ### BUILD
 ###
 
+echo ":scala: Compiling ..."
 /usr/local/bin/sbt                  \
   -jvm-opts build/buildkite-jvmopts \
   -no-colors                        \
@@ -22,10 +23,12 @@ cd `dirname $0`/..
 
 # Start a new Postgres container for this build
 # TODO: read postgres version from the build
+echo ":postgres: Starting Postgres test instance ..."
 CID=`docker run --detach --publish 5432 postgres:9.6.0`
 
 # Add an exit handler to ensure we always clean up.
 function cleanup {
+  echo ":postgres: Cleaning up Postgres test instance ..."
   docker stop $CID
   docker rm --volumes --force $CID
 }
@@ -37,11 +40,12 @@ HOST_AND_PORT=`docker port $CID 5432/tcp`
 # The postgres user already exists, so we can go ahead and create the database
 until docker exec $CID psql -U postgres -c 'create database gem'
 do
-  echo "waiting for postgres container..."
+  echo ":postgres: Waiting for Postgres to start up ..."
   sleep 0.5
 done
 
 # Set up the schema and compile tests
+echo ":scala: Compiling tests ..."
 /usr/local/bin/sbt                                        \
   -jvm-opts build/buildkite-jvmopts                       \
   -no-colors                                              \
@@ -51,6 +55,7 @@ done
   test:compile
 
 # Run tests
+echo ":scala: Running tests ..."
 /usr/local/bin/sbt                                        \
   -jvm-opts build/buildkite-jvmopts                       \
   -no-colors                                              \
@@ -62,14 +67,35 @@ done
 ### JAVASCRIPT PACKAGING
 ###
 
+echo ":javascript: Packaging Javascript ..."
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
   -no-colors                            \
   -Docs3.skipDependencyUpdates          \
   ui/fastOptJS
 
+echo ":webpack: Webpack ..."
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
   -no-colors                            \
   -Docs3.skipDependencyUpdates          \
   seqexec_web_client/fastOptJS::webpack
+
+###
+### DOCKER IMAGE
+###
+
+# If this is a merge into `develop` then this is a shippable version and we will build a docker
+# image for it. We can later deploy it to test or production.
+if [ "$BUILDKITE_PULL_REQUEST" = "false" ] && [ "$BUILDKITE_BRANCH" = "develop" ]; then
+  echo ":docker: Creating a Docker image ..."
+  /usr/local/bin/sbt                      \
+    -jvm-opts build/buildkite-jvmopts     \
+    -no-colors                            \
+    -Docs3.skipDependencyUpdates          \
+    main/docker:publish
+    main/docker:clean
+fi
+
+
+

--- a/build/buildkite-pipeline.yml
+++ b/build/buildkite-pipeline.yml
@@ -1,6 +1,7 @@
 steps:
   - command: "build/buildkite-build.sh"
     label: "Run the Build"
+    timeout_in_minutes: 20
     retry:
       automatic:
         - exit_status: 137

--- a/modules/ctl/src/main/scala/free/ctl.scala
+++ b/modules/ctl/src/main/scala/free/ctl.scala
@@ -53,7 +53,8 @@ object ctl {
         case None    =>
           o.lines.traverse(error(_))      *>
           error(s"exited (${o.exitCode})") *>
-          exit[A](o.exitCode)
+          error(s"Requirement failed. Exiting.") *>
+          exit[A](-1)
         case Some(a) => a.pure[CtlIO]
       }
     }

--- a/modules/ctl/src/main/scala/hi/deploy.scala
+++ b/modules/ctl/src/main/scala/hi/deploy.scala
@@ -13,11 +13,9 @@ object Deploy {
 
   private def destroyDeployment: CtlIO[Unit] =
     gosub("Destroying current deployment, if any.") {
-      findRunningContainersWithLabel("gem.version").flatMap {
-        case Nil => info("None found, nothing to do!")
-        case cs  => cs.traverse { c =>
-          info(s"Stopping and removing ${c.hash}.") *> destroyContainer(c)
-        }.void
+      currentDeployment.flatMap {
+        case None => info("None found, nothing to do!")
+        case Some(Deployment(g, p)) => destroyContainer(g, true) *> destroyContainer(p, false)
       }
     }
 

--- a/modules/ctl/src/main/scala/low/docker.scala
+++ b/modules/ctl/src/main/scala/low/docker.scala
@@ -13,7 +13,12 @@ import cats.implicits._
 object docker {
 
   final case class Network(hash: String, name: String)
-  final case class Image(hash: String)
+  final case class Image(hash: String) {
+    // Consider hashes to be the same if one contains the other. In practice this will mean they're
+    // the same.
+    def like(other: Image): Boolean =
+      hash.contains(other.hash) || other.hash.contains(hash)
+  }
   final case class Container(hash: String)
 
   def docker(args: String*): CtlIO[Output] =
@@ -61,7 +66,7 @@ object docker {
   // find *running* containers
   def findRunningContainersWithLabel(label: String): CtlIO[List[Container]] =
     docker("ps", "-q", "--filter", s"label=$label").require {
-      case Output(0, hs) => hs.map(Container)
+      case Output(0, hs) => hs.map(Container(_))
     }
 
   def containerImage(k: Container): CtlIO[Image] =

--- a/modules/ctl/src/main/scala/low/docker.scala
+++ b/modules/ctl/src/main/scala/low/docker.scala
@@ -67,8 +67,8 @@ object docker {
   def containerImage(k: Container): CtlIO[Image] =
     isRemote.flatMap { r =>
       docker("inspect", "--format",
-        if (r) "'{{ .Index }}'"
-        else    "{{ .Index }}", k.hash).require {
+        if (r) "'{{ .Image }}'"
+        else    "{{ .Image }}", k.hash).require {
           case Output(0, s :: Nil) => Image(s)
         }
     }

--- a/modules/ctl/src/main/scala/low/docker.scala
+++ b/modules/ctl/src/main/scala/low/docker.scala
@@ -114,12 +114,12 @@ object docker {
       case Output(0, _) => ()
     }
 
-  def destroyContainer(k: Container): CtlIO[Unit] =
+  def destroyContainer(k: Container, rmi: Boolean): CtlIO[Unit] =
     for {
       _ <- stopContainer(k)
       i <- containerImage(k)
       _ <- removeContainer(k)
-      _ <- removeImage(i)
+      _ <- removeImage(i).whenA(rmi)
     } yield ()
 
   def startContainer(k: Container): CtlIO[Unit] =

--- a/modules/ctl/src/main/scala/main.scala
+++ b/modules/ctl/src/main/scala/main.scala
@@ -21,7 +21,7 @@ object main {
                 .flatMap(impl.foldMap(_).value)
             }
       _  <- IO(Console.println) // scalastyle:ignore
-    } yield n.fold(0)(_.fold(identity, _ => 0))
+    } yield n.fold(-1)(_.fold(identity, _ => 0))
 
   def main(args: Array[String]): Unit =
     sys.exit(mainʹ(args.toList).unsafeRunSync)

--- a/project/ImageManifest.scala
+++ b/project/ImageManifest.scala
@@ -19,7 +19,7 @@ case class ImageManifest(history: NonEmptyList[String], timestamp: Instant, unst
   def labels: Map[String, String] =
     Map(
       Keys.Commit   -> commit,
-      Keys.History  -> history.intercalate(","),
+      // Keys.History  -> history.intercalate(","),
       Keys.Unstable -> unstable.toString,
       Keys.Version  -> version,
       Keys.Postgres -> postgresImage


### PR DESCRIPTION
This is work toward getting continuous deployment working. It fixes the deploy stuff to use the versioning scheme @cquiroz came up with, so we're now consistent there; and it adds a step to create a docker image for `develop` merge builds (i.e., not for PRs or other branches) and deploys it to the test machine `sbfocstest-lv1`, HTTP REST on 9090 and telnet on 9091. Each deployment destroys the previous one; there is no data migration yet.

This also splits the log up into sections and adds wee emojis to delight and entertain.

![image](https://user-images.githubusercontent.com/1200131/42714792-2e4482aa-86a9-11e8-91cc-603338cb2655.png)

