### PR TITLE
Fetch vs. Query

### DIFF
--- a/modules/db/src/main/scala/gem/dao/ObservationDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ObservationDao.scala
@@ -37,7 +37,7 @@ object ObservationDao {
 
   /**
    * Construct a program to select the specified observation, with the
-   * instrument but not targets nor steps.  Raises an error if the indicated
+   * instrument but not targets nor steps.  Raises an exception if the indicated
    * observation does not exist.
    */
   def fetchFlat(id: Observation.Id): ConnectionIO[(String, Instrument)] =
@@ -52,7 +52,7 @@ object ObservationDao {
 
   /**
    * Construct a program to select the specified observation, with the
-   * targets and instrument type but not steps.  Raises an error if the
+   * targets and instrument type but not steps.  Raises an exception if the
    * indicated observation does not exist.
    */
   def fetchTargets(id: Observation.Id): ConnectionIO[(String, TargetEnvironment)] =
@@ -73,7 +73,7 @@ object ObservationDao {
 
   /**
    * Construct a program to select the specified observation, with static
-   * config but not targets nor steps.  Raises an error if the indicated
+   * config but not targets nor steps.  Raises an exception if the indicated
    * observation does not exist.
    */
   def fetchStatic(id: Observation.Id): ConnectionIO[(String, StaticConfig)] =
@@ -94,7 +94,7 @@ object ObservationDao {
 
   /**
    * Construct a program to select the specified observation, with static
-   * config and steps but not targets.  Raises an error if the indicated
+   * config and steps but not targets.  Raises an exception if the indicated
    * observation does not exist.
    */
   def fetchConfig(id: Observation.Id): ConnectionIO[(String, StaticConfig, TreeMap[Location.Middle, Step])] =
@@ -115,8 +115,8 @@ object ObservationDao {
 
   /**
    * Construct a program to select a fully specified observation, with targets,
-   * static config and steps.  Raises an error if the indicated observation does
-   * not exist.
+   * static config and steps.  Raises an exception if the indicated observation
+   * does not exist.
    */
   def fetch(id: Observation.Id): ConnectionIO[Observation] =
     for {

--- a/modules/db/src/main/scala/gem/dao/ProgramDao.scala
+++ b/modules/db/src/main/scala/gem/dao/ProgramDao.scala
@@ -57,7 +57,7 @@ object ProgramDao {
   def selectFull(pid: Program.Id): ConnectionIO[Option[Program]] =
     (for {
       t  <- OptionT(selectFlat(pid))
-      os <- OptionT.liftF(ObservationDao.selectAll(pid))
+      os <- OptionT.liftF(ObservationDao.queryAll(pid))
     } yield Program(pid, t, os)).value
 
   object Statements {

--- a/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
+++ b/modules/db/src/main/scala/gem/dao/SmartGcalDao.scala
@@ -152,7 +152,7 @@ object SmartGcalDao {
     */
   def lookup(oid: Observation.Id, loc: Location.Middle): ExpansionResult[ExpandedSteps] =
     for {
-      o <- ObservationDao.selectStatic(oid).injectRight
+      o <- ObservationDao.fetchStatic(oid).injectRight
       s <- lookupʹ(StepDao.selectOne(oid, loc), loc, o._2)
     } yield s
 
@@ -184,7 +184,7 @@ object SmartGcalDao {
       }.void
 
     for {
-      obs   <- ObservationDao.selectStatic(oid).injectRight
+      obs   <- ObservationDao.fetchStatic(oid).injectRight
       steps <- StepDao.selectAll(oid).injectRight
       (locBefore, locAfter) = bounds(steps)
       gcal  <- lookupʹ(MaybeConnectionIO.fromOption(steps.get(loc)), loc, obs._2)

--- a/modules/service/src/main/scala/gem/Service.scala
+++ b/modules/service/src/main/scala/gem/Service.scala
@@ -28,11 +28,21 @@ final class Service[M[_]: Sync: LiftIO] private (private val xa: Transactor[M], 
     }
 
   /**
-   * Constuct a program that yields the `Observation` with the matching observation id.
+   * Constuct a program that yields the `Observation` with the matching
+   * observation id, raising an error if none.
    */
-  def queryObservationById(id: Observation.Id): M[Observation] =
+  def fetchObservationById(id: Observation.Id): M[Observation] =
+    log.log(user, s"fetchObservationById(${id.format})") {
+      ObservationDao.fetch(id).transact(xa)
+    }
+
+  /**
+   * Constuct a program that yields the `Observation` with the matching
+   * observation id wrapped in a `Some`, if any but `None` otherwise.
+   */
+  def queryObservationById(id: Observation.Id): M[Option[Observation]] =
     log.log(user, s"queryObservationById(${id.format})") {
-      ObservationDao.select(id).transact(xa)
+      ObservationDao.query(id).transact(xa)
     }
 
   /**

--- a/modules/web/src/main/scala/Application.scala
+++ b/modules/web/src/main/scala/Application.scala
@@ -50,11 +50,17 @@ object Application {
           }
         }
 
-      // Select an observation by id.
+      // Fetch an observation by id.
       case GET -> Root / "api" / "fetch" / "obs" / o as gs =>
         withObsId(o) { oid =>
-          gs.queryObservationById(oid).flatMap { obs =>
-            Ok(obs.asJson)
+          gs.fetchObservationById(oid).flatMap { obs => Ok(obs.asJson) }
+        }
+
+      // Query an observation by id.
+      case GET -> Root / "api" / "query" / "obs" / o as gs =>
+        withObsId(o) { oid =>
+          gs.queryObservationById(oid).flatMap { o =>
+            o.fold(NotFound())(obs => Ok(obs.asJson))
           }
         }
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -36,7 +36,7 @@ addSbtPlugin("de.heikoseeberger"  % "sbt-header"               % "4.1.0")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-git"                  % "0.9.3")
 addSbtPlugin("com.dwijnand"       % "sbt-dynver"               % "3.0.0")
 
-addSbtPlugin("org.wartremover"    % "sbt-wartremover"          % "2.3.4")
+addSbtPlugin("org.wartremover"    % "sbt-wartremover"          % "2.3.5")
 
 // Use NPM modules rather than webjars
 addSbtPlugin("ch.epfl.scala"      % "sbt-scalajs-bundler"      % "0.13.1")


### PR DESCRIPTION
This PR addresses feedback from #606, splitting the observation retrieval options in two: fetch vs. query.  Fetch expects an observation with the indicated ID to exist and raises an error if it doesn't while query returns optional results.

I let this update trickle all the way down to `ObservationDao`, though I suppose another option would be to leave the DAO with just the original exception raising option and handle the query option by dealing with the exception in `Service`.  