### PR TITLE
Switch to fixedDelay

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -143,7 +143,7 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
   def seqQueueRefreshStream: Stream[IO, executeEngine.EventType] =
     Scheduler[IO](corePoolSize = 1).flatMap { scheduler =>
       val fd = Duration(settings.odbQueuePollingInterval.toSeconds, TimeUnit.SECONDS)
-      scheduler.fixedRate[IO](fd).flatMap { _ =>
+      scheduler.fixedDelay[IO](fd).flatMap { _ =>
         Stream.emit(Event.getState[executeEngine.ConcreteTypes](refreshSequenceList()))
       }
     }


### PR DESCRIPTION
I've been trying to uncover a memory leak without much success. I suspect the odb refresh is the reason but I'm not totally sure

However talking to the fs2 they indicate it maybe related to our usage of `fixedRate` and suggest `fixedDelay` instead

This change doesn't affect the application but can give us a solution no the leak