### PR TITLE
SEQNG-595: Copy to clipboard component

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -453,7 +453,6 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
       "react-dom"               -> LibraryVersions.reactJS,
       "react-virtualized"       -> LibraryVersions.reactVirtualized,
       "react-draggable"         -> LibraryVersions.reactDraggable,
-      "react-copy-to-clipboard" -> LibraryVersions.reactClipboard,
       "jquery"                  -> LibraryVersions.jQuery,
       "semantic-ui-dropdown"    -> LibraryVersions.semanticUI,
       "semantic-ui-modal"       -> LibraryVersions.semanticUI,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -75,7 +75,7 @@ object Settings {
     val javaLogJS               = "0.1.5"
     val scalaJQuery             = "1.2"
     val scalaJSReactVirtualized = "0.3.2"
-    val scalaJSReactClipboard   = "0.3.1"
+    val scalaJSReactClipboard   = "0.4.0"
     val scalaJSReactDraggable   = "0.1.1"
 
     // Scala libraries
@@ -123,7 +123,6 @@ object Settings {
     val uglifyJs                = "1.2.4"
     val reactVirtualized        = "9.20.1"
     val reactDraggable          = "3.0.5"
-    val reactClipboard          = "5.0.0"
 
     val apacheXMLRPC            = "3.1.3"
     val opencsv                 = "2.1"


### PR DESCRIPTION
We have been using a simple react component to do copy to clipboard. This component is now outdated and not being maintained which is reflected in this error message

```
[error] warning " > react-copy-to-clipboard@5.0.0" has incorrect peer dependency "react@^15.3.0".
```

This PR removes this dependency and uses a pure scala component instead