### PR TITLE
SEQNG-606 Don't load sequence if instrument is in use.

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/Notification.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Notification.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model
+
+import gem.Observation
+import seqexec.model.enum.Instrument
+
+sealed trait Notification
+
+// Notification that user tried to run a sequence that used resource already in use
+final case class ResourceConflict(sid: Observation.Id) extends Notification
+// Notification that user tried to select a sequence for an instrument for which a sequence was already running
+final case class InstrumentInUse(sid: Observation.Id, ins: Instrument) extends Notification
+
+object Notification {
+  def header(n: Notification): String = n match {
+    case ResourceConflict(_)           => "Resource conflict"
+    case InstrumentInUse(_, _) => "Instrument busy"
+  }
+
+  def body(n: Notification): List[String] = n match {
+    case ResourceConflict(sid)              => List(
+      s"There is a conflict trying to run the sequence '${sid.format}'",
+      "Possibly another sequence is being executed on the same instrument"
+    )
+    case InstrumentInUse(sid, ins) => List(
+      s"Cannot select sequence '${sid.format}' for instrument '${ins.label}",
+      "Possibly another sequence is being executed on the same instrument"
+    )
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -19,9 +19,10 @@ import monocle.function.At.atMap
 import seqexec.engine.Engine
 import seqexec.model.{ ClientID, Conditions, Observer, Operator, SequenceState }
 import seqexec.model.enum.{CloudCover, Instrument, ImageQuality, SkyBackground, WaterVapor}
-import seqexec.model.UserDetails
+import seqexec.model.{UserDetails, Notification}
 
 package server {
+
   @Lenses
   final case class ObserverSequence(observer: Option[Observer], seq: SequenceGen)
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
@@ -49,6 +50,7 @@ package server {
   final case class SetWaterVapor(wv: WaterVapor, user: Option[UserDetails]) extends SeqEvent
   final case class SetSkyBackground(wv: SkyBackground, user: Option[UserDetails]) extends SeqEvent
   final case class SetCloudCover(cc: CloudCover, user: Option[UserDetails]) extends SeqEvent
+  final case class NotifyUser(memo: Notification, clientID: ClientID) extends SeqEvent
   case object NullSeqEvent extends SeqEvent
 
   sealed trait ControlStrategy


### PR DESCRIPTION
This change prevents to assign a sequence to an instrument if the current one is running.
It also includes some changes to a show a notification to the user. The actual pop-up will be implemented in SEQNG-712