### PR TITLE
Improve TCS subsystem logging

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
@@ -57,13 +57,13 @@ final case class Tcs(tcsController: TcsController, subsystems: NonEmptyList[Subs
 
   // Helper function to output the part of the TCS configuration that is actually applied.
   private def subsystemConfig(tcs: TcsConfig, subsystem: Subsystem): List[AnyRef] = subsystem match {
-    case Subsystem.M1 => List(tcs.gc.m1Guide.show)
-    case Subsystem.M2 => List(tcs.gc.m2Guide.show)
-    case Subsystem.OIWFS => List(tcs.gtc.oiwfs.show, tcs.ge.oiwfs.show)
-    case Subsystem.P1WFS => List(tcs.gtc.pwfs1.show, tcs.ge.pwfs1.show)
-    case Subsystem.P2WFS => List(tcs.gtc.pwfs2.show, tcs.ge.pwfs2.show)
-    case Subsystem.Mount => List(tcs.tc.show)
-    case Subsystem.HRProbe => List(tcs.agc.hrwfsPos.show)
+    case Subsystem.M1          => List(tcs.gc.m1Guide.show)
+    case Subsystem.M2          => List(tcs.gc.m2Guide.show)
+    case Subsystem.OIWFS       => List(tcs.gtc.oiwfs.show, tcs.ge.oiwfs.show)
+    case Subsystem.P1WFS       => List(tcs.gtc.pwfs1.show, tcs.ge.pwfs1.show)
+    case Subsystem.P2WFS       => List(tcs.gtc.pwfs2.show, tcs.ge.pwfs2.show)
+    case Subsystem.Mount       => List(tcs.tc.show)
+    case Subsystem.HRProbe     => List(tcs.agc.hrwfsPos.show)
     case Subsystem.ScienceFold => List(tcs.agc.sfPos.show)
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -349,18 +349,20 @@ object TcsController {
     def setIAA(v: InstrumentAlignAngle): TcsConfig = TcsConfig(gc, tc, gtc, ge, agc, v)
   }
 
-  sealed trait Subsystem
+  sealed trait Subsystem extends Product with Serializable
   object Subsystem {
-    object OIWFS extends Subsystem
-    object P1WFS extends Subsystem
-    object P2WFS extends Subsystem
-    object ScienceFold extends Subsystem
-    object HRProbe extends Subsystem
-    object Mount extends Subsystem
-    object M1 extends Subsystem
-    object M2 extends Subsystem
+    case object OIWFS       extends Subsystem
+    case object P1WFS       extends Subsystem
+    case object P2WFS       extends Subsystem
+    case object ScienceFold extends Subsystem
+    case object HRProbe     extends Subsystem
+    case object Mount       extends Subsystem
+    case object M1          extends Subsystem
+    case object M2          extends Subsystem
 
     val all: NonEmptyList[Subsystem] = NonEmptyList.of(OIWFS, P1WFS, P2WFS, ScienceFold, HRProbe, Mount, M1, M2)
+
+    implicit val show: Show[Subsystem] = Show.show { _.productPrefix }
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
@@ -4,11 +4,12 @@
 package seqexec.server.tcs
 
 import cats.data.{EitherT, NonEmptyList}
+import cats.implicits._
 import cats.effect.IO
-import seqexec.server.tcs.TcsController._
-import seqexec.server.{SeqAction, TrySeq}
 import edu.gemini.spModel.core.Wavelength
 import org.log4s.getLogger
+import seqexec.server.tcs.TcsController._
+import seqexec.server.{SeqAction, TrySeq}
 import squants.space.{Degrees, Millimeters, Nanometers}
 
 import cats.implicits._
@@ -43,7 +44,7 @@ object TcsControllerSim extends TcsController {
   ))
 
   override def applyConfig(subsystems: NonEmptyList[Subsystem], tc: TcsConfig): SeqAction[Unit] = {
-    def configSubsystem(subsystem: Subsystem): IO[Unit] = IO.apply(Log.info(s"Applying $subsystem configuration."))
+    def configSubsystem(subsystem: Subsystem): IO[Unit] = IO.apply(Log.info(s"Applying ${subsystem.show} configuration."))
 
     EitherT(
       subsystems.tail.foldLeft(configSubsystem(subsystems.head))((b, a) => b *> configSubsystem(a)).map(TrySeq(_)))


### PR DESCRIPTION
This is a small improvement on how tcs logging is done from:
![seqexec - gs-2018b-q-0-2 2018-08-02 11-11-56](https://user-images.githubusercontent.com/3615303/43598397-96bfc746-9652-11e8-81ef-506b3d5546ea.png)

to
![seqexec - gs-2018b-q-0-2 2018-08-02 11-19-23](https://user-images.githubusercontent.com/3615303/43598402-9c9cdcbc-9652-11e8-8189-b9c0bf2de591.png)
