### PR TITLE
SEQNG-708: Client does not update state of configured systems

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
@@ -8,19 +8,29 @@ import cats.implicits._
 import seqexec.model.enum._
 
 sealed trait Step {
-  val id: StepId
-  val config: StepConfig
-  val status: StepState
-  val breakpoint: Boolean
-  val skip: Boolean
-  val fileId: Option[dhs.ImageFileId]
+  def id: StepId
+  def config: StepConfig
+  def status: StepState
+  def breakpoint: Boolean
+  def skip: Boolean
+  def fileId: Option[dhs.ImageFileId]
 }
 object Step {
   val Zero: Step = StandardStep(id = -1, config = Map.empty, status = StepState.Pending, breakpoint = false, skip = false, fileId = None, configStatus = Nil, observeStatus = ActionStatus.Pending)
 
   implicit val equal: Eq[Step] =
-    Eq.by { x =>
-      (x.id, x.config, x.status, x.breakpoint, x.skip, x.fileId)
+    Eq.instance {
+      case (x: StandardStep, y: StandardStep) =>
+        (x.id === y.id) &&
+        (x.config === y.config) &&
+        (x.status === y.status) &&
+        (x.breakpoint === y.breakpoint) &&
+        (x.skip === y.skip) &&
+        (x.fileId === y.fileId) &&
+        (x.configStatus === y.configStatus) &&
+        (x.observeStatus === y.observeStatus)
+      case _ =>
+        false
     }
 
   implicit class StepOps(val s: Step) extends AnyVal {
@@ -85,9 +95,6 @@ final case class StandardStep(
   observeStatus: ActionStatus
 ) extends Step
 object StandardStep {
-  implicit val equal: Eq[StandardStep] =
-    Eq.by { x =>
-      (x.id, x.config, x.status, x.breakpoint, x.skip, x.fileId, x.configStatus, x.observeStatus)
-    }
+  implicit val equal: Eq[StandardStep] = Eq.by(x => x: Step)
 }
 // Other kinds of Steps to be defined.

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
@@ -33,6 +33,7 @@ object Resource {
 
   implicit val ordering: Ordering[Resource] =
     order.toOrdering
+
 }
 
 sealed abstract class Instrument(ordinal: Int, label: String)
@@ -51,7 +52,7 @@ object Instrument {
   case object NIFS  extends Instrument(19, "NIFS")
 
   implicit val equal: Eq[Instrument] =
-    Eq.fromUniversalEquals
+    Eq.by(x => x: Resource)
 
   implicit val show: Show[Instrument] =
     Show.show(_.label)

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -17,6 +17,8 @@ final class ModelSpec extends CatsSuite {
   checkAll("Eq[SystemName]", EqTests[SystemName].eqv)
   checkAll("Eq[StepConfig]", EqTests[StepConfig].eqv)
   checkAll("Order[Resource]", OrderTests[Resource].order)
+  checkAll("Eq[Resource]", EqTests[Resource].eqv)
+  checkAll("Eq[List]", EqTests[List[(Resource, ActionStatus)]].eqv)
   checkAll("Eq[Instrument]", EqTests[Instrument].eqv)
   checkAll("Eq[Operator]", EqTests[Operator].eqv)
   checkAll("Eq[Observer]", EqTests[Observer].eqv)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -98,11 +98,11 @@ object SeqexecMain {
           )
         ),
         lbConnect(LoginBox.apply),
-        userNotificationConnect(p => UserNotificationBox(UserNotificationBox.Props(p))),
+        userNotificationConnect(p => UserNotificationBox(UserNotificationBox.Props(p()))),
         Footer(Footer.Props(p.ctl, p.site))
       )
     )
-      .configure(Reusability.shouldComponentUpdate)
+    .configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(site: Site, ctl: RouterCtl[SeqexecPages]): Unmounted[Props, Unit, Unit] = component(Props(site, ctl))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/UserNotificationBox.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/UserNotificationBox.scala
@@ -3,7 +3,6 @@
 
 package seqexec.web.client.components
 
-import diode.react.ModelProxy
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.Reusability
@@ -21,7 +20,7 @@ import seqexec.web.client.reusability._
   */
 object UserNotificationBox {
 
-  final case class Props(notification: ModelProxy[UserNotificationState])
+  final case class Props(notification: UserNotificationState)
 
   implicit val propsReuse: Reusability[Props] = Reusability.by(_.notification)
 
@@ -29,7 +28,7 @@ object UserNotificationBox {
   private val component = ScalaComponent.builder[Props]("UserNotificationBox")
     .stateless
     .render_P { p =>
-      val UserNotificationState(_, not) = p.notification()
+      val UserNotificationState(_, not) = p.notification
       <.div(
         ^.cls := "ui tiny modal",
         not.map(h => Header(Notification.header(h))),
@@ -58,7 +57,7 @@ object UserNotificationBox {
 
         // Close the modal box if the model changes
         ctx.getDOMNode.toElement.foreach { dom =>
-          ctx.currentProps.notification() match {
+          ctx.currentProps.notification match {
             case UserNotificationState(SectionClosed, _) =>
               $(dom).modal("hide")
             case UserNotificationState(SectionOpen, _)   =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/reusability.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/reusability.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client
 
 import diode.data.PotState
-import diode.react.ModelProxy
+import cats.implicits._
 import gem.Observation
 import gem.enum.Site
 import japgolly.scalajs.react.CatsReact._
@@ -32,6 +32,4 @@ package object reusability {
   implicit val availableTabsReuse      : Reusability[AvailableTab]             = Reusability.byEq
   implicit val userDetailsReuse        : Reusability[UserDetails]              = Reusability.byEq
   implicit val userNotificationReuse   : Reusability[UserNotificationState]    = Reusability.byEq
-
-  implicit def modelProxyReuse[A: Reusability]: Reusability[ModelProxy[A]] = Reusability.by(_())
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/SequenceArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/SequenceArea.scala
@@ -62,7 +62,7 @@ object SequenceStepsTableContainer {
         ^.height := "100%",
         toolbar(p),
         p.stepsConnect(r =>
-          StepsTable(StepsTable.Props(p.router, p.statusAndStep.isLogged, r, x => $.runState(updateStepToRun(x)))))
+          StepsTable(StepsTable.Props(p.router, p.statusAndStep.isLogged, r(), x => $.runState(updateStepToRun(x)))))
       )
     }
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -6,14 +6,12 @@ package seqexec.web.client.components.sequence.steps
 import cats.Eq
 import cats.data.NonEmptyList
 import cats.implicits._
-import diode.react.ModelProxy
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.extra.Reusability
-import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.raw.JsNumber
 import monocle.Lens
 import monocle.macros.GenLens
@@ -29,6 +27,7 @@ import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.components.sequence.steps.OffsetFns._
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.{Size => SSize}
+import seqexec.web.client.reusability._
 import react.virtualized._
 import web.client.style._
 import web.client.table._
@@ -97,10 +96,10 @@ object StepsTable {
 
   final case class Props(router: RouterCtl[SeqexecPages],
                          canOperate: Boolean,
-                         stepsTable: ModelProxy[StepsTableAndStatusFocus],
+                         stepsTable: StepsTableAndStatusFocus,
                          onStepToRun: Int => Callback) {
-    def status: ClientStatus           = stepsTable().status
-    def steps: Option[StepsTableFocus] = stepsTable().stepsTable
+    def status: ClientStatus           = stepsTable.status
+    val steps: Option[StepsTableFocus] = stepsTable.stepsTable
     val stepsList: List[Step]          = steps.foldMap(_.steps)
     def rowCount: Int                  = stepsList.length
 
@@ -108,7 +107,7 @@ object StepsTable {
       steps.flatMap(_.steps.lift(idx)).fold(StepRow.Zero)(StepRow.apply)
 
     val configTableState: TableState[StepConfigTable.TableColumn] =
-      stepsTable().configTableState
+      stepsTable.configTableState
     // Find out if offsets should be displayed
     val offsetsDisplay: OffsetsDisplay = stepsList.offsetsDisplay
     private def showProp(p: InstrumentProperties): Boolean =
@@ -145,8 +144,7 @@ object StepsTable {
     val InitialTableState: State = State(TableState(NotModified, 0, all), None)
   }
 
-  implicit val stsfReuse: Reusability[StepsTableAndStatusFocus] = Reusability.byEq
-  implicit val propsReuse: Reusability[Props] = Reusability.by(x => (x.canOperate, x.stepsTable()))
+  implicit val propsReuse: Reusability[Props] = Reusability.by(x => (x.canOperate, x.stepsTable))
   implicit val stateReuse: Reusability[State] = Reusability.by(_.breakpointHover)
 
   val controlHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ClientStatus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ClientStatus.scala
@@ -5,6 +5,7 @@ package seqexec.web.client.model
 
 import cats.Eq
 import cats.implicits._
+import monocle.Lens
 import seqexec.model.UserDetails
 
 /**
@@ -18,5 +19,9 @@ final case class ClientStatus(u: Option[UserDetails], w: WebSocketConnection, sy
 
 object ClientStatus {
   implicit val eq: Eq[ClientStatus] =
-    Eq.by (x => (x.u, x.w, x.syncInProgress))
+    Eq.by(x => (x.u, x.w, x.syncInProgress))
+
+  val clientStatusFocusL: Lens[SeqexecAppRootModel, ClientStatus] =
+    Lens[SeqexecAppRootModel, ClientStatus](m => ClientStatus(m.uiModel.user, m.ws, m.uiModel.syncInProgress
+    ))(v => m => m.copy(ws = v.w, uiModel = m.uiModel.copy(user = v.u, syncInProgress = v.syncInProgress)))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -5,6 +5,7 @@ package seqexec.web.client
 
 import diode.Action
 import cats.Show
+import cats.implicits._
 import gem.Observation
 import gem.enum.Site
 import seqexec.model._
@@ -109,7 +110,7 @@ object actions {
 
   implicit val show: Show[Action] = Show.show {
     case s @ ServerMessage(u @ SeqexecModelUpdate(view)) =>
-      s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, loaded: '${view.loaded.mkString(",")}', (${view.queue.map(s => (s"id: ${s.id.format}", s"steps: ${s.steps.length}", s.steps.slice(0, scala.math.min(s.steps.length, 20)).collect(standardStep)))}))"
+      s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, loaded: '${view.loaded.mkString(",")}', (${view.queue.map(s => (s"id: ${s.id.format}", s"steps: ${s.steps.length}", s.steps.filter(_.status === StepState.Running).slice(0, scala.math.min(s.steps.length, 20)).collect(standardStep)))}))"
     case s @ RememberCompleted(view)                     =>
       s"${s.getClass.getSimpleName}(${view.id})"
     case a                                               =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
@@ -56,7 +56,8 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
     zoomRW(m => TableStates(m.uiModel.queueTableState, m.uiModel.configTableState)) ((m, v) => m.copy(uiModel = m.uiModel.copy(queueTableState = v.queueTable, configTableState = v.stepConfigTable)))
 
   // Reader to indicate the allowed interactions
-  val statusReader: ModelR[SeqexecAppRootModel, ClientStatus] = zoom(m => ClientStatus(m.uiModel.user, m.ws, m.uiModel.syncInProgress))
+  val statusReader: ModelR[SeqexecAppRootModel, ClientStatus] =
+    this.zoomL(ClientStatus.clientStatusFocusL)
 
   // Reader to update the sequences in both parts of the model being used
   val sequencesReaderRW: ModelRW[SeqexecAppRootModel, SequencesFocus] =
@@ -138,7 +139,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
   def stepsTableReader(id: Observation.Id): ModelR[SeqexecAppRootModel, StepsTableAndStatusFocus] =
     statusReader.zip(stepsTableReaderF(id)).zip(configTableState).zoom {
       case ((s, f), t) => StepsTableAndStatusFocus(s, f, t)
-    }
+    }(fastEq[StepsTableAndStatusFocus])
 
   def sequenceControlReader(obsId: Observation.Id): ModelR[SeqexecAppRootModel, SequenceControlFocus] =
     statusReader.zip(sequenceTab(obsId)).zoom {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -35,7 +35,10 @@ package circuit {
    * This lets us use monocle lenses to create diode ModelRW instances
    */
   class CircuitOps[M <: AnyRef](circuit: Circuit[M]) {
-    def zoomRWL[A: Eq](lens: Lens[M, A]): ModelRW[M, A] = circuit.zoomRW(lens.get)((m, a) => lens.set(a)(m))(fastEq[A])
+    def zoomRWL[A: Eq](lens: Lens[M, A]): ModelRW[M, A] =
+      circuit.zoomRW(lens.get)((m, a) => lens.set(a)(m))(fastEq[A])
+    def zoomL[A: Eq](lens: Lens[M, A]): ModelR[M, A] =
+      circuit.zoom[A](lens.get)(fastEq[A])
   }
 
   // All these classes are focused views of the root model. They are used to only update small sections of the
@@ -107,7 +110,7 @@ package circuit {
       Eq.by(x => (x.instrument, x.id, x.sequenceSelected, x.logDisplayed))
   }
 
-  final case class SequenceInfoFocus(isLogged: Boolean, obsName: Option[String], observer: Option[Observer], status: Option[SequenceState], targetName: Option[TargetName])
+  final case class SequenceInfoFocus(isLogged: Boolean, obsName: Option[String], observer: Option[Observer], status: Option[SequenceState], targetName: Option[TargetName]) extends UseValueEq
 
   object SequenceInfoFocus{
     implicit val eq: Eq[SequenceInfoFocus] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/model.scala
@@ -62,4 +62,6 @@ final case class SeqexecAppRootModel(ws: WebSocketConnection, site: Option[Site]
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SeqexecAppRootModel {
   val Initial: SeqexecAppRootModel = SeqexecAppRootModel(WebSocketConnection.Empty, None, None, SeqexecUIModel.Initial)
+
+  implicit val eq: Eq[SeqexecAppRootModel] = Eq.by(x => (x.ws, x.site, x.clientId, x.uiModel))
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
@@ -6,7 +6,9 @@ package seqexec.web.client
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import gem.Observation
-// import monocle.law.discipline.LensTests
+import monocle.law.discipline.LensTests
+import seqexec.web.client.model.ClientStatus
+import seqexec.web.client.model._
 import seqexec.web.client.circuit._
 import seqexec.web.client.circuit.SeqexecCircuit._
 import org.scalatest.prop.PropertyChecks
@@ -18,6 +20,8 @@ final class CircuitReaderSpec extends CatsSuite with PropertyChecks with Arbitra
   checkAll("Eq[SequenceInfoFocus]", EqTests[SequenceInfoFocus].eqv)
   // checkAll("sequencesFocusL", LensTests(SequencesFocus.sequencesFocusL))
   // checkAll("sodLocationFocusL", LensTests(SODLocationFocus.sodLocationFocusL))
+  // checkAll("initialSyncFocusL", LensTests(InitialSyncFocus.initialSyncFocusL))
+  checkAll("clientStatusFocusL", LensTests(ClientStatus.clientStatusFocusL))
 
   test("maintain reference equality for constant readers") {
       (webSocketFocusRW === webSocketFocusRW.value) should be(true)


### PR DESCRIPTION
This bug took a lot of effort to fix but uncovered a fundamental mismatch between diode's `ModelProxy` and scalajs-react `Reusability`. I've opted to get rid of `ModelProxy` on the components

Also `Eq` instances have been improved for `Step`

![screencast 2018-09-04 10-51-54](https://user-images.githubusercontent.com/3615303/45036103-f2e85a80-b031-11e8-8b7a-af28e3d5baf9.gif)
