### PR TITLE
SEQNG-633: Add timeout for configuring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -337,7 +337,7 @@ lazy val giapi = project
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(Cats.value, Mouse.value, Shapeless.value, CatsEffect.value, Fs2, GiapiJmsUtil, GiapiJmsProvider, GiapiStatusService, Giapi, GiapiCommandsClient) ++ Logging,
-    libraryDependencies ++= Seq(GmpStatusGateway % "test", GmpStatusDatabase % "test")
+    libraryDependencies ++= Seq(GmpStatusGateway % "test", GmpStatusDatabase % "test", GmpCmdJmsBridge % "test")
   )
 
 // Common utilities for web server projects

--- a/build.sbt
+++ b/build.sbt
@@ -337,7 +337,11 @@ lazy val giapi = project
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(Cats.value, Mouse.value, Shapeless.value, CatsEffect.value, Fs2, GiapiJmsUtil, GiapiJmsProvider, GiapiStatusService, Giapi, GiapiCommandsClient) ++ Logging,
-    libraryDependencies ++= Seq(GmpStatusGateway % "test", GmpStatusDatabase % "test", GmpCmdJmsBridge % "test")
+    libraryDependencies ++= Seq(GmpStatusGateway % "test", GmpStatusDatabase % "test", GmpCmdJmsBridge % "test", NopSlf4j % "test"),
+    excludeDependencies ++= Seq(
+      // Remove to silence logging on tests
+      ExclusionRule("ch.qos.logback", "logback-classic")
+    )
   )
 
 // Common utilities for web server projects

--- a/modules/giapi/src/main/scala/giapi/client/commands.scala
+++ b/modules/giapi/src/main/scala/giapi/client/commands.scala
@@ -19,10 +19,14 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 
 package commands {
   final case class CommandResult(response: Response)
-  final case class CommandResultException(response: Response, message: String) extends RuntimeException
+  final case class CommandResultException(response: Response, message: String)
+      extends RuntimeException
 
   object CommandResultException {
-    def timedOut(after: FiniteDuration): CommandResultException = CommandResultException(Response.ERROR, s"Timed out response after: $after")
+
+    def timedOut(after: FiniteDuration): CommandResultException =
+      CommandResultException(Response.ERROR,
+                             s"Timed out response after: $after")
   }
 
   final case class Configuration(config: Map[ConfigPath, String]) {
@@ -92,9 +96,9 @@ package object commands {
         cb(
           Left(
             CommandResultException(hr.getResponse,
-                  if (hr.getResponse === Response.NOANSWER)
-                    "No answer from the instrument"
-                  else hr.getMessage)))
+                                   if (hr.getResponse === Response.NOANSWER)
+                                     "No answer from the instrument"
+                                   else hr.getMessage)))
       } else if (hr.getResponse === Response.COMPLETED) {
         cb(Right(CommandResult(hr.getResponse)))
       }

--- a/modules/giapi/src/main/scala/giapi/client/commands.scala
+++ b/modules/giapi/src/main/scala/giapi/client/commands.scala
@@ -15,11 +15,15 @@ import edu.gemini.aspen.giapi.commands.HandlerResponse.Response
 import edu.gemini.aspen.giapi.commands.HandlerResponse
 import edu.gemini.aspen.gmp.commands.jms.client.CommandSenderClient
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 package commands {
   final case class CommandResult(response: Response)
   final case class CommandResultException(response: Response, message: String) extends RuntimeException
+
+  object CommandResultException {
+    def timedOut(after: FiniteDuration): CommandResultException = CommandResultException(Response.ERROR, s"Timed out response after: $after")
+  }
 
   final case class Configuration(config: Map[ConfigPath, String]) {
 

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GPIClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GPIClient.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
   */
 class GPIClient[F[_]](giapi: Giapi[F]) {
   // GPI documentation specify 60 seconds as the max time to move muchanism
-  val defaultCommandTimeout: FiniteDuration = 60.seconds
+  val DefaultCommandTimeout: FiniteDuration = 60.seconds
 
   ///////////////
   // Status items
@@ -43,45 +43,45 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
   def test: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.TEST, Activity.PRESET_START, Configuration.Zero),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def init: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.INIT, Activity.PRESET_START, Configuration.Zero),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def datum: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.DATUM, Activity.PRESET_START, Configuration.Zero),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def park: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.PARK, Activity.PRESET_START, Configuration.Zero),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def verify: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.VERIFY,
               Activity.PRESET_START,
-              Configuration.Zero), defaultCommandTimeout)
+              Configuration.Zero), DefaultCommandTimeout)
 
   def endVerify: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.END_VERIFY,
               Activity.PRESET_START,
-              Configuration.Zero), defaultCommandTimeout)
+              Configuration.Zero), DefaultCommandTimeout)
 
   def guide: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.GUIDE, Activity.PRESET_START, Configuration.Zero),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def endGuide: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.END_GUIDE,
               Activity.PRESET_START,
-              Configuration.Zero), defaultCommandTimeout)
+              Configuration.Zero), DefaultCommandTimeout)
 
   def observe[A: Show](dataLabel: A, expTime: FiniteDuration): F[CommandResult] =
     giapi.command(
@@ -95,28 +95,28 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
     giapi.command(
       Command(SequenceCommand.END_OBSERVE,
               Activity.PRESET_START,
-              Configuration.Zero), defaultCommandTimeout)
+              Configuration.Zero), DefaultCommandTimeout)
 
   def pause: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.PAUSE, Activity.PRESET_START, Configuration.Zero),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def continue: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.CONTINUE,
               Activity.PRESET_START,
-              Configuration.Zero), defaultCommandTimeout)
+              Configuration.Zero), DefaultCommandTimeout)
 
   def stop: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.STOP, Activity.PRESET_START, Configuration.Zero),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def abort: F[CommandResult] =
     giapi.command(
       Command(SequenceCommand.ABORT, Activity.PRESET_START, Configuration.Zero),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   ////////////////////////
   // GPI Specific commands
@@ -131,7 +131,7 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
         Activity.PRESET_START,
         Configuration.single(s"gpi:selectShutter.$shutterName",
                              position.fold(1, 0))
-      ), defaultCommandTimeout)
+      ), DefaultCommandTimeout)
 
   def entranceShutter(position: Boolean): F[CommandResult] =
     shutter("entranceShutter", position)
@@ -154,7 +154,7 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
       Command(SequenceCommand.APPLY,
               Activity.PRESET_START,
               Configuration.single("gpi:observationMode.mode", mode)),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def ifsFilter(filter: String): F[CommandResult] =
     giapi.command(
@@ -163,7 +163,7 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
         Activity.PRESET_START,
         Configuration.single("gpi:ifs:selectIfsFilter.maskStr", filter)
       ),
-      defaultCommandTimeout)
+      DefaultCommandTimeout)
 
   def ifsConfigure(integrationTime: Double,
                    coAdds: Int,
@@ -179,7 +179,7 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
           Configuration.single("gpi:configIfs.readoutMode", readoutMode)
         ).combineAll
       ),
-      defaultCommandTimeout
+      DefaultCommandTimeout
     )
 
   def genericApply(configuration: Configuration): F[CommandResult] =
@@ -188,7 +188,7 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
         SequenceCommand.APPLY,
         Activity.PRESET_START,
         configuration
-      ), defaultCommandTimeout)
+      ), DefaultCommandTimeout)
 }
 
 object GPIExample extends App {

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GPIClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GPIClient.scala
@@ -16,7 +16,8 @@ import scala.concurrent.duration._
   * Client for GPI
   */
 class GPIClient[F[_]](giapi: Giapi[F]) {
-  val defaultCommandTimeout: FiniteDuration = 2000.milliseconds
+  // GPI documentation specify 60 seconds as the max time to move muchanism
+  val defaultCommandTimeout: FiniteDuration = 60.seconds
 
   ///////////////
   // Status items

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GPIClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GPIClient.scala
@@ -41,19 +41,23 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
   ///////////////////
   def test: F[CommandResult] =
     giapi.command(
-      Command(SequenceCommand.TEST, Activity.PRESET_START, Configuration.Zero), defaultCommandTimeout)
+      Command(SequenceCommand.TEST, Activity.PRESET_START, Configuration.Zero),
+      defaultCommandTimeout)
 
   def init: F[CommandResult] =
     giapi.command(
-      Command(SequenceCommand.INIT, Activity.PRESET_START, Configuration.Zero), defaultCommandTimeout)
+      Command(SequenceCommand.INIT, Activity.PRESET_START, Configuration.Zero),
+      defaultCommandTimeout)
 
   def datum: F[CommandResult] =
     giapi.command(
-      Command(SequenceCommand.DATUM, Activity.PRESET_START, Configuration.Zero), defaultCommandTimeout)
+      Command(SequenceCommand.DATUM, Activity.PRESET_START, Configuration.Zero),
+      defaultCommandTimeout)
 
   def park: F[CommandResult] =
     giapi.command(
-      Command(SequenceCommand.PARK, Activity.PRESET_START, Configuration.Zero), defaultCommandTimeout)
+      Command(SequenceCommand.PARK, Activity.PRESET_START, Configuration.Zero),
+      defaultCommandTimeout)
 
   def verify: F[CommandResult] =
     giapi.command(
@@ -69,7 +73,8 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
 
   def guide: F[CommandResult] =
     giapi.command(
-      Command(SequenceCommand.GUIDE, Activity.PRESET_START, Configuration.Zero), defaultCommandTimeout)
+      Command(SequenceCommand.GUIDE, Activity.PRESET_START, Configuration.Zero),
+      defaultCommandTimeout)
 
   def endGuide: F[CommandResult] =
     giapi.command(
@@ -93,7 +98,8 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
 
   def pause: F[CommandResult] =
     giapi.command(
-      Command(SequenceCommand.PAUSE, Activity.PRESET_START, Configuration.Zero), defaultCommandTimeout)
+      Command(SequenceCommand.PAUSE, Activity.PRESET_START, Configuration.Zero),
+      defaultCommandTimeout)
 
   def continue: F[CommandResult] =
     giapi.command(
@@ -103,11 +109,13 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
 
   def stop: F[CommandResult] =
     giapi.command(
-      Command(SequenceCommand.STOP, Activity.PRESET_START, Configuration.Zero), defaultCommandTimeout)
+      Command(SequenceCommand.STOP, Activity.PRESET_START, Configuration.Zero),
+      defaultCommandTimeout)
 
   def abort: F[CommandResult] =
     giapi.command(
-      Command(SequenceCommand.ABORT, Activity.PRESET_START, Configuration.Zero), defaultCommandTimeout)
+      Command(SequenceCommand.ABORT, Activity.PRESET_START, Configuration.Zero),
+      defaultCommandTimeout)
 
   ////////////////////////
   // GPI Specific commands
@@ -144,7 +152,8 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
     giapi.command(
       Command(SequenceCommand.APPLY,
               Activity.PRESET_START,
-              Configuration.single("gpi:observationMode.mode", mode)), defaultCommandTimeout)
+              Configuration.single("gpi:observationMode.mode", mode)),
+      defaultCommandTimeout)
 
   def ifsFilter(filter: String): F[CommandResult] =
     giapi.command(
@@ -152,7 +161,8 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
         SequenceCommand.APPLY,
         Activity.PRESET_START,
         Configuration.single("gpi:ifs:selectIfsFilter.maskStr", filter)
-      ), defaultCommandTimeout)
+      ),
+      defaultCommandTimeout)
 
   def ifsConfigure(integrationTime: Double,
                    coAdds: Int,
@@ -167,7 +177,9 @@ class GPIClient[F[_]](giapi: Giapi[F]) {
           Configuration.single("gpi:configIfs.numCoadds", coAdds),
           Configuration.single("gpi:configIfs.readoutMode", readoutMode)
         ).combineAll
-      ), defaultCommandTimeout)
+      ),
+      defaultCommandTimeout
+    )
 
   def genericApply(configuration: Configuration): F[CommandResult] =
     giapi.command(
@@ -186,7 +198,8 @@ object GPIExample extends App {
   private val gpiStatus =
     Stream.bracket(
       Giapi
-        .giapiConnection[IO]("failover:(tcp://127.0.0.1:61616)", scala.concurrent.ExecutionContext.Implicits.global)
+        .giapiConnection[IO]("failover:(tcp://127.0.0.1:61616)",
+                             scala.concurrent.ExecutionContext.Implicits.global)
         .connect)(
       giapi => {
         val client =
@@ -206,7 +219,8 @@ object GPIExample extends App {
   private val gpiSequence =
     Stream.bracket(
       Giapi
-        .giapiConnection[IO]("failover:(tcp://127.0.0.1:61616)", scala.concurrent.ExecutionContext.Implicits.global)
+        .giapiConnection[IO]("failover:(tcp://127.0.0.1:61616)",
+                             scala.concurrent.ExecutionContext.Implicits.global)
         .connect)(
       giapi => {
         val client =

--- a/modules/giapi/src/test/scala/giapi/client/GiapiCommandSpec.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiCommandSpec.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package giapi.client
+
+import cats.effect.IO
+import cats.tests.CatsSuite
+import giapi.client.commands._
+import edu.gemini.jms.activemq.provider.ActiveMQJmsProvider
+import edu.gemini.aspen.giapi.commands.{Activity, Command => JCommand, SequenceCommand, CompletionListener, HandlerResponse}
+import edu.gemini.aspen.giapi.commands.HandlerResponse.Response
+import edu.gemini.aspen.gmp.commands.jms.clientbridge.CommandMessagesBridgeImpl
+import edu.gemini.aspen.gmp.commands.jms.clientbridge.CommandMessagesConsumer
+import edu.gemini.aspen.giapi.commands.CommandSender
+import fs2.Stream
+import scala.concurrent.duration._
+import org.scalatest.EitherValues
+
+final case class GmpCommands(amq: ActiveMQJmsProvider, cmc: CommandMessagesConsumer)
+
+object GmpCommands {
+
+  def amqUrl(name: String): String =
+    s"vm://$name?broker.useJmx=false&marshal=false&broker.persistent=false"
+
+  def amqUrlConnect(name: String): String =
+    s"vm://$name?marshal=false&broker.persistent=false&create=false"
+
+  /**
+    * Setup a mini gmp that can store and provide status items
+    */
+  def createGmpCommands(amqUrl: String, handleCommands: Boolean): IO[GmpCommands] = IO.apply {
+    // Local in memory broker
+    val amq = new ActiveMQJmsProvider(amqUrl)
+    amq.startConnection()
+    val cs = new CommandSender() {
+
+      override def sendCommand(command: JCommand, listener: CompletionListener): HandlerResponse =
+        sendCommand(command, listener, 0)
+      override def sendCommand(command: JCommand, listener: CompletionListener, timeout: Long): HandlerResponse =
+        command.getSequenceCommand match {
+          case SequenceCommand.INIT => HandlerResponse.COMPLETED
+          case _                    => HandlerResponse.NOANSWER
+        }
+
+    }
+    val cmb = new CommandMessagesBridgeImpl(amq, cs)
+    val commandMessagesConsumer = new CommandMessagesConsumer(cmb)
+    if (handleCommands) {
+      commandMessagesConsumer.startJms(amq)
+    }
+
+    GmpCommands(amq, commandMessagesConsumer)
+  }
+
+  def closeGmpCommands(gmp: GmpCommands): IO[Unit] = IO.apply {
+    gmp.cmc.stopJms()
+    gmp.amq.stopConnection()
+  }
+}
+
+/**
+  * Tests of the giapi api
+  */
+final class GiapiCommandSpec extends CatsSuite with EitherValues {
+
+  test("Test sending a command with no handlers") {
+    val result = Stream.bracket(
+      GmpCommands.createGmpCommands(GmpCommands.amqUrl("test1"), false))(
+      _ =>
+        Stream.bracket(
+          Giapi
+            .giapiConnection[IO](GmpCommands.amqUrlConnect("test1"), 2000.millis)
+            .connect)(c => Stream.eval(c.command(Command(SequenceCommand.TEST, Activity.PRESET, Configuration.Zero)).attempt), _.close),
+      GmpCommands.closeGmpCommands
+    )
+    result.compile.last.unsafeRunSync.map(_.left.value) should contain(CommandResultException(Response.ERROR, "Message cannot be null"))
+  }
+
+  test("Test sending a command with no answer") {
+    val result = Stream.bracket(
+      GmpCommands.createGmpCommands(GmpCommands.amqUrl("test1"), true))(
+      _ =>
+        Stream.bracket(
+          Giapi
+            .giapiConnection[IO](GmpCommands.amqUrlConnect("test1"), 2000.millis)
+            .connect)(c => Stream.eval(c.command(Command(SequenceCommand.TEST, Activity.PRESET, Configuration.Zero)).attempt), _.close),
+      GmpCommands.closeGmpCommands
+    )
+    result.compile.last.unsafeRunSync.map(_.left.value) should contain(CommandResultException(Response.NOANSWER, "No answer from the instrument"))
+  }
+
+  test("Test sending a command with immediate answer") {
+    val result = Stream.bracket(
+      GmpCommands.createGmpCommands(GmpCommands.amqUrl("test2"), true))(
+      _ =>
+        Stream.bracket(
+          Giapi
+            .giapiConnection[IO](GmpCommands.amqUrlConnect("test2"), 2000.millis)
+            .connect)(c => Stream.eval(c.command(Command(SequenceCommand.INIT, Activity.PRESET, Configuration.Zero)).attempt), _.close),
+      GmpCommands.closeGmpCommands
+    )
+    result.compile.last.unsafeRunSync.map(_.right.value) should contain(CommandResult(Response.COMPLETED))
+  }
+}

--- a/modules/giapi/src/test/scala/giapi/client/GiapiCommandSpec.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiCommandSpec.scala
@@ -74,7 +74,7 @@ final class GiapiCommandSpec extends CatsSuite with EitherValues {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpCommands.amqUrlConnect("test1"))
+            .giapiConnection[IO](GmpCommands.amqUrlConnect("test1"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(c => Stream.eval(c.command(Command(SequenceCommand.TEST, Activity.PRESET, Configuration.Zero), 1.second).attempt), _.close),
       GmpCommands.closeGmpCommands
     )
@@ -87,7 +87,7 @@ final class GiapiCommandSpec extends CatsSuite with EitherValues {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpCommands.amqUrlConnect("test2"))
+            .giapiConnection[IO](GmpCommands.amqUrlConnect("test2"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(c => Stream.eval(c.command(Command(SequenceCommand.TEST, Activity.PRESET, Configuration.Zero), 1.second).attempt), _.close),
       GmpCommands.closeGmpCommands
     )
@@ -100,7 +100,7 @@ final class GiapiCommandSpec extends CatsSuite with EitherValues {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpCommands.amqUrlConnect("test3"))
+            .giapiConnection[IO](GmpCommands.amqUrlConnect("test3"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(c => Stream.eval(c.command(Command(SequenceCommand.INIT, Activity.PRESET, Configuration.Zero), 1.second).attempt), _.close),
       GmpCommands.closeGmpCommands
     )
@@ -114,7 +114,7 @@ final class GiapiCommandSpec extends CatsSuite with EitherValues {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpCommands.amqUrlConnect("test4"))
+            .giapiConnection[IO](GmpCommands.amqUrlConnect("test4"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(c => Stream.eval(c.command(Command(SequenceCommand.PARK, Activity.PRESET, Configuration.Zero), timeout).attempt), _.close),
       GmpCommands.closeGmpCommands
     )

--- a/modules/giapi/src/test/scala/giapi/client/GiapiStatusSpec.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiStatusSpec.scala
@@ -81,7 +81,7 @@ final class GiapiStatusSpec extends CatsSuite {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests1"))
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests1"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(c => Stream.eval(c.get[Int](intItemName)), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -94,7 +94,7 @@ final class GiapiStatusSpec extends CatsSuite {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests2"))
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests2"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(c => Stream.eval(c.get[String](strItemName)), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -109,7 +109,7 @@ final class GiapiStatusSpec extends CatsSuite {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests3"))
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests3"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(c => Stream.eval(c.get[Int]("item:u")), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -124,7 +124,7 @@ final class GiapiStatusSpec extends CatsSuite {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests4"))
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests4"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(c => Stream.eval(c.getO[Int]("item:u")), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -140,7 +140,7 @@ final class GiapiStatusSpec extends CatsSuite {
       g =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests5"))
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests5"), scala.concurrent.ExecutionContext.Implicits.global)
             .connect)(
           c => Stream.eval(GmpStatus.closeGmpStatus(g) >> c.get[Int](intItemName)),
           _.close),

--- a/modules/giapi/src/test/scala/giapi/client/GiapiStatusSpec.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiStatusSpec.scala
@@ -80,11 +80,11 @@ final class GiapiStatusSpec extends CatsSuite {
 
   test("Test reading an existing status item") {
     val result = Stream.bracket(
-      GmpStatus.createGmpStatus(GmpStatus.amqUrl("test1"), intItemName, strItemName))(
+      GmpStatus.createGmpStatus(GmpStatus.amqUrl("tests1"), intItemName, strItemName))(
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("test1"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests1"), 2000.millis)
             .connect)(c => Stream.eval(c.get[Int](intItemName)), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -93,11 +93,11 @@ final class GiapiStatusSpec extends CatsSuite {
 
   test("Test reading an status with string type") {
     val result = Stream.bracket(
-      GmpStatus.createGmpStatus(GmpStatus.amqUrl("test2"), intItemName, strItemName))(
+      GmpStatus.createGmpStatus(GmpStatus.amqUrl("tests2"), intItemName, strItemName))(
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("test2"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests2"), 2000.millis)
             .connect)(c => Stream.eval(c.get[String](strItemName)), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -108,11 +108,11 @@ final class GiapiStatusSpec extends CatsSuite {
 
   test("Test reading an unknown status item") {
     val result = Stream.bracket(
-      GmpStatus.createGmpStatus(GmpStatus.amqUrl("test3"), intItemName, strItemName))(
+      GmpStatus.createGmpStatus(GmpStatus.amqUrl("tests3"), intItemName, strItemName))(
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("test3"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests3"), 2000.millis)
             .connect)(c => Stream.eval(c.get[Int]("item:u")), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -123,11 +123,11 @@ final class GiapiStatusSpec extends CatsSuite {
 
   test("Test reading an unknown status item as optional") {
     val result = Stream.bracket(
-      GmpStatus.createGmpStatus(GmpStatus.amqUrl("test3"), intItemName, strItemName))(
+      GmpStatus.createGmpStatus(GmpStatus.amqUrl("tests4"), intItemName, strItemName))(
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("test3"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests4"), 2000.millis)
             .connect)(c => Stream.eval(c.getO[Int]("item:u")), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -139,11 +139,11 @@ final class GiapiStatusSpec extends CatsSuite {
   test("Closing connection should terminate") {
     // This should fail but we are mostly concerned with ensuring that it terminates
     val result = Stream.bracket(
-      GmpStatus.createGmpStatus(GmpStatus.amqUrl("test4"), intItemName, strItemName))(
+      GmpStatus.createGmpStatus(GmpStatus.amqUrl("tests5"), intItemName, strItemName))(
       g =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("test4"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests5"), 2000.millis)
             .connect)(
           c => Stream.eval(GmpStatus.closeGmpStatus(g) >> c.get[Int](intItemName)),
           _.close),

--- a/modules/giapi/src/test/scala/giapi/client/GiapiStatusSpec.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiStatusSpec.scala
@@ -8,10 +8,8 @@ import cats.tests.CatsSuite
 import edu.gemini.aspen.giapi.status.impl.BasicStatus
 import edu.gemini.aspen.giapi.util.jms.JmsKeys
 import edu.gemini.aspen.gmp.statusdb.StatusDatabase
-import edu.gemini.aspen.gmp.statusgw.jms.{
-  JmsStatusDispatcher,
-  StatusItemRequestListener
-}
+import edu.gemini.aspen.gmp.statusgw.jms.JmsStatusDispatcher
+import edu.gemini.aspen.gmp.statusgw.jms.StatusItemRequestListener
 import edu.gemini.jms.activemq.provider.ActiveMQJmsProvider
 import edu.gemini.jms.api.{
   BaseMessageConsumer,
@@ -20,7 +18,6 @@ import edu.gemini.jms.api.{
   JmsSimpleMessageSelector
 }
 import fs2.Stream
-import scala.concurrent.duration._
 
 final case class GmpStatus(amq: ActiveMQJmsProvider,
                      dispatcher: JmsStatusDispatcher,
@@ -84,7 +81,7 @@ final class GiapiStatusSpec extends CatsSuite {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests1"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests1"))
             .connect)(c => Stream.eval(c.get[Int](intItemName)), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -97,7 +94,7 @@ final class GiapiStatusSpec extends CatsSuite {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests2"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests2"))
             .connect)(c => Stream.eval(c.get[String](strItemName)), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -112,7 +109,7 @@ final class GiapiStatusSpec extends CatsSuite {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests3"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests3"))
             .connect)(c => Stream.eval(c.get[Int]("item:u")), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -127,7 +124,7 @@ final class GiapiStatusSpec extends CatsSuite {
       _ =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests4"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests4"))
             .connect)(c => Stream.eval(c.getO[Int]("item:u")), _.close),
       GmpStatus.closeGmpStatus
     )
@@ -143,7 +140,7 @@ final class GiapiStatusSpec extends CatsSuite {
       g =>
         Stream.bracket(
           Giapi
-            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests5"), 2000.millis)
+            .giapiConnection[IO](GmpStatus.amqUrlConnect("tests5"))
             .connect)(
           c => Stream.eval(GmpStatus.closeGmpStatus(g) >> c.get[Int](intItemName)),
           _.close),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -481,7 +481,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     val gpiControl = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gpi")
     val gpiUrl  = cfg.require[String]("seqexec-engine.gpiUrl")
     if (gpiControl.command) {
-      Giapi.giapiConnection[IO](gpiUrl, 2000.millis).connect
+      Giapi.giapiConnection[IO](gpiUrl).connect
     } else {
       Giapi.giapiConnectionIO.connect
     }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -63,7 +63,7 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings) {
     settings.gmosControl.command.fold(GmosSouthControllerEpics, GmosControllerSim.south),
     settings.gmosControl.command.fold(GmosNorthControllerEpics, GmosControllerSim.north),
     settings.gnirsControl.command.fold(GnirsControllerEpics, GnirsControllerSim),
-    GPIController(new GPIClient(settings.gpiGiapi, scala.concurrent.ExecutionContext.Implicits.global), gpiGDS)
+    GPIController(new GPIClient(settings.gpiGiapi), gpiGDS)
   )
 
   private val translatorSettings = SeqTranslate.Settings(
@@ -481,7 +481,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     val gpiControl = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gpi")
     val gpiUrl  = cfg.require[String]("seqexec-engine.gpiUrl")
     if (gpiControl.command) {
-      Giapi.giapiConnection[IO](gpiUrl).connect
+      Giapi.giapiConnection[IO](gpiUrl, scala.concurrent.ExecutionContext.Implicits.global).connect
     } else {
       Giapi.giapiConnectionIO.connect
     }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPI.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPI.scala
@@ -40,7 +40,7 @@ final case class GPI[F[_]: Sync](controller: GPIController[F])
       config: Config): SeqObserveF[F, ImageFileId, ObserveCommand.Result] =
     Reader { fileId =>
       controller
-        .observe(fileId)
+        .observe(fileId, calcObserveTime(config))
         .map(_ => ObserveCommand.Success: ObserveCommand.Result)
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
@@ -203,7 +203,8 @@ final case class GPIController[F[_]: Sync](gpiClient: GPIClient[F],
     } yield ()
 
   def observe(fileId: ImageFileId, expTime: Time): SeqActionF[F, ImageFileId] =
-    EitherT(gpiClient.observe(fileId, (2 * expTime.millis).milliseconds).map(_ => fileId).attempt)
+    // Let's give it enough time to timeout
+    EitherT(gpiClient.observe(fileId, (3 * expTime.millis / 2).milliseconds).map(_ => fileId).attempt)
       .leftMap {
         case CommandResultException(_, "Message cannot be null") => Execution("Unhandled observe command")
         case CommandResultException(_, m)                        => Execution(m)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
@@ -203,8 +203,7 @@ final case class GPIController[F[_]: Sync](gpiClient: GPIClient[F],
     } yield ()
 
   def observe(fileId: ImageFileId, expTime: Time): SeqActionF[F, ImageFileId] =
-    // Let's give it enough time to timeout
-    EitherT(gpiClient.observe(fileId, (3 * expTime.millis / 2).milliseconds).map(_ => fileId).attempt)
+    EitherT(gpiClient.observe(fileId, expTime.toMilliseconds.milliseconds).map(_ => fileId).attempt)
       .leftMap {
         case CommandResultException(_, "Message cannot be null") => Execution("Unhandled observe command")
         case CommandResultException(_, m)                        => Execution(m)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
@@ -23,11 +23,12 @@ import giapi.client.commands.{CommandResult, CommandResultException, Configurati
 import giapi.client.gpi.GPIClient
 import mouse.boolean._
 import org.log4s.getLogger
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.keywords.GDSClient
 import seqexec.server.SeqActionF
 import seqexec.server.SeqexecFailure.{Execution, SeqexecException}
+import squants.time.Time
 
 object GPILookupTables {
 
@@ -201,8 +202,8 @@ final case class GPIController[F[_]: Sync](gpiClient: GPIClient[F],
             Sync[F].delay(Log.debug("Completed GPI configuration")))
     } yield ()
 
-  def observe(fileId: ImageFileId): SeqActionF[F, ImageFileId] =
-    EitherT(gpiClient.observe(fileId).map(_ => fileId).attempt)
+  def observe(fileId: ImageFileId, expTime: Time): SeqActionF[F, ImageFileId] =
+    EitherT(gpiClient.observe(fileId, (2 * expTime.millis).milliseconds).map(_ => fileId).attempt)
       .leftMap {
         case CommandResultException(_, "Message cannot be null") => Execution("Unhandled observe command")
         case CommandResultException(_, m)                        => Execution(m)

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -73,7 +73,7 @@ class SeqTranslateSpec extends FlatSpec {
     GmosControllerSim.south,
     GmosControllerSim.north,
     GnirsControllerSim,
-    GPIController(new GPIClient(Giapi.giapiConnectionIO.connect.unsafeRunSync, scala.concurrent.ExecutionContext.Implicits.global),
+    GPIController(new GPIClient(Giapi.giapiConnectionIO.connect.unsafeRunSync),
     new GDSClient(GDSClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc")))
   )
 

--- a/modules/seqexec/web/server/src/main/resources/app.conf
+++ b/modules/seqexec/web/server/src/main/resources/app.conf
@@ -46,7 +46,7 @@ seqexec-engine {
         ghost = "simulated"
         gmos = "simulated"
         gnirs = "simulated"
-        gpi = "full"
+        gpi = "simulated"
         gpiGds = "simulated"
         gsaoi = "simulated"
         gws = "simulated"
@@ -67,7 +67,6 @@ seqexec-engine {
     smartGCalHost = "gsodbtest.gemini.edu"
     # Tmp file for development
     smartGCalDir = "/tmp/smartgcal"
-    #gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
-    gpiUrl = "failover:(tcp://172.17.107.50:61616)?timeout=4000"
-    gpiGDS = "http://172.17.107.50:8888/xmlrpc"
+    gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
+    gpiGDS = "http://localhost:8888/xmlrpc"
 }

--- a/modules/seqexec/web/server/src/main/resources/app.conf
+++ b/modules/seqexec/web/server/src/main/resources/app.conf
@@ -46,7 +46,7 @@ seqexec-engine {
         ghost = "simulated"
         gmos = "simulated"
         gnirs = "simulated"
-        gpi = "simulated"
+        gpi = "full"
         gpiGds = "simulated"
         gsaoi = "simulated"
         gws = "simulated"
@@ -67,6 +67,7 @@ seqexec-engine {
     smartGCalHost = "gsodbtest.gemini.edu"
     # Tmp file for development
     smartGCalDir = "/tmp/smartgcal"
-    gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
-    gpiGDS = "http://localhost:8888/xmlrpc"
+    #gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
+    gpiUrl = "failover:(tcp://172.17.107.50:61616)?timeout=4000"
+    gpiGDS = "http://172.17.107.50:8888/xmlrpc"
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -166,6 +166,7 @@ object Settings {
     val JwtCore                = "com.pauldijou"             %%  "jwt-core"                          % LibraryVersions.jwt
     val Slf4j                  = "org.slf4j"                 %   "slf4j-api"                         % LibraryVersions.slf4j
     val JuliSlf4j              = "org.slf4j"                 %   "jul-to-slf4j"                      % LibraryVersions.slf4j
+    val NopSlf4j               = "org.slf4j"                 %   "slf4j-nop"                         % LibraryVersions.slf4j
     val Logback                = Seq(
       "ch.qos.logback"       % "logback-core"             % LibraryVersions.logback,
       "ch.qos.logback"       % "logback-classic"          % LibraryVersions.logback,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -135,6 +135,7 @@ object Settings {
     val giapiStatusService      = "0.6.2"
     val gmpStatusGateway        = "0.3.2"
     val gmpStatusDatabase       = "0.3.2"
+    val gmpCmdClientBridge      = "0.6.2"
     val guava                   = "25.0-jre"
   }
 
@@ -257,6 +258,7 @@ object Settings {
     val GiapiStatusService  = "edu.gemini.aspen"     % "giapi-status-service"    % LibraryVersions.giapiStatusService
     val GmpStatusGateway    = "edu.gemini.aspen.gmp" % "gmp-status-gateway"      % LibraryVersions.gmpStatusGateway
     val GmpStatusDatabase   = "edu.gemini.aspen.gmp" % "gmp-statusdb"            % LibraryVersions.gmpStatusDatabase
+    val GmpCmdJmsBridge     = "edu.gemini.aspen.gmp" % "gmp-commands-jms-bridge" % LibraryVersions.gmpCmdClientBridge
     val Guava               = "com.google.guava"     % "guava"                   % LibraryVersions.guava
   }
 


### PR DESCRIPTION
This is a fairly important change and should not be merged until tested with an instrument.

When a giapi command is sent it can reply that something is excuted right away or that it will complete later. At the moment we assume that it will eventually complete but that may not be always true due to instrument code bugs or other unforseen events.

This PR changes the api so each command will take a timeout and fail if the timeout isn't fullfilled

This led to using some advanced `cats-effect` functions which took me a while to grasp.

The PR also improves the testing situation and it even test the particular case of a command never completing
