### PR TITLE
SEQNG-703: Remove use of RefTo in the model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -504,7 +504,7 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
     buildInfoObject := "OcsBuildInfo",
     buildInfoPackage := "seqexec.web.client"
   )
-  .dependsOn(web_client_common, seqexec_web_shared.js % "compile->compile;test->test", seqexec_model.js % "compile->compile;test->test")
+  .dependsOn(web_client_common % "compile->compile;test->test", seqexec_web_shared.js % "compile->compile;test->test", seqexec_model.js % "compile->compile;test->test")
 
 // List all the modules and their inter dependencies
 lazy val seqexec_server = project

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -16,7 +16,7 @@ import org.scalacheck.Arbitrary._
 
 import scala.collection.immutable.TreeMap
 
-trait Arbitraries extends gem.config.Arbitraries  {
+trait Arbitraries extends gem.config.Arbitraries {
   import ArbEnumerated._
   import ArbTargetEnvironment._
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/SequencesQueue.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/SequencesQueue.scala
@@ -6,12 +6,15 @@ package seqexec.model
 import cats._
 import cats.implicits._
 import gem.Observation
+import monocle.Getter
+import monocle.macros.Lenses
 import seqexec.model.enum.Instrument
 
 /**
   * Represents a queue with different levels of details. E.g. it could be a list of Ids
   * Or a list of fully hydrated SequenceViews
   */
+@Lenses
 final case class SequencesQueue[T](
   loaded:     Map[Instrument, Observation.Id],
   conditions: Conditions,
@@ -19,9 +22,12 @@ final case class SequencesQueue[T](
   queue:      List[T]
 )
 
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SequencesQueue {
 
   implicit def equal[T: Eq]: Eq[SequencesQueue[T]] =
-    Eq.by(x => (x.conditions, x.operator, x.queue))
+    Eq.by(x => (x.loaded, x.conditions, x.operator, x.queue))
 
+  def queueItemG[T](predicate: T => Boolean): Getter[SequencesQueue[T], Option[T]] =
+    SequencesQueue.queue composeGetter Getter[List[T], Option[T]] { _.find(predicate) }
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -57,7 +57,7 @@ trait SeqexecModelArbitraries extends ArbObservation {
   implicit val spsArb = Arbitrary[StepState] {
     for {
       v1 <- Gen.oneOf(StepState.Pending, StepState.Completed, StepState.Skipped, StepState.Running, StepState.Paused)
-      v2 <- arbitrary[String].map(StepState.Failed.apply)
+      v2 <- Gen.alphaStr.map(StepState.Failed.apply)
       r  <- Gen.oneOf(v1, v2)
     } yield r
   }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -5,7 +5,6 @@ package seqexec.model
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.Arbitrary._
-import java.time.Instant
 import cats.implicits._
 import gem.Observation
 import gem.arb.ArbObservation
@@ -26,12 +25,6 @@ trait SeqexecModelArbitraries extends ArbObservation {
 
   implicit val clientIdArb: Arbitrary[ClientID] = Arbitrary(Gen.uuid)
 
-  implicit val instArb: Arbitrary[Instant] = Arbitrary {
-    for {
-      i <- Gen.choose(0L, Long.MaxValue)
-    } yield Instant.ofEpochMilli(i)
-  }
-
   implicit val levArb = Arbitrary[ServerLogLevel](Gen.oneOf(ServerLogLevel.INFO, ServerLogLevel.WARN, ServerLogLevel.ERROR))
   implicit val resArb = Arbitrary[Resource](Gen.oneOf(Resource.P1, Resource.OI, Resource.TCS, Resource.Gcal, Resource.Gems, Resource.Altair, Instrument.F2, Instrument.GmosS, Instrument.GmosN, Instrument.GPI, Instrument.GSAOI, Instrument.GNIRS, Instrument.NIRI, Instrument.NIFS))
   implicit val insArb = Arbitrary[Instrument](Gen.oneOf(Instrument.F2, Instrument.GmosS, Instrument.GmosN, Instrument.GPI, Instrument.GSAOI, Instrument.GNIRS, Instrument.NIRI, Instrument.NIFS))
@@ -51,7 +44,7 @@ trait SeqexecModelArbitraries extends ArbObservation {
     } yield UserDetails(u, n)
   }
 
-  implicit val obArb  = Arbitrary[Observer] { arbitrary[String].map(Observer.apply) }
+  implicit val obArb  = Arbitrary[Observer] { Gen.alphaStr.map(Observer.apply) }
   implicit val smArb  = Arbitrary[SequenceMetadata] {
     for {
       i <- arbitrary[Instrument]

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -9,11 +9,12 @@ import org.scalacheck.Cogen
 import org.scalacheck.Gen
 import org.scalacheck.Arbitrary._
 import gem.Observation
+import gem.arb.ArbTime
 import java.time.Instant
 import seqexec.model.enum._
 import seqexec.model.SeqexecModelArbitraries._
 
-trait SequenceEventsArbitraries {
+trait SequenceEventsArbitraries extends ArbTime {
 
   implicit val coeArb = Arbitrary[ConnectionOpenEvent] {
     for {
@@ -63,7 +64,7 @@ trait SequenceEventsArbitraries {
     for {
       l <- arbitrary[ServerLogLevel]
       t <- arbitrary[Instant]
-      m <- arbitrary[String]
+      m <- Gen.alphaStr
     } yield ServerLogMessage(l, t, m)
   }
   implicit val neArb  = Arbitrary[NullEvent.type] { NullEvent }
@@ -211,6 +212,9 @@ trait SequenceEventsArbitraries {
 
   implicit val serCogen: Cogen[SequenceError] =
     Cogen[(Observation.Id, SequencesQueue[SequenceView])].contramap(x => (x.obsId, x.view))
+
+  implicit val slmCogen: Cogen[ServerLogMessage] =
+    Cogen[(ServerLogLevel, Instant, String)].contramap(x => (x.level, x.timestamp, x.msg))
 
   implicit val nlmCogen: Cogen[NewLogMessage] =
     Cogen[String].contramap(_.msg)

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -73,6 +73,7 @@ body {
 
 .SeqexecStyles-instrumentTab {
   min-width: 20%;
+  outline: none;
 }
 
 .SeqexecStyles-activeInstrumentContent {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
@@ -49,7 +49,7 @@ object QueueTableBody {
   private val TargetNameColumnWidth    = 140
   private val QueueColumnStyle: String = SeqexecStyles.queueTextColumn.htmlClass
 
-  sealed trait TableColumn
+  sealed trait TableColumn extends Product with Serializable
   case object IconColumn       extends TableColumn
   case object ObsIdColumn      extends TableColumn
   case object StateColumn      extends TableColumn

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -22,7 +22,7 @@ import seqexec.web.client.actions.UpdateStepsConfigTableState
 import web.client.table._
 
 object StepConfigTable {
-  sealed trait TableColumn
+  sealed trait TableColumn extends Product with Serializable
   case object NameColumn  extends TableColumn
   case object ValueColumn extends TableColumn
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.model
+
+import cats.implicits._
+import gem.Observation
+import monocle.Getter
+import monocle.macros.Lenses
+import seqexec.model.{ Conditions, Observer, UserDetails, SequencesQueue, SequenceView }
+import seqexec.web.common.FixedLengthBuffer
+import seqexec.web.client.components.sequence.steps.StepConfigTable
+import seqexec.web.client.components.QueueTableBody
+import web.client.table._
+
+/**
+ * UI model, changes here will update the UI
+ */
+@Lenses
+final case class SeqexecUIModel(navLocation: Pages.SeqexecPages,
+                          user: Option[UserDetails],
+                          sequences: SequencesQueue[SequenceView],
+                          loginBox: SectionVisibilityState,
+                          resourceConflict: ResourcesConflict,
+                          globalLog: GlobalLog,
+                          sequencesOnDisplay: SequencesOnDisplay,
+                          syncInProgress: Boolean,
+                          configTableState: TableState[StepConfigTable.TableColumn],
+                          queueTableState: TableState[QueueTableBody.TableColumn],
+                          defaultObserver: Observer,
+                          firstLoad: Boolean)
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object SeqexecUIModel {
+  val noSequencesLoaded: SequencesQueue[SequenceView] = SequencesQueue[SequenceView](Map.empty, Conditions.Default, None, Nil)
+  val Initial: SeqexecUIModel = SeqexecUIModel(
+    Pages.Root,
+    None,
+    noSequencesLoaded,
+    SectionClosed,
+    ResourcesConflict(SectionClosed, None),
+    GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
+    SequencesOnDisplay.empty,
+    syncInProgress = false,
+    StepConfigTable.InitialTableState,
+    QueueTableBody.InitialTableState.tableState,
+    Observer(""),
+    firstLoad = true)
+
+  def sequenceReader(id: Observation.Id): Getter[SeqexecUIModel, Option[SequenceView]] =
+    SeqexecUIModel.sequences composeGetter SequencesQueue.queueItemG[SequenceView](_.id === id)
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -3,9 +3,8 @@
 
 package seqexec.web.client.model
 
+import cats.Eq
 import cats.implicits._
-import gem.Observation
-import monocle.Getter
 import monocle.macros.Lenses
 import seqexec.model.{ Conditions, Observer, UserDetails, SequencesQueue, SequenceView }
 import seqexec.web.common.FixedLengthBuffer
@@ -47,7 +46,6 @@ object SeqexecUIModel {
     Observer(""),
     firstLoad = true)
 
-  def sequenceReader(id: Observation.Id): Getter[SeqexecUIModel, Option[SequenceView]] =
-    SeqexecUIModel.sequences composeGetter SequencesQueue.queueItemG[SequenceView](_.id === id)
-
+  implicit val eq: Eq[SeqexecUIModel] =
+    Eq.by(x => (x.navLocation, x.user, x.sequences, x.loginBox, x.resourceConflict, x.globalLog, x.sequencesOnDisplay, x.configTableState, x.queueTableState, x.defaultObserver, x.firstLoad))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -51,18 +51,18 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
     }
 
   def updateFromQueue(s: SequencesQueue[SequenceView]): SequencesOnDisplay = {
-    updateLoaded(s.loaded.values.toList.map { id =>
+    val updated = updateLoaded(s.loaded.values.toList.map { id =>
       s.queue.find(_.id === id)
-    })
-    // sequences.map {
-    //   case InstrumentSequenceTab(_, Some(curr), _, _) => curr.id
-    //   case PreviewSequenceTab(Some(curr), _) => curr.id
-    // }
+    }).sequences.map {
+      case p @ PreviewSequenceTab(Some(curr), r) => s.queue.find(_.id === curr.id).map(s => PreviewSequenceTab(Some(s), r)).getOrElse(p)
+      case t => t
+    }
+    SequencesOnDisplay(updated)
   }
   /**
    * Replace the list of loaded sequences
    */
-  def updateLoaded(s: List[Option[SequenceView]]): SequencesOnDisplay = {
+  private def updateLoaded(s: List[Option[SequenceView]]): SequencesOnDisplay = {
     // Build the new tabs
     val instTabs = s.collect { case Some(x) => InstrumentSequenceTab(x.metadata.instrument, x.some, None, None)  }
     // Store current focus

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -36,7 +36,7 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
   /**
    * List of loaded sequence ids
    */
-  val loadedId: List[Observation.Id] =
+  val loadedIds: List[Observation.Id] =
     sequences.toNel.collect {
       case InstrumentSequenceTab(_, Some(curr), _, _) => curr.id
     }
@@ -93,7 +93,7 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
    */
   def previewSequence(i: Instrument, s: Option[SequenceView]): SequencesOnDisplay = {
     val obsId = s.map(_.id)
-    val isLoaded = obsId.exists(loadedId.contains)
+    val isLoaded = obsId.exists(loadedIds.contains)
     // Replace the sequence for the instrument or the completed sequence and reset displaying a step
     val seq = if (s.exists(x => x.metadata.instrument === i && !isLoaded)) {
       val q = sequences.findFocus(_.isPreview).map(_.modify((SequenceTab.currentSequenceL.set(s) andThen SequenceTab.stepConfigL.set(None))(_)))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -110,7 +110,7 @@ object actions {
 
   implicit val show: Show[Action] = Show.show {
     case s @ ServerMessage(u @ SeqexecModelUpdate(view)) =>
-      s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}(${view.queue.map(s => (s.id, s.steps.collect(standardStep)))}))"
+      s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, loaded: '${view.loaded.mkString(",")}', (${view.queue.map(s => (s"id: ${s.id.format}", s"steps: ${s.steps.length}", s.steps.slice(0, scala.math.min(s.steps.length, 20)).collect(standardStep)))}))"
     case s @ RememberCompleted(view)                     =>
       s"${s.getClass.getSimpleName}(${view.id})"
     case a                                               =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -97,8 +97,6 @@ object actions {
 
   final case class UpdateStepsConfigTableState(s: TableState[StepConfigTable.TableColumn]) extends Action
   final case class UpdateQueueTableState(s: TableState[QueueTableBody.TableColumn]) extends Action
-  final case class UpdateLoadedSequences(ids: List[Observation.Id]) extends Action
-  final case class UpdateOnLoadUpdate(i: Instrument, id: Observation.Id, loaded: List[Observation.Id]) extends Action
   final case class LoadSequence(observer: Observer, i: Instrument, id: Observation.Id) extends Action
   case object CleanSequences extends Action
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
@@ -3,7 +3,6 @@
 
 package seqexec.web.client.circuit
 
-import cats.Eq
 import cats.implicits._
 import cats.data.NonEmptyList
 import diode._
@@ -46,14 +45,6 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   private val logger = Logger.getLogger(SeqexecCircuit.getClass.getSimpleName)
   addProcessor(new LoggingProcessor[SeqexecAppRootModel]())
 
-  implicit def fastEq[A: Eq]: FastEq[A] = new FastEq[A] {
-    override def eqv(a: A, b: A): Boolean = a === b
-  }
-
-  implicit def fastNelEq[A: Eq]: FastEq[NonEmptyList[A]] = new FastEq[NonEmptyList[A]] {
-    override def eqv(a: NonEmptyList[A], b: NonEmptyList[A]): Boolean = a === b
-  }
-
   // Model read-writers
   val webSocketFocusRW: ModelRW[SeqexecAppRootModel, WebSocketsFocus] =
     zoomRW(m => WebSocketsFocus(m.uiModel.navLocation, m.uiModel.sequences, m.uiModel.user, m.uiModel.defaultObserver, m.clientId, m.site)) ((m, v) => m.copy(uiModel = m.uiModel.copy(sequences = v.sequences, user = v.user, defaultObserver = v.defaultObserver), clientId = v.clientId, site = v.site))
@@ -68,7 +59,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   val statusReader: ModelR[SeqexecAppRootModel, ClientStatus] = zoom(m => ClientStatus(m.uiModel.user, m.ws, m.uiModel.syncInProgress))
 
   // Reader to update the sequences in both parts of the model being used
-  val sequencesReaderRW: ModelRW[SeqexecAppRootModel, SequencesFocus] = zoomRW(m => SequencesFocus(m.uiModel.sequences, m.uiModel.sequencesOnDisplay))((m, v) => m.copy(uiModel = m.uiModel.copy(sequences = v.sequences, sequencesOnDisplay = v.sod)))
+  val sequencesReaderRW: ModelRW[SeqexecAppRootModel, SequencesFocus] = this.zoomRWL(SeqexecAppRootModel.uiModel ^|-> SequencesFocus.sequencesFocusL)
 
   // Some useful readers
   val statusAndLoadedSequencesReader: ModelR[SeqexecAppRootModel, StatusAndLoadedSequencesFocus] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
@@ -72,7 +72,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
       case (s, (queue, (sod, queueTable))) =>
         val sequencesInQueue = queue.map { s =>
           val active = sod.idDisplayed(s.id)
-          val loaded = sod.loadedId.contains(s.id)
+          val loaded = sod.loadedIds.contains(s.id)
           val targetName = firstScienceStepTargetNameT.headOption(s)
           SequenceInQueue(s.id, s.status, s.metadata.instrument, active, loaded, s.metadata.name, targetName, s.runningStep)
         }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
@@ -59,7 +59,12 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   val statusReader: ModelR[SeqexecAppRootModel, ClientStatus] = zoom(m => ClientStatus(m.uiModel.user, m.ws, m.uiModel.syncInProgress))
 
   // Reader to update the sequences in both parts of the model being used
-  val sequencesReaderRW: ModelRW[SeqexecAppRootModel, SequencesFocus] = this.zoomRWL(SeqexecAppRootModel.uiModel ^|-> SequencesFocus.sequencesFocusL)
+  val sequencesReaderRW: ModelRW[SeqexecAppRootModel, SequencesFocus] =
+    this.zoomRWL(SeqexecAppRootModel.uiModel ^|-> SequencesFocus.sequencesFocusL)
+
+  // Reader to update the selected sequences and location
+  val sodLocationReaderRW: ModelRW[SeqexecAppRootModel, SODLocationFocus] =
+    this.zoomRWL(SeqexecAppRootModel.uiModel ^|-> SODLocationFocus.sodLocationFocusL)
 
   // Some useful readers
   val statusAndLoadedSequencesReader: ModelR[SeqexecAppRootModel, StatusAndLoadedSequencesFocus] =
@@ -162,7 +167,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   private val syncRequestsHandler      = new SyncRequestsHandler(zoomTo(_.uiModel.syncInProgress))
   private val debuggingHandler         = new DebuggingHandler(zoomTo(_.uiModel.sequences))
   private val stepConfigStateHandler   = new StepConfigTableStateHandler(tableStateRW)
-  private val loadSequencesHandler     = new LoadedSequencesHandler(zoomTo(_.uiModel.sequencesOnDisplay))
+  private val loadSequencesHandler     = new LoadedSequencesHandler(sodLocationReaderRW)
   private val siteHandler              = new SiteHandler(zoomTo(_.site))
 
   def dispatchCB[A <: Action](a: A): Callback = Callback(dispatch(a))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -54,6 +54,18 @@ package circuit {
       Lens[SeqexecUIModel, SequencesFocus](m => SequencesFocus(m.sequences, m.sequencesOnDisplay))(v => m => m.copy(sequences = v.sequences, sequencesOnDisplay = v.sod))
   }
 
+  @Lenses
+  final case class SODLocationFocus(location: Pages.SeqexecPages, sod: SequencesOnDisplay)
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object SODLocationFocus {
+    implicit val eq: Eq[SODLocationFocus] =
+      Eq.by(x => (x.location, x.sod))
+
+    val sodLocationFocusL: Lens[SeqexecUIModel, SODLocationFocus] =
+      Lens[SeqexecUIModel, SODLocationFocus](m => SODLocationFocus(m.navLocation, m.sequencesOnDisplay))(v => m => m.copy(navLocation = v.location, sequencesOnDisplay = v.sod))
+  }
+
   final case class InitialSyncFocus(location: Pages.SeqexecPages, firstLoad: Boolean) extends UseValueEq
 
   final case class SequenceInQueue(id: Observation.Id, status: SequenceState, instrument: Instrument, active: Boolean, loaded: Boolean, name: String, targetName: Option[TargetName], runningStep: Option[RunningStep]) extends UseValueEq

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -9,6 +9,7 @@ import cats.data.NonEmptyList
 import diode._
 import gem.Observation
 import gem.enum.Site
+import monocle.macros.Lenses
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.web.client.model._
@@ -20,6 +21,15 @@ package circuit {
   // All these classes are focused views of the root model. They are used to only update small sections of the
   // UI even if other parts of the root model change
   final case class WebSocketsFocus(location: Pages.SeqexecPages, sequences: SequencesQueue[SequenceView], user: Option[UserDetails], defaultObserver: Observer, clientId: Option[ClientID], site: Option[Site]) extends UseValueEq
+
+  @Lenses
+  final case class SequencesFocus(sequences: SequencesQueue[SequenceView], sod: SequencesOnDisplay)
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object SequencesFocus {
+    implicit val eq: Eq[SequencesFocus] =
+      Eq.by(x => (x.sequences, x.sod))
+  }
 
   final case class InitialSyncFocus(location: Pages.SeqexecPages, firstLoad: Boolean) extends UseValueEq
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
@@ -15,18 +15,28 @@ import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
  */
 class LoadedSequencesHandler[M](modelRW: ModelRW[M, SequencesOnDisplay]) extends ActionHandler(modelRW) with Handlers {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
-    // case ServerMessage(LoadSequenceUpdated(i, sid, view)) =>
+    case ServerMessage(LoadSequenceUpdated(i, sid, view)) =>
     //   if (value.loadedIds =!= view.loaded.values.toList) {
     //     effectOnly(Effect(Future(UpdateOnLoadUpdate(i, sid, view.loaded.values.toList))))
     //   } else {
     //     noChange
     //   }
+      updated(value.updateFromQueue(view).unsetPreviewOn(sid).focusOnSequence(i, sid))
 
-    case ServerMessage(ClearLoadedSequencesUpdated(_)) =>
-      updated(value.updateLoaded(Nil))
-
+    // case ServerMessage(ClearLoadedSequencesUpdated(_)) =>
+    //   updated(value.updateLoaded(Nil))
+    //
     case ServerMessage(s: SeqexecModelUpdate) =>
       updated(value.updateFromQueue(s.view))
+
+    // case UpdateLoadedSequences(loaded) =>
+    //   // we need to send an effect for this to get the references to work correctly
+    //   val refs = loaded.map(SeqexecCircuit.sequenceRef)
+    //   updated(value.updateLoaded(refs.toList))
+    //
+    // case UpdateOnLoadUpdate(i, sid, ids) =>
+    //   val refs = ids.map(SeqexecCircuit.sequenceRef)
+    //   updated(value.unsetPreviewOn(sid).updateLoaded(refs.toList).focusOnSequence(i, sid))
 
     case LoadSequence(observer, i, id) =>
       val loadSequence = Effect(SeqexecWebClient.loadSequence(i, id, observer).map(_ => NoAction))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
@@ -3,14 +3,11 @@
 
 package seqexec.web.client.handlers
 
-import cats.implicits._
 import diode.{ActionHandler, ActionResult, Effect, ModelRW, NoAction}
 import seqexec.model.events._
 import seqexec.web.client.model.SequencesOnDisplay
-import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
-import scala.concurrent.Future
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 /**
@@ -18,32 +15,18 @@ import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
  */
 class LoadedSequencesHandler[M](modelRW: ModelRW[M, SequencesOnDisplay]) extends ActionHandler(modelRW) with Handlers {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
-    case ServerMessage(LoadSequenceUpdated(i, sid, view)) =>
-      if (value.loadedIds =!= view.loaded.values.toList) {
-        effectOnly(Effect(Future(UpdateOnLoadUpdate(i, sid, view.loaded.values.toList))))
-      } else {
-        noChange
-      }
+    // case ServerMessage(LoadSequenceUpdated(i, sid, view)) =>
+    //   if (value.loadedIds =!= view.loaded.values.toList) {
+    //     effectOnly(Effect(Future(UpdateOnLoadUpdate(i, sid, view.loaded.values.toList))))
+    //   } else {
+    //     noChange
+    //   }
 
     case ServerMessage(ClearLoadedSequencesUpdated(_)) =>
       updated(value.updateLoaded(Nil))
 
     case ServerMessage(s: SeqexecModelUpdate) =>
-      // we need to send an effect for this to get the references to work correctly
-      if (value.loadedIds =!= s.view.loaded.values.toList) {
-        effectOnly(Effect(Future(UpdateLoadedSequences(s.view.loaded.values.toList))))
-      } else {
-        noChange
-      }
-
-    case UpdateLoadedSequences(loaded) =>
-      // we need to send an effect for this to get the references to work correctly
-      val refs = loaded.map(SeqexecCircuit.sequenceRef)
-      updated(value.updateLoaded(refs.toList))
-
-    case UpdateOnLoadUpdate(i, sid, ids) =>
-      val refs = ids.map(SeqexecCircuit.sequenceRef)
-      updated(value.unsetPreviewOn(sid).updateLoaded(refs.toList).focusOnSequence(i, sid))
+      updated(value.updateFromQueue(s.view))
 
     case LoadSequence(observer, i, id) =>
       val loadSequence = Effect(SeqexecWebClient.loadSequence(i, id, observer).map(_ => NoAction))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
@@ -3,40 +3,28 @@
 
 package seqexec.web.client.handlers
 
+import cats.implicits._
 import diode.{ActionHandler, ActionResult, Effect, ModelRW, NoAction}
 import seqexec.model.events._
-import seqexec.web.client.model.SequencesOnDisplay
+import seqexec.web.client.model.Pages.SequencePage
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
+import seqexec.web.client.circuit.SODLocationFocus
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 /**
  * Handles updates to the selected sequences set
  */
-class LoadedSequencesHandler[M](modelRW: ModelRW[M, SequencesOnDisplay]) extends ActionHandler(modelRW) with Handlers {
+class LoadedSequencesHandler[M](modelRW: ModelRW[M, SODLocationFocus]) extends ActionHandler(modelRW) with Handlers {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(LoadSequenceUpdated(i, sid, view)) =>
-    //   if (value.loadedIds =!= view.loaded.values.toList) {
-    //     effectOnly(Effect(Future(UpdateOnLoadUpdate(i, sid, view.loaded.values.toList))))
-    //   } else {
-    //     noChange
-    //   }
-      updated(value.updateFromQueue(view).unsetPreviewOn(sid).focusOnSequence(i, sid))
+      // Update selected and the page
+      val upSelected = SODLocationFocus.sod.modify(_.updateFromQueue(view).unsetPreviewOn(sid).focusOnSequence(i, sid))
+      val upLocation = SODLocationFocus.location.set(SequencePage(i, sid, 0))
+      updated((upSelected >>> upLocation)(value))
 
-    // case ServerMessage(ClearLoadedSequencesUpdated(_)) =>
-    //   updated(value.updateLoaded(Nil))
-    //
     case ServerMessage(s: SeqexecModelUpdate) =>
-      updated(value.updateFromQueue(s.view))
-
-    // case UpdateLoadedSequences(loaded) =>
-    //   // we need to send an effect for this to get the references to work correctly
-    //   val refs = loaded.map(SeqexecCircuit.sequenceRef)
-    //   updated(value.updateLoaded(refs.toList))
-    //
-    // case UpdateOnLoadUpdate(i, sid, ids) =>
-    //   val refs = ids.map(SeqexecCircuit.sequenceRef)
-    //   updated(value.unsetPreviewOn(sid).updateLoaded(refs.toList).focusOnSequence(i, sid))
+      updated(SODLocationFocus.sod.modify(_.updateFromQueue(s.view))(value))
 
     case LoadSequence(observer, i, id) =>
       val loadSequence = Effect(SeqexecWebClient.loadSequence(i, id, observer).map(_ => NoAction))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/SequenceDisplayHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/SequenceDisplayHandler.scala
@@ -5,45 +5,45 @@ package seqexec.web.client.handlers
 
 import cats.implicits._
 import diode.{ActionHandler, ActionResult, ModelRW}
-import seqexec.web.client.model._
+import seqexec.model.{ SequencesQueue, SequenceView }
 import seqexec.web.client.actions._
 import seqexec.web.client.circuit._
 
 /**
   * Handles actions related to the changing the selection of the displayed sequence
   */
-class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesOnDisplay]) extends ActionHandler(modelRW) with Handlers {
+class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus]) extends ActionHandler(modelRW) with Handlers {
   def handleSelectSequenceDisplay: PartialFunction[Any, ActionResult[M]] = {
     case SelectIdToDisplay(i, id, _) =>
-      updated(value.focusOnSequence(i, id).hideStepConfig)
+      updated(SequencesFocus.sod.modify(_.focusOnSequence(i, id).hideStepConfig)(value))
 
     case SelectSequencePreview(i, id, _) =>
-      val seq = SeqexecCircuit.sequenceRef(id)
-      updated(value.previewSequence(i, seq).hideStepConfig)
+      val seq = SequencesQueue.queueItemG[SequenceView](_.id === id).get(value.sequences)
+      updated(SequencesFocus.sod.modify(_.previewSequence(i, seq).hideStepConfig)(value))
 
     case SelectEmptyPreview =>
-      updated(value.unsetPreview.focusOnPreview)
+      updated(SequencesFocus.sod.modify(_.unsetPreview.focusOnPreview)(value))
 
   }
 
   def handleShowHideStep: PartialFunction[Any, ActionResult[M]] = {
     case ShowPreviewStepConfig(i, id, step) =>
-      val seq = SeqexecCircuit.sequenceRef(id)
-      updated(value.previewSequence(i, seq).showStepConfig(id, step - 1))
+      val seq = SequencesQueue.queueItemG[SequenceView](_.id === id).get(value.sequences)
+      updated(SequencesFocus.sod.modify(_.previewSequence(i, seq).showStepConfig(id, step - 1))(value))
 
     case ShowStepConfig(i, id, step)        =>
-      updated(value.focusOnSequence(i, id).showStepConfig(id, step - 1))
+      updated(SequencesFocus.sod.modify(_.focusOnSequence(i, id).showStepConfig(id, step - 1))(value))
 
   }
 
   def handleRememberCompleted: PartialFunction[Any, ActionResult[M]] = {
     case RememberCompleted(s) =>
-      updated(value.markCompleted(s))
+      updated(SequencesFocus.sod.modify(_.markCompleted(s))(value))
   }
 
   def handleClean: PartialFunction[Any, ActionResult[M]] = {
     case CleanSequences =>
-      updated(value.cleanAll)
+      updated(SequencesFocus.sod.modify(_.cleanAll)(value))
   }
 
   override def handle: PartialFunction[Any, ActionResult[M]] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -8,15 +8,11 @@ import cats.implicits._
 import diode.data.Pot
 import gem.Observation
 import gem.enum.Site
-import monocle.Getter
 import monocle.macros.Lenses
 import org.scalajs.dom.WebSocket
-import seqexec.model.{ ClientID, Conditions, Observer, UserDetails, SequencesQueue, SequenceView }
+import seqexec.model.ClientID
 import seqexec.model.events._
 import seqexec.web.common.FixedLengthBuffer
-import seqexec.web.client.components.sequence.steps.StepConfigTable
-import seqexec.web.client.components.QueueTableBody
-import web.client.table._
 
 final case class RunningStep(last: Int, total: Int)
 
@@ -60,48 +56,12 @@ final case class GlobalLog(log: FixedLengthBuffer[ServerLogMessage], display: Se
 final case class ResourcesConflict(visibility: SectionVisibilityState, id: Option[Observation.Id])
 
 /**
- * UI model, changes here will update the UI
- */
-@Lenses
-final case class SeqexecUIModel(navLocation: Pages.SeqexecPages,
-                          user: Option[UserDetails],
-                          sequences: SequencesQueue[SequenceView],
-                          loginBox: SectionVisibilityState,
-                          resourceConflict: ResourcesConflict,
-                          globalLog: GlobalLog,
-                          sequencesOnDisplay: SequencesOnDisplay,
-                          syncInProgress: Boolean,
-                          configTableState: TableState[StepConfigTable.TableColumn],
-                          queueTableState: TableState[QueueTableBody.TableColumn],
-                          defaultObserver: Observer,
-                          firstLoad: Boolean)
-
-@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-object SeqexecUIModel {
-  val noSequencesLoaded: SequencesQueue[SequenceView] = SequencesQueue[SequenceView](Map.empty, Conditions.Default, None, Nil)
-  val Initial: SeqexecUIModel = SeqexecUIModel(
-    Pages.Root,
-    None,
-    noSequencesLoaded,
-    SectionClosed,
-    ResourcesConflict(SectionClosed, None),
-    GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
-    SequencesOnDisplay.empty,
-    syncInProgress = false,
-    StepConfigTable.InitialTableState,
-    QueueTableBody.InitialTableState.tableState,
-    Observer(""),
-    firstLoad = true)
-
-  def sequenceReader(id: Observation.Id): Getter[SeqexecUIModel, Option[SequenceView]] =
-    SeqexecUIModel.sequences composeGetter SequencesQueue.queueItemG[SequenceView](_.id === id)
-  }
-
-/**
   * Root of the UI Model of the application
   */
+@Lenses
 final case class SeqexecAppRootModel(ws: WebSocketConnection, site: Option[Site], clientId: Option[ClientID], uiModel: SeqexecUIModel)
 
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SeqexecAppRootModel {
   val Initial: SeqexecAppRootModel = SeqexecAppRootModel(WebSocketConnection.Empty, None, None, SeqexecUIModel.Initial)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -50,10 +50,18 @@ object WebSocketConnection {
   */
 final case class GlobalLog(log: FixedLengthBuffer[ServerLogMessage], display: SectionVisibilityState)
 
+object GlobalLog {
+  implicit val eq: Eq[GlobalLog] = Eq.by(x => (x.log, x.display))
+}
+
 /**
  * Model to display a resource conflict
  */
 final case class ResourcesConflict(visibility: SectionVisibilityState, id: Option[Observation.Id])
+
+object ResourcesConflict {
+  implicit val eq: Eq[ResourcesConflict] = Eq.by(x => (x.visibility, x.id))
+}
 
 /**
   * Root of the UI Model of the application

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -8,12 +8,14 @@ import cats.implicits._
 import diode.data.Pot
 import gem.Observation
 import gem.enum.Site
+import monocle.Getter
+import monocle.macros.Lenses
+import org.scalajs.dom.WebSocket
 import seqexec.model.{ ClientID, Conditions, Observer, UserDetails, SequencesQueue, SequenceView }
 import seqexec.model.events._
 import seqexec.web.common.FixedLengthBuffer
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.QueueTableBody
-import org.scalajs.dom.WebSocket
 import web.client.table._
 
 final case class RunningStep(last: Int, total: Int)
@@ -60,6 +62,7 @@ final case class ResourcesConflict(visibility: SectionVisibilityState, id: Optio
 /**
  * UI model, changes here will update the UI
  */
+@Lenses
 final case class SeqexecUIModel(navLocation: Pages.SeqexecPages,
                           user: Option[UserDetails],
                           sequences: SequencesQueue[SequenceView],
@@ -73,6 +76,7 @@ final case class SeqexecUIModel(navLocation: Pages.SeqexecPages,
                           defaultObserver: Observer,
                           firstLoad: Boolean)
 
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SeqexecUIModel {
   val noSequencesLoaded: SequencesQueue[SequenceView] = SequencesQueue[SequenceView](Map.empty, Conditions.Default, None, Nil)
   val Initial: SeqexecUIModel = SeqexecUIModel(
@@ -88,7 +92,10 @@ object SeqexecUIModel {
     QueueTableBody.InitialTableState.tableState,
     Observer(""),
     firstLoad = true)
-}
+
+  def sequenceReader(id: Observation.Id): Getter[SeqexecUIModel, Option[SequenceView]] =
+    SeqexecUIModel.sequences composeGetter SequencesQueue.queueItemG[SequenceView](_.id === id)
+  }
 
 /**
   * Root of the UI Model of the application

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/package.scala
@@ -14,9 +14,6 @@ package object model {
       (x.url, x.protocol, x.readyState)
     }
 
-  implicit def eqRefTo[A: Eq]: Eq[RefTo[A]] =
-    Eq.by(_.apply())
-
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   implicit def eqPot[A: Eq]: Eq[Pot[A]] = Eq.instance {
     case (Empty, Empty)                           => true

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -378,4 +378,14 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     Cogen[(Pages.SeqexecPages, Option[UserDetails], SequencesQueue[SequenceView], SectionVisibilityState, ResourcesConflict, GlobalLog, SequencesOnDisplay, Boolean, TableState[StepConfigTable.TableColumn], TableState[QueueTableBody.TableColumn], Observer, Boolean)]
       .contramap(x => (x.navLocation, x.user, x.sequences, x.loginBox, x.resourceConflict, x.globalLog, x.sequencesOnDisplay, x.syncInProgress, x.configTableState, x.queueTableState, x.defaultObserver, x.firstLoad))
 
+  implicit val arbSODLocationFocus: Arbitrary[SODLocationFocus] =
+    Arbitrary {
+      for {
+        navLocation        <- arbitrary[Pages.SeqexecPages]
+        sequencesOnDisplay <- arbitrary[SequencesOnDisplay]
+      } yield SODLocationFocus(navLocation, sequencesOnDisplay)
+    }
+
+  implicit val sodLocationFocusogen: Cogen[SODLocationFocus] =
+    Cogen[(Pages.SeqexecPages, SequencesOnDisplay)].contramap(x => (x.location, x.sod))
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -8,19 +8,24 @@ import diode.data._
 import gem.arb.ArbObservation
 import gem.Observation
 import seqexec.model.enum.Instrument
-import seqexec.model.{ Observer, TargetName, SequencesQueue, SequenceState, SequenceView, Step }
+import seqexec.model.{ Observer, TargetName, SequencesQueue, SequenceState, SequenceView, Step, UserDetails }
+import seqexec.model.events.ServerLogMessage
 import seqexec.model.SeqexecModelArbitraries._
+import seqexec.model.SequenceEventsArbitraries.{slmArb, slmCogen}
+import seqexec.web.common.{ FixedLengthBuffer, Zipper }
+import seqexec.web.common.ArbitrariesWebCommon._
 import seqexec.web.client.model._
 import seqexec.web.client.circuit._
-import seqexec.model.UserDetails
-import seqexec.web.common.Zipper
-import seqexec.web.common.ArbitrariesWebCommon._
+import seqexec.web.client.model.Pages._
 import seqexec.web.client.components.sequence.steps.OffsetFns.OffsetsDisplay
+import seqexec.web.client.components.sequence.steps.StepConfigTable
+import seqexec.web.client.components.QueueTableBody
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{Arbitrary, _}
 import org.scalajs.dom.WebSocket
+import web.client.table.{ TableArbitraries, TableState }
 
-trait ArbitrariesWebClient extends ArbObservation {
+trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
 
   implicit val arbInstrumentSequenceTab: Arbitrary[InstrumentSequenceTab] =
     Arbitrary {
@@ -239,5 +244,138 @@ trait ArbitrariesWebClient extends ArbObservation {
     Cogen[(Boolean, Option[String], Option[Observer], Option[SequenceState], Option[TargetName])].contramap { x =>
       (x.isLogged, x.obsName, x.observer, x.status, x.targetName)
     }
+
+  implicit val arbPreviewPage: Arbitrary[PreviewPage] =
+    Arbitrary {
+      for {
+        i  <- arbitrary[Instrument]
+        oi <- arbitrary[Observation.Id]
+        sd <- arbitrary[Int]
+      } yield PreviewPage(i, oi, sd)
+    }
+
+  implicit val previewPageCogen: Cogen[PreviewPage] =
+    Cogen[(Instrument, Observation.Id, Int)]
+      .contramap(x => (x.instrument, x.obsId, x.step))
+
+  implicit val arbSequencePage: Arbitrary[SequencePage] =
+    Arbitrary {
+      for {
+        i  <- arbitrary[Instrument]
+        oi <- arbitrary[Observation.Id]
+        sd <- arbitrary[Int]
+      } yield SequencePage(i, oi, sd)
+    }
+
+  implicit val sequencePageCogen: Cogen[SequencePage] =
+    Cogen[(Instrument, Observation.Id, Int)]
+      .contramap(x => (x.instrument, x.obsId, x.step))
+
+  implicit val arbPreviewConfigPage: Arbitrary[PreviewConfigPage] =
+    Arbitrary {
+      for {
+        i  <- arbitrary[Instrument]
+        oi <- arbitrary[Observation.Id]
+        st <- Gen.posNum[Int]
+      } yield PreviewConfigPage(i, oi, st)
+    }
+
+  implicit val previewConfigPageCogen: Cogen[PreviewConfigPage] =
+    Cogen[(Instrument, Observation.Id, Int)]
+      .contramap(x => (x.instrument, x.obsId, x.step))
+
+  implicit val arbSequenceConfigPage: Arbitrary[SequenceConfigPage] =
+    Arbitrary {
+      for {
+        i  <- arbitrary[Instrument]
+        oi <- arbitrary[Observation.Id]
+        st <- Gen.posNum[Int]
+      } yield SequenceConfigPage(i, oi, st)
+    }
+
+  implicit val sequenceConfigPageCogen: Cogen[SequenceConfigPage] =
+    Cogen[(Instrument, Observation.Id, Int)]
+      .contramap(x => (x.instrument, x.obsId, x.step))
+
+  implicit val arbSeqexecPages: Arbitrary[SeqexecPages] =
+    Arbitrary {
+      for {
+        r  <- Gen.const(Root)
+        sc <- Gen.const(SoundTest)
+        ep <- Gen.const(EmptyPreviewPage)
+        pp <- arbitrary[PreviewPage]
+        sp <- arbitrary[SequencePage]
+        pc <- arbitrary[PreviewConfigPage]
+        sc <- arbitrary[SequenceConfigPage]
+        p  <- Gen.oneOf(r, sc, ep, pp, sp, pc, sc)
+      } yield p
+    }
+
+  implicit val seqexecPageCogen: Cogen[SeqexecPages] =
+    Cogen[Option[Option[Option[Either[(Instrument, Observation.Id, Int), Either[(Instrument, Observation.Id, Int), Either[(Instrument, Observation.Id, Int), (Instrument, Observation.Id, Int)]]]]]]].contramap {
+      case Root                        => None
+      case SoundTest                   => Some(None)
+      case EmptyPreviewPage            => Some(Some(None))
+      case PreviewPage(i, o, s)        => Some(Some(Some(Left((i, o, s)))))
+      case SequencePage(i, o, s)       => Some(Some(Some(Right(Left((i, o, s))))))
+      case SequenceConfigPage(i, o, s) => Some(Some(Some(Right(Right(Left((i, o, s)))))))
+      case PreviewConfigPage(i, o, s)  => Some(Some(Some(Right(Right(Right((i, o, s)))))))
+    }
+
+  implicit val arbResourcesConflict: Arbitrary[ResourcesConflict] =
+    Arbitrary {
+      for {
+        v  <- arbitrary[SectionVisibilityState]
+        id <- arbitrary[Option[Observation.Id]]
+      } yield ResourcesConflict(v, id)
+    }
+
+  implicit val resourcesConflictCogen: Cogen[ResourcesConflict] =
+    Cogen[(SectionVisibilityState, Option[Observation.Id])].contramap(x => (x.visibility, x.id))
+
+  implicit val arbGlobalLog: Arbitrary[GlobalLog] =
+    Arbitrary {
+      for {
+        b  <- arbitrary[FixedLengthBuffer[ServerLogMessage]]
+        v  <- arbitrary[SectionVisibilityState]
+      } yield GlobalLog(b, v)
+    }
+
+  implicit val globalLogCogen: Cogen[GlobalLog] =
+    Cogen[(FixedLengthBuffer[ServerLogMessage], SectionVisibilityState)].contramap(x => (x.log, x.display))
+
+  implicit val arbStepConfigTableTableColumn: Arbitrary[StepConfigTable.TableColumn] =
+    Arbitrary(Gen.oneOf(StepConfigTable.NameColumn, StepConfigTable.ValueColumn))
+
+  implicit val stepConfigTableColumnCogen: Cogen[StepConfigTable.TableColumn] =
+    Cogen[String].contramap(_.productPrefix)
+
+  implicit val arbQueueTableBodyTableColumn: Arbitrary[QueueTableBody.TableColumn] =
+    Arbitrary(Gen.oneOf(QueueTableBody.all.map(_.column).toList))
+
+  implicit val queueTableBodyTableColumnCogen: Cogen[QueueTableBody.TableColumn] =
+    Cogen[String].contramap(_.productPrefix)
+
+  implicit val arbSeqexecUIModel: Arbitrary[SeqexecUIModel] =
+    Arbitrary {
+      for {
+        navLocation        <- arbitrary[Pages.SeqexecPages]
+        user               <- arbitrary[Option[UserDetails]]
+        sequences          <- arbitrary[SequencesQueue[SequenceView]]
+        loginBox           <- arbitrary[SectionVisibilityState]
+        resourceConflict   <- arbitrary[ResourcesConflict]
+        globalLog          <- arbitrary[GlobalLog]
+        sequencesOnDisplay <- arbitrary[SequencesOnDisplay]
+        syncInProgress     <- arbitrary[Boolean]
+        configTableState   <- arbitrary[TableState[StepConfigTable.TableColumn]]
+        queueTableState    <- arbitrary[TableState[QueueTableBody.TableColumn]]
+        defaultObserver    <- arbitrary[Observer]
+        firstLoad          <- arbitrary[Boolean]
+      } yield SeqexecUIModel(navLocation, user, sequences, loginBox, resourceConflict, globalLog, sequencesOnDisplay, syncInProgress, configTableState, queueTableState, defaultObserver, firstLoad)
+    }
+
+  implicit val seqUIModelCogen: Cogen[SeqexecUIModel] =
+    Cogen[(Pages.SeqexecPages, Option[UserDetails], SequencesQueue[SequenceView], SectionVisibilityState, ResourcesConflict, GlobalLog, SequencesOnDisplay, Boolean, TableState[StepConfigTable.TableColumn], TableState[QueueTableBody.TableColumn], Observer, Boolean)]
+      .contramap(x => (x.navLocation, x.user, x.sequences, x.loginBox, x.resourceConflict, x.globalLog, x.sequencesOnDisplay, x.syncInProgress, x.configTableState, x.queueTableState, x.defaultObserver, x.firstLoad))
 
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
@@ -13,11 +13,14 @@ import org.scalatest.prop.PropertyChecks
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 final class CircuitReaderSpec extends CatsSuite with PropertyChecks with ArbitrariesWebClient {
   checkAll("Eq[SequenceTabContentFocus]", EqTests[SequenceTabContentFocus].eqv)
+  checkAll("Eq[SequencesFocus]", EqTests[SequencesFocus].eqv)
+  checkAll("Eq[SequenceInfoFocus]", EqTests[SequenceInfoFocus].eqv)
 
   test("maintain reference equality for constant readers") {
       (webSocketFocusRW === webSocketFocusRW.value) should be(true)
       (initialSyncFocusRW === initialSyncFocusRW.value) should be(true)
       (tableStateRW === tableStateRW.value) should be(true)
+      (sequencesReaderRW === sequencesReaderRW.value) should be(true)
       (statusAndLoadedSequencesReader === statusAndLoadedSequencesReader.value) should be(true)
       (statusReader === statusReader.value) should be(true)
       (sequenceInConflictReader === sequenceInConflictReader.value) should be(true)
@@ -35,7 +38,6 @@ final class CircuitReaderSpec extends CatsSuite with PropertyChecks with Arbitra
       (stepsTableReaderF(i) === stepsTableReaderF(i).value) should be(true)
       (stepsTableReader(i) === stepsTableReader(i).value) should be(true)
       (sequenceControlReader(i) === sequenceControlReader(i).value) should be(true)
-      (sequenceReader(i) === sequenceReader(i).value) should be(true)
     }
   }
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
@@ -6,6 +6,7 @@ package seqexec.web.client
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.Observation
+import monocle.law.discipline.LensTests
 import seqexec.web.client.circuit._
 import seqexec.web.client.circuit.SeqexecCircuit._
 import org.scalatest.prop.PropertyChecks
@@ -15,6 +16,7 @@ final class CircuitReaderSpec extends CatsSuite with PropertyChecks with Arbitra
   checkAll("Eq[SequenceTabContentFocus]", EqTests[SequenceTabContentFocus].eqv)
   checkAll("Eq[SequencesFocus]", EqTests[SequencesFocus].eqv)
   checkAll("Eq[SequenceInfoFocus]", EqTests[SequenceInfoFocus].eqv)
+  checkAll("sequencesFocusL", LensTests(SequencesFocus.sequencesFocusL))
 
   test("maintain reference equality for constant readers") {
       (webSocketFocusRW === webSocketFocusRW.value) should be(true)

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
@@ -6,7 +6,7 @@ package seqexec.web.client
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.Observation
-import monocle.law.discipline.LensTests
+// import monocle.law.discipline.LensTests
 import seqexec.web.client.circuit._
 import seqexec.web.client.circuit.SeqexecCircuit._
 import org.scalatest.prop.PropertyChecks
@@ -16,13 +16,15 @@ final class CircuitReaderSpec extends CatsSuite with PropertyChecks with Arbitra
   checkAll("Eq[SequenceTabContentFocus]", EqTests[SequenceTabContentFocus].eqv)
   checkAll("Eq[SequencesFocus]", EqTests[SequencesFocus].eqv)
   checkAll("Eq[SequenceInfoFocus]", EqTests[SequenceInfoFocus].eqv)
-  checkAll("sequencesFocusL", LensTests(SequencesFocus.sequencesFocusL))
+  // checkAll("sequencesFocusL", LensTests(SequencesFocus.sequencesFocusL))
+  // checkAll("sodLocationFocusL", LensTests(SODLocationFocus.sodLocationFocusL))
 
   test("maintain reference equality for constant readers") {
       (webSocketFocusRW === webSocketFocusRW.value) should be(true)
       (initialSyncFocusRW === initialSyncFocusRW.value) should be(true)
       (tableStateRW === tableStateRW.value) should be(true)
       (sequencesReaderRW === sequencesReaderRW.value) should be(true)
+      (sodLocationReaderRW === sodLocationReaderRW.value) should be(true)
       (statusAndLoadedSequencesReader === statusAndLoadedSequencesReader.value) should be(true)
       (statusReader === statusReader.value) should be(true)
       (sequenceInConflictReader === sequenceInConflictReader.value) should be(true)

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -27,8 +27,12 @@ final class ModelSpec extends CatsSuite with ArbitrariesWebClient {
   checkAll("Eq[SequenceTabActive]", EqTests[SequenceTabActive].eqv)
   checkAll("Eq[InstrumentSequenceTab]", EqTests[InstrumentSequenceTab].eqv)
   checkAll("Eq[PreviewSequenceTab]", EqTests[PreviewSequenceTab].eqv)
+  checkAll("Eq[Pages.SeqexecPages]", EqTests[Pages.SeqexecPages].eqv)
   checkAll("Eq[SequenceTab]", EqTests[SequenceTab].eqv)
   checkAll("Eq[SequencesOnDisplay]", EqTests[SequencesOnDisplay].eqv)
+  checkAll("Eq[ResourcesConflict]", EqTests[ResourcesConflict].eqv)
+  checkAll("Eq[GlobalLog]", EqTests[GlobalLog].eqv)
+  checkAll("Eq[SeqexecUIModel]", EqTests[SeqexecUIModel].eqv)
 
   // lenses
   checkAll("Lens[SequenceTab, Option[Int]]", LensTests(SequenceTab.stepConfigL))

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -28,6 +28,7 @@ final class ModelSpec extends CatsSuite with ArbitrariesWebClient {
   checkAll("Eq[InstrumentSequenceTab]", EqTests[InstrumentSequenceTab].eqv)
   checkAll("Eq[PreviewSequenceTab]", EqTests[PreviewSequenceTab].eqv)
   checkAll("Eq[SequenceTab]", EqTests[SequenceTab].eqv)
+  checkAll("Eq[SequencesOnDisplay]", EqTests[SequencesOnDisplay].eqv)
 
   // lenses
   checkAll("Lens[SequenceTab, Option[Int]]", LensTests(SequenceTab.stepConfigL))

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/common/ArbitrariesWebCommon.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/common/ArbitrariesWebCommon.scala
@@ -11,7 +11,7 @@ object ArbitrariesWebCommon {
 
   implicit def arbFixedLengthBuffer[A: Arbitrary]: Arbitrary[FixedLengthBuffer[A]] =
     Arbitrary {
-      val maxSize = 1000
+      val maxSize = 100
       for {
         l <- Gen.choose(1, maxSize)
         s <- Gen.choose(0, l - 1)
@@ -24,7 +24,7 @@ object ArbitrariesWebCommon {
 
   implicit def arbZipper[A: Arbitrary]: Arbitrary[Zipper[A]] =
     Arbitrary {
-      val maxSize = 1000
+      val maxSize = 100
       for {
         h <- arbitrary[A]
         l <- Gen.choose(1, maxSize)

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableArbitraries.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableArbitraries.scala
@@ -1,0 +1,109 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package web.client.table
+
+import cats.Eq
+import cats.implicits._
+import cats.data.NonEmptyList
+import japgolly.scalajs.react.raw.JsNumber
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import web.client.utils._
+
+trait TableArbitraries {
+  implicit val arbUserModified: Arbitrary[UserModified] = Arbitrary {
+    Gen.oneOf(IsModified, NotModified)
+  }
+
+  implicit val userModifiedCogen: Cogen[UserModified] =
+    Cogen[String].contramap(_.productPrefix)
+
+  val genFixedColumnWidth: Gen[FixedColumnWidth] =
+    Gen.posNum[Int].map(FixedColumnWidth.apply)
+
+  implicit val fixedColumnWidthArb: Arbitrary[FixedColumnWidth] =
+    Arbitrary(genFixedColumnWidth)
+
+  implicit val fixedColumnWidthCogen: Cogen[FixedColumnWidth] =
+    Cogen[Int].contramap(_.width)
+
+  val genPercentageColumnWidth: Gen[PercentageColumnWidth] =
+    Gen.choose[Double](0, 1).map(PercentageColumnWidth.apply)
+
+  implicit val percentageColumnWidthArb: Arbitrary[PercentageColumnWidth] =
+    Arbitrary(genPercentageColumnWidth)
+
+  implicit val percentColumnWidthCogen: Cogen[PercentageColumnWidth] =
+    Cogen[Double].contramap(_.percentage)
+
+  implicit val arbColumnWidth: Arbitrary[ColumnWidth] = Arbitrary {
+    Gen.oneOf(genFixedColumnWidth, genPercentageColumnWidth)
+  }
+
+  implicit val columnWidthCogen: Cogen[ColumnWidth] =
+    Cogen[Either[FixedColumnWidth, PercentageColumnWidth]].contramap {
+      case x: FixedColumnWidth      => x.asLeft
+      case x: PercentageColumnWidth => x.asRight
+    }
+
+  implicit val arbJsNumber: Arbitrary[JsNumber] = Arbitrary {
+    // type JsNumber = Byte | Short | Int | Float | Double
+    Gen.oneOf[JsNumber](arbitrary[Byte],
+                        arbitrary[Short],
+                        arbitrary[Int],
+                        arbitrary[Float],
+                        arbitrary[Double])
+  }
+
+  implicit val jsNumberCogen: Cogen[JsNumber] =
+    Cogen[Double].contramap { x =>
+      (x: Any) match {
+        case y: Byte   => y.toDouble
+        case y: Short  => y.toDouble
+        case y: Int    => y.toDouble
+        case y: Float  => y.toDouble
+        case y: Double => y
+      }
+    }
+
+  implicit def columnMetaArb[A: Arbitrary]: Arbitrary[ColumnMeta[A]] =
+    Arbitrary {
+      for {
+        a <- arbitrary[A]
+        n <- Gen.alphaStr
+        l <- Gen.alphaStr
+        v <- arbitrary[Boolean]
+        w <- arbitrary[ColumnWidth]
+      } yield ColumnMeta(a, n, l, v, w)
+    }
+
+  implicit def columnMetaCogen[A: Cogen]: Cogen[ColumnMeta[A]] =
+    Cogen[(A, String, String, Boolean, ColumnWidth)].contramap(x =>
+      (x.column, x.name, x.label, x.visible, x.width))
+
+  implicit def tableStateArb[A: Arbitrary: Eq]: Arbitrary[TableState[A]] =
+    Arbitrary {
+      for {
+        u <- arbitrary[UserModified]
+        s <- Gen.posNum[Int]
+        c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
+      } yield TableState(u, s, NonEmptyList.fromListUnsafe(c))
+    }
+
+  implicit def tableStateCogen[A: Cogen]: Cogen[TableState[A]] =
+    Cogen[(UserModified, Double, List[ColumnMeta[A]])].contramap(x =>
+      (x.userModified, x.scrollPosition.toDouble, x.columns.toList))
+
+  implicit def columnMetaNelArb[A: Arbitrary: Eq]: Arbitrary[NonEmptyList[ColumnMeta[A]]] =
+    Arbitrary {
+      for {
+        c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
+      } yield NonEmptyList.fromListUnsafe(c)
+    }
+
+  implicit def columnMetaNelCogen[A: Cogen]: Cogen[NonEmptyList[ColumnMeta[A]]] =
+    Cogen[List[ColumnMeta[A]]].contramap(_.toList)
+}
+
+object TableArbitraries extends TableArbitraries

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
@@ -3,110 +3,11 @@
 
 package web.client.table
 
-import cats.Eq
 import cats.tests.CatsSuite
-import cats.data.NonEmptyList
 import cats.kernel.laws.discipline.EqTests
-import japgolly.scalajs.react.raw.JsNumber
 import monocle.law.discipline.LensTests
-import org.scalacheck._
-import org.scalacheck.Arbitrary._
-import web.client.utils._
 
-final class TableSpec extends CatsSuite {
-  implicit val arbUserModified: Arbitrary[UserModified] = Arbitrary {
-    Gen.oneOf(IsModified, NotModified)
-  }
-
-  implicit val userModifiedCogen: Cogen[UserModified] =
-    Cogen[String].contramap(_.productPrefix)
-
-  val genFixedColumnWidth: Gen[FixedColumnWidth] =
-    Gen.posNum[Int].map(FixedColumnWidth.apply)
-
-  implicit val fixedColumnWidthArb: Arbitrary[FixedColumnWidth] =
-    Arbitrary(genFixedColumnWidth)
-
-  implicit val fixedColumnWidthCogen: Cogen[FixedColumnWidth] =
-    Cogen[Int].contramap(_.width)
-
-  val genPercentageColumnWidth: Gen[PercentageColumnWidth] =
-    Gen.choose[Double](0, 1).map(PercentageColumnWidth.apply)
-
-  implicit val percentageColumnWidthArb: Arbitrary[PercentageColumnWidth] =
-    Arbitrary(genPercentageColumnWidth)
-
-  implicit val percentColumnWidthCogen: Cogen[PercentageColumnWidth] =
-    Cogen[Double].contramap(_.percentage)
-
-  implicit val arbColumnWidth: Arbitrary[ColumnWidth] = Arbitrary {
-    Gen.oneOf(genFixedColumnWidth, genPercentageColumnWidth)
-  }
-
-  implicit val columnWidthCogen: Cogen[ColumnWidth] =
-    Cogen[Either[FixedColumnWidth, PercentageColumnWidth]].contramap {
-      case x: FixedColumnWidth      => x.asLeft
-      case x: PercentageColumnWidth => x.asRight
-    }
-
-  implicit val arbJsNumber: Arbitrary[JsNumber] = Arbitrary {
-    // type JsNumber = Byte | Short | Int | Float | Double
-    Gen.oneOf[JsNumber](arbitrary[Byte],
-                        arbitrary[Short],
-                        arbitrary[Int],
-                        arbitrary[Float],
-                        arbitrary[Double])
-  }
-
-  implicit val jsNumberCogen: Cogen[JsNumber] =
-    Cogen[Double].contramap { x =>
-      (x: Any) match {
-        case y: Byte   => y.toDouble
-        case y: Short  => y.toDouble
-        case y: Int    => y.toDouble
-        case y: Float  => y.toDouble
-        case y: Double => y
-      }
-    }
-
-  implicit def columnMetaArb[A: Arbitrary]: Arbitrary[ColumnMeta[A]] =
-    Arbitrary {
-      for {
-        a <- arbitrary[A]
-        n <- arbitrary[String]
-        l <- arbitrary[String]
-        v <- arbitrary[Boolean]
-        w <- arbitrary[ColumnWidth]
-      } yield ColumnMeta(a, n, l, v, w)
-    }
-
-  implicit def columnMetaCogen[A: Cogen]: Cogen[ColumnMeta[A]] =
-    Cogen[(A, String, String, Boolean, ColumnWidth)].contramap(x =>
-      (x.column, x.name, x.label, x.visible, x.width))
-
-  implicit def tableStateArb[A: Arbitrary: Eq]: Arbitrary[TableState[A]] =
-    Arbitrary {
-      for {
-        u <- arbitrary[UserModified]
-        s <- arbitrary[JsNumber]
-        c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
-      } yield TableState(u, s, NonEmptyList.fromListUnsafe(c))
-    }
-
-  implicit def tableStateCogen[A: Cogen]: Cogen[TableState[A]] =
-    Cogen[(UserModified, Double, List[ColumnMeta[A]])].contramap(x =>
-      (x.userModified, x.scrollPosition.toDouble, x.columns.toList))
-
-  implicit def columnMetaNelArb[A: Arbitrary: Eq]: Arbitrary[NonEmptyList[ColumnMeta[A]]] =
-    Arbitrary {
-      for {
-        c <- Gen.nonEmptyListOf[ColumnMeta[A]](arbitrary[ColumnMeta[A]])
-      } yield NonEmptyList.fromListUnsafe(c)
-    }
-
-  implicit def columnMetaNelCogen[A: Cogen]: Cogen[NonEmptyList[ColumnMeta[A]]] =
-    Cogen[List[ColumnMeta[A]]].contramap(_.toList)
-
+final class TableSpec extends CatsSuite with TableArbitraries {
   checkAll("Eq[UserModified]", EqTests[UserModified].eqv)
   checkAll("Eq[FixedColumnWidth]", EqTests[FixedColumnWidth].eqv)
   checkAll("Eq[PercentageColumnWidth]", EqTests[PercentageColumnWidth].eqv)


### PR DESCRIPTION
In diode one of the features is `RefTo` which lets you do references across the model. While teorethically nice in practice they don't work well as we need usually two actions to get the model correct. This is more evident when doing a load sequence which ends up being unnecessarily slow

In this PR I remove this simplifying the updates though by necessity this requires a bit more manual bookkeeping.

In addition I'm using monocle Lenses to generate diode `ModelRW` instances as they are easier to build and compose

The PR is largish but it is mostly test code