### PR TITLE
SEQNG-705: Fix for hovering out of range

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -68,7 +68,12 @@ package circuit {
       Eq.by(x => (x.id, x.instrument, x.state, x.steps, x.stepConfigDisplayed, x.nextStepToRun, x.isPreview))
   }
 
-  final case class StepsTableAndStatusFocus(status: ClientStatus, stepsTable: Option[StepsTableFocus], configTableState: TableState[StepConfigTable.TableColumn]) extends UseValueEq
+  final case class StepsTableAndStatusFocus(status: ClientStatus, stepsTable: Option[StepsTableFocus], configTableState: TableState[StepConfigTable.TableColumn])
+
+  object StepsTableAndStatusFocus {
+    implicit val eq: Eq[StepsTableAndStatusFocus] =
+      Eq.by(x => (x.status, x.stepsTable, x.configTableState))
+  }
 
   final case class ControlModel(id: Observation.Id, isPartiallyExecuted: Boolean, nextStepToRun: Option[Int], status: SequenceState, inConflict: Boolean) extends UseValueEq
 


### PR DESCRIPTION
When setting a breakpoint the table jumps to the first row which is quite annoying.

Also there is a bug on SEQNG-491 when a sequence is larger than the table. If you scroll to a lower position and hover the scroll position is reset to 0 which essentially makes it impossible to click on a lower breakpoint

This PR fixes both by keeping track of the scroll position and resetting it on reload.

![screencast 2018-08-28 18-12-40](https://user-images.githubusercontent.com/3615303/44751461-a4e1cd00-aaee-11e8-8349-1f5237cdef47.gif)


Performance is also improved by reducing the amount of redraws