### PR TITLE
SEQNG-715 Fixed code that updates and reloads sequences

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -562,7 +562,7 @@ lazy val seqexec_engine = project
   .in(file("modules/seqexec/engine"))
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(GitBranchPrompt)
-  .dependsOn(seqexec_model.jvm)
+  .dependsOn(seqexec_model.jvm % "compile->compile;test->test")
   .settings(commonSettings: _*)
   .settings(
     addCompilerPlugin(Plugins.kindProjectorPlugin),

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -415,7 +415,7 @@ object Engine {
 
   object State {
     def empty: State = State(Map.empty)
-    def atSequence(id: Observation.Id): Optional[Map[Observation.Id, Sequence.State], Sequence.State] = index(id)
+    private def atSequence(id: Observation.Id): Optional[Map[Observation.Id, Sequence.State], Sequence.State] = index(id)
     def sequenceState[D](id: Observation.Id): Optional[State, Sequence.State] = State.sequences ^|-? atSequence(id)
   }
 

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -12,10 +12,9 @@ import seqexec.engine.Result.{PartialVal, PauseContext, RetVal}
 import seqexec.model.{ClientID, SequenceState}
 import fs2.Stream
 import gem.Observation
-import monocle.Lens
+import monocle.{Lens, Optional}
 import monocle.macros.Lenses
-import monocle.function.At.at
-import monocle.function.At.atMap
+import monocle.function.Index.index
 import mouse.boolean._
 import org.log4s.getLogger
 
@@ -135,7 +134,7 @@ class Engine[D, U](stateL: Lens[D, Engine.State]) {
     */
   def load(id: Observation.Id, seq: Sequence): Endo[D] =
     stateL.modify(st =>
-      st.copy(sequences = st.sequences.get(id).map(t => st.sequences.updated(id, t.update(seq))
+      st.copy(sequences = st.sequences.get(id).map(t => st.sequences.updated(id, Sequence.State.reload(seq.steps, t))
         ).getOrElse(st.sequences.updated(id, Sequence.State.init(seq))))
     )
 
@@ -148,6 +147,15 @@ class Engine[D, U](stateL: Lens[D, Engine.State]) {
         ).getOrElse(st.sequences)
       )
     )
+
+  /**
+    * Refresh the steps executions of an existing sequence
+    * @param id sequence identifier
+    * @param steps List of new steps definitions
+    * @return
+    */
+  def update(id: Observation.Id, steps: List[Step]): Endo[D] =
+    (stateL ^|-? Engine.State.sequenceState(id)).modify(_.update(steps.map(_.executions)))
 
   /**
     * Adds the current `Execution` to the completed `Queue`, makes the next
@@ -388,10 +396,10 @@ class Engine[D, U](stateL: Lens[D, Engine.State]) {
     inspect(stateL.get(_).sequences.get(id).map(f))
 
   private def modifyS(id: Observation.Id)(f: Sequence.State => Sequence.State): HandleP[Unit] =
-    modify((stateL ^|-> Engine.State.sequenceState(id)).modify(s => s.map(f)))
+    modify((stateL ^|-? Engine.State.sequenceState(id)).modify(f))
 
   private def putS(id: Observation.Id)(s: Sequence.State): HandleP[Unit] =
-    modify((stateL ^|-> Engine.State.sequenceState(id)).set(s.some))
+    modify((stateL ^|-? Engine.State.sequenceState(id)).set(s))
 
   // For debugging
   def printSequenceState(id: Observation.Id): HandleP[Unit] =
@@ -407,8 +415,8 @@ object Engine {
 
   object State {
     def empty: State = State(Map.empty)
-    def atSequence(id: Observation.Id): Lens[Map[Observation.Id, Sequence.State], Option[Sequence.State]] = at(id)
-    def sequenceState[D](id: Observation.Id): Lens[State, Option[Sequence.State]] = State.sequences ^|-> atSequence(id)
+    def atSequence(id: Observation.Id): Optional[Map[Observation.Id, Sequence.State], Sequence.State] = index(id)
+    def sequenceState[D](id: Observation.Id): Optional[State, Sequence.State] = State.sequences ^|-? atSequence(id)
   }
 
   abstract class Types {

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/EngineSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/EngineSpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.engine
+
+import cats.Eq
+import cats.tests.CatsSuite
+import gem.Observation
+import gem.arb.ArbObservation
+import monocle.law.discipline.OptionalTests
+import org.scalacheck.{Arbitrary, Cogen}
+import org.scalacheck.Arbitrary._
+import seqexec.engine
+import seqexec.model.SeqexecModelArbitraries._
+import seqexec.model.SequenceState
+
+final class EngineSpec extends CatsSuite with ArbObservation {
+  implicit val seqstateEq: Eq[engine.Sequence.State] = Eq.fromUniversalEquals
+  implicit val execstateEq: Eq[engine.Engine.State] = Eq.by(x => x.sequences)
+
+  implicit val sequenceArb: Arbitrary[Sequence] = Arbitrary{
+    for{
+      id <- arbitrary[Observation.Id](ArbObservation.arbObservationId)
+    } yield Sequence(id, List())
+  }
+
+  implicit val sequenceStateArb: Arbitrary[Sequence.State] = Arbitrary{
+    for{
+      seq <- arbitrary[Sequence]
+      st <- arbitrary[SequenceState]
+    } yield Sequence.State.Final(seq, st)
+  }
+
+  implicit val sequenceStateCogen: Cogen[Sequence.State] = Cogen[Observation.Id].contramap(_.toSequence.id)
+
+  implicit val engineStateArb: Arbitrary[Engine.State] = Arbitrary {
+    for {
+      q <- arbitrary[Map[Observation.Id, Sequence.State]]
+    } yield Engine.State(q)
+  }
+
+  checkAll("sequence optional",
+           OptionalTests[Engine.State, Sequence.State, Observation.Id](Engine.State.sequenceState))
+
+}

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -57,17 +57,17 @@ class SeqTranslateSpec extends FlatSpec {
     (EngineState.executionState ^|-> Engine.State.sequences ^|-? index[Map[Observation.Id,Sequence.State], Observation.Id, Sequence.State](seqId) ^|-> Sequence.State.status).set(SequenceState.Running.init))(EngineState.default)
 
   // Observe started
-  private val s0: EngineState = (EngineState.executionState ^|-> Engine.State.sequences ^|-? index(seqId)).modify(_.start(0))(baseState)
+  private val s0: EngineState = (EngineState.executionState ^|-? Engine.State.sequenceState(seqId)).modify(_.start(0))(baseState)
   // Observe pending
   private val s1: EngineState = baseState
   // Observe completed
-  private val s2: EngineState = (EngineState.executionState ^|-> Engine.State.sequences ^|-? index(seqId)).modify(_.mark(0)(Result.OK(Result.Observed(fileId))))(baseState)
+  private val s2: EngineState = (EngineState.executionState ^|-? Engine.State.sequenceState(seqId)).modify(_.mark(0)(Result.OK(Result.Observed(fileId))))(baseState)
   // Observe started, but with file Id already allocated
-  private val s3: EngineState = (EngineState.executionState ^|-> Engine.State.sequences ^|-? index(seqId)).modify(_.start(0).mark(0)(Result.Partial(Result.FileIdAllocated(fileId), IO(Result.OK(Result.Observed(fileId))))))(baseState)
+  private val s3: EngineState = (EngineState.executionState ^|-? Engine.State.sequenceState(seqId)).modify(_.start(0).mark(0)(Result.Partial(Result.FileIdAllocated(fileId), IO(Result.OK(Result.Observed(fileId))))))(baseState)
   // Observe paused
-  private val s4: EngineState = (EngineState.executionState ^|-> Engine.State.sequences ^|-? index(seqId)).modify(_.mark(0)(Result.Paused(ObserveContext(_ => SeqAction(Result.OK(Result.Observed(fileId))), Seconds(1)))))(baseState)
+  private val s4: EngineState = (EngineState.executionState ^|-? Engine.State.sequenceState(seqId)).modify(_.mark(0)(Result.Paused(ObserveContext(_ => SeqAction(Result.OK(Result.Observed(fileId))), Seconds(1)))))(baseState)
   // Observe failed
-  private val s5: EngineState = (EngineState.executionState ^|-> Engine.State.sequences ^|-? index(seqId)).modify(_.mark(0)(Result.Error("error")))(baseState)
+  private val s5: EngineState = (EngineState.executionState ^|-? Engine.State.sequenceState(seqId)).modify(_.mark(0)(Result.Error("error")))(baseState)
 
   private val systems = SeqTranslate.Systems(
     new ODBProxy(new Peer("localhost", 8443, null), ODBProxy.DummyOdbCommands),


### PR DESCRIPTION
The `update` method in `Sequence.State.Zipper` was trying to do too many things. It was used to refresh the steps `executions` when, for example, the operator name changed, and also to update the whole sequence when reloading it from the ODB. I separated it into two functions, `update` and `reload`.