### PR TITLE
SEQNG-662: Reduce semantic ui css

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/dev.js
+++ b/modules/seqexec/web/client/src/main/resources/dev.js
@@ -1,4 +1,4 @@
-import "node_modules/semantic-ui-less/semantic.less";
+import "./theme/semantic.less";
 import "./less/style.less";
 var App = require("sjs/seqexec_web_client-fastopt.js");
 

--- a/modules/seqexec/web/client/src/main/resources/prod.js
+++ b/modules/seqexec/web/client/src/main/resources/prod.js
@@ -1,4 +1,4 @@
-import "node_modules/semantic-ui-less/semantic.less";
+import "./theme/semantic.less";
 import "./less/style.less";
 var App = require("sjs/seqexec_web_client-opt.js");
 

--- a/modules/seqexec/web/client/src/main/resources/theme/semantic.less
+++ b/modules/seqexec/web/client/src/main/resources/theme/semantic.less
@@ -1,0 +1,156 @@
+/*
+
+███████╗███████╗███╗   ███╗ █████╗ ███╗   ██╗████████╗██╗ ██████╗    ██╗   ██╗██╗
+██╔════╝██╔════╝████╗ ████║██╔══██╗████╗  ██║╚══██╔══╝██║██╔════╝    ██║   ██║██║
+███████╗█████╗  ██╔████╔██║███████║██╔██╗ ██║   ██║   ██║██║         ██║   ██║██║
+╚════██║██╔══╝  ██║╚██╔╝██║██╔══██║██║╚██╗██║   ██║   ██║██║         ██║   ██║██║
+███████║███████╗██║ ╚═╝ ██║██║  ██║██║ ╚████║   ██║   ██║╚██████╗    ╚██████╔╝██║
+╚══════╝╚══════╝╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝   ╚═╝   ╚═╝ ╚═════╝     ╚═════╝ ╚═╝
+
+  Import this file into your LESS project to use Semantic UI without build tools
+*/
+
+/* Global */
+& {
+  @import "~semantic-ui-less/definitions/globals/reset";
+}
+& {
+  @import "~semantic-ui-less/definitions/globals/site";
+}
+
+/* Elements */
+& {
+  @import "~semantic-ui-less/definitions/elements/button";
+}
+& {
+  @import "~semantic-ui-less/definitions/elements/container";
+}
+& {
+  @import "~semantic-ui-less/definitions/elements/divider";
+}
+// & {
+//   @import "~semantic-ui-less/definitions/elements/flag";
+// }
+& {
+  @import "~semantic-ui-less/definitions/elements/header";
+}
+& {
+  @import "~semantic-ui-less/definitions/elements/icon";
+}
+& {
+  @import "~semantic-ui-less/definitions/elements/image";
+}
+& {
+  @import "~semantic-ui-less/definitions/elements/input";
+}
+& {
+  @import "~semantic-ui-less/definitions/elements/label";
+}
+// & {
+//   @import "~semantic-ui-less/definitions/elements/list";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/elements/loader";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/elements/rail";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/elements/reveal";
+// }
+& {
+  @import "~semantic-ui-less/definitions/elements/segment";
+}
+// & {
+//   @import "~semantic-ui-less/definitions/elements/step";
+// }
+
+/* Collections */
+// & {
+//   @import "~semantic-ui-less/definitions/collections/breadcrumb";
+// }
+& {
+  @import "~semantic-ui-less/definitions/collections/form";
+}
+& {
+  @import "~semantic-ui-less/definitions/collections/grid";
+}
+& {
+  @import "~semantic-ui-less/definitions/collections/menu";
+}
+& {
+  @import "~semantic-ui-less/definitions/collections/message";
+}
+& {
+  @import "~semantic-ui-less/definitions/collections/table";
+}
+
+/* Views */
+// & {
+//   @import "~semantic-ui-less/definitions/views/ad";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/views/card";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/views/comment";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/views/feed";
+// }
+& {
+  @import "~semantic-ui-less/definitions/views/item";
+}
+// & {
+//   @import "~semantic-ui-less/definitions/views/statistic";
+// }
+
+/* Modules */
+// & {
+//   @import "~semantic-ui-less/definitions/modules/accordion";
+// }
+& {
+  @import "~semantic-ui-less/definitions/modules/checkbox";
+}
+& {
+  @import "~semantic-ui-less/definitions/modules/dimmer";
+}
+& {
+  @import "~semantic-ui-less/definitions/modules/dropdown";
+}
+// & {
+//   @import "~semantic-ui-less/definitions/modules/embed";
+// }
+& {
+  @import "~semantic-ui-less/definitions/modules/modal";
+}
+// & {
+//   @import "~semantic-ui-less/definitions/modules/nag";
+// }
+& {
+  @import "~semantic-ui-less/definitions/modules/popup";
+}
+& {
+  @import "~semantic-ui-less/definitions/modules/progress";
+}
+// & {
+//   @import "~semantic-ui-less/definitions/modules/rating";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/modules/search";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/modules/shape";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/modules/sidebar";
+// }
+// & {
+//   @import "~semantic-ui-less/definitions/modules/sticky";
+// }
+& {
+  @import "~semantic-ui-less/definitions/modules/tab";
+}
+& {
+  @import "~semantic-ui-less/definitions/modules/transition";
+}

--- a/modules/seqexec/web/client/src/webpack/webpack.parts.js
+++ b/modules/seqexec/web/client/src/webpack/webpack.parts.js
@@ -115,8 +115,6 @@ module.exports.resolve = {
 module.exports.resolveSemanticUI = {
   resolve: {
     alias: {
-      // Required to find the Semantic-UI-less module
-      node_modules: path.resolve(__dirname, "node_modules"),
       // Required for the custom Semantic UI theme
       "../../theme.config$": path.join(resourcesDir, "theme/theme.config")
     }


### PR DESCRIPTION
Semantic UI Css is fairly big but it can be reduced by selecting a subset of the widgets

This PR does that reducing the css size from 545Kb to 408Kb