### PR TITLE
SEQNG-661: Resizable config table and preserve state

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -361,12 +361,15 @@ lazy val web_client_common = project
       // By necessity facades will have unused params
       "-Ywarn-unused:params"
     ))),
+    // Needed for Monocle macros
+    addCompilerPlugin(Plugins.paradisePlugin),
     libraryDependencies ++= Seq(
       Cats.value,
+      Mouse.value,
       ScalaJSDom.value,
       JQuery.value,
       ScalaJSReactVirtualized.value,
-      ScalaJSReactDraggable.value) ++ ReactScalaJS.value
+      ScalaJSReactDraggable.value) ++ ReactScalaJS.value ++ Monocle.value
   )
 
 // a special crossProject for configuring a JS/JVM/shared structure

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ lazy val ocs3 = preventPublication(project.in(file(".")))
     ui,
     giapi,
     web_server_common,
-    web_client,
+    web_client_common,
     seqexec_model_JS,
     seqexec_model_JVM,
     seqexec_engine,
@@ -349,8 +349,8 @@ lazy val web_server_common = project
     libraryDependencies ++= CatsEffect.value +: (Http4s ++ Logging)
   )
 
-// Common utilities for web clinet projects
-lazy val web_client = project
+// Common utilities for web client projects
+lazy val web_client_common = project
   .in(file("modules/shared/web/client"))
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(ScalaJSPlugin)
@@ -361,7 +361,12 @@ lazy val web_client = project
       // By necessity facades will have unused params
       "-Ywarn-unused:params"
     ))),
-    libraryDependencies ++= Seq(Cats.value, ScalaJSDom.value, JQuery.value) ++ ReactScalaJS.value
+    libraryDependencies ++= Seq(
+      Cats.value,
+      ScalaJSDom.value,
+      JQuery.value,
+      ScalaJSReactVirtualized.value,
+      ScalaJSReactDraggable.value) ++ ReactScalaJS.value
   )
 
 // a special crossProject for configuring a JS/JVM/shared structure
@@ -485,7 +490,6 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
       JavaTimeJS.value,
       JavaLogJS.value,
       ScalaJSReactVirtualized.value,
-      ScalaJSReactDraggable.value,
       ScalaJSReactClipboard.value
     ) ++ ReactScalaJS.value ++ Diode.value
   )
@@ -495,7 +499,7 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
     buildInfoObject := "OcsBuildInfo",
     buildInfoPackage := "seqexec.web.client"
   )
-  .dependsOn(web_client, seqexec_web_shared_JS % "compile->compile;test->test", seqexec_model_JS % "compile->compile;test->test")
+  .dependsOn(web_client_common, seqexec_web_shared_JS % "compile->compile;test->test", seqexec_model_JS % "compile->compile;test->test")
 
 // List all the modules and their inter dependencies
 lazy val seqexec_server = project

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
@@ -142,7 +142,7 @@ object QueueTableBody {
                    s.active,
                    s.runningStep)
         }
-        .getOrElse(QueueRow.Zero)
+        .getOrElse(QueueRow.zero)
 
     val rowCount: Int =
       sequencesList.size
@@ -332,7 +332,7 @@ object QueueTableBody {
          l.active,
          l.runningStep))
 
-    val Zero: QueueRow =
+    def zero: QueueRow =
       apply(Observation.Id.unsafeFromString("Zero-1"),
             SequenceState.Idle,
             Instrument.F2,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
@@ -77,35 +77,35 @@ object QueueTableBody {
     name = "obsid",
     label = "Obs. ID",
     visible = true,
-    PercentageColumnWidth(1.0))
+    PercentageColumnWidth.Full)
 
   val StateColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     StateColumn,
     name = "state",
     label = "State",
     visible = true,
-    PercentageColumnWidth(1.0))
+    PercentageColumnWidth.Full)
 
   val InstrumentColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     InstrumentColumn,
     name = "instrument",
     label = "Instrument",
     visible = true,
-    PercentageColumnWidth(1.0))
+    PercentageColumnWidth.Full)
 
   val ObsNameColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObsNameColumn,
     name = "obsName",
     label = "Obs. Name",
     visible = true,
-    PercentageColumnWidth(1.0))
+    PercentageColumnWidth.Full)
 
   val TargetNameColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     TargetNameColumn,
     name = "target",
     label = "Target",
     visible = true,
-    PercentageColumnWidth(1.0))
+    PercentageColumnWidth.Full)
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] = NonEmptyList.of(
     IconColumnMeta,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
@@ -37,19 +37,6 @@ import seqexec.web.client.semanticui.elements.icon.Icon.{
 import web.client.style._
 import web.client.utils._
 import web.client.table._
-import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react._
-import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.router.RouterCtl
-import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
-import japgolly.scalajs.react.raw.JsNumber
-import react.virtualized._
-
-import scala.math.max
-import cats.implicits._
-import cats.data.NonEmptyList
-import cats.Eq
-import mouse.all._
 
 object QueueTableBody {
   type Backend = RenderScope[Props, TableState, Unit]

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -49,7 +49,7 @@ object StepConfigTable {
     def rowGetter(idx: Int): SettingsRow =
       settingsList
         .lift(idx)
-        .fold(SettingsRow.Zero)(Function.tupled(SettingsRow.apply))
+        .fold(SettingsRow.zero)(Function.tupled(SettingsRow.apply))
   }
 
   // ScalaJS defined trait
@@ -75,7 +75,7 @@ object StepConfigTable {
     def unapply(l: SettingsRow): Option[(SystemName, String, String)] =
       Some((l.sub, l.name, l.value))
 
-    val Zero: SettingsRow = apply(SystemName.ocs, "", "")
+    def zero: SettingsRow = apply(SystemName.ocs, "", "")
   }
 
   val TableColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -83,14 +83,14 @@ object StepConfigTable {
     name = "name",
     label = "Name",
     visible = true,
-    PercentageColumnWidth(0.5))
+    PercentageColumnWidth.Half)
 
   val ValueColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ValueColumn,
     name = "value",
     label = "Value",
     visible = true,
-    PercentageColumnWidth(0.5))
+    PercentageColumnWidth.Half)
 
   val InitialTableState: TableState[TableColumn] = TableState[TableColumn](
     NotModified,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -154,9 +154,9 @@ object StepConfigTable {
   }
 
   private val component = ScalaComponent.builder[Props]("StepConfig")
-    .initialStateFromProps(_.startState)
-    .render { b =>
-      Table(settingsTableProps(b.props), columns(b): _*)
+    .stateless
+    .render_P { p =>
+      Table(settingsTableProps(p), columns(p): _*)
     }
     .build
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -3,16 +3,27 @@
 
 package seqexec.web.client.components.sequence.steps
 
-import scala.scalajs.js
-import seqexec.model.Model.{Step, SystemName}
-import seqexec.web.client.components.SeqexecStyles
+import cats.Eq
+import cats.data.NonEmptyList
+import cats.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.raw.JsNumber
+import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import cats.implicits._
 import react.virtualized._
+import scala.scalajs.js
+import seqexec.model.Model.{Step, SystemName}
+import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.circuit.SeqexecCircuit
+import seqexec.web.client.actions.UpdateStepsTableState
+import web.client.utils._
+import web.client.table._
 
 object StepConfigTable {
+  type Backend = RenderScope[Props, TableState, Unit]
+
   final case class Props(step: Step, size: Size) {
     val settingsList: List[(SystemName, String, String)] =
       step.config.toList.flatMap {
@@ -52,11 +63,59 @@ object StepConfigTable {
     val Zero: SettingsRow = apply(SystemName.ocs, "", "")
   }
 
-  private def columns(p: Props): List[Table.ColumnArg] =
-    List(
-      Column(Column.props(p.size.width.toInt / 2, "name", label = "Name", flexShrink = 0, flexGrow = 0, className = SeqexecStyles.paddedStepRow.htmlClass)),
-      Column(Column.props(p.size.width.toInt / 2, "value", label = "Value", flexShrink = 0, flexGrow = 0, className = SeqexecStyles.paddedStepRow.htmlClass))
-    )
+  sealed trait TableColumn
+  case object NameColumn  extends TableColumn
+  case object ValueColumn extends TableColumn
+
+  object TableColumn {
+    implicit val eq: Eq[TableColumn] = Eq.fromUniversalEquals
+  }
+
+  final case class ColumnMeta(column: TableColumn, name: String, label: String, width: Double)
+
+  object ColumnMeta {
+    val TableColumnMeta: ColumnMeta = ColumnMeta(NameColumn, "name", "Name", 0.5)
+    val ValueColumnMeta: ColumnMeta = ColumnMeta(ValueColumn, "value", "Value", 0.5)
+  }
+
+  final case class TableState(userModified: Boolean,
+                              columns: NonEmptyList[ColumnMeta]) {
+    // Changes the relative widths when a column is being dragged
+    def applyOffset(column: TableColumn, delta: Double): TableState = {
+      val indexOf = columns.toList.indexWhere(_.column === column)
+      // Shift the selected column and the next one
+      val result = columns.toList.zipWithIndex.map {
+        case (c @ ColumnMeta(_, _, _, x), idx) if idx === indexOf     =>
+          c.copy(width = (x + delta))
+        case (c @ ColumnMeta(_, _, _, x), idx) if idx === indexOf + 1 =>
+          c.copy(width = (x - delta))
+        case (c, _)                                                => c
+      }
+      copy(userModified = true, columns = NonEmptyList.fromListUnsafe(result))
+    }
+  }
+
+  object TableState {
+    val Zero: TableState = TableState(false, NonEmptyList.of(ColumnMeta.TableColumnMeta, ColumnMeta.ValueColumnMeta))
+  }
+
+  private def columns(b: Backend): List[Table.ColumnArg] = {
+    val width = b.props.size.width
+    // Tell the model to resize a column
+    def resizeRow(c: TableColumn): (String, JsNumber) => Callback =
+      (_, dx) =>
+        b.modState { s =>
+          val percentDelta = dx.toDouble / width
+          s.applyOffset(c, percentDelta)
+      }
+
+    b.state.columns.zipWithIndex.map {
+      case (ColumnMeta(c, name, label, percentage), i) if i < b.state.columns.length - 1 =>
+        Column(Column.props(width * percentage, name, label = label, flexShrink = 0, flexGrow = 0, headerRenderer = resizableHeaderRenderer(resizeRow(c)), className = SeqexecStyles.paddedStepRow.htmlClass))
+      case (ColumnMeta(_, name, label, percentage), _)                                   =>
+        Column(Column.props(width * percentage, name, label = label, flexShrink = 0, flexGrow = 0, className = SeqexecStyles.paddedStepRow.htmlClass))
+    }.toList
+  }
 
   def rowClassName(p: Props)(i: Int): String = ((i, p.rowGetter(i)) match {
     case (-1, _)                                                  =>
@@ -95,11 +154,11 @@ object StepConfigTable {
   }
 
   private val component = ScalaComponent.builder[Props]("StepConfig")
-    .stateless
-    .render_P { p =>
-      Table(settingsTableProps(p), columns(p): _*)
+    .initialStateFromProps(_.startState)
+    .render { b =>
+      Table(settingsTableProps(b.props), columns(b): _*)
     }
     .build
 
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+  def apply(p: Props): Unmounted[Props, TableState, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -70,6 +70,7 @@ object StepsTable {
     val stepsList: List[Step] = steps.map(_.steps).getOrElse(Nil)
     def rowCount: Int = stepsList.length
     def rowGetter(idx: Int): StepRow = steps.flatMap(_.steps.lift(idx)).fold(StepRow.Zero)(StepRow.apply)
+    val configTableState: StepConfigTable.TableState = stepsTable().configTableState
     // Find out if offsets should be displayed
     val offsetsDisplay: OffsetsDisplay = stepsList.offsetsDisplay
   }
@@ -248,7 +249,7 @@ object StepsTable {
         p.steps.whenDefined { tab =>
           tab.stepConfigDisplayed.map { i =>
             val steps = p.stepsList.lift(i).getOrElse(Step.Zero)
-            AutoSizer(AutoSizer.props(s => StepConfigTable(StepConfigTable.Props(steps, s))))
+            AutoSizer(AutoSizer.props(s => StepConfigTable(StepConfigTable.Props(steps, s, p.configTableState))))
           }.getOrElse {
             AutoSizer(AutoSizer.props(s => ref.component(stepsTableProps(p)(s))(columns(p, s).map(_.vdomElement): _*)))
           }.vdomElement

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -3,8 +3,14 @@
 
 package seqexec.web.client.components.sequence.steps
 
-import scala.scalajs.js
+import cats.implicits._
 import diode.react.ModelProxy
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.extra.router.RouterCtl
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import scala.scalajs.js
+import mouse.boolean._
 import seqexec.model.Model.{Instrument, StandardStep, Step, StepState, StepType}
 import seqexec.model.properties
 import seqexec.web.client.lenses._
@@ -14,14 +20,9 @@ import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.components.sequence.steps.OffsetFns._
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.{Size => SSize}
-import web.client.style._
-import japgolly.scalajs.react._
-import japgolly.scalajs.react.extra.router.RouterCtl
-import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.vdom.html_<^._
-import cats.implicits._
 import react.virtualized._
-import mouse.boolean._
+import web.client.style._
+import web.client.table._
 
 object ColWidths {
   val ControlWidth: Int = 40
@@ -70,7 +71,7 @@ object StepsTable {
     val stepsList: List[Step] = steps.map(_.steps).getOrElse(Nil)
     def rowCount: Int = stepsList.length
     def rowGetter(idx: Int): StepRow = steps.flatMap(_.steps.lift(idx)).fold(StepRow.Zero)(StepRow.apply)
-    val configTableState: StepConfigTable.TableState = stepsTable().configTableState
+    val configTableState: TableState[StepConfigTable.TableColumn] = stepsTable().configTableState
     // Find out if offsets should be displayed
     val offsetsDisplay: OffsetsDisplay = stepsList.offsetsDisplay
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -13,6 +13,7 @@ import seqexec.model.events._
 import seqexec.web.client.model._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import org.scalajs.dom.WebSocket
+import web.client.table._
 
 object actions {
 
@@ -89,7 +90,7 @@ object actions {
   final case class UpdateSkyBackground(sb: SkyBackground) extends Action
   final case class UpdateWaterVapor(wv: WaterVapor) extends Action
 
-  final case class UpdateStepsTableState(s: StepConfigTable.TableState) extends Action
+  final case class UpdateStepsTableState(s: TableState[StepConfigTable.TableColumn]) extends Action
 
   // Used for UI debugging
   final case class MarkStepAsRunning(s: Observation.Id, step: Int) extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -88,6 +88,8 @@ object actions {
   final case class UpdateSkyBackground(sb: SkyBackground) extends Action
   final case class UpdateWaterVapor(wv: WaterVapor) extends Action
 
+  final case class UpdateStepsTableState(s: StepConfigTable.TableState) extends Action
+
   // Used for UI debugging
   final case class MarkStepAsRunning(s: Observation.Id, step: Int) extends Action
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -11,6 +11,7 @@ import seqexec.model.UserDetails
 import seqexec.model.Model._
 import seqexec.model.events._
 import seqexec.web.client.model._
+import seqexec.web.client.components.sequence.steps.StepConfigTable
 import org.scalajs.dom.WebSocket
 
 object actions {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -12,6 +12,7 @@ import seqexec.model.Model._
 import seqexec.model.events._
 import seqexec.web.client.model._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
+import seqexec.web.client.components.QueueTableBody
 import org.scalajs.dom.WebSocket
 import web.client.table._
 
@@ -90,7 +91,8 @@ object actions {
   final case class UpdateSkyBackground(sb: SkyBackground) extends Action
   final case class UpdateWaterVapor(wv: WaterVapor) extends Action
 
-  final case class UpdateStepsTableState(s: TableState[StepConfigTable.TableColumn]) extends Action
+  final case class UpdateStepsConfigTableState(s: TableState[StepConfigTable.TableColumn]) extends Action
+  final case class UpdateQueueTableState(s: TableState[QueueTableBody.TableColumn]) extends Action
 
   // Used for UI debugging
   final case class MarkStepAsRunning(s: Observation.Id, step: Int) extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
@@ -22,6 +22,7 @@ import seqexec.web.client.handlers._
 import seqexec.web.client.ModelOps._
 import seqexec.web.client.actions.{AppendToLog, CloseLoginBox, CloseResourcesBox, OpenLoginBox, OpenResourcesBox, ServerMessage, show}
 import seqexec.web.client.components.sequence.steps.StepConfigTable
+import web.client.table._
 
 object circuit {
   /**
@@ -53,7 +54,7 @@ object circuit {
   final case class StatusAndObserverFocus(isLogged: Boolean, name: Option[String], instrument: Instrument, id: Option[Observation.Id], observer: Option[Observer], status: Option[SequenceState], targetName: Option[TargetName]) extends UseValueEq
   final case class StatusAndStepFocus(isLogged: Boolean, instrument: Instrument, id: Option[Observation.Id], stepConfigDisplayed: Option[Int], totalSteps: Int) extends UseValueEq
   final case class StepsTableFocus(id: Observation.Id, instrument: Instrument, state: SequenceState, steps: List[Step], stepConfigDisplayed: Option[Int], nextStepToRun: Option[Int]) extends UseValueEq
-  final case class StepsTableAndStatusFocus(status: ClientStatus, stepsTable: Option[StepsTableFocus], configTableState: StepConfigTable.TableState) extends UseValueEq
+  final case class StepsTableAndStatusFocus(status: ClientStatus, stepsTable: Option[StepsTableFocus], configTableState: TableState[StepConfigTable.TableColumn]) extends UseValueEq
   final case class ControlModel(id: Observation.Id, isPartiallyExecuted: Boolean, nextStepToRun: Option[Int], status: SequenceState, inConflict: Boolean) extends UseValueEq
   final case class SequenceControlFocus(isLogged: Boolean, isConnected: Boolean, control: Option[ControlModel], syncInProgress: Boolean) extends UseValueEq
 
@@ -198,7 +199,7 @@ object circuit {
     def sequenceReader(id: Observation.Id): ModelR[_, Option[SequenceView]] =
       zoom(_.uiModel.sequences.queue.find(_.id === id))
 
-    val configTableState: ModelR[SeqexecAppRootModel, StepConfigTable.TableState] =
+    val configTableState: ModelR[SeqexecAppRootModel, TableState[StepConfigTable.TableColumn]] =
       zoom(_.uiModel.configTableState)
 
     /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
@@ -34,6 +34,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.scalajs.js.typedarray.{ArrayBuffer, TypedArrayBuffer}
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+import web.client.table._
 
 object handlers {
   private val VoidEffect = Effect(Future(NoAction: Action))
@@ -711,7 +712,7 @@ object handlers {
   /**
     * Handle to preserve the steps table state
     */
-  class StepConfigTableStateHandler[M](modelRW: ModelRW[M, StepConfigTable.TableState]) extends ActionHandler(modelRW) with Handlers {
+  class StepConfigTableStateHandler[M](modelRW: ModelRW[M, TableState[StepConfigTable.TableColumn]]) extends ActionHandler(modelRW) with Handlers {
     override def handle: PartialFunction[Any, ActionResult[M]] = {
       case UpdateStepsTableState(state) =>
         updatedSilent(state) // We should only do silent updates as these change too quickly

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
@@ -29,12 +29,10 @@ import seqexec.web.client.circuit._
 import seqexec.web.client.services.log.ConsoleHandler
 import seqexec.web.client.services.{Audio, SeqexecWebClient}
 import seqexec.web.client.services.WebpackResources._
-import seqexec.web.client.components.sequence.steps.StepConfigTable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.scalajs.js.typedarray.{ArrayBuffer, TypedArrayBuffer}
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
-import web.client.table._
 
 object handlers {
   private val VoidEffect = Effect(Future(NoAction: Action))
@@ -712,10 +710,13 @@ object handlers {
   /**
     * Handle to preserve the steps table state
     */
-  class StepConfigTableStateHandler[M](modelRW: ModelRW[M, TableState[StepConfigTable.TableColumn]]) extends ActionHandler(modelRW) with Handlers {
+  class StepConfigTableStateHandler[M](modelRW: ModelRW[M, TableStates]) extends ActionHandler(modelRW) with Handlers {
     override def handle: PartialFunction[Any, ActionResult[M]] = {
-      case UpdateStepsTableState(state) =>
-        updatedSilent(state) // We should only do silent updates as these change too quickly
+      case UpdateStepsConfigTableState(state) =>
+        updatedSilent(value.copy(stepConfigTable = state)) // We should only do silent updates as these change too quickly
+
+      case UpdateQueueTableState(state) =>
+        updatedSilent(value.copy(queueTable = state)) // We should only do silent updates as these change too quickly
     }
   }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
@@ -29,6 +29,7 @@ import seqexec.web.client.circuit._
 import seqexec.web.client.services.log.ConsoleHandler
 import seqexec.web.client.services.{Audio, SeqexecWebClient}
 import seqexec.web.client.services.WebpackResources._
+import seqexec.web.client.components.sequence.steps.StepConfigTable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.scalajs.js.typedarray.{ArrayBuffer, TypedArrayBuffer}
@@ -704,6 +705,16 @@ object handlers {
           case v: SequenceView if v.id === obsId => v.showAsRunning(step)
           case v                                 => v
         }))
+    }
+  }
+
+  /**
+    * Handle to preserve the steps table state
+    */
+  class StepConfigTableStateHandler[M](modelRW: ModelRW[M, StepConfigTable.TableState]) extends ActionHandler(modelRW) with Handlers {
+    override def handle: PartialFunction[Any, ActionResult[M]] = {
+      case UpdateStepsTableState(state) =>
+        updatedSilent(state) // We should only do silent updates as these change too quickly
     }
   }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -15,6 +15,7 @@ import seqexec.model.events._
 import seqexec.web.client.ModelOps._
 import seqexec.web.common.{Zipper, FixedLengthBuffer}
 import seqexec.web.client.components.sequence.steps.StepConfigTable
+import seqexec.web.client.components.QueueTableBody
 import org.scalajs.dom.WebSocket
 import web.client.table._
 
@@ -182,6 +183,7 @@ object model {
                             sequencesOnDisplay: SequencesOnDisplay,
                             syncInProgress: Boolean,
                             configTableState: TableState[StepConfigTable.TableColumn],
+                            queueTableState: TableState[QueueTableBody.TableColumn],
                             firstLoad: Boolean)
 
   object SeqexecUIModel {
@@ -196,6 +198,7 @@ object model {
       SequencesOnDisplay.empty,
       syncInProgress = false,
       StepConfigTable.InitialTableState,
+      QueueTableBody.InitialTableState.tableState,
       firstLoad = true)
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -14,6 +14,7 @@ import seqexec.model.Model._
 import seqexec.model.events._
 import seqexec.web.client.ModelOps._
 import seqexec.web.common.{Zipper, FixedLengthBuffer}
+import seqexec.web.client.components.sequence.steps.StepConfigTable
 import org.scalajs.dom.WebSocket
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
@@ -179,6 +180,7 @@ object model {
                             globalLog: GlobalLog,
                             sequencesOnDisplay: SequencesOnDisplay,
                             syncInProgress: Boolean,
+                            configTableState: StepConfigTable.TableState,
                             firstLoad: Boolean)
 
   object SeqexecUIModel {
@@ -192,6 +194,7 @@ object model {
       GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
       SequencesOnDisplay.empty,
       syncInProgress = false,
+      StepConfigTable.TableState.Zero,
       firstLoad = true)
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -16,6 +16,7 @@ import seqexec.web.client.ModelOps._
 import seqexec.web.common.{Zipper, FixedLengthBuffer}
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import org.scalajs.dom.WebSocket
+import web.client.table._
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object model {
@@ -180,7 +181,7 @@ object model {
                             globalLog: GlobalLog,
                             sequencesOnDisplay: SequencesOnDisplay,
                             syncInProgress: Boolean,
-                            configTableState: StepConfigTable.TableState,
+                            configTableState: TableState[StepConfigTable.TableColumn],
                             firstLoad: Boolean)
 
   object SeqexecUIModel {
@@ -194,7 +195,7 @@ object model {
       GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
       SequencesOnDisplay.empty,
       syncInProgress = false,
-      StepConfigTable.TableState.Zero,
+      StepConfigTable.InitialTableState,
       firstLoad = true)
   }
 

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -26,7 +26,7 @@ package table {
   object UserModified {
     implicit val eq: Eq[UserModified] = Eq.fromUniversalEquals
 
-    def fromBool(b: Boolean): UserModified = b.fold(IsModified, NotModified)
+    def fromBool(b: Boolean): UserModified = if (b) IsModified else NotModified
   }
 
   sealed trait ColumnWidth extends Product with Serializable

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -31,7 +31,10 @@ package table {
   final case class FixedColumnWidth(width: Int) extends ColumnWidth
   final case class PercentageColumnWidth(percentage: Double) extends ColumnWidth
 
-  final case class TableState[A: Eq](userModified: UserModified, columns: NonEmptyList[ColumnMeta[A]]) {
+  /**
+   * State of a table
+   */
+  final case class TableState[A: Eq](userModified: UserModified, scrollPosition: JsNumber, columns: NonEmptyList[ColumnMeta[A]]) {
 
     // Changes the relative widths when a column is being dragged
     def applyOffset(column: A, delta: Double): TableState[A] = {
@@ -67,7 +70,14 @@ package table {
 
     def columns[A: Eq]: Lens[TableState[A], NonEmptyList[ColumnMeta[A]]] =
       Lens[TableState[A], NonEmptyList[ColumnMeta[A]]](_.columns)(n => a => a.copy(columns = n))
+
+    def scrollPosition[A: Eq]: Lens[TableState[A], JsNumber] =
+      Lens[TableState[A], JsNumber](_.scrollPosition)(n => a => a.copy(scrollPosition = n))
   }
+
+  /**
+   * Metadata for a column
+   */
   final case class ColumnMeta[A](column: A, name: String, label: String, visible: Boolean, width: ColumnWidth)
 }
 

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package web.client
+
+import cats.data.NonEmptyList
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.raw.JsNumber
+import japgolly.scalajs.react.Callback
+import org.scalajs.dom.MouseEvent
+import react.virtualized._
+import react.draggable._
+import scala.scalajs.js
+
+package table {
+  final case class TableState[A](userModified: Boolean, columns: NonEmptyList[A])
+}
+
+package object table {
+  // Renderer for a resizable column
+  def resizableHeaderRenderer(
+      rs: (String, JsNumber) => Callback): HeaderRenderer[js.Object] =
+    (_, dataKey: String, _, label: VdomNode, _, _) =>
+      ReactFragment.withKey(dataKey)(
+        <.div(
+          ^.cls := "ReactVirtualized__Table__headerTruncatedText",
+          label
+        ),
+        Draggable(
+          Draggable.props(
+            axis = Axis.X,
+            defaultClassName = "DragHandle",
+            defaultClassNameDragging = "DragHandleActive",
+            onDrag = (ev: MouseEvent, d: DraggableData) => rs(dataKey, d.deltaX),
+            position = ControlPosition(0)
+          ),
+          <.span(^.cls := "DragHandleIcon", "⋮")
+        )
+    )
+}

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
@@ -45,47 +45,58 @@ final class TableSpec extends CatsSuite {
 
   implicit val arbJsNumber: Arbitrary[JsNumber] = Arbitrary {
     // type JsNumber = Byte | Short | Int | Float | Double
-    Gen.oneOf[JsNumber](arbitrary[Byte], arbitrary[Short], arbitrary[Int], arbitrary[Float], arbitrary[Double])
+    Gen.oneOf[JsNumber](arbitrary[Byte],
+                        arbitrary[Short],
+                        arbitrary[Int],
+                        arbitrary[Float],
+                        arbitrary[Double])
   }
 
   implicit val jsNumberCogen: Cogen[JsNumber] =
-    Cogen[Double].contramap {x => (x: Any) match {
-      case y: Byte   => y.toDouble
-      case y: Short  => y.toDouble
-      case y: Int    => y.toDouble
-      case y: Float  => y.toDouble
-      case y: Double => y
-    }}
+    Cogen[Double].contramap { x =>
+      (x: Any) match {
+        case y: Byte   => y.toDouble
+        case y: Short  => y.toDouble
+        case y: Int    => y.toDouble
+        case y: Float  => y.toDouble
+        case y: Double => y
+      }
+    }
 
-  implicit def columnMetaArb[A: Arbitrary]: Arbitrary[ColumnMeta[A]] = Arbitrary {
-    for {
-      a <- arbitrary[A]
-      n <- arbitrary[String]
-      l <- arbitrary[String]
-      v <- arbitrary[Boolean]
-      w <- arbitrary[ColumnWidth]
-    } yield ColumnMeta(a, n, l, v, w)
-  }
+  implicit def columnMetaArb[A: Arbitrary]: Arbitrary[ColumnMeta[A]] =
+    Arbitrary {
+      for {
+        a <- arbitrary[A]
+        n <- arbitrary[String]
+        l <- arbitrary[String]
+        v <- arbitrary[Boolean]
+        w <- arbitrary[ColumnWidth]
+      } yield ColumnMeta(a, n, l, v, w)
+    }
 
   implicit def columnMetaCogen[A: Cogen]: Cogen[ColumnMeta[A]] =
-    Cogen[(A, String, String, Boolean, ColumnWidth)].contramap(x => (x.column, x.name, x.label, x.visible, x.width))
+    Cogen[(A, String, String, Boolean, ColumnWidth)].contramap(x =>
+      (x.column, x.name, x.label, x.visible, x.width))
 
-  implicit def tableStateArb[A: Arbitrary: Eq]: Arbitrary[TableState[A]] = Arbitrary {
-    for {
-      u <- arbitrary[UserModified]
-      s <- arbitrary[JsNumber]
-      c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
-    } yield TableState(u, s, NonEmptyList.fromListUnsafe(c))
-  }
+  implicit def tableStateArb[A: Arbitrary: Eq]: Arbitrary[TableState[A]] =
+    Arbitrary {
+      for {
+        u <- arbitrary[UserModified]
+        s <- arbitrary[JsNumber]
+        c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
+      } yield TableState(u, s, NonEmptyList.fromListUnsafe(c))
+    }
 
   implicit def tableStateCogen[A: Cogen]: Cogen[TableState[A]] =
-    Cogen[(UserModified, Double, List[ColumnMeta[A]])].contramap(x => (x.userModified, x.scrollPosition.toDouble, x.columns.toList))
+    Cogen[(UserModified, Double, List[ColumnMeta[A]])].contramap(x =>
+      (x.userModified, x.scrollPosition.toDouble, x.columns.toList))
 
-  implicit def columnMetaNonEmptyListArb[A: Arbitrary: Eq]: Arbitrary[NonEmptyList[ColumnMeta[A]]] = Arbitrary {
-    for {
-      c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
-    } yield NonEmptyList.fromListUnsafe(c)
-  }
+  implicit def columnMetaNelArb[A: Arbitrary: Eq]: Arbitrary[NonEmptyList[ColumnMeta[A]]] =
+    Arbitrary {
+      for {
+        c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
+      } yield NonEmptyList.fromListUnsafe(c)
+    }
 
   implicit def columnMetaNelCogen[A: Cogen]: Cogen[NonEmptyList[ColumnMeta[A]]] =
     Cogen[List[ColumnMeta[A]]].contramap(_.toList)
@@ -93,6 +104,8 @@ final class TableSpec extends CatsSuite {
   checkAll("Eq[UserModified]", EqTests[UserModified].eqv)
   checkAll("Eq[ColumnMeta[Int]]", EqTests[ColumnMeta[Int]].eqv)
   checkAll("Eq[TableState[Int]]", EqTests[TableState[Int]].eqv)
-  checkAll("Lens[TableState[A], UserModified]", LensTests(TableState.userModified[Int]))
-  checkAll("Lens[TableState[A], NonEmptyList[ColumnMeta[A]]]", LensTests(TableState.columns[Int]))
+  checkAll("Lens[TableState[A], UserModified]",
+           LensTests(TableState.userModified[Int]))
+  checkAll("Lens[TableState[A], NonEmptyList[ColumnMeta[A]]]",
+           LensTests(TableState.columns[Int]))
 }

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
@@ -24,11 +24,17 @@ final class TableSpec extends CatsSuite {
   val genFixedColumnWidth: Gen[FixedColumnWidth] =
     Gen.posNum[Int].map(FixedColumnWidth.apply)
 
+  implicit val fixedColumnWidthArb: Arbitrary[FixedColumnWidth] =
+    Arbitrary(genFixedColumnWidth)
+
   implicit val fixedColumnWidthCogen: Cogen[FixedColumnWidth] =
     Cogen[Int].contramap(_.width)
 
   val genPercentageColumnWidth: Gen[PercentageColumnWidth] =
     Gen.choose[Double](0, 1).map(PercentageColumnWidth.apply)
+
+  implicit val percentageColumnWidthArb: Arbitrary[PercentageColumnWidth] =
+    Arbitrary(genPercentageColumnWidth)
 
   implicit val percentColumnWidthCogen: Cogen[PercentageColumnWidth] =
     Cogen[Double].contramap(_.percentage)
@@ -102,6 +108,9 @@ final class TableSpec extends CatsSuite {
     Cogen[List[ColumnMeta[A]]].contramap(_.toList)
 
   checkAll("Eq[UserModified]", EqTests[UserModified].eqv)
+  checkAll("Eq[FixedColumnWidth]", EqTests[FixedColumnWidth].eqv)
+  checkAll("Eq[PercentageColumnWidth]", EqTests[PercentageColumnWidth].eqv)
+  checkAll("Eq[ColumnWidth]", EqTests[ColumnWidth].eqv)
   checkAll("Eq[ColumnMeta[Int]]", EqTests[ColumnMeta[Int]].eqv)
   checkAll("Eq[TableState[Int]]", EqTests[TableState[Int]].eqv)
   checkAll("Lens[TableState[A], UserModified]",

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
@@ -1,0 +1,98 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package web.client.table
+
+import cats.Eq
+import cats.tests.CatsSuite
+import cats.data.NonEmptyList
+import cats.kernel.laws.discipline.EqTests
+import japgolly.scalajs.react.raw.JsNumber
+import monocle.law.discipline.LensTests
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import web.client.utils._
+
+final class TableSpec extends CatsSuite {
+  implicit val arbUserModified: Arbitrary[UserModified] = Arbitrary {
+    Gen.oneOf(IsModified, NotModified)
+  }
+
+  implicit val userModifiedCogen: Cogen[UserModified] =
+    Cogen[String].contramap(_.productPrefix)
+
+  val genFixedColumnWidth: Gen[FixedColumnWidth] =
+    Gen.posNum[Int].map(FixedColumnWidth.apply)
+
+  implicit val fixedColumnWidthCogen: Cogen[FixedColumnWidth] =
+    Cogen[Int].contramap(_.width)
+
+  val genPercentageColumnWidth: Gen[PercentageColumnWidth] =
+    Gen.choose[Double](0, 1).map(PercentageColumnWidth.apply)
+
+  implicit val percentColumnWidthCogen: Cogen[PercentageColumnWidth] =
+    Cogen[Double].contramap(_.percentage)
+
+  implicit val arbColumnWidth: Arbitrary[ColumnWidth] = Arbitrary {
+    Gen.oneOf(genFixedColumnWidth, genPercentageColumnWidth)
+  }
+
+  implicit val columnWidthCogen: Cogen[ColumnWidth] =
+    Cogen[Either[FixedColumnWidth, PercentageColumnWidth]].contramap {
+      case x: FixedColumnWidth      => x.asLeft
+      case x: PercentageColumnWidth => x.asRight
+    }
+
+  implicit val arbJsNumber: Arbitrary[JsNumber] = Arbitrary {
+    // type JsNumber = Byte | Short | Int | Float | Double
+    Gen.oneOf[JsNumber](arbitrary[Byte], arbitrary[Short], arbitrary[Int], arbitrary[Float], arbitrary[Double])
+  }
+
+  implicit val jsNumberCogen: Cogen[JsNumber] =
+    Cogen[Double].contramap {x => (x: Any) match {
+      case y: Byte   => y.toDouble
+      case y: Short  => y.toDouble
+      case y: Int    => y.toDouble
+      case y: Float  => y.toDouble
+      case y: Double => y
+    }}
+
+  implicit def columnMetaArb[A: Arbitrary]: Arbitrary[ColumnMeta[A]] = Arbitrary {
+    for {
+      a <- arbitrary[A]
+      n <- arbitrary[String]
+      l <- arbitrary[String]
+      v <- arbitrary[Boolean]
+      w <- arbitrary[ColumnWidth]
+    } yield ColumnMeta(a, n, l, v, w)
+  }
+
+  implicit def columnMetaCogen[A: Cogen]: Cogen[ColumnMeta[A]] =
+    Cogen[(A, String, String, Boolean, ColumnWidth)].contramap(x => (x.column, x.name, x.label, x.visible, x.width))
+
+  implicit def tableStateArb[A: Arbitrary: Eq]: Arbitrary[TableState[A]] = Arbitrary {
+    for {
+      u <- arbitrary[UserModified]
+      s <- arbitrary[JsNumber]
+      c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
+    } yield TableState(u, s, NonEmptyList.fromListUnsafe(c))
+  }
+
+  implicit def tableStateCogen[A: Cogen]: Cogen[TableState[A]] =
+    Cogen[(UserModified, Double, List[ColumnMeta[A]])].contramap(x => (x.userModified, x.scrollPosition.toDouble, x.columns.toList))
+
+  implicit def columnMetaNonEmptyListArb[A: Arbitrary: Eq]: Arbitrary[NonEmptyList[ColumnMeta[A]]] = Arbitrary {
+    for {
+      c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
+    } yield NonEmptyList.fromListUnsafe(c)
+  }
+
+  implicit def columnMetaNelCogen[A: Cogen]: Cogen[NonEmptyList[ColumnMeta[A]]] =
+    Cogen[List[ColumnMeta[A]]].contramap(_.toList)
+
+  checkAll("Eq[UserModified]", EqTests[UserModified].eqv)
+  checkAll("Eq[ColumnMeta[Int]]", EqTests[ColumnMeta[Int]].eqv)
+  checkAll("Eq[TableState[Int]]", EqTests[TableState[Int]].eqv)
+  checkAll("Lens[TableState[A], UserModified]", LensTests(TableState.userModified[Int]))
+  checkAll("Lens[TableState[A], NonEmptyList[ColumnMeta[A]]]", LensTests(TableState.columns[Int]))
+}


### PR DESCRIPTION
This is a fairly large PR which makes the basis to make all tables columns-resizable and to remove a family of quirks related to state being lost when the core model changes. The changes are fairly big so I'm testing them on the step config table before tackling the Steps table where the bugs are more evident

This PR contains:
* Made the Step Config table columns resizable
* Factor out some common code for tables with resizable columns
* Preserve the resize and scroll position across model changes. This can be observed on the image below where the column sizes and scroll position is kept when the step changes:

![screencast 2018-07-24 10-38-30](https://user-images.githubusercontent.com/3615303/43145762-d18614a6-8f2d-11e8-88c7-f25400626e5e.gif)
