### PR TITLE
Asset size checks

### DIFF
--- a/build/buildkite-build.sh
+++ b/build/buildkite-build.sh
@@ -90,13 +90,23 @@ echo "--- :javascript: Linking Javascript"
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
   -Docs3.skipDependencyUpdates          \
+  seqexec_web_client/fastOptJS          \
   ui/fastOptJS
 
 echo "--- :webpack: Webpack"
 /usr/local/bin/sbt                      \
   -jvm-opts build/buildkite-jvmopts     \
   -Docs3.skipDependencyUpdates          \
-  seqexec_web_client/fastOptJS::webpack
+  seqexec_web_client/fastOptJS::webpack \
+  seqexec_web_client/fullOptJS::webpack
+
+###
+### WEIGH
+###
+if [ "$BUILDKITE" = "true" ] && [ -n "$GITHUB_TOKEN" ]; then
+  echo "--- :github: Calculate assets' sizes"
+  $BUILDKITE_BUILD_CHECKOUT_PATH/build/weigh.sh
+fi
 
 ###
 ### DOCKER IMAGE

--- a/build/weigh.sh
+++ b/build/weigh.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-cd $TRAVIS_BUILD_DIR/modules/seqexec/web/client/target/scala-2.12/scalajs-bundler/main/
-python $TRAVIS_BUILD_DIR/build/weigh_in.py seqexec-library.js
-python $TRAVIS_BUILD_DIR/build/weigh_in.py seqexec_web_client-fastopt-library.js
-cd $TRAVIS_BUILD_DIR/modules/ui/target/scala-2.12/
-python $TRAVIS_BUILD_DIR/build/weigh_in.py ui-fastopt.js
+cd $BUILDKITE_BUILD_CHECKOUT_PATH/modules/seqexec/web/client/target/scala-2.12/scalajs-bundler/main/
+python $BUILDKITE_BUILD_CHECKOUT_PATH/build/weigh_in.py seqexec-library.js
+python $BUILDKITE_BUILD_CHECKOUT_PATH/build/weigh_in.py seqexec_web_client-fastopt-library.js
+python $BUILDKITE_BUILD_CHECKOUT_PATH/build/weigh_in.py seqexec.js
+python $BUILDKITE_BUILD_CHECKOUT_PATH/build/weigh_in.py seqexec.css
+cd $BUILDKITE_BUILD_CHECKOUT_PATH/modules/ui/target/scala-2.12/
+python $BUILDKITE_BUILD_CHECKOUT_PATH/build/weigh_in.py ui-fastopt.js

--- a/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
@@ -7,6 +7,8 @@ const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
 
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
+const ci = process.env.CI; // When on CI don't add hashes
+
 const Web = Merge(
   ScalaJSConfig,
   parts.resolve,
@@ -14,7 +16,8 @@ const Web = Merge(
   parts.resourceModules,
   parts.extractCSS({
     devMode: false,
-    use: ["css-loader", parts.autoprefix(), "less-loader"] // Order is very important: css, post-css, less
+    use: ["css-loader", parts.autoprefix(), "less-loader"], // Order is very important: css, post-css, less
+    ci: ci
   }),
   parts.minifyJavaScript(),
   parts.minifyCSS({
@@ -33,7 +36,7 @@ const Web = Merge(
       seqexec: [path.resolve(parts.resourcesDir, "./prod.js")]
     },
     output: {
-      filename: "[name].[chunkhash].js",
+      filename: ci ? "[name].js" : "[name].[chunkhash].js",
       publicPath: "/" // Required to make url navigation work
     },
     plugins: [

--- a/modules/seqexec/web/client/src/webpack/webpack.parts.js
+++ b/modules/seqexec/web/client/src/webpack/webpack.parts.js
@@ -57,11 +57,19 @@ module.exports.lessLoader = (options = {}) => {
 };
 
 // Extract css to a file, use only in production
-module.exports.extractCSS = ({ devMode, include, exclude, use = [] }) => {
+module.exports.extractCSS = ({
+  devMode,
+  include,
+  exclude,
+  use = [],
+  ci = false
+}) => {
+  const filename = ci ? "[name].css" : "[name].[contenthash].css";
+  const chunkFilename = ci ? "[id].css" : "[id].[contenthash].css";
   // Output extracted CSS to a file
   const plugin = new MiniCssExtractPlugin({
-    filename: devMode ? "[name].css" : "[name].[contenthash].css",
-    chunkFilename: devMode ? "[id].css" : "[id].[contenthash].css"
+    filename: devMode ? "[name].css" : filename,
+    chunkFilename: devMode ? "[id].css" : chunkFilename
   });
 
   return {


### PR DESCRIPTION
We used to have checks on the js asset sizes on travis. The move to buildkite broke them and this PR restores them by adapting the script setting github statuses

I also added checks for the fully optimized assets