### PR TITLE
remove history label, add history file

### DIFF
--- a/project/ImageManifest.scala
+++ b/project/ImageManifest.scala
@@ -19,7 +19,6 @@ case class ImageManifest(history: NonEmptyList[String], timestamp: Instant, unst
   def labels: Map[String, String] =
     Map(
       Keys.Commit   -> commit,
-      // Keys.History  -> history.intercalate(","),
       Keys.Unstable -> unstable.toString,
       Keys.Version  -> version,
       Keys.Postgres -> postgresImage
@@ -40,7 +39,6 @@ object ImageManifest {
   /** Module of docker label keys. */
   object Keys {
     val Commit   = "gem.commit"
-    val History  = "gem.history"
     val Unstable = "gem.unstable"
     val Version  = "gem.version"
     val Postgres = "gem.postgres"


### PR DESCRIPTION
This removes the `gem.history` label from our docker images (this used to contain a list of commit hashes but it turns out there's a size limit) and instead generates a `GIT_HISTORY` file with one commit hash per line (head is the release commit) that shows up at `/opt/docker/GIT_HISTORY` in the container filesystem. This allows the production release process to verify that the running version's commit hash exists in the new version's history. If so then database migration is supported and we can attempt an upgrade release.

For reference

    docker run --entrypoint "/bin/cat" <image-hash> /opt/docker/GIT_HISTORY

will list the file contents. I will circle back and fix the upgrade deployment logic to use this.