### PR TITLE
SEQNG-598: Reset websocket connection upon HMR updates

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/dev.js
+++ b/modules/seqexec/web/client/src/main/resources/dev.js
@@ -14,6 +14,9 @@ $.fn.modal = require("semantic-ui-modal");
 $.fn.popup = require("semantic-ui-popup");
 
 if (module.hot) {
+  module.hot.dispose(data => {
+    App.seqexec.SeqexecApp.stop();
+  });
   module.hot.accept();
   App.seqexec.SeqexecApp.start();
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/SeqexecApp.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/SeqexecApp.scala
@@ -12,7 +12,7 @@ import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import seqexec.web.client.components.SeqexecUI
 import seqexec.web.client.services.log.ConsoleHandler
 import seqexec.web.client.services.SeqexecWebClient
-import seqexec.web.client.actions.Initialize
+import seqexec.web.client.actions.{Initialize, WSClose}
 import seqexec.web.client.circuit.SeqexecCircuit
 
 /**
@@ -61,6 +61,11 @@ object SeqexecApp {
       elem
     }
   }
+
+  @JSExport
+  def stop(): Unit =
+    // Close the websocket
+    SeqexecCircuit.dispatch(WSClose)
 
   @JSExport
   def start(): Unit =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -75,6 +75,7 @@ object actions {
 
   // Actions related to web sockets
   final case class WSConnect(delay: Int) extends Action
+  case object WSClose extends Action
   case object Reconnect extends Action
   case object Connecting extends Action
   final case class Connected(ws: WebSocket, delay: Int) extends Action


### PR DESCRIPTION
This is a UI development only improvement

When doing UI development we use webpack-dev-server with Hot module replacement (HMR) which listens for code updates and refreshes the page. It is a very good utility and helps a lot during UI development

However, the seqexec ui uses websockets and those are not closed when the ui is reloaded leading to some overhead and duplicate messages. This PR listens to HMR reloads and kills the previous web socket connection