### PR TITLE
SEQNG-669: Add a border to inactive instrument tabs

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -58,6 +58,7 @@ body {
 }
 
 .SeqexecStyles-activeInstrumentLabel {
+  padding-bottom: 0.2em;
   text-align: center;
 }
 

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -1,15 +1,13 @@
 @import "~semantic-ui-less/themes/default/globals/site.variables";
 @import "~semantic-ui-less/themes/default/collections/table.variables";
+@import "~semantic-ui-less/themes/default/elements/segment.variables";
 
 @color_2: #573a08;
 @color_3: black;
 @text_color: rgba(0, 0, 0, 0.95);
 @color_5: #9f3a38;
-@color_6: rgba(40, 40, 40, 0.3);
 @color_7: rgba(0, 0, 0, 0.87);
 @color_8: #2c662d;
-@background_color_1: white;
-@background_color_2: rgb(243, 244, 245);
 @background_color_3: lightcyan;
 @background_color_4: #fffaf3;
 @background_color_5: #f5f5f5;
@@ -17,10 +15,8 @@
 @background_color_7: rgba(0, 0, 0, 0.05);
 @background_color_8: #fff6f6;
 @background_color_10: #fcfff5;
-@border_color: rgba(34, 36, 38, 0.15);
 @table_row_left_padding: 7px;
 @breakpoint_line_color: #a5673f;
-@gutter_start_color: rgba(34, 36, 38, 0.15);
 @gutter_end_color: rgba(
   34,
   36,
@@ -29,7 +25,7 @@
 ); // Alpha cannot be 0, it breaks in some browsers
 
 body {
-  background-color: @background_color_1;
+  background-color: @white;
   display: flex;
   flex-direction: column;
 }
@@ -62,7 +58,6 @@ body {
 }
 
 .SeqexecStyles-activeInstrumentLabel {
-  padding-bottom: 0.2em;
   text-align: center;
 }
 
@@ -76,8 +71,15 @@ body {
 }
 
 .SeqexecStyles-activeInstrumentContent {
-  padding: 0.6em 0.9em;
-  background-color: @background_color_2 !important;
+  background-color: @secondaryBackground !important;
+}
+
+.SeqexecStyles-inactiveInstrumentContent {
+  border-top: @border !important;
+  border-left: @border !important;
+  border-top-left-radius: @borderRadius;
+  border-top-right-radius: @borderRadius;
+  box-shadow: @boxShadow;
 }
 
 .SeqexecStyles-errorTab {
@@ -91,7 +93,7 @@ body {
 .SeqexecStyles-headerSidebarStyle {
   border-width: 1px;
   border-style: solid;
-  border-color: @border_color;
+  border-color: @borderColor;
   .normalizedSegment;
   .widerColumn;
 }
@@ -122,6 +124,13 @@ body {
 
 .SeqexecStyles-sequencesArea {
   .widerColumn;
+}
+
+.SeqexecStyles-sequencesArea
+  > div
+  > .tabular.menu
+  > .SeqexecStyles-inactiveInstrumentContent:last-child {
+  border-right: @border !important;
 }
 
 .SeqexecStyles-errorText {
@@ -316,25 +325,25 @@ body {
 
 .borderRight() {
   border-right-style: solid;
-  border-right-color: @border_color;
+  border-right-color: @borderColor;
   border-right-width: 1px;
 }
 
 .borderLeft() {
   border-left-style: solid;
-  border-left-color: @border_color;
+  border-left-color: @borderColor;
   border-left-width: 1px;
 }
 
 .borderTop() {
   border-top-style: solid;
-  border-top-color: @border_color;
+  border-top-color: @borderColor;
   border-top-width: 1px;
 }
 
 .borderBottom() {
   border-bottom-style: solid;
-  border-bottom-color: @border_color;
+  border-bottom-color: @borderColor;
   border-bottom-width: 1px;
 }
 
@@ -354,7 +363,7 @@ body {
   text-overflow: ellipsis;
   word-wrap: break-word;
   white-space: nowrap;
-  background-color: @background_color_1;
+  background-color: @white;
   color: @text_color;
   overflow: unset !important;
   .borderTop();
@@ -372,7 +381,7 @@ body {
 .SeqexecStyles-infoLog {
   .borderTop();
   .borderRight();
-  background-color: @background_color_1;
+  background-color: @white;
   color: @text_color;
 }
 
@@ -459,7 +468,7 @@ body {
   .stepRowWithBreakpoint();
   background-image: linear-gradient(
     to right,
-    @gutter_start_color 0px,
+    @borderColor 0px,
     @gutter_end_color 19px,
     @breakpoint_line_color 19px,
     @breakpoint_line_color
@@ -504,9 +513,9 @@ body {
       rgba(249, 0, 1, 0) 0%,
       rgba(249, 0, 1, 0) 0%
     ),
-    linear-gradient(to right, @gutter_start_color 0px, @gutter_end_color 19px) !important;
+    linear-gradient(to right, @borderColor 0px, @gutter_end_color 19px) !important;
   background-clip: padding-box;
-  background-color: @background_color_1;
+  background-color: @white;
   width: 21px;
   min-width: 21px;
   .borderRight();

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -23,6 +23,8 @@ object SeqexecStyles {
 
   val activeInstrumentContent: GStyle = GStyle.fromString("SeqexecStyles-activeInstrumentContent")
 
+  val inactiveInstrumentContent: GStyle = GStyle.fromString("SeqexecStyles-inactiveInstrumentContent")
+
   val errorTab: GStyle = GStyle.fromString("SeqexecStyles-errorTab")
 
   val fieldsNoBottom: GStyle = GStyle.fromString("SeqexecStyles-fieldsNoBottom")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -65,6 +65,7 @@ object InstrumentTab {
           "error"  -> hasError
         ),
         SeqexecStyles.instrumentTab,
+        SeqexecStyles.inactiveInstrumentContent.unless(active),
         SeqexecStyles.activeInstrumentContent.when(active),
         SeqexecStyles.errorTab.when(hasError),
         dataTab := instrument.show

--- a/modules/seqexec/web/client/src/webpack/dev.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/dev.webpack.config.js
@@ -15,7 +15,7 @@ const Web = Merge(
   parts.resourceModules,
   parts.extractCSS({
     devMode: true,
-    use: ["css-loader", parts.lessLoader({ sourceMap: true })]
+    use: ["css-loader", parts.lessLoader()]
   }),
   parts.extraAssets,
   parts.fontAssets,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -93,7 +93,7 @@ object Settings {
     val argonaut                = "6.2.2"
     val commonsHttp             = "2.0.2"
     val unboundId               = "3.2.1"
-    val jwt                     = "0.16.0"
+    val jwt                     = "0.17.0"
     val slf4j                   = "1.7.25"
     val log4s                   = "1.6.1"
     val logback                 = "1.2.3"


### PR DESCRIPTION
It was requested for the inactive instrument tabs to have a border too:

![seqexec - gs-2018b-q-0-4 2018-07-30 11-46-28](https://user-images.githubusercontent.com/3615303/43408131-85668324-93ee-11e8-83ae-7b70635f35af.png)
