### PR TITLE
extract seqexec enums

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -9,7 +9,8 @@ import cats.effect.IO
 import cats.implicits._
 import seqexec.engine.Event._
 import seqexec.engine.Result.{PartialVal, PauseContext, RetVal}
-import seqexec.model.Model.{ClientID, Conditions, Observer, Resource, SequenceState}
+import seqexec.model.enum.Resource
+import seqexec.model.Model.{ClientID, Conditions, Observer, SequenceState}
 import fs2.Stream
 import gem.Observation
 import monocle.Lens

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Execution.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Execution.scala
@@ -4,7 +4,7 @@
 package seqexec.engine
 
 import cats.Eq
-import seqexec.model.Model.Resource
+import seqexec.model.enum.Resource
 import monocle.function.Index.{index, listIndex}
 import monocle.syntax.apply._
 import mouse.boolean._

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
@@ -3,7 +3,8 @@
 
 package seqexec.engine
 
-import seqexec.model.Model.{Observer, Resource, SequenceMetadata, SequenceState, StepState}
+import seqexec.model.Model.{Observer, SequenceMetadata, SequenceState }
+import seqexec.model.enum.{ Resource, StepState }
 import gem.Observation
 import cats.implicits._
 import monocle.Lens

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Step.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Step.scala
@@ -3,7 +3,8 @@
 
 package seqexec.engine
 
-import seqexec.model.Model.{Resource, StepConfig, StepState}
+import seqexec.model.Model.StepConfig
+import seqexec.model.enum.{ Resource, StepState }
 
 import cats.implicits._
 import monocle.Lens

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/SequenceSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/SequenceSpec.scala
@@ -5,7 +5,7 @@ package seqexec.engine
 
 import java.util.UUID
 import seqexec.model.Model.{SequenceMetadata, SequenceState, StepConfig}
-import seqexec.model.Model.Instrument.F2
+import seqexec.model.enum.Instrument.F2
 import seqexec.model.{ActionType, UserDetails}
 import scala.Function.const
 import org.scalatest.FlatSpec

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/StepSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/StepSpec.scala
@@ -6,8 +6,9 @@ package seqexec.engine
 import java.util.UUID
 import cats.data.Kleisli
 import cats.effect.IO
-import seqexec.model.Model.Instrument.{F2, GmosS}
-import seqexec.model.Model.{Resource, SequenceMetadata, SequenceState, StepConfig, StepState}
+import seqexec.model.enum.Instrument.{ F2, GmosS }
+import seqexec.model.Model.{ SequenceMetadata, SequenceState, StepConfig }
+import seqexec.model.enum.{ Resource, StepState }
 import seqexec.model.{ActionType, UserDetails}
 import fs2.async.mutable.Queue
 import fs2.{Stream, async}

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
@@ -5,11 +5,12 @@ package seqexec.engine
 
 import java.util.UUID
 import seqexec.engine.Sequence.State.Final
-import seqexec.model.Model.StepState
+import seqexec.model.enum.StepState
 import seqexec.model.Model.Operator
-import seqexec.model.Model.{Resource, SequenceMetadata, SequenceState, StepConfig}
-import seqexec.model.Model.Instrument.{F2, GmosS}
-import seqexec.model.Model.Resource.TCS
+import seqexec.model.Model.{ SequenceMetadata, SequenceState, StepConfig }
+import seqexec.model.enum.Instrument.{F2, GmosS}
+import seqexec.model.enum.Resource
+import seqexec.model.enum.Resource.TCS
 import seqexec.model.{ActionType, UserDetails}
 import fs2.async
 import fs2.async.mutable.Semaphore

--- a/modules/seqexec/model/src/main/scala/seqexec/model/ActionType.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ActionType.scala
@@ -3,7 +3,7 @@
 
 package seqexec.model
 
-import seqexec.model.Model.Resource
+import seqexec.model.enum.Resource
 
 import cats.Eq
 import cats.implicits._

--- a/modules/seqexec/model/src/main/scala/seqexec/model/Model.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Model.scala
@@ -7,66 +7,13 @@ import monocle.macros.Lenses
 
 import cats._
 import cats.implicits._
-import cats.data.NonEmptyList
 import gem.Observation
+import seqexec.model.enum._
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.IsInstanceOf"))
 // scalastyle:off
 object Model {
 
-  sealed trait ServerLogLevel extends Product with Serializable
-  object ServerLogLevel {
-    case object INFO extends ServerLogLevel
-    case object WARN extends ServerLogLevel
-    case object ERROR extends ServerLogLevel
-
-    val all: List[ServerLogLevel] = List(INFO, WARN, ERROR)
-
-    implicit val eq: Eq[ServerLogLevel] = Eq.fromUniversalEquals
-    implicit val show: Show[ServerLogLevel] = Show.show {
-      case INFO  => "INFO"
-      case WARN  => "WARNING"
-      case ERROR => "ERROR"
-    }
-  }
-
-  // The system name in ocs is a string but we can represent the important ones as an ADT
-  sealed trait SystemName {
-    def withParam(p: String): String = s"${this.show}:$p"
-  }
-  object SystemName {
-    case object ocs extends SystemName
-    case object observe extends SystemName
-    case object instrument extends SystemName
-    case object telescope extends SystemName
-    case object gcal extends SystemName
-    case object calibration extends SystemName
-    case object meta extends SystemName
-
-    def unsafeFromString(system: String): SystemName = system match {
-      case "ocs"         => ocs
-      case "instrument"  => instrument
-      case "telescope"   => telescope
-      case "gcal"        => gcal
-      case "observe"     => observe
-      case "calibration" => calibration
-      case "meta"        => meta
-      case s             => sys.error(s"Unknown system name $s")
-    }
-
-    val all: List[SystemName] = List(ocs, instrument, telescope, gcal)
-
-    implicit val show: Show[SystemName] = Show.show {
-      case `ocs`         => "ocs"
-      case `instrument`  => "instrument"
-      case `telescope`   => "telescope"
-      case `gcal`        => "gcal"
-      case `observe`     => "observe"
-      case `calibration` => "calibration"
-      case `meta`        => "meta"
-    }
-    implicit val equal: Eq[SystemName] = Eq.fromUniversalEquals
-  }
   type ParamName = String
   type ParamValue = String
   type Parameters = Map[ParamName, ParamValue]
@@ -78,82 +25,6 @@ object Model {
   type ClientID = java.util.UUID
   implicit val clientIdEq: Eq[ClientID] = Eq.fromUniversalEquals
   val DaytimeCalibrationTargetName = "Daytime calibration"
-
-  /**
-    * A Seqexec resource represents any system that can be only used by one single agent.
-    *
-    */
-  sealed trait Resource
-
-  object Resource {
-
-    case object P1 extends Resource
-    case object OI extends Resource
-    // Mount and science fold cannot be controlled independently. Maybe in the future.
-    // For now, I replaced them with TCS
-  //  case object Mount extends Resource
-  //  case object ScienceFold extends Resource
-    case object TCS extends Resource
-    case object Gcal extends Resource
-    case object Gems extends Resource
-    case object Altair extends Resource
-
-    implicit val order: Order[Resource] = Order.by {
-      case TCS               => 1
-      case Gcal              => 2
-      case Gems              => 3
-      case Altair            => 4
-      case OI                => 5
-      case P1                => 6
-      case Instrument.F2     => 11
-      case Instrument.GmosS  => 12
-      case Instrument.GmosN  => 13
-      case Instrument.GPI    => 14
-      case Instrument.GSAOI  => 15
-      case Instrument.GNIRS  => 16
-      case Instrument.NIRI   => 17
-      case Instrument.NIFS   => 18
-      case Instrument.GHOST  => 19
-    }
-    implicit val show: Show[Resource] = Show.show {
-      case TCS               => "TCS"
-      case Gcal              => "Gcal"
-      case Gems              => "Gems"
-      case Altair            => "Altair"
-      case OI                => "OI"
-      case P1                => "P1"
-      case i: Instrument     => i.show
-    }
-    implicit val ordering: scala.math.Ordering[Resource] = order.toOrdering
-  }
-  sealed trait Instrument extends Resource
-  object Instrument {
-    case object F2 extends Instrument
-    case object GHOST extends Instrument
-    case object GmosS extends Instrument
-    case object GmosN extends Instrument
-    case object GNIRS extends Instrument
-    case object GPI extends Instrument
-    case object GSAOI extends Instrument
-    case object NIRI extends Instrument
-    case object NIFS extends Instrument
-
-    implicit val equal: Eq[Instrument] = Eq.fromUniversalEquals
-    implicit val show: Show[Instrument] = Show.show {
-      case F2    => "Flamingos2"
-      case GHOST => "GHOST"
-      case GmosS => "GMOS-S"
-      case GmosN => "GMOS-N"
-      case GPI   => "GPI"
-      case GSAOI => "GSAOI"
-      case GNIRS => "GNIRS"
-      case NIRI  => "NIRI"
-      case NIFS  => "NIFS"
-    }
-    val gsInstruments: NonEmptyList[Instrument] = NonEmptyList.of(F2, GHOST, GmosS, GPI, GSAOI)
-    val gnInstruments: NonEmptyList[Instrument] = NonEmptyList.of(GmosN, GNIRS, NIRI, NIFS)
-    val all: NonEmptyList[Instrument] = gsInstruments.concatNel(gnInstruments)
-  }
 
   final case class Operator(value: String)
 
@@ -168,42 +39,6 @@ object Model {
     val Zero: Observer = Observer("")
     implicit val equal: Eq[Observer] = Eq.fromUniversalEquals
     implicit val shows: Show[Observer] = Show.show(_.value)
-  }
-
-  sealed trait StepState extends Product with Serializable {
-    def canRunFrom: Boolean = false
-  }
-  object StepState {
-    case object Pending extends StepState {
-      override val canRunFrom: Boolean = true
-    }
-    case object Completed extends StepState
-    case object Skipped extends StepState
-    final case class Failed(msg: String) extends StepState {
-      override val canRunFrom: Boolean = true
-    }
-    case object Running extends StepState
-    case object Paused extends StepState {
-      override val canRunFrom: Boolean = true
-    }
-
-    implicit val equal: Eq[StepState] = Eq.fromUniversalEquals
-  }
-
-  sealed trait ActionStatus extends Product with Serializable
-  object ActionStatus {
-    // Action is not yet run
-    case object Pending extends ActionStatus
-    // Action run and completed
-    case object Completed extends ActionStatus
-    // Action currently running
-    case object Running extends ActionStatus
-    // Action run but paused
-    case object Paused extends ActionStatus
-    // Action run but failed to complete
-    case object Failed extends ActionStatus
-
-    implicit val equal: Eq[ActionStatus] = Eq.fromUniversalEquals
   }
 
   sealed trait Step {
@@ -380,32 +215,6 @@ object Model {
       }
   }
 
-  // Complements to the science model
-  sealed trait StepType extends Product with Serializable
-
-  object StepType {
-    case object Object extends StepType
-    case object Arc extends StepType
-    case object Flat extends StepType
-    case object Bias extends StepType
-    case object Dark extends StepType
-    case object Calibration extends StepType
-
-    implicit val eq: Eq[StepType] = Eq.fromUniversalEquals
-    implicit val show: Show[StepType] = Show.show {
-      case Object      => "OBJECT"
-      case Arc         => "ARC"
-      case Flat        => "FLAT"
-      case Bias        => "BIAS"
-      case Dark        => "DARK"
-      case Calibration => "CAL"
-    }
-
-    val all: List[StepType] = List(Object, Arc, Flat, Bias, Dark, Calibration)
-    private val names = all.map(x => (x.show, x)).toMap
-
-    def fromString(s: String): Option[StepType] = names.get(s)
-  }
 
   sealed trait OffsetAxis {
     val configItem: String
@@ -462,46 +271,7 @@ object Model {
     implicit val show: Show[TelescopeOffset] = Show.fromToString
   }
 
-  sealed trait Guiding extends Product with Serializable {
-    val configValue: String
-  }
-  object Guiding {
-    case object Guide extends Guiding {
-      val configValue: String = "guide"
-    }
-    case object Park extends Guiding {
-      val configValue: String = "park"
-    }
-    case object Freeze extends Guiding {
-      val configValue: String = "freeze"
-    }
 
-    implicit val equal: Eq[Guiding] = Eq.fromUniversalEquals
-
-    def fromString(s: String): Option[Guiding] = s match {
-      case "guide"  => Guiding.Guide.some
-      case "park"   => Guiding.Park.some
-      case "freeze" => Guiding.Freeze.some
-      case _        => none
-    }
-  }
-
-  sealed trait FPUMode extends Product with Serializable
-  object FPUMode {
-    case object BuiltIn extends FPUMode
-    case object Custom extends FPUMode
-
-    implicit val equal: Eq[FPUMode] = Eq.fromUniversalEquals
-    implicit val show: Show[FPUMode] = Show.fromToString
-
-    def fromString(s: String): Option[FPUMode] = s match {
-      case "BUILTIN"     => FPUMode.BuiltIn.some
-      case "CUSTOM_MASK" => FPUMode.Custom.some
-      case _             => none
-    }
-  }
-
-  // Ported from OCS' SPSiteQuality.java
 
   @Lenses final case class Conditions(
     cc: CloudCover,
@@ -547,93 +317,8 @@ object Model {
     }
   }
 
-  sealed trait CloudCover extends Product with Serializable {
-    val toInt: Int
-  }
-  object CloudCover {
-    case object Percent50 extends CloudCover { override val toInt: Int = 50  }
-    case object Percent70 extends CloudCover { override val toInt: Int = 70  }
-    case object Percent80 extends CloudCover { override val toInt: Int = 80  }
-    case object Any       extends CloudCover { override val toInt: Int = 100 } // ODB is 100
 
-    val all: List[CloudCover] = List(Percent50, Percent70, Percent80, Any)
 
-    implicit val equalCloudCover: Eq[CloudCover] = Eq.fromUniversalEquals
-
-    implicit val showCloudCover: Show[CloudCover] = Show.show[CloudCover] {
-      case Percent50 => "50%/Clear"
-      case Percent70 => "70%/Cirrus"
-      case Percent80 => "80%/Cloudy"
-      case Any       => "Any"
-    }
-
-  }
-
-  sealed trait ImageQuality extends Product with Serializable {
-    val toInt: Int
-  }
-  object ImageQuality {
-    case object Percent20 extends ImageQuality { override val toInt: Int = 20  }
-    case object Percent70 extends ImageQuality { override val toInt: Int = 70  }
-    case object Percent85 extends ImageQuality { override val toInt: Int = 85  }
-    case object Any       extends ImageQuality { override val toInt: Int = 100 } // ODB is 100
-
-    val all: List[ImageQuality] = List(Percent20, Percent70, Percent85, Any)
-
-    implicit val equalImageQuality: Eq[ImageQuality] = Eq.fromUniversalEquals
-
-    implicit val showImageQuality: Show[ImageQuality] = Show.show[ImageQuality] {
-      case Percent20 => "20%/Best"
-      case Percent70 => "70%/Good"
-      case Percent85 => "85%/Poor"
-      case Any       => "Any"
-    }
-
-  }
-
-  sealed trait SkyBackground extends Product with Serializable {
-    val toInt: Int
-  }
-  object SkyBackground {
-    case object Percent20 extends SkyBackground { override val toInt: Int = 20  }
-    case object Percent50 extends SkyBackground { override val toInt: Int = 50  }
-    case object Percent80 extends SkyBackground { override val toInt: Int = 80  }
-    case object Any       extends SkyBackground { override val toInt: Int = 100 } // ODB is 100
-
-    val all: List[SkyBackground] = List(Percent20, Percent50, Percent80, Any)
-
-    implicit val equal: Eq[SkyBackground] = Eq.fromUniversalEquals
-
-    implicit val showSkyBackground: Show[SkyBackground] = Show.show[SkyBackground] {
-      case Percent20 => "20%/Darkest"
-      case Percent50 => "50%/Dark"
-      case Percent80 => "80%/Grey"
-      case Any       => "Any/Bright"
-    }
-
-  }
-
-  sealed trait WaterVapor extends Product with Serializable {
-    val toInt: Int
-  }
-  object WaterVapor {
-    case object Percent20 extends WaterVapor { override val toInt: Int = 20  }
-    case object Percent50 extends WaterVapor { override val toInt: Int = 50  }
-    case object Percent80 extends WaterVapor { override val toInt: Int = 80  }
-    case object Any       extends WaterVapor { override val toInt: Int = 100 } // ODB is 100
-
-    val all: List[WaterVapor] = List(Percent20, Percent50, Percent80, Any)
-
-    implicit val equal: Eq[WaterVapor] = Eq.fromUniversalEquals
-
-    implicit val showWaterVapor: Show[WaterVapor] = Show.show[WaterVapor] {
-      case Percent20 => "20%/Low"
-      case Percent50 => "50%/Median"
-      case Percent80 => "85%/High"
-      case Any       => "Any"
-    }
-
-  }
 
   // Log message types
   type Time = java.time.Instant

--- a/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
@@ -4,6 +4,7 @@
 package seqexec.model
 
 import seqexec.model.Model._
+import seqexec.model.enum._
 import seqexec.model.events._
 
 import monocle.{Lens, Optional, Prism, Traversal}
@@ -122,13 +123,13 @@ trait ModelLenses {
 
   // Find the Parameters of the steps containing science steps
   val scienceStepT: Traversal[StepConfig, Parameters] = filterEntry[SystemName, Parameters] {
-    case (s, p) => s === SystemName.observe && p.exists {
-      case (k, v) => k === SystemName.observe.withParam("observeType") && v === "OBJECT"
+    case (s, p) => s === SystemName.Observe && p.exists {
+      case (k, v) => k === SystemName.Observe.withParam("observeType") && v === "OBJECT"
     }
   }
 
   val scienceTargetNameO: Optional[Parameters, TargetName] =
-    paramValueL(SystemName.observe.withParam("object")) ^<-? // find the target name
+    paramValueL(SystemName.Observe.withParam("object")) ^<-? // find the target name
     some                                                     // focus on the option
 
   val stringToStepTypeP: Prism[String, StepType] = Prism(StepType.fromString)(_.show)
@@ -147,48 +148,48 @@ trait ModelLenses {
     prism                                         // step type
 
   val stepTypeO: Optional[Step, StepType] =
-    stepObserveOptional(SystemName.observe, "observeType", stringToStepTypeP)
+    stepObserveOptional(SystemName.Observe, "observeType", stringToStepTypeP)
 
   // Composite lens to find the observe exposure time
   val observeExposureTimeO: Optional[Step, Double] =
-    stepObserveOptional(SystemName.observe, "exposureTime", stringToDoubleP)
+    stepObserveOptional(SystemName.Observe, "exposureTime", stringToDoubleP)
 
   // Composite lens to find the observe coadds
   val observeCoaddsO: Optional[Step, Int] =
-    stepObserveOptional(SystemName.observe, "coadds", stringToIntP)
+    stepObserveOptional(SystemName.Observe, "coadds", stringToIntP)
 
   val stringToFPUModeP: Prism[String, FPUMode] = Prism(FPUMode.fromString)(_.show)
   // Composite lens to find the instrument fpu model
   val instrumentFPUModeO: Optional[Step, FPUMode] =
-    stepObserveOptional(SystemName.instrument, "fpuMode", stringToFPUModeP)
+    stepObserveOptional(SystemName.Instrument, "fpuMode", stringToFPUModeP)
 
   // Composite lens to find the instrument fpu
   val instrumentFPUO: Optional[Step, String] =
-    stepObserveOptional(SystemName.instrument, "fpu", Iso.id[String].asPrism)
+    stepObserveOptional(SystemName.Instrument, "fpu", Iso.id[String].asPrism)
 
   // Composite lens to find the instrument fpu custom mask
   val instrumentFPUCustomMaskO: Optional[Step, String] =
-    stepObserveOptional(SystemName.instrument, "fpuCustomMask", Iso.id[String].asPrism)
+    stepObserveOptional(SystemName.Instrument, "fpuCustomMask", Iso.id[String].asPrism)
 
   // Composite lens to find the instrument filter
   val instrumentFilterO: Optional[Step, String] =
-    stepObserveOptional(SystemName.instrument, "filter", Iso.id[String].asPrism)
+    stepObserveOptional(SystemName.Instrument, "filter", Iso.id[String].asPrism)
 
   // Composite lens to find the instrument disperser for GMOS
   val instrumentDisperserO: Optional[Step, String] =
-    stepObserveOptional(SystemName.instrument, "disperser", Iso.id[String].asPrism)
+    stepObserveOptional(SystemName.Instrument, "disperser", Iso.id[String].asPrism)
 
   // Composite lens to find the instrument observing mode on GPI
   val instrumentObservingModeO: Optional[Step, String] =
-    stepObserveOptional(SystemName.instrument, "observingMode", Iso.id[String].asPrism)
+    stepObserveOptional(SystemName.Instrument, "observingMode", Iso.id[String].asPrism)
 
   // Composite lens to find the central wavelength for a disperser
   val instrumentDisperserLambdaO: Optional[Step, Double] =
-    stepObserveOptional(SystemName.instrument, "disperserLambda", stringToDoubleP)
+    stepObserveOptional(SystemName.Instrument, "disperserLambda", stringToDoubleP)
 
   // Lens to find p offset
   def telescopeOffsetO(x: OffsetAxis): Optional[Step, Double] =
-    stepObserveOptional(SystemName.telescope, x.configItem, stringToDoubleP)
+    stepObserveOptional(SystemName.Telescope, x.configItem, stringToDoubleP)
 
   val telescopeOffsetPO: Optional[Step, TelescopeOffset.P] = telescopeOffsetO(OffsetAxis.AxisP) ^<-> telescopeOffsetPI
   val telescopeOffsetQO: Optional[Step, TelescopeOffset.Q] = telescopeOffsetO(OffsetAxis.AxisQ) ^<-> telescopeOffsetQI
@@ -199,9 +200,9 @@ trait ModelLenses {
   val telescopeGuidingWithT: Traversal[Step, Guiding] =
     standardStepP                                                       ^|->  // which is a standard step
     stepConfigL                                                         ^|->  // configuration of the step
-    systemConfigL(SystemName.telescope)                                 ^<-?  // Observe config
+    systemConfigL(SystemName.Telescope)                                 ^<-?  // Observe config
     some                                                                ^|->> // some
-    paramValuesWithPrefixT(SystemName.telescope.withParam("guideWith")) ^<-?  // find the guiding with params
+    paramValuesWithPrefixT(SystemName.Telescope.withParam("guideWith")) ^<-?  // find the guiding with params
     stringToGuidingP                                                          // to guiding
 
   // Composite lens to find the step config
@@ -213,12 +214,12 @@ trait ModelLenses {
   // Composite lens to find the target name on observation
   val observeTargetNameT: Traversal[SeqexecEvent, TargetName] =
     sequenceConfigT                                 ^|-?  // configuration of the step
-    configParamValueO(SystemName.observe, "object")       // on the configuration find the target name
+    configParamValueO(SystemName.Observe, "object")       // on the configuration find the target name
 
   // Composite lens to find the target name on telescope
   val telescopeTargetNameT: Traversal[SeqexecEvent, TargetName] =
     sequenceConfigT                                       ^|-?  // configuration of the step
-    configParamValueO(SystemName.telescope, "Base:name")        // on the configuration find the target name
+    configParamValueO(SystemName.Telescope, "Base:name")        // on the configuration find the target name
 
   // Composite lens to find the first science step and from there the target name
   val firstScienceStepTargetNameT: Traversal[SequenceView, TargetName] =

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ActionStatus.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ActionStatus.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.Eq
+
+sealed trait ActionStatus extends Product with Serializable
+
+object ActionStatus {
+
+  /** Action is not yet run. */
+  case object Pending extends ActionStatus
+
+  /** Action run and completed. */
+  case object Completed extends ActionStatus
+
+  /** Action currently running. */
+  case object Running extends ActionStatus
+
+  /** Action run but paused. */
+  case object Paused extends ActionStatus
+
+  /** Action run but failed to complete. */
+  case object Failed extends ActionStatus
+
+  implicit val equal: Eq[ActionStatus] =
+    Eq.fromUniversalEquals
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/CloudCover.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/CloudCover.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Show }
+
+sealed abstract class CloudCover(val toInt: Int, val label: String)
+  extends Product with Serializable
+
+object CloudCover {
+
+  case object Percent50 extends CloudCover(50,  "50%/Clear")
+  case object Percent70 extends CloudCover(70,  "70%/Cirrus")
+  case object Percent80 extends CloudCover(80,  "80%/Cloudy")
+  case object Any       extends CloudCover(100, "Any")
+
+  val all: List[CloudCover] =
+    List(Percent50, Percent70, Percent80, Any)
+
+  implicit val equalCloudCover: Eq[CloudCover] =
+    Eq.fromUniversalEquals
+
+  implicit val showCloudCover: Show[CloudCover] =
+    Show.show(_.label)
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/FPUMode.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/FPUMode.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Show }
+import cats.implicits._
+
+sealed abstract class FPUMode(val label: String)
+  extends Product with Serializable
+
+object FPUMode {
+
+  case object BuiltIn extends FPUMode("BUILTIN")
+  case object Custom  extends FPUMode("CUSTOM_MASK")
+
+  val all: List[FPUMode] =
+    List(BuiltIn, Custom)
+
+  implicit val equal: Eq[FPUMode] =
+    Eq.fromUniversalEquals
+
+  implicit val show: Show[FPUMode] =
+    Show.fromToString
+
+  def fromString(s: String): Option[FPUMode] =
+    all.find(_.label === s)
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/Guiding.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/Guiding.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.Eq
+import cats.implicits._
+
+sealed abstract class Guiding(val configValue: String)
+  extends Product with Serializable
+
+object Guiding {
+
+  case object Guide  extends Guiding("guide")
+  case object Park   extends Guiding("park")
+  case object Freeze extends Guiding("freeze")
+
+  val all: List[Guiding] =
+    List(Guide, Park, Freeze)
+
+  implicit val equal: Eq[Guiding] =
+    Eq.fromUniversalEquals
+
+  def fromString(s: String): Option[Guiding] =
+    all.find(_.configValue === s)
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ImageQuality.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ImageQuality.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Show }
+
+sealed abstract class ImageQuality(val toInt: Int, val label: String)
+  extends Product with Serializable
+
+object ImageQuality {
+
+  case object Percent20 extends ImageQuality(20,  "20%/Best")
+  case object Percent70 extends ImageQuality(70,  "70%/Good")
+  case object Percent85 extends ImageQuality(85,  "85%/Poor")
+  case object Any       extends ImageQuality(100, "Any")
+
+  val all: List[ImageQuality] =
+    List(Percent20, Percent70, Percent85, Any)
+
+  implicit val equalImageQuality: Eq[ImageQuality] =
+    Eq.fromUniversalEquals
+
+  implicit val showImageQuality: Show[ImageQuality] =
+    Show.show(_.label)
+
+}
+

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Order, Show }
+import cats.data.NonEmptyList
+import cats.implicits._
+
+/** A Seqexec resource represents any system that can be only used by one single agent. */
+sealed abstract class Resource(val ordinal: Int, val label: String)
+  extends Product with Serializable
+
+object Resource {
+
+  case object P1     extends Resource(1, "P1")
+  case object OI     extends Resource(2, "OI")
+  case object TCS    extends Resource(3, "TCS")
+  case object Gcal   extends Resource(4, "Gcal")
+  case object Gems   extends Resource(5, "Gems")
+  case object Altair extends Resource(6, "Altair")
+
+  // Mount and science fold cannot be controlled independently. Maybe in the future.
+  // For now, I replaced them with TCS
+  //  case object Mount extends Resource
+  //  case object ScienceFold extends Resource
+
+  implicit val order: Order[Resource] =
+    Order.by(_.ordinal)
+
+  implicit val show: Show[Resource] =
+    Show.show(_.label)
+
+  implicit val ordering: Ordering[Resource] =
+    order.toOrdering
+}
+
+sealed abstract class Instrument(ordinal: Int, label: String)
+  extends Resource(ordinal, label)
+
+object Instrument {
+
+  case object F2    extends Instrument(11, "Flamingos2")
+  case object GHOST extends Instrument(12, "GHOST")
+  case object GmosS extends Instrument(13, "GMOS-S")
+  case object GmosN extends Instrument(14, "GMOS-N")
+  case object GNIRS extends Instrument(15, "GPI")
+  case object GPI   extends Instrument(16, "GSAOI")
+  case object GSAOI extends Instrument(17, "GNIRS")
+  case object NIRI  extends Instrument(18, "NIRI")
+  case object NIFS  extends Instrument(19, "NIFS")
+
+  implicit val equal: Eq[Instrument] =
+    Eq.fromUniversalEquals
+
+  implicit val show: Show[Instrument] =
+    Show.show(_.label)
+
+  val gsInstruments: NonEmptyList[Instrument] =
+    NonEmptyList.of(F2, GHOST, GmosS, GPI, GSAOI)
+
+  val gnInstruments: NonEmptyList[Instrument] =
+    NonEmptyList.of(GmosN, GNIRS, NIRI, NIFS)
+
+  val all: NonEmptyList[Instrument] =
+    gsInstruments.concatNel(gnInstruments)
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ServerLogLevel.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ServerLogLevel.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Show }
+
+sealed abstract class ServerLogLevel(val label: String)
+  extends Product with Serializable
+
+object ServerLogLevel {
+
+  case object INFO  extends ServerLogLevel("INFO")
+  case object WARN  extends ServerLogLevel("WARNING")
+  case object ERROR extends ServerLogLevel("ERROR")
+
+  val all: List[ServerLogLevel] =
+    List(INFO, WARN, ERROR)
+
+  implicit val eq: Eq[ServerLogLevel] =
+    Eq.fromUniversalEquals
+
+  implicit val show: Show[ServerLogLevel] =
+    Show.show(_.label)
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/SkyBackground.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/SkyBackground.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Show }
+
+sealed abstract class SkyBackground(val toInt: Int, val label: String)
+  extends Product with Serializable
+
+object SkyBackground {
+
+  case object Percent20 extends SkyBackground(20 , "20%/Darkest")
+  case object Percent50 extends SkyBackground(50 , "50%/Dark")
+  case object Percent80 extends SkyBackground(80 , "80%/Grey")
+  case object Any       extends SkyBackground(100, "Any/Bright")
+
+  val all: List[SkyBackground] =
+    List(Percent20, Percent50, Percent80, Any)
+
+  implicit val equal: Eq[SkyBackground] =
+    Eq.fromUniversalEquals
+
+  implicit val showSkyBackground: Show[SkyBackground] =
+    Show.show(_.label)
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/StepState.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/StepState.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.Eq
+
+sealed abstract class StepState(val canRunFrom: Boolean)
+  extends Product with Serializable
+
+object StepState {
+
+        case object Pending             extends StepState(true)
+        case object Completed           extends StepState(false)
+        case object Skipped             extends StepState(false)
+  final case class  Failed(msg: String) extends StepState(true)
+        case object Running             extends StepState(false)
+        case object Paused              extends StepState(true)
+
+  implicit val equal: Eq[StepState] =
+    Eq.fromUniversalEquals
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/StepType.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/StepType.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Show }
+import cats.implicits._
+
+sealed abstract class StepType(val label: String)
+  extends Product with Serializable
+
+object StepType {
+
+  case object Object      extends StepType("OBJECT")
+  case object Arc         extends StepType("ARC")
+  case object Flat        extends StepType("FLAT")
+  case object Bias        extends StepType("BIAS")
+  case object Dark        extends StepType("DARK")
+  case object Calibration extends StepType("CAL")
+
+  implicit val eq: Eq[StepType] =
+    Eq.fromUniversalEquals
+
+  implicit val show: Show[StepType] =
+    Show.show(_.label)
+
+  val all: List[StepType] =
+    List(Object, Arc, Flat, Bias, Dark, Calibration)
+
+  def fromString(s: String): Option[StepType] =
+    all.find(_.label === s)
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/SystemName.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/SystemName.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Show }
+import cats.implicits._
+
+sealed abstract class SystemName(val system: String) {
+
+  def withParam(p: String): String =
+    s"$system:$p"
+
+}
+
+object SystemName {
+
+  case object Ocs         extends SystemName("ocs")
+  case object Observe     extends SystemName("observe")
+  case object Instrument  extends SystemName("instrument")
+  case object Telescope   extends SystemName("telescope")
+  case object Gcal        extends SystemName("gcal")
+  case object Calibration extends SystemName("calibration")
+  case object Meta        extends SystemName("meta")
+
+  val all: List[SystemName] =
+    List(Ocs, Observe, Instrument, Telescope, Gcal, Calibration, Meta)
+
+  def fromString(system: String): Option[SystemName] =
+    all.find(_.system === system)
+
+  def unsafeFromString(system: String): SystemName =
+    fromString(system).getOrElse(sys.error(s"Unknown system name $system"))
+
+  implicit val show: Show[SystemName] =
+    Show.show(_.system)
+
+  implicit val equal: Eq[SystemName] =
+    Eq.fromUniversalEquals
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/WaterVapor.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/WaterVapor.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import cats.{ Eq, Show }
+
+sealed abstract class WaterVapor(val toInt: Int, val label: String)
+  extends Product with Serializable
+
+object WaterVapor {
+
+  case object Percent20 extends WaterVapor(20,  "20%/Low")
+  case object Percent50 extends WaterVapor(50,  "50%/Median")
+  case object Percent80 extends WaterVapor(80,  "85%/High")
+  case object Any       extends WaterVapor(100, "Any")
+
+  val all: List[WaterVapor] =
+    List(Percent20, Percent50, Percent80, Any)
+
+  implicit val equal: Eq[WaterVapor] =
+    Eq.fromUniversalEquals
+
+  implicit val showWaterVapor: Show[WaterVapor] =
+    Show.show(_.label)
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
@@ -4,6 +4,7 @@
 package seqexec.model
 
 import seqexec.model.Model._
+import seqexec.model.enum._
 import java.time.Instant
 
 import dhs.ImageFileId

--- a/modules/seqexec/model/src/main/scala/seqexec/model/operations.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/operations.scala
@@ -3,8 +3,9 @@
 
 package seqexec.model
 
-import seqexec.model.Model.{Instrument, Step}
-import seqexec.model.Model.Instrument._
+import seqexec.model.Model.Step
+import seqexec.model.enum.Instrument
+import seqexec.model.enum.Instrument._
 import mouse.boolean._
 
 object operations {

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelLensesSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelLensesSpec.scala
@@ -8,7 +8,8 @@ import SequenceEventsArbitraries._
 import SharedModelArbitraries._
 import monocle.law.discipline.{IsoTests, LensTests, OptionalTests, PrismTests, TraversalTests}
 import org.scalacheck.Arbitrary._
-import seqexec.model.Model.{OffsetAxis, SystemName}
+import seqexec.model.Model.OffsetAxis
+import seqexec.model.enum._
 
 final class ModelLensesSpec extends CatsSuite with ModelLenses {
   checkAll("event observer name lens", LensTests(obsNameL))
@@ -20,8 +21,8 @@ final class ModelLensesSpec extends CatsSuite with ModelLenses {
   checkAll("standard step config lens", LensTests(stepConfigL))
   checkAll("events prism", PrismTests(sequenceEventsP))
   checkAll("param value lens", LensTests(paramValueL("object")))
-  checkAll("system parameters lens", LensTests(systemConfigL(SystemName.observe)))
-  checkAll("config param value optional", OptionalTests(configParamValueO(SystemName.observe, "object")))
+  checkAll("system parameters lens", LensTests(systemConfigL(SystemName.Observe)))
+  checkAll("config param value optional", OptionalTests(configParamValueO(SystemName.Observe, "object")))
   checkAll("sequence view Lens", LensTests(sequenceQueueViewL))
   checkAll("sequencename traversal", TraversalTests(sequenceNameT))
   checkAll("sequence config traversal", TraversalTests(sequenceConfigT))

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -4,8 +4,10 @@
 package seqexec.model
 
 import Model._
+
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline._
+import seqexec.model.enum._
 
 /**
   * Tests Model typeclasses

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -11,6 +11,7 @@ import org.scalacheck.Gen
 import org.scalacheck.Arbitrary._
 import gem.Observation
 import java.time.Instant
+import seqexec.model.enum._
 
 // Keep the arbitraries in a separate trait to improve caching
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SharedModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SharedModelArbitraries.scala
@@ -10,6 +10,7 @@ import java.time.Instant
 import cats.implicits._
 import gem.Observation
 import gem.arb.ArbObservation
+import seqexec.model.enum._
 
 // Keep the arbitraries in a separate trait to improve caching
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
@@ -4,7 +4,8 @@
 package seqexec.server
 
 import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
-import seqexec.model.Model.{StepConfig, SystemName}
+import seqexec.model.enum.SystemName
+import seqexec.model.Model.StepConfig
 
 import java.beans.PropertyDescriptor
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -327,7 +327,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     case Instrument.GNIRS => TrySeq(Gnirs(systems.gnirs, systems.dhs))
     case Instrument.GPI   => TrySeq(GPI(systems.gpi))
     case Instrument.GHOST => TrySeq(GHOST(GHOSTController[IO](GDSClient(GDSClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))))) // todo put the controller on systems
-    case _                      => TrySeq.fail(Unexpected(s"Instrument $inst not supported."))
+    case _                => TrySeq.fail(Unexpected(s"Instrument $inst not supported."))
   }
 
   private def calcResources(sys: List[System[IO]]): Set[Resource] =
@@ -343,7 +343,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     case Instrument.NIRI  => true
     case Instrument.GPI   => true
     case Instrument.GHOST => false
-    case _                      => false
+    case _                => false
   }
 
   private def flatOrArcTcsSubsystems(inst: Instrument): NonEmptyList[TcsController.Subsystem] = NonEmptyList.of(ScienceFold, (if (hasOI(inst)) List(OIWFS) else List.empty): _*)
@@ -386,13 +386,13 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
         toInstrumentSys(inst).map(GnirsHeader.header(_, gnirsReader, tcsKReader))
       case Instrument.GPI    =>
         toInstrumentSys(inst).map(GPIHeader.header(_, systems.gpi.gdsClient, tcsKReader, ObsKeywordReaderImpl(config, site)))
-      case Instrument.GHOST    =>
+      case Instrument.GHOST  =>
         // TODO Do an actual GHOST header
         new Header() {
           def sendAfter(id: ImageFileId) = SeqAction.void
           def sendBefore(obsId: Observation.Id, id: ImageFileId) = SeqAction.void
         }.asRight
-      case _                       =>
+      case _                 =>
         TrySeq.fail(Unexpected(s"Instrument $inst not supported."))
     }
   }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -21,8 +21,9 @@ import org.log4s._
 import org.http4s.Uri._
 import seqexec.engine.Result.{Configured, FileIdAllocated, Observed}
 import seqexec.engine.{Action, ActionMetadata, Event, Result, Sequence, Step, fromIO}
-import seqexec.model.Model.{Instrument, Resource, SequenceMetadata, StepState}
-import seqexec.model.{ActionType, Model}
+import seqexec.model.enum.{ Instrument, Resource, StepState }
+import seqexec.model.Model.SequenceMetadata
+import seqexec.model.ActionType
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.SeqTranslate.{Settings, Systems}
@@ -319,13 +320,13 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-  private def toInstrumentSys(inst: Model.Instrument): TrySeq[InstrumentSystem[IO]] = inst match {
-    case Model.Instrument.F2    => TrySeq(Flamingos2(systems.flamingos2, systems.dhs))
-    case Model.Instrument.GmosS => TrySeq(GmosSouth(systems.gmosSouth, systems.dhs))
-    case Model.Instrument.GmosN => TrySeq(GmosNorth(systems.gmosNorth, systems.dhs))
-    case Model.Instrument.GNIRS => TrySeq(Gnirs(systems.gnirs, systems.dhs))
-    case Model.Instrument.GPI   => TrySeq(GPI(systems.gpi))
-    case Model.Instrument.GHOST => TrySeq(GHOST(GHOSTController[IO](GDSClient(GDSClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))))) // todo put the controller on systems
+  private def toInstrumentSys(inst: Instrument): TrySeq[InstrumentSystem[IO]] = inst match {
+    case Instrument.F2    => TrySeq(Flamingos2(systems.flamingos2, systems.dhs))
+    case Instrument.GmosS => TrySeq(GmosSouth(systems.gmosSouth, systems.dhs))
+    case Instrument.GmosN => TrySeq(GmosNorth(systems.gmosNorth, systems.dhs))
+    case Instrument.GNIRS => TrySeq(Gnirs(systems.gnirs, systems.dhs))
+    case Instrument.GPI   => TrySeq(GPI(systems.gpi))
+    case Instrument.GHOST => TrySeq(GHOST(GHOSTController[IO](GDSClient(GDSClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))))) // todo put the controller on systems
     case _                      => TrySeq.fail(Unexpected(s"Instrument $inst not supported."))
   }
 
@@ -334,18 +335,18 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   import TcsController.Subsystem._
 
-  private def hasOI(inst: Model.Instrument): Boolean = inst match {
-    case Model.Instrument.F2    => true
-    case Model.Instrument.GmosS => true
-    case Model.Instrument.GmosN => true
-    case Model.Instrument.NIFS  => true
-    case Model.Instrument.NIRI  => true
-    case Model.Instrument.GPI   => true
-    case Model.Instrument.GHOST => false
+  private def hasOI(inst: Instrument): Boolean = inst match {
+    case Instrument.F2    => true
+    case Instrument.GmosS => true
+    case Instrument.GmosN => true
+    case Instrument.NIFS  => true
+    case Instrument.NIRI  => true
+    case Instrument.GPI   => true
+    case Instrument.GHOST => false
     case _                      => false
   }
 
-  private def flatOrArcTcsSubsystems(inst: Model.Instrument): NonEmptyList[TcsController.Subsystem] = NonEmptyList.of(ScienceFold, (if (hasOI(inst)) List(OIWFS) else List.empty): _*)
+  private def flatOrArcTcsSubsystems(inst: Instrument): NonEmptyList[TcsController.Subsystem] = NonEmptyList.of(ScienceFold, (if (hasOI(inst)) List(OIWFS) else List.empty): _*)
 
   private def calcSystems(stepType: StepType): TrySeq[List[System[IO]]] = {
     stepType match {
@@ -371,21 +372,21 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 
   }
 
-  private def calcInstHeader(config: Config, inst: Model.Instrument): TrySeq[Header] = {
+  private def calcInstHeader(config: Config, inst: Instrument): TrySeq[Header] = {
     val tcsKReader = if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader
     inst match {
-      case Model.Instrument.F2     =>
+      case Instrument.F2     =>
         toInstrumentSys(inst).map(Flamingos2Header.header(_, new Flamingos2Header.ObsKeywordsReaderImpl(config), tcsKReader))
-      case Model.Instrument.GmosS |
-           Model.Instrument.GmosN  =>
+      case Instrument.GmosS |
+           Instrument.GmosN  =>
         val gmosInstReader = if (settings.gmosKeywords) GmosHeader.InstKeywordReaderImpl else GmosHeader.DummyInstKeywordReader
         toInstrumentSys(inst).map(GmosHeader.header(_, GmosHeader.ObsKeywordsReaderImpl(config), gmosInstReader, tcsKReader))
-      case Model.Instrument.GNIRS  =>
+      case Instrument.GNIRS  =>
         val gnirsReader = if(settings.gnirsKeywords) GnirsKeywordReaderImpl else GnirsKeywordReaderDummy
         toInstrumentSys(inst).map(GnirsHeader.header(_, gnirsReader, tcsKReader))
-      case Model.Instrument.GPI    =>
+      case Instrument.GPI    =>
         toInstrumentSys(inst).map(GPIHeader.header(_, systems.gpi.gdsClient, tcsKReader, ObsKeywordReaderImpl(config, site)))
-      case Model.Instrument.GHOST    =>
+      case Instrument.GHOST    =>
         // TODO Do an actual GHOST header
         new Header() {
           def sendAfter(id: ImageFileId) = SeqAction.void
@@ -452,34 +453,34 @@ object SeqTranslate {
 
 
   private sealed trait StepType {
-    val instrument: Model.Instrument
+    val instrument: Instrument
   }
 
-  private def extractInstrument(config: Config): TrySeq[Model.Instrument] = {
+  private def extractInstrument(config: Config): TrySeq[Instrument] = {
     config.extractAs[String](INSTRUMENT_KEY / INSTRUMENT_NAME_PROP).asTrySeq.flatMap {
-      case Flamingos2.name => TrySeq(Model.Instrument.F2)
-      case GmosSouth.name  => TrySeq(Model.Instrument.GmosS)
-      case GmosNorth.name  => TrySeq(Model.Instrument.GmosN)
-      case Gnirs.name      => TrySeq(Model.Instrument.GNIRS)
-      case GPI.name        => TrySeq(Model.Instrument.GPI)
-      case GHOST.name      => TrySeq(Model.Instrument.GHOST)
+      case Flamingos2.name => TrySeq(Instrument.F2)
+      case GmosSouth.name  => TrySeq(Instrument.GmosS)
+      case GmosNorth.name  => TrySeq(Instrument.GmosN)
+      case Gnirs.name      => TrySeq(Instrument.GNIRS)
+      case GPI.name        => TrySeq(Instrument.GPI)
+      case GHOST.name      => TrySeq(Instrument.GHOST)
       case ins             => TrySeq.fail(UnrecognizedInstrument(s"inst $ins"))
     }
   }
 
-  private final case class CelestialObject(override val instrument: Model.Instrument) extends StepType
-  private final case class Dark(override val instrument: Model.Instrument) extends StepType
-  private final case class NodAndShuffle(override val instrument: Model.Instrument) extends StepType
-  private final case class Gems(override val instrument: Model.Instrument) extends StepType
-  private final case class Altair(override val instrument: Model.Instrument) extends StepType
-  private final case class FlatOrArc(override val instrument: Model.Instrument) extends StepType
-  private final case class DarkOrBias(override val instrument: Model.Instrument) extends StepType
+  private final case class CelestialObject(override val instrument: Instrument) extends StepType
+  private final case class Dark(override val instrument: Instrument) extends StepType
+  private final case class NodAndShuffle(override val instrument: Instrument) extends StepType
+  private final case class Gems(override val instrument: Instrument) extends StepType
+  private final case class Altair(override val instrument: Instrument) extends StepType
+  private final case class FlatOrArc(override val instrument: Instrument) extends StepType
+  private final case class DarkOrBias(override val instrument: Instrument) extends StepType
   private case object AlignAndCalib extends StepType {
-    override val instrument: Instrument = Model.Instrument.GPI
+    override val instrument: Instrument = Instrument.GPI
   }
 
   private def calcStepType(config: Config): TrySeq[StepType] = {
-    def extractGaos(inst: Model.Instrument): TrySeq[StepType] = config.extractAs[String](new ItemKey(AO_CONFIG_NAME) / AO_SYSTEM_PROP) match {
+    def extractGaos(inst: Instrument): TrySeq[StepType] = config.extractAs[String](new ItemKey(AO_CONFIG_NAME) / AO_SYSTEM_PROP) match {
       case Left(ConfigUtilOps.ConversionError(_, _))              => TrySeq.fail(Unexpected("Unable to get AO system from sequence"))
       case Left(ConfigUtilOps.ContentError(_))                    => TrySeq.fail(Unexpected("Logical error"))
       case Left(ConfigUtilOps.KeyNotFound(_))                     => TrySeq(CelestialObject(inst))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -20,6 +20,7 @@ import seqexec.engine
 import seqexec.engine.Result.{FileIdAllocated, Partial}
 import seqexec.engine.{Step => _, _}
 import seqexec.model.Model._
+import seqexec.model.enum._
 import seqexec.model.events._
 import seqexec.model.{ActionType, UserDetails}
 import seqexec.server.ConfigUtilOps._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/System.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/System.scala
@@ -3,7 +3,7 @@
 
 package seqexec.server
 
-import seqexec.model.Model.Resource
+import seqexec.model.enum.Resource
 import edu.gemini.spModel.config2.Config
 
 trait System[F[_]] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -12,7 +12,7 @@ import edu.gemini.spModel.obscomp.InstConstants.{DARK_OBSERVE_TYPE, OBSERVE_TYPE
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import java.lang.{Double => JDouble}
 import scala.concurrent.duration.{Duration, SECONDS}
-import seqexec.model.Model.{Instrument, Resource}
+import seqexec.model.enum.{ Instrument, Resource }
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.flamingos2.Flamingos2Controller._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/Gcal.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/Gcal.scala
@@ -13,7 +13,7 @@ import edu.gemini.spModel.gemini.calunit.CalUnitParams.Lamp
 import edu.gemini.spModel.seqcomp.SeqConfigNames.CALIBRATION_KEY
 import scala.Function.const
 import scala.collection.JavaConverters._
-import seqexec.model.Model.Resource
+import seqexec.model.enum.Resource
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gcal.GcalController._
 import seqexec.server.{ConfigResult, ConfigUtilOps, SeqAction, SeqexecFailure, System, TrySeq}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOST.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOST.scala
@@ -13,7 +13,7 @@ import edu.gemini.spModel.gemini.ghost.Ghost
 import gem.math.{Angle, HourAngle}
 import scala.concurrent.duration._
 import seqexec.model.dhs.ImageFileId
-import seqexec.model.Model.{Instrument, Resource}
+import seqexec.model.enum.{ Instrument, Resource }
 import seqexec.server.ConfigUtilOps._
 import seqexec.server._
 import seqexec.server.keywords.{GDSClient, GDSInstrument, KeywordsClient}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -3,7 +3,7 @@
 
 package seqexec.server.gmos
 
-import seqexec.model.Model.{Instrument, Resource}
+import seqexec.model.enum.{ Instrument, Resource }
 import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -3,8 +3,7 @@
 
 package seqexec.server.gmos
 
-import seqexec.model.Model
-import seqexec.model.Model.Instrument
+import seqexec.model.enum.{ Instrument, Resource }
 import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
@@ -25,7 +24,7 @@ final case class GmosSouth(c: GmosSouthController, dhsClient: DhsClient) extends
     override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] = config.extractAs[SouthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
     override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] = config.extractAs[SouthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
   })(southConfigTypes) {
-  override val resource: Model.Resource = Instrument.GmosS
+  override val resource: Resource = Instrument.GmosS
   override val dhsInstrumentName: String = "GMOS-S"
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -13,8 +13,7 @@ import edu.gemini.spModel.gemini.gnirs.InstGNIRS._
 import edu.gemini.spModel.obscomp.InstConstants.{BIAS_OBSERVE_TYPE, DARK_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
 import edu.gemini.spModel.seqcomp.SeqConfigNames.{INSTRUMENT_KEY, OBSERVE_KEY}
 import java.lang.{Double => JDouble, Integer => JInt}
-import seqexec.model.Model
-import seqexec.model.Model.Instrument
+import seqexec.model.enum.{ Instrument, Resource }
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gnirs.GnirsController.{CCConfig, DCConfig, Other, ReadMode}
@@ -43,7 +42,7 @@ final case class Gnirs(controller: GnirsController, dhsClient: DhsClient) extend
   override def calcObserveTime(config: Config): Time =
     (extractExposureTime(config), extractCoadds(config)).mapN(_ * _.toDouble).getOrElse(10000.seconds)
 
-  override val resource: Model.Resource = Instrument.GNIRS
+  override val resource: Resource = Instrument.GNIRS
 
   override def configure(config: Config): SeqAction[ConfigResult[IO]] =
     SeqAction.either(fromSequenceConfig(config)).flatMap(controller.applyConfig).map(_ => ConfigResult(this))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPI.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPI.scala
@@ -12,7 +12,7 @@ import edu.gemini.spModel.gemini.gpi.Gpi._
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import java.lang.{Boolean => JBoolean, Double => JDouble, Integer => JInt}
 import seqexec.model.dhs.ImageFileId
-import seqexec.model.Model.{Instrument, Resource}
+import seqexec.model.enum.{ Instrument, Resource }
 import seqexec.server.ConfigUtilOps._
 import seqexec.server._
 import seqexec.server.gpi.GPIController._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -17,7 +17,8 @@ import monocle.macros.GenLens
 import monocle.function.At.at
 import monocle.function.At.atMap
 import seqexec.engine.{ActionMetadata, ActionMetadataGenerator, Engine}
-import seqexec.model.Model.{CloudCover, Conditions, Instrument, ImageQuality, Observer, Operator, SequenceState, SkyBackground, WaterVapor}
+import seqexec.model.enum.{ CloudCover, Instrument, ImageQuality, SkyBackground, WaterVapor}
+import seqexec.model.Model.{ Conditions, Observer, Operator, SequenceState }
 import seqexec.model.UserDetails
 
 package server {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
@@ -15,7 +15,7 @@ import org.log4s.getLogger
 import mouse.all._
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
-import seqexec.model.Model.Resource
+import seqexec.model.enum.Resource
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.tcs.TcsController._
 import seqexec.server.{ConfigResult, SeqAction, System}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -6,7 +6,7 @@ package seqexec.server.tcs
 import cats._
 import cats.data.{NonEmptyList, OneAnd}
 import cats.implicits._
-import seqexec.model.Model.Instrument
+import seqexec.model.enum.Instrument
 import seqexec.server.SeqAction
 import edu.gemini.spModel.core.Wavelength
 import squants.{Angle, Length}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
@@ -4,7 +4,7 @@
 package seqexec.server.tcs
 
 import seqexec.server.tcs.TcsController._
-import seqexec.model.Model
+import seqexec.model.enum.Instrument
 import seqexec.server.{EpicsCodex, EpicsCommand, SeqAction, SeqexecFailure, TrySeq}
 import edu.gemini.spModel.core.Wavelength
 import org.log4s.getLogger
@@ -166,15 +166,15 @@ object TcsControllerEpics extends TcsController {
     } yield TrySeq(GuidersEnabled(GuiderSensorOptionP1(p1On), GuiderSensorOptionP2(p2On), GuiderSensorOptionOI(oiOn)))
   }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read guider detectors state from TCS.")))
 
-  private def getInstPort(inst: Model.Instrument): Option[Int] = (inst match {
-    case Model.Instrument.GmosS |
-         Model.Instrument.GmosN  => TcsEpics.instance.gmosPort
-    case Model.Instrument.GSAOI  => TcsEpics.instance.gsaoiPort
-    case Model.Instrument.F2     => TcsEpics.instance.f2Port
-    case Model.Instrument.GPI    => TcsEpics.instance.gpiPort
-    case Model.Instrument.NIRI   => TcsEpics.instance.niriPort
-    case Model.Instrument.GNIRS  => TcsEpics.instance.gnirsPort
-    case Model.Instrument.NIFS   => TcsEpics.instance.nifsPort
+  private def getInstPort(inst: Instrument): Option[Int] = (inst match {
+    case Instrument.GmosS |
+         Instrument.GmosN  => TcsEpics.instance.gmosPort
+    case Instrument.GSAOI  => TcsEpics.instance.gsaoiPort
+    case Instrument.F2     => TcsEpics.instance.f2Port
+    case Instrument.GPI    => TcsEpics.instance.gpiPort
+    case Instrument.NIRI   => TcsEpics.instance.niriPort
+    case Instrument.GNIRS  => TcsEpics.instance.gnirsPort
+    case Instrument.NIFS   => TcsEpics.instance.nifsPort
     case _                       => None
   }).flatMap(p => if (p === 0) None else Some(p))
 
@@ -195,16 +195,16 @@ object TcsControllerEpics extends TcsController {
         Eq.fromUniversalEquals // natural equality here
     }
 
-    val instNameMap: Map[Model.Instrument, SFInstName] = Map(
-      Model.Instrument.GmosS -> SFInstName("gmos"),
-      Model.Instrument.GmosN -> SFInstName("gmos"),
-      Model.Instrument.GSAOI -> SFInstName("gsaoi"),
-      Model.Instrument.GNIRS -> SFInstName("gnirs"),
-      Model.Instrument.F2    -> SFInstName("f2"),
-      Model.Instrument.GPI   -> SFInstName("gpi")
+    val instNameMap: Map[Instrument, SFInstName] = Map(
+      Instrument.GmosS -> SFInstName("gmos"),
+      Instrument.GmosN -> SFInstName("gmos"),
+      Instrument.GSAOI -> SFInstName("gsaoi"),
+      Instrument.GNIRS -> SFInstName("gnirs"),
+      Instrument.F2    -> SFInstName("f2"),
+      Instrument.GPI   -> SFInstName("gpi")
     )
 
-    private def findInstrument(str: String): Option[Model.Instrument] = instNameMap.find{ case (_, n) => str.startsWith(n.self)}.map(_._1)
+    private def findInstrument(str: String): Option[Instrument] = instNameMap.find{ case (_, n) => str.startsWith(n.self)}.map(_._1)
 
     implicit val decodeScienceFoldPosition: DecodeEpicsValue[String, Option[ScienceFoldPosition]] = DecodeEpicsValue(
       (t: String) => if (t.startsWith(PARK_POS)) Parked.some

--- a/modules/seqexec/server/src/test/scala/seqexec/server/ConfigUtilSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/ConfigUtilSpec.scala
@@ -5,7 +5,7 @@ package seqexec.server
 
 import edu.gemini.spModel.config2.{Config, DefaultConfig, ItemEntry, ItemKey}
 import edu.gemini.spModel.seqcomp.SeqConfigNames
-import seqexec.model.Model.SystemName
+import seqexec.model.enum.SystemName
 import org.scalacheck.{Arbitrary, _}
 import org.scalacheck.Arbitrary._
 import org.scalatest.prop.PropertyChecks

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -13,7 +13,7 @@ import gem.Observation
 import gem.enum.Site
 import seqexec.engine.{Action, Result, Sequence, Step}
 import seqexec.model.ActionType
-import seqexec.model.Model.Instrument.GmosS
+import seqexec.model.enum.Instrument.GmosS
 import seqexec.model.Model.{SequenceMetadata, SequenceState, StepConfig}
 import seqexec.server.SeqTranslate.ObserveContext
 import seqexec.server.keywords.DhsClientSim

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -20,7 +20,8 @@ import seqexec.engine.Result.PauseContext
 import seqexec.engine._
 import seqexec.server.SeqexecEngine.Settings
 import seqexec.server.keywords.GDSClient
-import seqexec.model.Model.{ActionStatus, CloudCover, Conditions, ImageQuality, Instrument, Operator, Resource, SequenceMetadata, SequenceState, SkyBackground, WaterVapor}
+import seqexec.model.enum.{ ActionStatus, CloudCover, ImageQuality, Instrument, Resource, SkyBackground, WaterVapor}
+import seqexec.model.Model.{ Conditions, Operator, SequenceMetadata, SequenceState }
 import seqexec.model.{ActionType, UserDetails}
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
@@ -20,7 +20,8 @@ import seqexec.server.gcal.GcalController
 import seqexec.server.gcal.GcalController._
 import seqexec.server.tcs.{CRFollow, TcsController, TcsControllerEpics}
 import seqexec.server.keywords._
-import seqexec.model.Model.{Conditions, Instrument, Operator}
+import seqexec.model.enum.Instrument
+import seqexec.model.Model.{ Conditions, Operator }
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams
 import edu.gemini.spModel.gemini.gpi.Gpi.{Apodizer => LegacyApodizer}

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerLensesSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerLensesSpec.scala
@@ -5,7 +5,7 @@ package seqexec.server
 
 import cats.tests.CatsSuite
 import monocle.law.discipline.LensTests
-import seqexec.model.Model.Instrument
+import seqexec.model.enum.Instrument
 import seqexec.model.SharedModelArbitraries._
 import gem.arb.ArbObservation
 import gem.Observation

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -19,7 +19,7 @@ import java.time.format.DateTimeFormatter
 import react.virtualized._
 import react.clipboard._
 import scala.scalajs.js
-import seqexec.model.Model.ServerLogLevel
+import seqexec.model.enum.ServerLogLevel
 import seqexec.model.events._
 import seqexec.web.client.semanticui.elements.checkbox.Checkbox
 import seqexec.web.client.semanticui.elements.icon.Icon.{IconCopy, IconAngleDoubleDown, IconAngleDoubleUp}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
@@ -20,9 +20,9 @@ import monocle.macros.GenLens
 import react.virtualized._
 import scala.math.max
 import scala.scalajs.js
+import seqexec.model.enum.Instrument
 import seqexec.model.Model.{
   DaytimeCalibrationTargetName,
-  Instrument,
   SequenceState
 }
 import seqexec.web.client.circuit._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
@@ -23,7 +23,7 @@ import seqexec.web.client.model.Pages._
 import seqexec.web.client.ModelOps._
 import seqexec.web.client.actions.{NavigateSilentTo, RequestSoundEcho}
 import seqexec.web.client.components.sequence.{HeadersSideBar, SequenceArea}
-import seqexec.model.Model.Instrument
+import seqexec.model.enum.Instrument
 import seqexec.web.client.model.WebSocketConnection
 import web.client.style._
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/HeadersSideBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/HeadersSideBar.scala
@@ -4,7 +4,8 @@
 package seqexec.web.client.components.sequence
 
 import diode.react.ModelProxy
-import seqexec.model.Model.{CloudCover, ImageQuality, Operator, SkyBackground, WaterVapor}
+import seqexec.model.enum.{ CloudCover, ImageQuality, SkyBackground, WaterVapor }
+import seqexec.model.Model.Operator
 import seqexec.web.client.semanticui.elements.dropdown.DropdownMenu
 import seqexec.web.client.semanticui.elements.label.FormLabel
 import seqexec.web.client.semanticui.elements.input.InputEV

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
@@ -4,7 +4,8 @@
 package seqexec.web.client.components.sequence.steps
 
 import cats.Eq
-import seqexec.model.Model.{Guiding, Offset, OffsetAxis, Step, TelescopeOffset}
+import seqexec.model.enum.Guiding
+import seqexec.model.Model.{ Offset, OffsetAxis, Step, TelescopeOffset }
 import seqexec.web.client.lenses.{telescopeOffsetPO, telescopeOffsetQO}
 import seqexec.web.client.lenses._
 import seqexec.web.client.components.SeqexecStyles

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -14,7 +14,8 @@ import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import cats.implicits._
 import react.virtualized._
 import scala.scalajs.js
-import seqexec.model.Model.{Step, SystemName}
+import seqexec.model.Model.Step
+import seqexec.model.enum.SystemName
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.actions.UpdateStepsConfigTableState
@@ -74,7 +75,7 @@ object StepConfigTable {
     def unapply(l: SettingsRow): Option[(SystemName, String, String)] =
       Some((l.sub, l.name, l.value))
 
-    def zero: SettingsRow = apply(SystemName.ocs, "", "")
+    def zero: SettingsRow = apply(SystemName.Ocs, "", "")
   }
 
   val TableColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
@@ -130,9 +131,9 @@ object StepConfigTable {
     ((i, p.rowGetter(i)) match {
       case (-1, _) =>
         SeqexecStyles.headerRowStyle
-      case (_, SettingsRow(s, _, _)) if s === SystemName.instrument =>
+      case (_, SettingsRow(s, _, _)) if s === SystemName.Instrument =>
         SeqexecStyles.stepRow |+| SeqexecStyles.rowPositive
-      case (_, SettingsRow(s, _, _)) if s === SystemName.telescope  =>
+      case (_, SettingsRow(s, _, _)) if s === SystemName.Telescope  =>
         SeqexecStyles.stepRow |+| SeqexecStyles.rowWarning
       case (_, SettingsRow(_, n, _)) if n.startsWith("observe:")    =>
         SeqexecStyles.stepRow |+| SeqexecStyles.observeConfig

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -4,7 +4,8 @@
 package seqexec.web.client.components.sequence.steps
 
 import seqexec.model.dhs.ImageFileId
-import seqexec.model.Model.{ActionStatus, Resource, StandardStep, Step, StepState}
+import seqexec.model.enum.{ ActionStatus, Resource, StepState}
+import seqexec.model.Model.{ StandardStep, Step }
 import seqexec.web.client.circuit.{ClientStatus, StepsTableFocus}
 import seqexec.web.client.ModelOps._
 import seqexec.web.client.components.SeqexecStyles

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -10,7 +10,8 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import gem.Observation
 import gem.enum.{GpiDisperser, GpiFilter, GpiObservingMode}
-import seqexec.model.Model.{FPUMode, Instrument, Step, StepType, StepState}
+import seqexec.model.enum.{ FPUMode, Instrument, StepType, StepState }
+import seqexec.model.Model.Step
 import seqexec.web.client.actions.{NavigateSilentTo, FlipSkipStep, FlipBreakpointStep}
 import seqexec.model.enumerations
 import seqexec.web.client.circuit.{ClientStatus, SeqexecCircuit, StepsTableFocus}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -11,6 +11,7 @@ import japgolly.scalajs.react.{Callback, CallbackTo, ScalaComponent, CatsReact}
 import gem.Observation
 import mouse.all._
 import seqexec.model.Model._
+import seqexec.model.enum._
 import seqexec.model.operations.ObservationOperations._
 import seqexec.model.operations._
 import seqexec.web.client.ModelOps._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -10,7 +10,8 @@ import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import scala.scalajs.js
-import seqexec.model.Model.{Instrument, StandardStep, Step, StepState, StepType}
+import seqexec.model.enum.{ Instrument, StepState, StepType }
+import seqexec.model.Model.{ Step, StandardStep }
 import seqexec.web.client.lenses._
 import seqexec.web.client.model.Pages.SeqexecPages
 import seqexec.web.client.ModelOps._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceAnonymousToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceAnonymousToolbar.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client.components.sequence.toolbars
 
 import gem.enum.Site
-import seqexec.model.Model.Instrument
+import seqexec.model.enum.Instrument
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.ModelOps._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -10,7 +10,7 @@ import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import seqexec.model.Model.Instrument
+import seqexec.model.enum.Instrument
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.ModelOps._
 import seqexec.web.client.circuit.SeqexecCircuit

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -7,15 +7,17 @@ import cats.Show
 import cats.implicits._
 import cats.data.NonEmptyList
 import gem.enum.Site
-import seqexec.model.Model.{
+import seqexec.model.enum.{
   ActionStatus,
   Instrument,
   Resource,
+  StepState
+}
+import seqexec.model.Model.{
   SequenceState,
   SequenceView,
   StandardStep,
-  Step,
-  StepState
+  Step
 }
 
 /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -9,6 +9,7 @@ import gem.Observation
 import gem.enum.Site
 import seqexec.model.UserDetails
 import seqexec.model.Model._
+import seqexec.model.enum._
 import seqexec.model.events._
 import seqexec.web.client.model._
 import seqexec.web.client.components.sequence.steps.StepConfigTable

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit.scala
@@ -13,6 +13,7 @@ import gem.enum.Site
 import java.util.logging.Logger
 import japgolly.scalajs.react.Callback
 import seqexec.model.UserDetails
+import seqexec.model.enum._
 import seqexec.model.events._
 import seqexec.model.Model._
 import seqexec.web.client.model._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers.scala
@@ -18,6 +18,7 @@ import org.scalajs.dom._
 import seqexec.model.UserDetails
 import seqexec.model.boopickle._
 import seqexec.model.Model._
+import seqexec.model.enum._
 import seqexec.model.events._
 import seqexec.web.client.model._
 import seqexec.web.client.model.Pages._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -11,6 +11,7 @@ import gem.Observation
 import gem.enum.Site
 import seqexec.model.UserDetails
 import seqexec.model.Model._
+import seqexec.model.enum._
 import seqexec.model.events._
 import seqexec.web.client.ModelOps._
 import seqexec.web.common.{Zipper, FixedLengthBuffer}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -11,7 +11,8 @@ import org.scalajs.dom.ext.{Ajax, AjaxException}
 import org.scalajs.dom.XMLHttpRequest
 import seqexec.model.{UserDetails, UserLoginRequest}
 import seqexec.model.boopickle._
-import seqexec.model.Model.{ClientID, CloudCover, Conditions, ImageQuality, Operator, SequencesQueue, SkyBackground, Step, WaterVapor}
+import seqexec.model.enum.{ CloudCover, ImageQuality, SkyBackground, WaterVapor}
+import seqexec.model.Model.{ ClientID, Conditions, Operator, SequencesQueue, Step }
 import seqexec.web.common.{HttpStatusCodes, LogMessage, RegularCommand}
 import seqexec.web.common.LogMessage._
 import scala.scalajs.js.URIUtils._

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -8,6 +8,7 @@ import diode.RootModelR
 import diode.data._
 import gem.arb.ArbObservation
 import gem.Observation
+import seqexec.model.enum.Instrument
 import seqexec.model.Model._
 import seqexec.web.client.model._
 import seqexec.web.client.circuit._

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client
 
 import gem.Observation
-import seqexec.model.Model.Instrument
+import seqexec.model.enum.Instrument
 import seqexec.web.client.circuit.SeqexecCircuit._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -8,7 +8,8 @@ import gem.Observation
 import seqexec.server.Commands
 import seqexec.server.SeqexecEngine
 import seqexec.server
-import seqexec.model.Model.{SequencesQueue, CloudCover, Conditions, ImageQuality, Observer, Operator, SkyBackground, WaterVapor}
+import seqexec.model.enum.{ CloudCover, ImageQuality, SkyBackground, WaterVapor}
+import seqexec.model.Model.{ SequencesQueue, Conditions, Observer, Operator }
 import seqexec.model.UserDetails
 import seqexec.web.server.model.CommandsModel._
 import seqexec.web.server.http4s.encoder._

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/encoder/BooEncoders.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/encoder/BooEncoders.scala
@@ -10,7 +10,8 @@ import org.http4s.{EntityDecoder, EntityEncoder}
 import org.http4s.booPickle._
 import seqexec.model._
 import seqexec.model.boopickle.GemModelBooPicklers
-import seqexec.model.Model.{CloudCover, Conditions, ImageQuality, Operator, SequencesQueue, SkyBackground, WaterVapor}
+import seqexec.model.enum.{ CloudCover, ImageQuality, SkyBackground, WaterVapor}
+import seqexec.model.Model.{ Conditions, Operator, SequencesQueue }
 import seqexec.web.common.{CliCommand, LogMessage}
 import seqexec.web.common.LogMessage._
 

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/package.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/package.scala
@@ -5,7 +5,8 @@ package seqexec.web.server
 
 import cats.implicits._
 import gem.Observation
-import seqexec.model.Model.{Instrument, ClientID}
+import seqexec.model.enum.Instrument
+import seqexec.model.Model.ClientID
 
 trait Var {
   object ObsIdVar {

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/logging/AppenderForClients.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/logging/AppenderForClients.scala
@@ -10,7 +10,7 @@ import cats.implicits._
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
-import seqexec.model.Model.ServerLogLevel
+import seqexec.model.enum.ServerLogLevel
 import seqexec.model.events._
 import fs2.async.mutable.Topic
 

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -6,6 +6,7 @@ package seqexec.model.boopickle
 import boopickle.Default._
 import gem.Observation
 import java.time.Instant
+import seqexec.model.enum._
 import seqexec.model.Model._
 import seqexec.model.UserDetails
 import seqexec.model.events._

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
@@ -3,6 +3,7 @@
 
 package seqexec.model.boopickle
 
+import seqexec.model.enum._
 import seqexec.model.Model._
 import seqexec.model.events._
 import seqexec.model.UserDetails


### PR DESCRIPTION
I'm going to be doing some janitorial work on the seqexec codebase, to help readability. This just moves the enumerated types from `Model.scala` and into their own source files, in their own package.