### PR TITLE
SEQNG-704: Bad queue layout if column resized too small

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -765,6 +765,10 @@ body {
 
 .ReactVirtualized__Table__headerTruncatedText {
   flex: auto;
+  min-width: 20px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 // Get the same background color as a button
@@ -859,7 +863,7 @@ body {
 
 .ReactVirtualized__Table__rowColumn {
   .borderLeft();
-  min-width: 0;
+  min-width: 20px;
   display: flex;
   align-items: center;
   font-size: small;

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -949,7 +949,7 @@ body {
     min-height: 216px;
   }
   .SeqexecStyles-instrumentTabSegment {
-    min-height: 25.4em;
+    min-height: 20.4em;
   }
 }
 .mobileSegment() {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -152,14 +152,17 @@ object LogArea {
 
   private val ST = ReactS.Fix[State]
 
-  private val ClipboardWidth = 37
+  private val ClipboardWidth = 37.0
+  private val TimestampMinWidth = 90.1667 + SeqexecStyles.TableBorderWidth
+  private val LevelMinWidth = 59.3333 + SeqexecStyles.TableBorderWidth
+  private val MessageMinWidth = 89.35 + SeqexecStyles.TableBorderWidth
 
   val TimestampColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     column  = TimestampColumn,
     name    = "local",
     label   = "Timestamp",
     visible = true,
-    width   = PercentageColumnWidth.unsafeFromDouble(0.2)
+    width   = PercentageColumnWidth.unsafeFromDouble(0.2, TimestampMinWidth)
   )
 
   val LevelColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
@@ -167,7 +170,7 @@ object LogArea {
     name    = "level",
     label   = "Level",
     visible = true,
-    width   = PercentageColumnWidth.unsafeFromDouble(0.1)
+    width   = PercentageColumnWidth.unsafeFromDouble(0.1, LevelMinWidth)
   )
 
   val MsgColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
@@ -175,7 +178,7 @@ object LogArea {
     name    = "msg",
     label   = "Message",
     visible = true,
-    width   = PercentageColumnWidth.unsafeFromDouble(0.7)
+    width   = PercentageColumnWidth.unsafeFromDouble(0.7, MessageMinWidth)
   )
 
   val ClipboardColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
@@ -183,7 +186,7 @@ object LogArea {
     name    = "clip",
     label   = "",
     visible = true,
-    width   = FixedColumnWidth(ClipboardWidth)
+    width   = FixedColumnWidth.unsafeFromDouble(ClipboardWidth)
   )
 
   private val LogColumnStyle: String = SeqexecStyles.queueText.htmlClass
@@ -277,7 +280,7 @@ object LogArea {
         headerClassName = SeqexecStyles.tableHeader.htmlClass,
         headerHeight = SeqexecStyles.headerHeight
       ),
-      s.tableState.columnBuilder(size.width, colBuilder(b, size)): _*
+      s.tableState.columnBuilder(size, colBuilder(b, size)): _*
     ).vdomElement
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -14,6 +14,7 @@ object SeqexecStyles {
   val rowHeight: Int = 30
   val overscanRowCount: Int = 10
   val runningRowHeight: Int = 60
+  val TableBorderWidth: Double = 1.0
 
   val activeInstrumentLabel: GStyle = GStyle.fromString("SeqexecStyles-activeInstrumentLabel")
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
@@ -30,7 +30,7 @@ object OffsetFns {
 
   object OffsetsDisplay {
     case object NoDisplay extends OffsetsDisplay
-    final case class DisplayOffsets(offsetsWidth: Int) extends OffsetsDisplay
+    final case class DisplayOffsets(offsetsWidth: Double) extends OffsetsDisplay
     implicit val eq: Eq[OffsetsDisplay] =
       Eq.by {
         case NoDisplay         => None
@@ -53,12 +53,12 @@ object OffsetFns {
   val offsetPText: Step => String = offsetText(OffsetAxis.AxisP) _
   val offsetQText: Step => String = offsetText(OffsetAxis.AxisQ) _
 
-  val pLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisP))
-  val qLabelWidth: Int = tableTextWidth(offsetAxis(OffsetAxis.AxisQ))
+  val pLabelWidth: Double = tableTextWidth(offsetAxis(OffsetAxis.AxisP))
+  val qLabelWidth: Double = tableTextWidth(offsetAxis(OffsetAxis.AxisQ))
 
   // Calculate the widest offset step
-  private def sequenceOffsetWidthsF(steps: List[Step]): (Int, Int) =
-    steps.map(s => (tableTextWidth(offsetPText(s)), tableTextWidth(offsetQText(s)))).foldLeft((0, 0)) {
+  private def sequenceOffsetWidthsF(steps: List[Step]): (Double, Double) =
+    steps.map(s => (tableTextWidth(offsetPText(s)), tableTextWidth(offsetQText(s)))).foldLeft((0.0, 0.0)) {
       case ((p1, q1), (p2, q2)) => (p1.max(p2), q1.max(q2))
     }
 
@@ -68,7 +68,7 @@ object OffsetFns {
   }
 
   implicit class OffsetFnsOps(val steps: List[Step]) extends AnyVal {
-    def sequenceOffsetWidths: (Int, Int) = sequenceOffsetWidthsF(steps)
+    def sequenceOffsetWidths: (Double, Double) = sequenceOffsetWidthsF(steps)
     def areNonZeroOffsets: Boolean = areNonZeroOffsetsF(steps)
     // Find out if offsets should be displayed
     def offsetsDisplay: OffsetsDisplay = {
@@ -86,6 +86,7 @@ object OffsetsDisplayCell {
 
   final case class Props(offsetsDisplay: OffsetsDisplay, step: Step)
 
+  implicit val doubleReuse: Reusability[Double] = Reusability.double(0.0001)
   implicit val ofdReuse: Reusability[OffsetsDisplay] = Reusability.derive[OffsetsDisplay]
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -83,14 +83,14 @@ object StepConfigTable {
     name    = "name",
     label   = "Name",
     visible = true,
-    width   = PercentageColumnWidth.Half)
+    width   = PercentageColumnWidth.unsafeFromDouble(percentage = 0.5, minWidth = 57.3833 + SeqexecStyles.TableBorderWidth))
 
   val ValueColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     column  = ValueColumn,
     name    = "value",
     label   = "Value",
     visible = true,
-    width   = PercentageColumnWidth.Half)
+    width   = PercentageColumnWidth.unsafeFromDouble(percentage = 0.5, minWidth = 60.0))
 
   val InitialTableState: TableState[TableColumn] = TableState[TableColumn](
     userModified   = NotModified,
@@ -171,7 +171,7 @@ object StepConfigTable {
     .builder[Props]("StepConfig")
     .initialStateFromProps(_.startState)
     .render { b =>
-      Table(settingsTableProps(b), b.state.columnBuilder(b.props.size.width, colBuilder(b)): _*)
+      Table(settingsTableProps(b), b.state.columnBuilder(b.props.size, colBuilder(b)): _*)
     }
     .build
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -33,18 +33,18 @@ import web.client.style._
 import web.client.table._
 
 object ColWidths {
-  val ControlWidth: Int       = 40
-  val IdxWidth: Int           = 50
-  val StateWidth: Int         = 200
-  val StatusWidth: Int        = 100
-  val OffsetWidthBase: Int    = 75
-  val ExposureWidth: Int      = 75
-  val DisperserWidth: Int     = 100
-  val ObservingModeWidth: Int = 180
-  val FilterWidth: Int        = 100
-  val FPUWidth: Int           = 100
-  val ObjectTypeWidth: Int    = 75
-  val SettingsWidth: Int      = 34
+  val ControlWidth: Double       = 40
+  val IdxWidth: Double           = 50
+  val StateWidth: Double         = 200
+  val StatusWidth: Double        = 100
+  val OffsetWidthBase: Double    = 75
+  val ExposureWidth: Double      = 75
+  val DisperserWidth: Double     = 100
+  val ObservingModeWidth: Double = 180
+  val FilterWidth: Double        = 100
+  val FPUWidth: Double           = 100
+  val ObjectTypeWidth: Double    = 75
+  val SettingsWidth: Double      = 34
 }
 
 /**
@@ -65,7 +65,7 @@ object StepsTable {
     name = "status",
     label = "",
     visible = true,
-    FixedColumnWidth(ColWidths.ControlWidth))
+    FixedColumnWidth.unsafeFromDouble(ColWidths.ControlWidth))
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] = NonEmptyList.of(IconColumnMeta)
 
@@ -322,7 +322,7 @@ object StepsTable {
           )))
 
   def offsetColumn(p: Props,
-                   offsetVisible: Boolean): (Option[Table.ColumnArg], Int) =
+                   offsetVisible: Boolean): (Option[Table.ColumnArg], Double) =
     p.offsetsDisplay match {
       case OffsetsDisplay.DisplayOffsets(x) if p.showOffsets =>
         val width = ColWidths.OffsetWidthBase + x
@@ -468,12 +468,12 @@ object StepsTable {
     val colsWidth =
       ColWidths.ControlWidth +
         ColWidths.IdxWidth +
-        offsetCol.fold(0)(_ => offsetWidth) +
-        exposureCol.fold(0)(_ => ColWidths.ExposureWidth) +
-        disperserCol.fold(0)(_ => ColWidths.DisperserWidth) +
-        filterCol.fold(0)(_ => ColWidths.FilterWidth) +
-        fpuCol.fold(0)(_ => ColWidths.FPUWidth) +
-        observingModeCol.fold(0)(_ => ColWidths.ObservingModeWidth) +
+        offsetCol.fold(0.0)(_ => offsetWidth) +
+        exposureCol.fold(0.0)(_ => ColWidths.ExposureWidth) +
+        disperserCol.fold(0.0)(_ => ColWidths.DisperserWidth) +
+        filterCol.fold(0.0)(_ => ColWidths.FilterWidth) +
+        fpuCol.fold(0.0)(_ => ColWidths.FPUWidth) +
+        observingModeCol.fold(0.0)(_ => ColWidths.ObservingModeWidth) +
         ColWidths.ObjectTypeWidth +
         ColWidths.SettingsWidth
     val controlWidth = s.width - colsWidth

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -54,42 +54,38 @@ object StepConfigToolbar {
 
       <.div(
         ^.cls := "ui grid",
-        <.div(
-          ^.cls := "ui row",
-          SeqexecStyles.shorterRow,
-          <.div(
-            ^.cls := "left column bottom aligned sixteen wide computer ten wide tablet only",
-            p.sequenceConnect(p => SequenceInfo(SequenceInfo.Props(p)))
-          )
-        ),
       <.div(
-        ^.cls := "ui row two column",
+        ^.cls := "ui row three column",
         SeqexecStyles.shorterRow,
-        SeqexecStyles.lowerRow,
         <.div(
-          ^.cls := "ui left floated eight wide column",
+          ^.cls := "ui left floated two wide column",
           SeqexecStyles.shorterFields,
           // Back to sequence button
           p.router.link(sequencePage)
-            (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = p.router.setUrlAndDispatchCB(sequencePage)), "Back"))),
-          <.div(
-            ^.cls := "ui right floated eight wide column",
-            SeqexecStyles.shorterFields,
-            ButtonGroup(
-              ButtonGroup.Props(List(GStyle.fromString("right floated"))),
-              // Previous step button
-              (p.step > 0).option(p.router.link(prevStepPage)
-                (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = p.router.setUrlAndDispatchCB(prevStepPage)), "Prev"))),
-              Label(Label.Props(
-                RunningStep(p.step, p.total).show,
-                size = Size.Large,
-                extraStyles = List(SeqexecStyles.labelAsButton))),
-              // Next step button
-              (p.step < p.total - 1).option(p.router.link(nextStepPage)
-                (Button(Button.Props(icon = Some(IconChevronRight), labeled = RightLabeled, onClick = p.router.setUrlAndDispatchCB(nextStepPage)), "Next")))
-              )
+            (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = p.router.setUrlAndDispatchCB(sequencePage)), "Back"))
+        ),
+        <.div(
+          ^.cls := "left floated six wide column bottom aligned computer only",
+          p.sequenceConnect(p => SequenceInfo(SequenceInfo.Props(p)))
+        ),
+        <.div(
+          ^.cls := "ui right floated eight wide column",
+          SeqexecStyles.shorterFields,
+          ButtonGroup(
+            ButtonGroup.Props(List(GStyle.fromString("right floated"))),
+            // Previous step button
+            (p.step > 0).option(p.router.link(prevStepPage)
+              (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = p.router.setUrlAndDispatchCB(prevStepPage)), "Prev"))),
+            Label(Label.Props(
+              RunningStep(p.step, p.total).show,
+              size = Size.Large,
+              extraStyles = List(SeqexecStyles.labelAsButton))),
+            // Next step button
+            (p.step < p.total - 1).option(p.router.link(nextStepPage)
+              (Button(Button.Props(icon = Some(IconChevronRight), labeled = RightLabeled, onClick = p.router.setUrlAndDispatchCB(nextStepPage)), "Next")))
             )
           )
+        )
       )
     }.build
 

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -87,12 +87,12 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val arbOffsetsDisplay: Arbitrary[OffsetsDisplay] =
     Arbitrary {
       for {
-        s <- Gen.option(Gen.posNum[Int])
+        s <- Gen.option(Gen.posNum[Double])
       } yield s.fold(OffsetsDisplay.NoDisplay: OffsetsDisplay)(OffsetsDisplay.DisplayOffsets.apply)
     }
 
   implicit val odCogen: Cogen[OffsetsDisplay] =
-    Cogen[Option[Int]].contramap {
+    Cogen[Option[Double]].contramap {
       case OffsetsDisplay.NoDisplay         => None
       case OffsetsDisplay.DisplayOffsets(i) => Some(i)
     }

--- a/modules/shared/web/client/src/main/scala/web/client/utils.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/utils.scala
@@ -12,15 +12,15 @@ trait utils {
   type Ctx2D  = dom.CanvasRenderingContext2D
 
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def textWidth(text: String, font: String): Int = {
+  def textWidth(text: String, font: String): Double = {
     val canvas = dom.document.createElement("canvas").asInstanceOf[Canvas]
     val ctx    = canvas.getContext("2d").asInstanceOf[Ctx2D]
     ctx.font = font
     val metrics = ctx.measureText(text)
-    math.round(metrics.width.toFloat)
+    metrics.width
   }
 
-  def tableTextWidth(text: String): Int = textWidth(text, "bold 14px sans-serif")
+  def tableTextWidth(text: String): Double = textWidth(text, "bold 14px sans-serif")
 
 }
 

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableArbitraries.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableArbitraries.scala
@@ -20,16 +20,19 @@ trait TableArbitraries {
     Cogen[String].contramap(_.productPrefix)
 
   val genFixedColumnWidth: Gen[FixedColumnWidth] =
-    Gen.posNum[Int].map(FixedColumnWidth.apply)
+    Gen.posNum[Double].map(FixedColumnWidth.apply)
 
   implicit val fixedColumnWidthArb: Arbitrary[FixedColumnWidth] =
     Arbitrary(genFixedColumnWidth)
 
   implicit val fixedColumnWidthCogen: Cogen[FixedColumnWidth] =
-    Cogen[Int].contramap(_.width)
+    Cogen[Double].contramap(_.width)
 
   val genPercentageColumnWidth: Gen[PercentageColumnWidth] =
-    Gen.choose[Double](0, 1).map(PercentageColumnWidth.apply)
+    for {
+      p <- Gen.choose[Double](0, 1)
+      m <- Gen.choose[Double](0, 100)
+    } yield PercentageColumnWidth(p, m)
 
   implicit val percentageColumnWidthArb: Arbitrary[PercentageColumnWidth] =
     Arbitrary(genPercentageColumnWidth)


### PR DESCRIPTION
On the resizable columns if one makes a column too narrow you get weird effects like:

![seqexec-anomaly-004](https://user-images.githubusercontent.com/3615303/45054214-b4b75f00-b062-11e8-8a40-e501e2b8a6a5.png)

This provides a fix by setting a minimum width and also adds some small style fixes

![seqexec - gs 2018-09-04 16-55-21](https://user-images.githubusercontent.com/3615303/45054450-6a82ad80-b063-11e8-8aa9-76c5b9c1ec05.png)

This is happening because the header width has a minimum which depends on how css clips it. For the same reason cannot be easily measured and it is easier to just measure it on the browser