### PR TITLE
SEQNG-652 Show GMOS configuration in log.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -3,6 +3,7 @@
 
 package seqexec.server.gmos
 
+import cats.Show
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.gmos.GmosController.Config.DCConfig
 import seqexec.server.SeqexecFailure.Unexpected
@@ -175,5 +176,8 @@ object GmosController {
   type GmosSouthController = GmosController[SouthTypes]
 
   type GmosNorthController = GmosController[NorthTypes]
+
+  implicit def configShow[T<:SiteDependentTypes]: Show[GmosConfig[T]] =
+    Show.show { config => s"(${config.cc.filter}, ${config.cc.disperser}, ${config.cc.fpu}, ${config.cc.stage}, ${config.cc.stage}, ${config.cc.dtaX}, ${config.cc.adc}, ${config.cc.useElectronicOffset}, ${config.dc.t}, ${config.dc.b}, ${config.dc.s}, ${config.dc.bi}, ${config.dc.roi.rois})" }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -176,6 +176,7 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
 
   override def applyConfig(config: GmosController.GmosConfig[T]): SeqAction[Unit] = for {
     _ <- EitherT.right(IO(Log.info("Start Gmos configuration")))
+    _ <- EitherT.right(IO(Log.debug(s"Gmos configuration: ${config.show}")))
     _ <- setDCConfig(config.dc)
     _ <- setCCConfig(config.cc)
     _ <- GmosEpics.instance.configCmd.setTimeout(ConfigTimeout)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
@@ -3,15 +3,12 @@
 
 package seqexec.server.gmos
 
-import cats.Show
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.gmos.GmosController.{GmosConfig, NorthTypes, SiteDependentTypes, SouthTypes}
 import seqexec.server.{InstrumentControllerSim, ObserveCommand, SeqAction}
 import squants.Time
 
 private class GmosControllerSim[T<:SiteDependentTypes](name: String) extends GmosController[T] {
-
-  implicit val configShow: Show[GmosConfig[T]] = Show.show { config => s"(${config.cc.filter}, ${config.cc.disperser}, ${config.cc.fpu}, ${config.cc.stage}, ${config.cc.stage}, ${config.cc.dtaX}, ${config.cc.adc}, ${config.cc.useElectronicOffset}, ${config.dc.t}, ${config.dc.b}, ${config.dc.s}, ${config.dc.bi}, ${config.dc.roi.rois})" }
 
   override def getConfig: SeqAction[GmosConfig[T]] = ??? // scalastyle:ignore
 


### PR DESCRIPTION
This is useful for debugging, and needed to further investigate SEQNG-652.