### PR TITLE
Code simplifications

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -3,22 +3,22 @@
 
 package seqexec.server.flamingos2
 
+import cats.data.{EitherT, Reader}
+import cats.effect.IO
+import cats.implicits._
+import edu.gemini.spModel.config2.Config
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2._
+import edu.gemini.spModel.obscomp.InstConstants.{DARK_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
+import edu.gemini.spModel.seqcomp.SeqConfigNames._
+import java.lang.{Double => JDouble}
+import scala.concurrent.duration.{Duration, SECONDS}
 import seqexec.model.Model.{Instrument, Resource}
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.flamingos2.Flamingos2Controller._
 import seqexec.server._
 import seqexec.server.keywords.{DhsInstrument, DhsClient, KeywordsClient}
-import edu.gemini.spModel.config2.Config
-import edu.gemini.spModel.gemini.flamingos2.Flamingos2._
-import edu.gemini.spModel.obscomp.InstConstants.{DARK_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
-import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import squants.time.{Seconds, Time}
-
-import scala.concurrent.duration.{Duration, SECONDS}
-import cats.data.{EitherT, Reader}
-import cats.effect.IO
-import cats.implicits._
 
 final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsClient) extends InstrumentSystem[IO] with DhsInstrument {
 
@@ -48,7 +48,9 @@ final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsCl
 
   override def notifyObserveStart = SeqAction.void
 
-  override def calcObserveTime(config: Config): Time = config.extract(OBSERVE_KEY / EXPOSURE_TIME_PROP).as[java.lang.Double].map(x => Seconds(x.toDouble)).getOrElse(Seconds(360))
+  override def calcObserveTime(config: Config): Time =
+    config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP)
+      .map(x => Seconds(x.toDouble)).getOrElse(Seconds(360))
 }
 
 object Flamingos2 {
@@ -56,7 +58,7 @@ object Flamingos2 {
 
   val sfName: String = "f2"
 
-  def fpuFromFPUnit(fpu: FPUnit):FocalPlaneUnit = fpu match {
+  def fpuFromFPUnit(fpu: FPUnit): FocalPlaneUnit = fpu match {
     case FPUnit.FPU_NONE       => FocalPlaneUnit.Open
     case FPUnit.SUBPIX_PINHOLE => FocalPlaneUnit.GridSub1Pix
     case FPUnit.PINHOLE        => FocalPlaneUnit.Grid2Pix
@@ -85,9 +87,9 @@ object Flamingos2 {
     val a = INSTRUMENT_KEY / FPU_PROP
     val b = INSTRUMENT_KEY / FPU_MASK_PROP
 
-    config.extract(a).as[FPUnit].flatMap(x =>
+    config.extractAs[FPUnit](a).flatMap(x =>
       if(x =!= FPUnit.CUSTOM_MASK) fpuFromFPUnit(x).asRight
-      else config.extract(b).as[String].map(FocalPlaneUnit.Custom)
+      else config.extractAs[String](b).map(FocalPlaneUnit.Custom)
     )
   }
 
@@ -110,28 +112,28 @@ object Flamingos2 {
 
   def ccConfigFromSequenceConfig(config: Config): TrySeq[CCConfig] =
     (for {
-      obsType <- config.extract(OBSERVE_KEY / OBSERVE_TYPE_PROP).as[String]
+      obsType <- config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
       // WINDOW_COVER_PROP is optional. If not present, then window cover position is inferred from observe type.
-      p <- config.extract(INSTRUMENT_KEY / WINDOW_COVER_PROP).as[WindowCover].recover { case _:ConfigUtilOps.ExtractFailure => windowCoverFromObserveType(obsType)}
-      q <- config.extract(INSTRUMENT_KEY / DECKER_PROP).as[Decker]
+      p <- config.extractAs[WindowCover](INSTRUMENT_KEY / WINDOW_COVER_PROP).recover { case _:ConfigUtilOps.ExtractFailure => windowCoverFromObserveType(obsType)}
+      q <- config.extractAs[Decker](INSTRUMENT_KEY / DECKER_PROP)
       r <- fpuConfig(config)
-      s <- config.extract(INSTRUMENT_KEY / FILTER_PROP).as[Filter]
-      t <- config.extract(INSTRUMENT_KEY / LYOT_WHEEL_PROP).as[LyotWheel]
-      u <- config.extract(INSTRUMENT_KEY / DISPERSER_PROP).as[Disperser].map(disperserFromObserveType(obsType, _))
+      s <- config.extractAs[Filter](INSTRUMENT_KEY / FILTER_PROP)
+      t <- config.extractAs[LyotWheel](INSTRUMENT_KEY / LYOT_WHEEL_PROP)
+      u <- config.extractAs[Disperser](INSTRUMENT_KEY / DISPERSER_PROP).map(disperserFromObserveType(obsType, _))
     } yield CCConfig(p, q, r, s, t, u)).leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
   def dcConfigFromSequenceConfig(config: Config): TrySeq[DCConfig] =
     (for {
-      p <- config.extract(OBSERVE_KEY / EXPOSURE_TIME_PROP).as[java.lang.Double].map(x => Duration(x, SECONDS))
+      p <- config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP).map(x => Duration(x, SECONDS))
       // Reads is usually inferred from the read mode, but it can be explicit.
-      q <- config.extract(OBSERVE_KEY / READS_PROP).as[Reads] match {
+      q <- config.extractAs[Reads](OBSERVE_KEY / READS_PROP) match {
             case a @ Right(_) => a
-            case _            => config.extract(INSTRUMENT_KEY / READMODE_PROP).as[ReadMode]
+            case _            => config.extractAs[ReadMode](INSTRUMENT_KEY / READMODE_PROP)
                                   .map(readsFromReadMode)
           }
       // Readout mode defaults to SCIENCE if not present.
-      r <- config.extract(INSTRUMENT_KEY / READOUT_MODE_PROP).as[ReadoutMode].getOrElse(ReadoutMode.SCIENCE).asRight
-      s <- config.extract(INSTRUMENT_KEY / DECKER_PROP).as[Decker]
+      r <- config.extractAs[ReadoutMode](INSTRUMENT_KEY / READOUT_MODE_PROP).getOrElse(ReadoutMode.SCIENCE).asRight
+      s <- config.extractAs[Decker](INSTRUMENT_KEY / DECKER_PROP)
     } yield DCConfig(p, q, r, s)).leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
   def fromSequenceConfig(config: Config): SeqAction[Flamingos2Config] = EitherT( IO ( for {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -56,11 +56,11 @@ object Flamingos2Header {
   }
 
   class ObsKeywordsReaderImpl(config: Config) extends ObsKeywordsReader {
-    override def getPreimage: SeqAction[YesNoType] = EitherT(IO.pure(config.extract(INSTRUMENT_KEY / MOS_PREIMAGING_PROP)
-      .as[YesNoType].leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
+    override def getPreimage: SeqAction[YesNoType] = EitherT(IO.pure(config.extractAs[YesNoType](INSTRUMENT_KEY / MOS_PREIMAGING_PROP)
+      leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
 
-    override def getReadMode: SeqAction[ReadMode] = EitherT(IO.pure(config.extract(INSTRUMENT_KEY / READMODE_PROP)
-      .as[ReadMode].leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
+    override def getReadMode: SeqAction[ReadMode] = EitherT(IO.pure(config.extractAs[ReadMode](INSTRUMENT_KEY / READMODE_PROP)
+      leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
   }
 
   trait InstKeywordsReader {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
@@ -106,8 +106,8 @@ object GmosHeader {
     }
 
     final case class ObsKeywordsReaderImpl(config: Config) extends ObsKeywordsReader {
-      override def preimage: SeqAction[YesNoType] = EitherT(IO.pure(config.extract(INSTRUMENT_KEY / IS_MOS_PREIMAGING_PROP)
-        .as[YesNoType].leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
+      override def preimage: SeqAction[YesNoType] = EitherT(IO.pure(config.extractAs[YesNoType](INSTRUMENT_KEY / IS_MOS_PREIMAGING_PROP)
+        .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))))
     }
 
     trait InstKeywordsReader {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -19,10 +19,10 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 final case class GmosNorth(c: GmosNorthController, dhsClient: DhsClient) extends Gmos[NorthTypes](c,
   new SiteSpecifics[NorthTypes] {
     override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
-    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] = config.extract(INSTRUMENT_KEY / FILTER_PROP).as[NorthTypes#Filter]
-    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] = config.extract(INSTRUMENT_KEY / DISPERSER_PROP).as[NorthTypes#Disperser]
-    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] = config.extract(INSTRUMENT_KEY / FPU_PROP_NAME).as[NorthTypes#FPU]
-    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] = config.extract(INSTRUMENT_KEY / STAGE_MODE_PROP).as[NorthTypes#GmosStageMode]
+    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] = config.extractAs[NorthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
+    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] = config.extractAs[NorthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
+    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] = config.extractAs[NorthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
+    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] = config.extractAs[NorthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
   })(northConfigTypes) {
   override val resource: Resource = Instrument.GmosN
   override val dhsInstrumentName: String = "GMOS-N"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -20,10 +20,10 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 final case class GmosSouth(c: GmosSouthController, dhsClient: DhsClient) extends Gmos[SouthTypes](c,
   new SiteSpecifics[SouthTypes] {
     override val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
-    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] = config.extract(INSTRUMENT_KEY / FILTER_PROP).as[SouthTypes#Filter]
-    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] = config.extract(INSTRUMENT_KEY / DISPERSER_PROP).as[SouthTypes#Disperser]
-    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] = config.extract(INSTRUMENT_KEY / FPU_PROP_NAME).as[SouthTypes#FPU]
-    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] = config.extract(INSTRUMENT_KEY / STAGE_MODE_PROP).as[SouthTypes#GmosStageMode]
+    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] = config.extractAs[SouthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
+    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] = config.extractAs[SouthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
+    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] = config.extractAs[SouthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
+    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] = config.extractAs[SouthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
   })(southConfigTypes) {
   override val resource: Model.Resource = Instrument.GmosS
   override val dhsInstrumentName: String = "GMOS-S"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPI.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPI.scala
@@ -68,41 +68,28 @@ object GPI {
     for {
       useAo      <- config.extractAs[JBoolean](INSTRUMENT_KEY / USE_AO_PROP)
       useCal     <- config.extractAs[JBoolean](INSTRUMENT_KEY / USE_CAL_PROP)
-      aoOptimize <- config
-                      .extractAs[JBoolean](INSTRUMENT_KEY / AO_OPTIMIZE_PROP)
-      alignFpm   <- config
-                      .extractAs[JBoolean](INSTRUMENT_KEY / ALIGN_FPM_PINHOLE_BIAS_PROP)
-      magH       <- config
-                      .extractAs[JDouble](INSTRUMENT_KEY / MAG_H_PROP)
-      magI       <- config
-                      .extractAs[JDouble](INSTRUMENT_KEY / MAG_I_PROP)
+      aoOptimize <- config.extractAs[JBoolean](INSTRUMENT_KEY / AO_OPTIMIZE_PROP)
+      alignFpm   <- config.extractAs[JBoolean](INSTRUMENT_KEY / ALIGN_FPM_PINHOLE_BIAS_PROP)
+      magH       <- config.extractAs[JDouble](INSTRUMENT_KEY / MAG_H_PROP)
+      magI       <- config.extractAs[JDouble](INSTRUMENT_KEY / MAG_I_PROP)
     } yield AOFlags(useAo, useCal, aoOptimize, alignFpm, magH, magI)
 
   private def gpiASU(
       config: Config): Either[ExtractFailure, ArtificialSources] =
     for {
-      ir          <- config
-                       .extractAs[ArtificialSource](INSTRUMENT_KEY / IR_LASER_LAMP_PROP)
-      vis         <- config
-                       .extractAs[ArtificialSource](INSTRUMENT_KEY / VISIBLE_LASER_LAMP_PROP)
-      sc          <- config
-                       .extractAs[ArtificialSource](INSTRUMENT_KEY / SUPER_CONTINUUM_LAMP_PROP)
-      attenuation <- config
-                       .extractAs[JDouble](
-                        INSTRUMENT_KEY / ARTIFICIAL_SOURCE_ATTENUATION_PROP)
+      ir          <- config.extractAs[ArtificialSource](INSTRUMENT_KEY / IR_LASER_LAMP_PROP)
+      vis         <- config.extractAs[ArtificialSource](INSTRUMENT_KEY / VISIBLE_LASER_LAMP_PROP)
+      sc          <- config.extractAs[ArtificialSource](INSTRUMENT_KEY / SUPER_CONTINUUM_LAMP_PROP)
+      attenuation <- config.extractAs[JDouble](INSTRUMENT_KEY / ARTIFICIAL_SOURCE_ATTENUATION_PROP)
                        .map(_.toDouble)
     } yield ArtificialSources(ir, vis, sc, attenuation)
 
   private def gpiShutters(config: Config): Either[ExtractFailure, Shutters] =
     for {
-      entrance     <- config
-                        .extractAs[Shutter](INSTRUMENT_KEY / ENTRANCE_SHUTTER_PROP)
-      calEntrance  <- config
-                        .extractAs[Shutter](INSTRUMENT_KEY / CAL_ENTRANCE_SHUTTER_PROP)
-      scienceArm   <- config
-                        .extractAs[Shutter](INSTRUMENT_KEY / SCIENCE_ARM_SHUTTER_PROP)
-      referenceArm <- config
-                        .extractAs[Shutter](INSTRUMENT_KEY / REFERENCE_ARM_SHUTTER_PROP)
+      entrance     <- config.extractAs[Shutter](INSTRUMENT_KEY / ENTRANCE_SHUTTER_PROP)
+      calEntrance  <- config.extractAs[Shutter](INSTRUMENT_KEY / CAL_ENTRANCE_SHUTTER_PROP)
+      scienceArm   <- config.extractAs[Shutter](INSTRUMENT_KEY / SCIENCE_ARM_SHUTTER_PROP)
+      referenceArm <- config.extractAs[Shutter](INSTRUMENT_KEY / REFERENCE_ARM_SHUTTER_PROP)
     } yield Shutters(entrance, calEntrance, scienceArm, referenceArm)
 
   private def gpiMode(config: Config): Either[ExtractFailure, Either[ObservingMode, NonStandardModeParams]] =
@@ -111,14 +98,10 @@ object GPI {
       .flatMap { mode =>
         if (mode === ObservingMode.NONSTANDARD) {
           for {
-            apodizer <- config
-                        .extractAs[Apodizer](INSTRUMENT_KEY / APODIZER_PROP)
-            fpm      <- config
-                        .extractAs[FPM](INSTRUMENT_KEY / FPM_PROP)
-            lyot     <- config
-                        .extractAs[Lyot](INSTRUMENT_KEY / LYOT_PROP)
-            filter   <- config
-                        .extractAs[Filter](INSTRUMENT_KEY / FILTER_PROP)
+            apodizer <- config.extractAs[Apodizer](INSTRUMENT_KEY / APODIZER_PROP)
+            fpm      <- config.extractAs[FPM](INSTRUMENT_KEY / FPM_PROP)
+            lyot     <- config.extractAs[Lyot](INSTRUMENT_KEY / LYOT_PROP)
+            filter   <- config.extractAs[Filter](INSTRUMENT_KEY / FILTER_PROP)
           } yield NonStandardModeParams(apodizer, fpm, lyot, filter).asRight
         } else mode.asLeft.asRight
       }
@@ -127,16 +110,13 @@ object GPI {
     EitherT(Sync[F].delay(
       (for {
         adc      <- config.extractAs[Adc](INSTRUMENT_KEY / ADC_PROP)
-        exp      <- config
-                      .extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP)
+        exp      <- config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP)
                       .map(x => Duration(x, SECONDS))
-        coa      <- config
-                      .extractAs[JInt](OBSERVE_KEY / COADDS_PROP)
+        coa      <- config.extractAs[JInt](OBSERVE_KEY / COADDS_PROP)
                       .map(_.toInt)
         mode     <- gpiMode(config)
         pol      <- config.extractAs[Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
-        polA     <- config
-                      .extractAs[JDouble](INSTRUMENT_KEY / HALF_WAVE_PLATE_ANGLE_VALUE_PROP)
+        polA     <- config.extractAs[JDouble](INSTRUMENT_KEY / HALF_WAVE_PLATE_ANGLE_VALUE_PROP)
                       .map(_.toDouble)
         shutters <- gpiShutters(config)
         asu      <- gpiASU(config)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
@@ -117,11 +117,11 @@ object Tcs {
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def build[T, P: ClassTag](f: P => Endo[T], k: ItemKey, config: Config): Endo[T] =
-    config.extract(k).as[P].map(f).foldK
+    config.extractAs[P](k).map(f).foldK
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def build[T, P: ClassTag, Q: ClassTag](f: (P, Q) => Endo[T], k1: ItemKey, k2: ItemKey, config: Config): Endo[T] =
-    config.extract(k1).as[P].product(config.extract(k2).as[Q]).map(f.tupled).foldK
+    config.extractAs[P](k1).product(config.extractAs[Q](k2)).map(f.tupled).foldK
 
   // Parameter specific build functions
   def buildPwfs1Config(guideWithPWFS1: StandardGuideOptions.Value): Endo[TcsConfig] = { s0 =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
@@ -121,7 +121,7 @@ object Tcs {
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def build[T, P: ClassTag, Q: ClassTag](f: (P, Q) => Endo[T], k1: ItemKey, k2: ItemKey, config: Config): Endo[T] =
-    config.extractAs[P](k1).product(config.extractAs[Q](k2)).map(f.tupled).foldK
+    (config.extractAs[P](k1), config.extractAs[Q](k2)).mapN(f).foldK
 
   // Parameter specific build functions
   def buildPwfs1Config(guideWithPWFS1: StandardGuideOptions.Value): Endo[TcsConfig] = { s0 =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -128,10 +128,10 @@ object LogArea {
     }
 
     val columns = List(
-      Column(Column.props(TimestampWidth, "local", label = "Timestamp", disableSort = true, flexShrink = 0, flexGrow = 0, className = LogColumnStyle)),
-      Column(Column.props(LevelWidth, "level", label = "Level", disableSort = true, flexShrink = 0, flexGrow = 0, className = LogColumnStyle)),
-      Column(Column.props(size.width.toInt - TimestampWidth - LevelWidth - ClipboardWidth, "msg", label = "Message", disableSort = true, flexShrink = 0, flexGrow = 0, className = LogColumnStyle)),
-      Column(Column.props(ClipboardWidth, "clip", disableSort = true, flexShrink = 0, flexGrow = 0, headerRenderer = clipboardHeaderRenderer, cellRenderer = clipboardCellRenderer, className = SeqexecStyles.clipboardIconDiv.htmlClass, headerClassName = SeqexecStyles.clipboardIconHeader.htmlClass))
+      Column(Column.propsNoFlex(TimestampWidth, "local", label = "Timestamp", className = LogColumnStyle)),
+      Column(Column.propsNoFlex(LevelWidth, "level", label = "Level", className = LogColumnStyle)),
+      Column(Column.propsNoFlex(size.width.toInt - TimestampWidth - LevelWidth - ClipboardWidth, "msg", label = "Message", className = LogColumnStyle)),
+      Column(Column.propsNoFlex(ClipboardWidth, "clip", headerRenderer = clipboardHeaderRenderer, cellRenderer = clipboardCellRenderer, className = SeqexecStyles.clipboardIconDiv.htmlClass, headerClassName = SeqexecStyles.clipboardIconHeader.htmlClass))
     )
 
     def rowClassName(s: State)(i: Int): String = ((i, p.rowGetter(s)(i)) match {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
@@ -461,11 +461,9 @@ object QueueTableBody {
     b.state.visibleColumnsSizes(size).collect {
       case (IconColumn, width, _) =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width,
             dataKey = "status",
-            flexShrink = 0,
-            flexGrow = 0,
             label = "",
             cellRenderer = statusIconRenderer(props),
             headerRenderer = statusHeaderRenderer,
@@ -473,11 +471,9 @@ object QueueTableBody {
           ))
       case (ObsIdColumn, width, _) =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width,
             dataKey = "obsid",
-            flexShrink = 0,
-            flexGrow = 0,
             minWidth = ObsIdColumnWidth,
             label = "Obs. ID",
             cellRenderer = obsIdRenderer(props),
@@ -486,12 +482,10 @@ object QueueTableBody {
           ))
       case (StateColumn, width, _) =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width,
             dataKey = "state",
             minWidth = StateColumnWidth,
-            flexShrink = 0,
-            flexGrow = 0,
             label = "State",
             cellRenderer = stateRenderer(props),
             headerRenderer = resizableHeaderRenderer(resizeRow(StateColumn)),
@@ -499,12 +493,10 @@ object QueueTableBody {
           ))
       case (InstrumentColumn, width, false) =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width,
             dataKey = "instrument",
             minWidth = InstrumentColumnWidth,
-            flexShrink = 0,
-            flexGrow = 0,
             label = "Instrument",
             cellRenderer = instrumentRenderer(props),
             headerRenderer =
@@ -513,36 +505,30 @@ object QueueTableBody {
           ))
       case (InstrumentColumn, width, true) =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width,
             dataKey = "instrument",
             minWidth = InstrumentColumnWidth,
-            flexShrink = 0,
-            flexGrow = 0,
             label = "Instrument",
             cellRenderer = instrumentRenderer(props),
             className = QueueColumnStyle
           ))
       case (ObsNameColumn, width, _) =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width,
             dataKey = "obsName",
             minWidth = ObsNameColumnWidth / 2,
-            flexShrink = 0,
-            flexGrow = 0,
             label = "Obs. Name",
             cellRenderer = obsNameRenderer(props),
             className = QueueColumnStyle
           ))
       case (TargetNameColumn, width, _) =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width,
             dataKey = "target",
             minWidth = TargetNameColumnWidth / 2,
-            flexShrink = 0,
-            flexGrow = 0,
             label = "Target",
             cellRenderer = targetRenderer(props),
             headerRenderer =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -112,23 +112,19 @@ object StepConfigTable {
       case (ColumnMeta(c, name, label, true, PercentageColumnWidth(percentage)), i)
         if i < b.state.columns.length - 1 =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width * percentage,
             name,
             label = label,
-            flexShrink = 0,
-            flexGrow = 0,
             headerRenderer = resizableHeaderRenderer(resizeRow(c)),
             className = SeqexecStyles.paddedStepRow.htmlClass
           ))
       case (ColumnMeta(_, name, label, true, PercentageColumnWidth(percentage)), _)
                                           =>
         Column(
-          Column.props(width * percentage,
+          Column.propsNoFlex(width * percentage,
                        name,
                        label = label,
-                       flexShrink = 0,
-                       flexGrow = 0,
                        className = SeqexecStyles.paddedStepRow.htmlClass))
     }.toList
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -217,7 +217,6 @@ object StepsTable {
         Column.propsNoFlex(ColWidths.IdxWidth,
                            "idx",
                            label = "Step",
-                           disableSort = true,
                            className = SeqexecStyles.paddedStepRow.htmlClass,
                            cellRenderer = stepIdRenderer))
 
@@ -229,7 +228,6 @@ object StepsTable {
               controlWidth,
               "state",
               label = "Control",
-              disableSort = true,
               className = SeqexecStyles.paddedStepRow.htmlClass,
               cellRenderer = stepProgressRenderer(i, p))))
 
@@ -241,7 +239,6 @@ object StepsTable {
               ColWidths.ControlWidth,
               "ctl",
               label = "Icon",
-              disableSort = true,
               cellRenderer = stepControlRenderer(i, p, recomputeRowHeightsCB),
               className = SeqexecStyles.controlCellRow.htmlClass,
               headerRenderer = controlHeaderRenderer,
@@ -258,7 +255,6 @@ object StepsTable {
              Column.propsNoFlex(width,
                                 "offset",
                                 label = "Offset",
-                                disableSort = true,
                                 cellRenderer =
                                   stepStatusRenderer(p.offsetsDisplay))).some
              .filter(_ => offsetVisible),
@@ -276,7 +272,6 @@ object StepsTable {
                       ColWidths.DisperserWidth,
                       "disperser",
                       label = "Disperser",
-                      disableSort = true,
                       className = SeqexecStyles.centeredCell.htmlClass,
                       cellRenderer = stepDisperserRenderer(s.instrument)
                     )))
@@ -294,7 +289,6 @@ object StepsTable {
                       ColWidths.ExposureWidth,
                       "exposure",
                       label = "Exposure",
-                      disableSort = true,
                       className = SeqexecStyles.centeredCell.htmlClass,
                       cellRenderer = stepExposureRenderer(i.instrument)
                     )))
@@ -310,7 +304,6 @@ object StepsTable {
                       ColWidths.FPUWidth,
                       "fpu",
                       label = "FPU",
-                      disableSort = true,
                       className = SeqexecStyles.centeredCell.htmlClass,
                       cellRenderer = stepFPURenderer(i.instrument))))
         if p.showFPU
@@ -326,7 +319,6 @@ object StepsTable {
                       ColWidths.ObservingModeWidth,
                       "obsMode",
                       label = "Observing Mode",
-                      disableSort = true,
                       className = SeqexecStyles.centeredCell.htmlClass,
                       cellRenderer = stepObsModeRenderer
                     )))
@@ -342,7 +334,6 @@ object StepsTable {
               ColWidths.FilterWidth,
               "filter",
               label = "Filter",
-              disableSort = true,
               className = SeqexecStyles.centeredCell.htmlClass,
               cellRenderer = stepFilterRenderer(i.instrument)
             )))
@@ -356,7 +347,6 @@ object StepsTable {
               ColWidths.ObjectTypeWidth,
               "type",
               label = "Type",
-              disableSort = true,
               className = SeqexecStyles.centeredCell.htmlClass,
               cellRenderer = stepObjectTypeRenderer(objectSize)
             )))
@@ -369,7 +359,6 @@ object StepsTable {
               ColWidths.SettingsWidth,
               "set",
               label = "",
-              disableSort = true,
               cellRenderer = settingsControlRenderer(p, i),
               className = SeqexecStyles.settingsCellRow.htmlClass,
               headerRenderer = settingsHeaderRenderer,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -74,7 +74,7 @@ object Settings {
     val javaTimeJS              = "2.0.0-M13"
     val javaLogJS               = "0.1.5"
     val scalaJQuery             = "1.2"
-    val scalaJSReactVirtualized = "0.3.3"
+    val scalaJSReactVirtualized = "0.3.4"
     val scalaJSReactClipboard   = "0.4.0"
     val scalaJSReactDraggable   = "0.1.1"
 


### PR DESCRIPTION
Some minor simplifications:

* Use `extractAs[A]` instead of `extract().as[A]`
* Remove some parameters on the table columns that default correctly upstream