### PR TITLE
Observation import and fetch service API

### DIFF
--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -95,7 +95,7 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
      * existing program with the same id.
      */
     def importProgram(host: String, pid: Program.Id): M[Either[String, Unit]] =
-      log.log(user, s"ocs2.importProgram($host, $pid") {
+      log.log(user, s"ocs2.importProgram($host, $pid)") {
         OdbClient.fetchProgram[IO](host, pid).liftIO[M].flatMap { _.traverse { case (p, ds) =>
           Importer.importProgram(p, ds).transact(xa)
         }}

--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -28,6 +28,14 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
     }
 
   /**
+   * Constuct a program that yields the `Observation` with the matching observation id.
+   */
+  def queryObservationById(id: Observation.Id): M[Observation] =
+    log.log(user, s"queryObservationById(${id.format})") {
+      ObservationDao.select(id).transact(xa)
+    }
+
+  /**
    * Construct a program that attempts to change the user's password, yielding `true` on success.
    */
   def changePassword(oldPassword: String, newPassword: String): M[Boolean] =
@@ -40,9 +48,10 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
     private val exporter = new gem.horizons.tcs.TcsEphemerisExport(xa)
     private val updater  = gem.horizons.HorizonsEphemerisUpdater(xa)
 
-    /** Constructs a program that writes an ephemeris file, returning the path
-      * of the file written.
-      */
+    /**
+     * Constructs a program that writes an ephemeris file, returning the path
+     * of the file written.
+     */
     def export(key: EphemerisKey, site: Site, start: Timestamp, end: Timestamp, dir: Path): M[Path] =
       log.log(user, s"ephemeris.export($key, $site, $start, $end, $dir)") {
         exporter.exportOne(key, site, start, end, dir).as(exporter.resolve(key, dir))
@@ -54,9 +63,10 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
         updater.report(key, site)
       }
 
-    /** Constructs a program that attempts to update ephemeris information,
-      * yielding ephemeris context.
-      */
+    /**
+     * Constructs a program that attempts to update ephemeris information,
+     * yielding ephemeris context.
+     */
     def update(key: EphemerisKey.Horizons, site: Site): M[EphemerisContext] =
       log.log(user, s"ephemeris.update($key, $site)") {
         updater.update(key, site) *> updater.report(key, site)
@@ -67,10 +77,11 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
 
     import gem.ocs2.{ Importer, OdbClient }
 
-    /** Constructs a program that fetches the corresponding observation from the
-      * indicated ODB and then stores it in the database, replacing any
-      * existing observation with the same id.
-      */
+    /**
+     * Constructs a program that fetches the corresponding observation from the
+     * indicated ODB and then stores it in the database, replacing any
+     * existing observation with the same id.
+     */
     def importObservation(host: String, oid: Observation.Id): M[Either[String, Unit]] =
       log.log(user, s"ocs2.importObservation($host, $oid)") {
         OdbClient.fetchObservation[IO](host, oid).liftIO[M].flatMap { _.traverse { case (o, ds) =>
@@ -78,10 +89,11 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
         }}
       }
 
-    /** Constructs a program that fetches the corresponding science program from
-      * the indicated ODB and then stores it in the database, replacing any
-      * existing program with the same id.
-      */
+    /**
+     * Constructs a program that fetches the corresponding science program from
+     * the indicated ODB and then stores it in the database, replacing any
+     * existing program with the same id.
+     */
     def importProgram(host: String, pid: Program.Id): M[Either[String, Unit]] =
       log.log(user, s"ocs2.importProgram($host, $pid") {
         OdbClient.fetchProgram[IO](host, pid).liftIO[M].flatMap { _.traverse { case (p, ds) =>

--- a/modules/web/src/main/scala/Application.scala
+++ b/modules/web/src/main/scala/Application.scala
@@ -51,12 +51,12 @@ object Application {
         }
 
       // Select an observation by id.
-//      case GET -> Root / "api" / "fetch" / "obs" / o as gs =>
-//        withObsId(o) { oid =>
-//          gs.queryObservationById(oid).flatMap { obs =>
-//            Ok(obs.asJson)
-//          }
-//        }
+      case GET -> Root / "api" / "fetch" / "obs" / o as gs =>
+        withObsId(o) { oid =>
+          gs.queryObservationById(oid).flatMap { obs =>
+            Ok(obs.asJson)
+          }
+        }
     }
 
 }


### PR DESCRIPTION
I'm reopening this PR in the new buildkite world now that the JSON codec for observations is working again. It provides a minimal API for fetching observations from the database, looking ahead to converting the seqexec.

I believe this signature in the `Service` API:

```scala
def queryObservationById(id: Observation.Id): M[Observation]
```

should probably be changed to handle the presumably common case in which the indicated observation doesn't exist.  I wanted to get feedback first though since we should have a common way of handling this and we may want to update the DAO API accordingly.  At the moment, everything assumes the named observation exists.