### PR TITLE
SEQNG-413: Jump to next step to run

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
@@ -371,9 +371,9 @@ object QueueTableBody {
 
   def pageOf(row: QueueRow): SeqexecPages =
     if (row.loaded) {
-      SequencePage(row.instrument, row.obsId, 0)
+      SequencePage(row.instrument, row.obsId, NextToRun)
     } else {
-      PreviewPage(row.instrument, row.obsId, 0)
+      PreviewPage(row.instrument, row.obsId, NextToRun)
     }
 
   private def linkedTextRenderer(p: Props)(
@@ -574,7 +574,7 @@ object QueueTableBody {
     val r = b.props.rowGetter(i)
     if (r.loaded) {
       // If already loaded switch tabs
-      b.props.ctl.dispatchAndSetUrlCB(SelectIdToDisplay(r.instrument, r.obsId, 0))
+      b.props.ctl.dispatchAndSetUrlCB(SelectIdToDisplay(r.instrument, r.obsId, NextToRun))
     } else { // Try to load it
       (for {
         u <- b.props.user

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/QueueTable.scala
@@ -142,6 +142,7 @@ object QueueTableBody {
                    s.name,
                    s.active,
                    s.loaded,
+                   s.nextStepToRun,
                    s.runningStep)
         }
         .getOrElse(QueueRow.Empty)
@@ -199,7 +200,7 @@ object QueueTableBody {
         this
       } else {
         val optimalSizes = sequences.foldLeft(columnsDefaultWidth) {
-          case (currWidths, SequenceInQueue(id, st, i, _, _, n, t, r)) =>
+          case (currWidths, SequenceInQueue(id, st, i, _, _, n, t, r, _)) =>
             val idWidth = max(currWidths.getOrElse(ObsIdColumn, ObsIdMinWidth),
                               tableTextWidth(id.format))
             val statusWidth =
@@ -305,8 +306,8 @@ object QueueTableBody {
     var name: String
     var active: Boolean
     var loaded: Boolean
+    var nextStepToRun: Option[Int]
     var runningStep: Option[RunningStep]
-
   }
 
   // scalastyle:on
@@ -320,6 +321,7 @@ object QueueTableBody {
               name: String,
               active: Boolean,
               loaded: Boolean,
+              nextStepToRun: Option[Int],
               runningStep: Option[RunningStep]): QueueRow = {
       val p = (new js.Object).asInstanceOf[QueueRow]
       p.obsId = obsId
@@ -328,6 +330,7 @@ object QueueTableBody {
       p.targetName = targetName
       p.name = name
       p.active = active
+      p.nextStepToRun = nextStepToRun
       p.runningStep = runningStep
       p.loaded = loaded
       p
@@ -340,6 +343,7 @@ object QueueTableBody {
                                       String,
                                       Boolean,
                                       Boolean,
+                                      Option[Int],
                                       Option[RunningStep])] =
       Some(
         (l.obsId,
@@ -349,6 +353,7 @@ object QueueTableBody {
          l.name,
          l.active,
          l.loaded,
+         l.nextStepToRun,
          l.runningStep))
 
     def Empty: QueueRow =
@@ -359,6 +364,7 @@ object QueueTableBody {
             "",
             active = false,
             loaded = false,
+            None,
             None)
   }
 
@@ -371,9 +377,9 @@ object QueueTableBody {
 
   def pageOf(row: QueueRow): SeqexecPages =
     if (row.loaded) {
-      SequencePage(row.instrument, row.obsId, NextToRun)
+      SequencePage(row.instrument, row.obsId, StepIdDisplayed(row.nextStepToRun.getOrElse(0)))
     } else {
-      PreviewPage(row.instrument, row.obsId, NextToRun)
+      PreviewPage(row.instrument, row.obsId, StepIdDisplayed(row.nextStepToRun.getOrElse(0)))
     }
 
   private def linkedTextRenderer(p: Props)(
@@ -454,16 +460,16 @@ object QueueTableBody {
     ((i, p.rowGetter(i)) match {
       case (-1, _) =>
         SeqexecStyles.headerRowStyle
-      case (_, QueueRow(_, s, _, _, _, _, _, _)) if s == SequenceState.Completed =>
+      case (_, QueueRow(_, s, _, _, _, _, _, _, _)) if s == SequenceState.Completed =>
         SeqexecStyles.stepRow |+| SeqexecStyles.rowPositive
-      case (_, QueueRow(_, s, _, _, _, _, _, _)) if s.isRunning                  =>
+      case (_, QueueRow(_, s, _, _, _, _, _, _, _)) if s.isRunning                  =>
         SeqexecStyles.stepRow |+| SeqexecStyles.rowWarning
-      case (_, QueueRow(_, s, _, _, _, _, _, _)) if s.isError                    =>
+      case (_, QueueRow(_, s, _, _, _, _, _, _, _)) if s.isError                    =>
         SeqexecStyles.stepRow |+| SeqexecStyles.rowNegative
-      case (_, QueueRow(_, s, _, _, _, _, active, _))
-          if active && !s.isInProcess                                         =>
+      case (_, QueueRow(_, s, _, _, _, _, active, _, _))
+          if active && !s.isInProcess                                               =>
         SeqexecStyles.stepRow |+| SeqexecStyles.rowActive
-      case _                                                                  =>
+      case _                                                                        =>
         SeqexecStyles.stepRow
     }).htmlClass
 
@@ -574,7 +580,7 @@ object QueueTableBody {
     val r = b.props.rowGetter(i)
     if (r.loaded) {
       // If already loaded switch tabs
-      b.props.ctl.dispatchAndSetUrlCB(SelectIdToDisplay(r.instrument, r.obsId, NextToRun))
+      b.props.ctl.dispatchAndSetUrlCB(SelectIdToDisplay(r.instrument, r.obsId, StepIdDisplayed(r.nextStepToRun.getOrElse(0))))
     } else { // Try to load it
       (for {
         u <- b.props.user

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
@@ -41,16 +41,16 @@ object SeqexecUI {
   }
   // Prism from url params to sequence page
   def sequencePageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), SequencePage] = Prism[(String, String, Int), SequencePage] {
-    case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequencePage(_, _, StepIdDisplayed(st)))
+    case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequencePage(_, _, StepIdDisplayed(st - 1)))
   } {
-    p => (p.instrument.show, p.obsId.format, p.step.step)
+    p => (p.instrument.show, p.obsId.format, p.step.step + 1)
   }
 
   // Prism from url params to the preview page
   def previewPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), PreviewPage] = Prism[(String, String, Int), PreviewPage] {
-    case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewPage(_, _, StepIdDisplayed(st)))
+    case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewPage(_, _, StepIdDisplayed(st - 1)))
   } {
-    p => (p.instrument.show, p.obsId.format, p.step.step)
+    p => (p.instrument.show, p.obsId.format, p.step.step + 1)
   }
 
   // Prism from url params to the preview page with config

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
@@ -38,17 +38,17 @@ object SeqexecUI {
     p => (p.instrument.show, p.obsId.format, p.step)
   }
   // Prism from url params to sequence page
-  def sequencePageP(instrumentNames: Map[String, Instrument]): Prism[(String, String), SequencePage] = Prism[(String, String), SequencePage] {
-    case (i, s) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequencePage(_, _, 0))
+  def sequencePageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), SequencePage] = Prism[(String, String, Int), SequencePage] {
+    case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequencePage(_, _, StepIdDisplayed(st)))
   } {
-    p => (p.instrument.show, p.obsId.format)
+    p => (p.instrument.show, p.obsId.format, 0)
   }
 
   // Prism from url params to the preview page
-  def previewPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String), PreviewPage] = Prism[(String, String), PreviewPage] {
-    case (i, s) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewPage(_, _, 0))
+  def previewPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), PreviewPage] = Prism[(String, String, Int), PreviewPage] {
+    case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewPage(_, _, StepIdDisplayed(st)))
   } {
-    p => (p.instrument.show, p.obsId.format)
+    p => (p.instrument.show, p.obsId.format, 0)
   }
 
   // Prism from url params to the preview page with config
@@ -71,9 +71,9 @@ object SeqexecUI {
       | staticRoute("/preview", EmptyPreviewPage) ~> renderR(r => SeqexecMain(site, r))
       | dynamicRouteCT(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/configuration/" ~ int)
         .pmapL(configPageP(instrumentNames))) ~> dynRenderR((_: SequenceConfigPage, r) => SeqexecMain(site, r))
-      | dynamicRouteCT(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+"))
+      | dynamicRouteCT(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/step/" ~ int)
         .pmapL(sequencePageP(instrumentNames))) ~> dynRenderR((_: SequencePage, r) => SeqexecMain(site, r))
-      | dynamicRouteCT(("/preview/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+"))
+      | dynamicRouteCT(("/preview/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/step/" ~ int)
         .pmapL(previewPageP(instrumentNames))) ~> dynRenderR((_: PreviewPage, r) => SeqexecMain(site, r))
       | dynamicRouteCT(("/preview/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/configuration/" ~ int)
         .pmapL(previewConfigPageP(instrumentNames))) ~> dynRenderR((_: PreviewConfigPage, r) => SeqexecMain(site, r))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
@@ -28,6 +28,8 @@ object SeqexecUI {
   def pageTitle(site: Site)(p: SeqexecPages): String = p match {
     case SequenceConfigPage(_, id, _) => s"Seqexec - ${id.format}"
     case SequencePage(_, id, _)       => s"Seqexec - ${id.format}"
+    case PreviewPage(_, id, _)        => s"Seqexec - ${id.format}"
+    case PreviewConfigPage(_, id, _)  => s"Seqexec - ${id.format}"
     case _                            => s"Seqexec - ${site.shortName}"
   }
 
@@ -41,14 +43,14 @@ object SeqexecUI {
   def sequencePageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), SequencePage] = Prism[(String, String, Int), SequencePage] {
     case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequencePage(_, _, StepIdDisplayed(st)))
   } {
-    p => (p.instrument.show, p.obsId.format, 0)
+    p => (p.instrument.show, p.obsId.format, p.step.step)
   }
 
   // Prism from url params to the preview page
   def previewPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), PreviewPage] = Prism[(String, String, Int), PreviewPage] {
     case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewPage(_, _, StepIdDisplayed(st)))
   } {
-    p => (p.instrument.show, p.obsId.format, 0)
+    p => (p.instrument.show, p.obsId.format, p.step.step)
   }
 
   // Prism from url params to the preview page with config

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -84,6 +84,7 @@ object InstrumentTab {
       val instName = instrument.foldMap(_.show)
       val dispName = if (isPreview) s"Preview: $instName" else instName
       val isLogged = b.props.loggedIn
+      val nextStepToRun = StepIdDisplayed(b.props.tab.runningStep.foldMap(_.last))
 
       val tabTitle = b.props.tab.runningStep match {
         case Some(RunningStep(current, total)) => s"${sequenceId.map(_.format).getOrElse("")} - ${current + 1}/$total"
@@ -104,7 +105,7 @@ object InstrumentTab {
 
       val linkPage: SeqexecPages =
         (sequenceId, instrument)
-          .mapN((id, inst) => if (isPreview) PreviewPage(inst, id, NextToRun) else SequencePage(inst, id, NextToRun))
+          .mapN((id, inst) => if (isPreview) PreviewPage(inst, id, nextStepToRun) else SequencePage(inst, id, nextStepToRun))
           .getOrElse(EmptyPreviewPage)
 
       val loadButton: Option[VdomNode] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -84,7 +84,7 @@ object InstrumentTab {
       val instName = instrument.foldMap(_.show)
       val dispName = if (isPreview) s"Preview: $instName" else instName
       val isLogged = b.props.loggedIn
-      val nextStepToRun = StepIdDisplayed(b.props.tab.runningStep.foldMap(_.last))
+      val nextStepToRun = StepIdDisplayed(b.props.tab.nextStepToRun.getOrElse(-1))
 
       val tabTitle = b.props.tab.runningStep match {
         case Some(RunningStep(current, total)) => s"${sequenceId.map(_.format).getOrElse("")} - ${current + 1}/$total"
@@ -183,7 +183,7 @@ object InstrumentsTabs {
     .stateless
     .render_P(p =>
       tabConnect { x =>
-        val runningInstruments = x().tabs.toList.collect { case AvailableTab(_, Some(SequenceState.Running(_, _)), Some(i), _, false, _, _) => i }
+        val runningInstruments = x().tabs.toList.collect { case AvailableTab(_, Some(SequenceState.Running(_, _)), Some(i), _, _, false, _, _) => i }
         val tabs = x().tabs.toList.filter(_.nonEmpty).sortBy {
           case t if t.isPreview => Int.MinValue.some
           case t                => t.instrument.map(_.ordinal)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -104,7 +104,7 @@ object InstrumentTab {
 
       val linkPage: SeqexecPages =
         (sequenceId, instrument)
-          .mapN((id, inst) => if (isPreview) PreviewPage(inst, id, 0) else SequencePage(inst, id, 0))
+          .mapN((id, inst) => if (isPreview) PreviewPage(inst, id, NextToRun) else SequencePage(inst, id, NextToRun))
           .getOrElse(EmptyPreviewPage)
 
       val loadButton: Option[VdomNode] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/InstrumentsTabs.scala
@@ -105,7 +105,13 @@ object InstrumentTab {
 
       val linkPage: SeqexecPages =
         (sequenceId, instrument)
-          .mapN((id, inst) => if (isPreview) PreviewPage(inst, id, nextStepToRun) else SequencePage(inst, id, nextStepToRun))
+          .mapN((id, inst) =>
+            if (isPreview) {
+              PreviewPage(inst, id, nextStepToRun)
+            } else {
+              SequencePage(inst, id, nextStepToRun)
+            }
+          )
           .getOrElse(EmptyPreviewPage)
 
       val loadButton: Option[VdomNode] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -124,7 +124,7 @@ object StepConfigTable {
 
   def updateScrollPosition(b: Backend, pos: JsNumber): Callback = {
     val s = TableState.scrollPosition[TableColumn].set(pos)(b.state)
-    b.setState(s) >> SeqexecCircuit.dispatchCB(UpdateStepsConfigTableState(s))
+    b.setState(s) *> SeqexecCircuit.dispatchCB(UpdateStepsConfigTableState(s))
   }
 
   def rowClassName(p: Props)(i: Int): String =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -33,6 +33,7 @@ import seqexec.web.client.reusability._
 import react.virtualized._
 import web.client.style._
 import web.client.table._
+import web.client.utils
 
 object ColWidths {
   val ControlWidth: Double       = 40
@@ -510,8 +511,9 @@ object StepsTable {
 
   def updateScrollPosition(b: Backend, pos: JsNumber): Callback = {
     val s = (State.userModified.set(IsModified) >>> State.scrollPosition.set(pos))(b.state)
-    b.setState(s) *>
-    b.props.obsId.map(id => SeqexecCircuit.dispatchCB(UpdateStepTableState(id, s.tableState))).getOrEmpty
+    (b.setState(s) *>
+    b.props.obsId.map(id => SeqexecCircuit.dispatchCB(UpdateStepTableState(id, s.tableState))).getOrEmpty).when(!utils.eq.eqv(pos, b.state.tableState.scrollPosition)) *>
+    Callback.empty
   }
 
   def startScrollTop(b: Backend): js.UndefOr[JsNumber] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -37,9 +37,9 @@ object StepConfigToolbar {
     .stateless
     .render_P { p =>
       val sequencePage = if (p.isPreview) {
-        PreviewPage(p.instrument, p.id, p.step)
+        PreviewPage(p.instrument, p.id, StepIdDisplayed(p.step))
       } else {
-        SequencePage(p.instrument, p.id, p.step)
+        SequencePage(p.instrument, p.id, StepIdDisplayed(p.step))
       }
       val nextStepPage = if (p.isPreview) {
         PreviewConfigPage(p.instrument, p.id, p.step + 2)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Pages.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Pages.scala
@@ -30,6 +30,12 @@ object Pages {
       case (StepIdDisplayed(i), StepIdDisplayed(j)) => i === j
       case _                                        => false
     }
+
+    implicit val monoid: Monoid[StepIdDisplayed] = new Monoid[StepIdDisplayed] {
+      override def empty: StepIdDisplayed = StepIdDisplayed(0)
+      override def combine(x: StepIdDisplayed, y: StepIdDisplayed): StepIdDisplayed =
+        StepIdDisplayed(x.step + y.step)
+    }
   }
 
   case object Root extends SeqexecPages

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Pages.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Pages.scala
@@ -20,16 +20,10 @@ object Pages {
   sealed trait SeqexecPages extends Product with Serializable
 
   // Indicates which step to display
-  // sealed trait StepDisplayed extends Product with Serializable
-  // case object NextToRun extends StepDisplayed
-  final case class StepIdDisplayed(step: Int)// extends StepDisplayed
+  final case class StepIdDisplayed(step: Int)
 
   object StepIdDisplayed {
-    implicit val equal: Eq[StepIdDisplayed] = Eq.instance {
-      // case (NextToRun, NextToRun)                   => true
-      case (StepIdDisplayed(i), StepIdDisplayed(j)) => i === j
-      case _                                        => false
-    }
+    implicit val equal: Eq[StepIdDisplayed] = Eq.fromUniversalEquals
 
     implicit val monoid: Monoid[StepIdDisplayed] = new Monoid[StepIdDisplayed] {
       override def empty: StepIdDisplayed = StepIdDisplayed(0)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Pages.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Pages.scala
@@ -20,13 +20,13 @@ object Pages {
   sealed trait SeqexecPages extends Product with Serializable
 
   // Indicates which step to display
-  sealed trait StepDisplayed extends Product with Serializable
-  case object NextToRun extends StepDisplayed
-  final case class StepIdDisplayed(step: Int) extends StepDisplayed
+  // sealed trait StepDisplayed extends Product with Serializable
+  // case object NextToRun extends StepDisplayed
+  final case class StepIdDisplayed(step: Int)// extends StepDisplayed
 
-  object StepDisplayed {
-    implicit val equal: Eq[StepDisplayed] = Eq.instance {
-      case (NextToRun, NextToRun)                   => true
+  object StepIdDisplayed {
+    implicit val equal: Eq[StepIdDisplayed] = Eq.instance {
+      // case (NextToRun, NextToRun)                   => true
       case (StepIdDisplayed(i), StepIdDisplayed(j)) => i === j
       case _                                        => false
     }
@@ -35,9 +35,9 @@ object Pages {
   case object Root extends SeqexecPages
   case object SoundTest extends SeqexecPages
   case object EmptyPreviewPage extends SeqexecPages
-  final case class PreviewPage(instrument: Instrument, obsId: Observation.Id, step: StepDisplayed) extends SeqexecPages
+  final case class PreviewPage(instrument: Instrument, obsId: Observation.Id, step: StepIdDisplayed) extends SeqexecPages
   final case class PreviewConfigPage(instrument: Instrument, obsId: Observation.Id, step: StepId) extends SeqexecPages
-  final case class SequencePage(instrument: Instrument, obsId: Observation.Id, step: StepDisplayed) extends SeqexecPages
+  final case class SequencePage(instrument: Instrument, obsId: Observation.Id, step: StepIdDisplayed) extends SeqexecPages
   final case class SequenceConfigPage(instrument: Instrument, obsId: Observation.Id, step: StepId) extends SeqexecPages
 
   implicit val equal: Eq[SeqexecPages] = Eq.instance {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Pages.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Pages.scala
@@ -19,12 +19,25 @@ import monocle.Prism
 object Pages {
   sealed trait SeqexecPages extends Product with Serializable
 
+  // Indicates which step to display
+  sealed trait StepDisplayed extends Product with Serializable
+  case object NextToRun extends StepDisplayed
+  final case class StepIdDisplayed(step: Int) extends StepDisplayed
+
+  object StepDisplayed {
+    implicit val equal: Eq[StepDisplayed] = Eq.instance {
+      case (NextToRun, NextToRun)                   => true
+      case (StepIdDisplayed(i), StepIdDisplayed(j)) => i === j
+      case _                                        => false
+    }
+  }
+
   case object Root extends SeqexecPages
   case object SoundTest extends SeqexecPages
   case object EmptyPreviewPage extends SeqexecPages
-  final case class PreviewPage(instrument: Instrument, obsId: Observation.Id, step: StepId) extends SeqexecPages
+  final case class PreviewPage(instrument: Instrument, obsId: Observation.Id, step: StepDisplayed) extends SeqexecPages
   final case class PreviewConfigPage(instrument: Instrument, obsId: Observation.Id, step: StepId) extends SeqexecPages
-  final case class SequencePage(instrument: Instrument, obsId: Observation.Id, step: StepId) extends SeqexecPages
+  final case class SequencePage(instrument: Instrument, obsId: Observation.Id, step: StepDisplayed) extends SeqexecPages
   final case class SequenceConfigPage(instrument: Instrument, obsId: Observation.Id, step: StepId) extends SeqexecPages
 
   implicit val equal: Eq[SeqexecPages] = Eq.instance {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -154,7 +154,7 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
 
   def availableTabs: NonEmptyList[AvailableTab] =
     NonEmptyList.fromListUnsafe(sequences.withFocus.map {
-      case (i, a) => AvailableTab(i.sequence.map(_.id), i.sequence.map(_.status), i.instrument, i.runningStep, i.isPreview, a, i.loading)
+      case (i, a) => AvailableTab(i.sequence.map(_.id), i.sequence.map(_.status), i.instrument, i.runningStep, i.nextStepToRun, i.isPreview, a, i.loading)
     }.toList)
 
   def cleanAll: SequencesOnDisplay =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -11,7 +11,9 @@ import seqexec.model.{ SequencesQueue, SequenceView }
 import seqexec.model.enum._
 import seqexec.web.common.Zipper
 import seqexec.web.client.circuit.SequenceObserverFocus
+import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.ModelOps._
+import web.client.table._
 
 // Model for the tabbed area of sequences
 final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
@@ -38,7 +40,7 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
    */
   val loadedIds: List[Observation.Id] =
     sequences.toNel.collect {
-      case InstrumentSequenceTab(_, Some(curr), _, _) => curr.id
+      case InstrumentSequenceTab(_, Some(curr), _, _, _) => curr.id
     }
 
   /**
@@ -46,15 +48,18 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
    */
   val tabIds: List[Observation.Id] =
     sequences.toNel.collect {
-      case InstrumentSequenceTab(_, Some(curr), _, _) => curr.id
-      case PreviewSequenceTab(Some(curr), _, _)       => curr.id
+      case InstrumentSequenceTab(_, Some(curr), _, _, _) => curr.id
+      case PreviewSequenceTab(Some(curr), _, _, _)       => curr.id
     }
 
   def updateFromQueue(s: SequencesQueue[SequenceView]): SequencesOnDisplay = {
     val updated = updateLoaded(s.loaded.values.toList.map { id =>
       s.queue.find(_.id === id)
     }).sequences.map {
-      case p @ PreviewSequenceTab(Some(curr), r, _) => s.queue.find(_.id === curr.id).map(s => PreviewSequenceTab(Some(s), r, false)).getOrElse(p)
+      case p @ PreviewSequenceTab(Some(curr), r, _, t) =>
+        s.queue.find(_.id === curr.id)
+          .map(s => PreviewSequenceTab(Some(s), r, false, t))
+          .getOrElse(p)
       case t => t
     }
     SequencesOnDisplay(updated)
@@ -64,7 +69,10 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
    */
   private def updateLoaded(s: List[Option[SequenceView]]): SequencesOnDisplay = {
     // Build the new tabs
-    val instTabs = s.collect { case Some(x) => InstrumentSequenceTab(x.metadata.instrument, x.some, None, None)  }
+    val instTabs = s.collect { case Some(x) =>
+      val curTableState = sequences.find(_.obsId.exists(_ === x.id)).map(_.tableState)
+      InstrumentSequenceTab(x.metadata.instrument, x.some, None, None, curTableState.getOrElse(StepsTable.State.InitialTableState))
+    }
     // Store current focus
     val currentFocus = sequences.focus
     // Save the current preview
@@ -75,14 +83,14 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
     val newZipper = Zipper[SequenceTab](Nil, onlyPreview, instTabs)
     // Restore focus
     val q = newZipper.findFocus {
-      case PreviewSequenceTab(_, _, _) if currentFocus.isPreview =>
+      case PreviewSequenceTab(_, _, _, _) if currentFocus.isPreview =>
         true
-      case PreviewSequenceTab(_, _, _)                           =>
+      case PreviewSequenceTab(_, _, _, _)                           =>
         false
-      case InstrumentSequenceTab(i, _, _, _)                     =>
+      case InstrumentSequenceTab(i, _, _, _, _)                     =>
         currentFocus match {
-          case InstrumentSequenceTab(j, _, _, _) => i === j
-          case PreviewSequenceTab(_, _, _)       => false
+          case InstrumentSequenceTab(j, _, _, _, _) => i === j
+          case PreviewSequenceTab(_, _, _, _)       => false
         }
     }
     copy(sequences = q.getOrElse(newZipper))
@@ -117,7 +125,7 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
   def unsetPreviewOn(id: Observation.Id): SequencesOnDisplay = {
     // Remove the sequence in the preview if it matches id
     val q = sequences.map {
-      case s @ PreviewSequenceTab(cur, _, _) if cur.exists(_.id === id) =>
+      case s @ PreviewSequenceTab(cur, _, _, _) if cur.exists(_.id === id) =>
         SequenceTab.currentSequenceL.set(None)(s)
       case s                                                            =>
         s
@@ -168,9 +176,9 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
   // Update the state when a load has failed
   def loadingComplete(id: Observation.Id): SequencesOnDisplay = {
     val q = sequences.map {
-      case s @ PreviewSequenceTab(cur, _, _) if cur.exists(_.id === id) =>
+      case s @ PreviewSequenceTab(cur, _, _, _) if cur.exists(_.id === id) =>
         PreviewSequenceTab.isLoading.set(false)(s)
-      case s                                                            =>
+      case s                                                               =>
         s
     }
     copy(sequences = q)
@@ -179,13 +187,30 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
   // Update the state when a load starts
   def markAsLoading(id: Observation.Id): SequencesOnDisplay = {
     val q = sequences.map {
-      case s @ PreviewSequenceTab(cur, _, _) if cur.exists(_.id === id) =>
+      case s @ PreviewSequenceTab(cur, _, _, _) if cur.exists(_.id === id) =>
         PreviewSequenceTab.isLoading.set(true)(s)
       case s                                                            =>
         s
     }
     copy(sequences = q)
   }
+
+  val stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]] =
+    sequences.toNel.collect {
+      case InstrumentSequenceTab(_, Some(curr), _, _, tableState) => (curr.id, tableState)
+      case PreviewSequenceTab(Some(curr), _, _, tableState)       => (curr.id, tableState)
+    }.toMap
+
+  def updateStepsTableStates(stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]]): SequencesOnDisplay =
+    copy(sequences = sequences.map {
+      case i @ InstrumentSequenceTab(_, Some(curr), _, _, _) =>
+        stepsTables.get(curr.id)
+          .map(s => i.copy(tableState = s))
+          .getOrElse(i)
+      case i @ PreviewSequenceTab(Some(curr), _, _, _) => stepsTables.get(curr.id).map(s => i.copy(tableState = s)).getOrElse(i)
+      case i => i
+    })
+
 }
 
 /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -207,7 +207,10 @@ final case class SequencesOnDisplay(sequences: Zipper[SequenceTab]) {
         stepsTables.get(curr.id)
           .map(s => i.copy(tableState = s))
           .getOrElse(i)
-      case i @ PreviewSequenceTab(Some(curr), _, _, _) => stepsTables.get(curr.id).map(s => i.copy(tableState = s)).getOrElse(i)
+      case i @ PreviewSequenceTab(Some(curr), _, _, _) =>
+        stepsTables.get(curr.id)
+          .map(s => i.copy(tableState = s))
+          .getOrElse(i)
       case i => i
     })
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -14,6 +14,7 @@ import seqexec.model.events._
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.QueueTableBody
+import seqexec.web.client.components.sequence.steps.StepsTable
 import org.scalajs.dom.WebSocket
 import web.client.table._
 
@@ -96,6 +97,7 @@ object actions {
 
   final case class UpdateStepsConfigTableState(s: TableState[StepConfigTable.TableColumn]) extends Action
   final case class UpdateQueueTableState(s: TableState[QueueTableBody.TableColumn]) extends Action
+  final case class UpdateStepTableState(id: Observation.Id, s: TableState[StepsTable.TableColumn]) extends Action
   final case class LoadSequence(observer: Observer, i: Instrument, id: Observation.Id) extends Action
   final case class SequenceLoadFailed(id: Observation.Id) extends Action
   case object CleanSequences extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -11,7 +11,7 @@ import gem.enum.Site
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.model.events._
-import seqexec.web.client.model._
+import seqexec.web.client.model.Pages._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.QueueTableBody
 import org.scalajs.dom.WebSocket
@@ -21,8 +21,8 @@ object actions {
 
   // scalastyle:off
   // Actions
-  final case class NavigateTo(page: Pages.SeqexecPages) extends Action
-  final case class NavigateSilentTo(page: Pages.SeqexecPages) extends Action
+  final case class NavigateTo(page: SeqexecPages) extends Action
+  final case class NavigateSilentTo(page: SeqexecPages) extends Action
   final case class Initialize(site: Site) extends Action
 
   // Actions to close and/open the login box
@@ -35,8 +35,8 @@ object actions {
   case object Logout extends Action
 
   // Action to select a sequence for display
-  final case class SelectIdToDisplay(i: Instrument, id: Observation.Id, step: StepId) extends Action
-  final case class SelectSequencePreview(i: Instrument, id: Observation.Id, step: StepId) extends Action
+  final case class SelectIdToDisplay(i: Instrument, id: Observation.Id, step: StepDisplayed) extends Action
+  final case class SelectSequencePreview(i: Instrument, id: Observation.Id, step: StepDisplayed) extends Action
   case object SelectEmptyPreview extends Action
   case object SelectRoot extends Action
   final case class ShowStepConfig(i: Instrument, id: Observation.Id, step: Int) extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -35,8 +35,8 @@ object actions {
   case object Logout extends Action
 
   // Action to select a sequence for display
-  final case class SelectIdToDisplay(i: Instrument, id: Observation.Id, step: StepDisplayed) extends Action
-  final case class SelectSequencePreview(i: Instrument, id: Observation.Id, step: StepDisplayed) extends Action
+  final case class SelectIdToDisplay(i: Instrument, id: Observation.Id, step: StepIdDisplayed) extends Action
+  final case class SelectSequencePreview(i: Instrument, id: Observation.Id, step: StepIdDisplayed) extends Action
   case object SelectEmptyPreview extends Action
   case object SelectRoot extends Action
   final case class ShowStepConfig(i: Instrument, id: Observation.Id, step: Int) extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
@@ -75,7 +75,7 @@ object SeqexecCircuit extends Circuit[SeqexecAppRootModel] with ReactConnector[S
           val active = sod.idDisplayed(s.id)
           val loaded = sod.loadedIds.contains(s.id)
           val targetName = firstScienceStepTargetNameT.headOption(s)
-          SequenceInQueue(s.id, s.status, s.metadata.instrument, active, loaded, s.metadata.name, targetName, s.runningStep)
+          SequenceInQueue(s.id, s.status, s.metadata.instrument, active, loaded, s.metadata.name, targetName, s.runningStep, s.nextStepToRun)
         }
         StatusAndLoadedSequencesFocus(s, sequencesInQueue.sorted, queueTable)
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -11,10 +11,12 @@ import gem.Observation
 import gem.enum.Site
 import monocle.Lens
 import monocle.macros.Lenses
+import monocle.function.At._
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.web.client.model._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
+import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.components.QueueTableBody
 import web.client.table._
 
@@ -124,11 +126,11 @@ package circuit {
       Eq.by(x => (x.isLogged, x.instrument, x.obsId, x.stepConfigDisplayed, x.totalSteps, x.isPreview))
   }
 
-  final case class StepsTableFocus(id: Observation.Id, instrument: Instrument, state: SequenceState, steps: List[Step], stepConfigDisplayed: Option[Int], nextStepToRun: Option[Int], isPreview: Boolean)
+  final case class StepsTableFocus(id: Observation.Id, instrument: Instrument, state: SequenceState, steps: List[Step], stepConfigDisplayed: Option[Int], nextStepToRun: Option[Int], isPreview: Boolean, tableState: TableState[StepsTable.TableColumn])
 
   object StepsTableFocus {
     implicit val eq: Eq[StepsTableFocus] =
-      Eq.by(x => (x.id, x.instrument, x.state, x.steps, x.stepConfigDisplayed, x.nextStepToRun, x.isPreview))
+      Eq.by(x => (x.id, x.instrument, x.state, x.steps, x.stepConfigDisplayed, x.nextStepToRun, x.isPreview, x.tableState))
   }
 
   final case class StepsTableAndStatusFocus(status: ClientStatus, stepsTable: Option[StepsTableFocus], configTableState: TableState[StepConfigTable.TableColumn])
@@ -142,5 +144,19 @@ package circuit {
 
   final case class SequenceControlFocus(isLogged: Boolean, isConnected: Boolean, control: Option[ControlModel], syncInProgress: Boolean) extends UseValueEq
 
-  final case class TableStates(queueTable: TableState[QueueTableBody.TableColumn], stepConfigTable: TableState[StepConfigTable.TableColumn]) extends UseValueEq
+  @Lenses
+  final case class TableStates(queueTable: TableState[QueueTableBody.TableColumn], stepConfigTable: TableState[StepConfigTable.TableColumn], stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]]) extends UseValueEq
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object TableStates {
+    implicit val eq: Eq[TableStates] =
+      Eq.by(x => (x.queueTable, x.stepConfigTable, x.stepsTables))
+
+    val tableStateL: Lens[SeqexecUIModel, TableStates] =
+      Lens[SeqexecUIModel, TableStates](m => TableStates(m.queueTableState, m.configTableState, m.sequencesOnDisplay.stepsTables))(v => m => m.copy(queueTableState = v.queueTable, configTableState = v.stepConfigTable, sequencesOnDisplay = m.sequencesOnDisplay.updateStepsTableStates(v.stepsTables)))
+
+    def stepTableAt(id: Observation.Id): Lens[TableStates, Option[TableState[StepsTable.TableColumn]]] =
+      TableStates.stepsTables ^|-> at(id)
+  }
+
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -82,7 +82,7 @@ package circuit {
   }
 
 
-  final case class SequenceInQueue(id: Observation.Id, status: SequenceState, instrument: Instrument, active: Boolean, loaded: Boolean, name: String, targetName: Option[TargetName], runningStep: Option[RunningStep]) extends UseValueEq
+  final case class SequenceInQueue(id: Observation.Id, status: SequenceState, instrument: Instrument, active: Boolean, loaded: Boolean, name: String, targetName: Option[TargetName], runningStep: Option[RunningStep], nextStepToRun: Option[Int]) extends UseValueEq
 
   object SequenceInQueue {
     implicit val order: Order[SequenceInQueue] = Order.by(_.id)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/InitialSyncHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/InitialSyncHandler.scala
@@ -32,7 +32,7 @@ class InitialSyncHandler[M](modelRW: ModelRW[M, InitialSyncFocus]) extends Actio
     // An unkown page was shown
     val effect = loaded.headOption.flatMap { id =>
       s.queue.find(_.id === id).map { s =>
-        val action = SelectIdToDisplay(s.metadata.instrument, id, 0)
+        val action = SelectIdToDisplay(s.metadata.instrument, id, NextToRun)
         (pageE(action), Effect(Future(action)))
       }
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/InitialSyncHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/InitialSyncHandler.scala
@@ -9,6 +9,7 @@ import seqexec.model.events.SeqexecModelUpdate
 import seqexec.web.client.actions._
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages._
+import seqexec.web.client.ModelOps._
 import scala.concurrent.Future
 import cats.implicits._
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
@@ -32,7 +33,8 @@ class InitialSyncHandler[M](modelRW: ModelRW[M, InitialSyncFocus]) extends Actio
     // An unkown page was shown
     val effect = loaded.headOption.flatMap { id =>
       s.queue.find(_.id === id).map { s =>
-        val action = SelectIdToDisplay(s.metadata.instrument, id, NextToRun)
+        val nextStep = StepIdDisplayed(s.runningStep.foldMap(_.last))
+        val action = SelectIdToDisplay(s.metadata.instrument, id, nextStep)
         (pageE(action), Effect(Future(action)))
       }
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
@@ -6,7 +6,7 @@ package seqexec.web.client.handlers
 import cats.implicits._
 import diode.{ActionHandler, ActionResult, Effect, ModelRW, NoAction}
 import seqexec.model.events._
-import seqexec.web.client.model.Pages.SequencePage
+import seqexec.web.client.model.Pages._
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
 import seqexec.web.client.circuit.SODLocationFocus
@@ -25,7 +25,7 @@ class LoadedSequencesHandler[M](modelRW: ModelRW[M, SODLocationFocus]) extends A
       } else {
         SODLocationFocus.sod.modify(_.updateFromQueue(view).loadingComplete(sid).unsetPreviewOn(sid))
       }
-      val upLocation = SODLocationFocus.location.set(SequencePage(i, sid, 0))
+      val upLocation = SODLocationFocus.location.set(SequencePage(i, sid, StepIdDisplayed(0)))
       updatedL(upSelected >>> upLocation)
 
     case ServerMessage(s: SeqexecModelUpdate) =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import diode.{ActionHandler, ActionResult, Effect, ModelRW, NoAction}
 import seqexec.model.events._
 import seqexec.web.client.model.Pages._
+import seqexec.web.client.ModelOps._
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
 import seqexec.web.client.circuit.SODLocationFocus
@@ -25,7 +26,8 @@ class LoadedSequencesHandler[M](modelRW: ModelRW[M, SODLocationFocus]) extends A
       } else {
         SODLocationFocus.sod.modify(_.updateFromQueue(view).loadingComplete(sid).unsetPreviewOn(sid))
       }
-      val upLocation = SODLocationFocus.location.set(SequencePage(i, sid, StepIdDisplayed(0)))
+      val nextStepToRun = view.queue.find(_.id === sid).foldMap(_.nextStepToRun)
+      val upLocation = SODLocationFocus.location.set(SequencePage(i, sid, nextStepToRun.foldMap(StepIdDisplayed.apply)))
       updatedL(upSelected >>> upLocation)
 
     case ServerMessage(s: SeqexecModelUpdate) =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/TableStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/TableStateHandler.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.handlers
+
+import diode.{ ActionHandler, ActionResult, ModelRW }
+import seqexec.web.client.actions._
+import seqexec.web.client.circuit._
+
+/**
+  * Handle to preserve the steps table state
+  */
+class TableStateHandler[M](modelRW: ModelRW[M, TableStates]) extends ActionHandler(modelRW) with Handlers[M, TableStates] {
+  override def handle: PartialFunction[Any, ActionResult[M]] = {
+    case UpdateStepsConfigTableState(state) =>
+      updatedSilentL(TableStates.stepConfigTable.set(state)) // We should only do silent updates as these change too quickly
+
+    case UpdateQueueTableState(state) =>
+      updatedSilentL(TableStates.queueTable.set(state)) // We should only do silent updates as these change too quickly
+
+    case UpdateStepTableState(id, state) =>
+      updatedSilentL(TableStates.stepTableAt(id).set(Some(state))) // We should only do silent updates as these change too quickly
+  }
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/handlers.scala
@@ -10,7 +10,6 @@ import seqexec.model.{ Observer, Operator, SequencesQueue, SequenceView }
 import seqexec.web.client.model._
 import seqexec.web.client.ModelOps._
 import seqexec.web.client.actions._
-import seqexec.web.client.circuit._
 import seqexec.web.client.services.SeqexecWebClient
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
@@ -126,18 +125,5 @@ class DebuggingHandler[M](modelRW: ModelRW[M, SequencesQueue[SequenceView]]) ext
         case v: SequenceView if v.id === obsId => v.showAsRunning(step)
         case v                                 => v
       }))
-  }
-}
-
-/**
-  * Handle to preserve the steps table state
-  */
-class StepConfigTableStateHandler[M](modelRW: ModelRW[M, TableStates]) extends ActionHandler(modelRW) with Handlers[M, TableStates] {
-  override def handle: PartialFunction[Any, ActionResult[M]] = {
-    case UpdateStepsConfigTableState(state) =>
-      updatedSilent(value.copy(stepConfigTable = state)) // We should only do silent updates as these change too quickly
-
-    case UpdateQueueTableState(state) =>
-      updatedSilent(value.copy(queueTable = state)) // We should only do silent updates as these change too quickly
   }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/package.scala
@@ -18,6 +18,9 @@ package handlers {
     def updatedL(lens: T => T): ActionResult[M] =
       updated(lens(value))
 
+    def updatedSilentL(lens: T => T): ActionResult[M] =
+      updatedSilent(lens(value))
+
     def updatedLE(lens: T => T, effect: Effect): ActionResult[M] =
       updated(lens(value), effect)
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -12,13 +12,13 @@ import seqexec.model.{ SequenceState, SequenceView }
 import seqexec.model.enum._
 import seqexec.web.client.ModelOps._
 
-final case class AvailableTab(id: Option[Observation.Id], status: Option[SequenceState], instrument: Option[Instrument], runningStep: Option[RunningStep], isPreview: Boolean, active: Boolean, loading: Boolean) {
+final case class AvailableTab(id: Option[Observation.Id], status: Option[SequenceState], instrument: Option[Instrument], runningStep: Option[RunningStep], nextStepToRun: Option[Int], isPreview: Boolean, active: Boolean, loading: Boolean) {
   val nonEmpty: Boolean = id.isDefined
 }
 
 object AvailableTab {
   implicit val eq: Eq[AvailableTab] =
-    Eq.by(x => (x.id, x.status, x.instrument, x.runningStep, x.isPreview, x.active, x.loading))
+    Eq.by(x => (x.id, x.status, x.instrument, x.runningStep, x.nextStepToRun, x.isPreview, x.active, x.loading))
 }
 
 final case class SequenceTabActive(tab: SequenceTab, active: Boolean)
@@ -59,6 +59,8 @@ sealed trait SequenceTab {
     case _: InstrumentSequenceTab => sequence.flatMap(_.runningStep)
     case _                        => none
   }
+
+  def nextStepToRun: Option[Int] = sequence.foldMap(_.nextStepToRun)
 
   def loading: Boolean = this match {
     case _: InstrumentSequenceTab => false

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -18,6 +18,7 @@ import seqexec.model.SequenceEventsArbitraries.{slmArb, slmCogen}
 import seqexec.web.common.{ FixedLengthBuffer, Zipper }
 import seqexec.web.common.ArbitrariesWebCommon._
 import seqexec.web.client.model._
+import seqexec.web.client.model.Pages._
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.components.sequence.steps.OffsetFns.OffsetsDisplay
@@ -211,6 +212,22 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val sequenceTabActiveCogen: Cogen[SequenceTabActive] =
     Cogen[(SequenceTab, Boolean)]
       .contramap(x => (x.tab, x.active))
+
+  implicit val arbStepDisplayed: Arbitrary[StepDisplayed] =
+    Arbitrary {
+      for {
+        n  <- Gen.const(NextToRun)
+        id <- arbitrary[Int].map(StepIdDisplayed.apply)
+        d  <- Gen.oneOf(n, id)
+      } yield d
+    }
+
+  implicit val StepDisplayedCogen: Cogen[StepDisplayed] =
+    Cogen[Option[Int]]
+      .contramap {
+        case StepIdDisplayed(i) => i.some
+        case NextToRun => none
+      }
 
   implicit val arbStepsTableFocus: Arbitrary[StepsTableFocus] =
     Arbitrary {

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -18,7 +18,6 @@ import seqexec.model.SequenceEventsArbitraries.{slmArb, slmCogen}
 import seqexec.web.common.{ FixedLengthBuffer, Zipper }
 import seqexec.web.common.ArbitrariesWebCommon._
 import seqexec.web.client.model._
-import seqexec.web.client.model.Pages._
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.components.sequence.steps.OffsetFns.OffsetsDisplay
@@ -213,21 +212,11 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     Cogen[(SequenceTab, Boolean)]
       .contramap(x => (x.tab, x.active))
 
-  implicit val arbStepDisplayed: Arbitrary[StepDisplayed] =
-    Arbitrary {
-      for {
-        n  <- Gen.const(NextToRun)
-        id <- arbitrary[Int].map(StepIdDisplayed.apply)
-        d  <- Gen.oneOf(n, id)
-      } yield d
-    }
+  implicit val arbStepIdDisplayed: Arbitrary[StepIdDisplayed] =
+    Arbitrary(arbitrary[Int].map(StepIdDisplayed.apply))
 
-  implicit val StepDisplayedCogen: Cogen[StepDisplayed] =
-    Cogen[Option[Int]]
-      .contramap {
-        case StepIdDisplayed(i) => i.some
-        case NextToRun => none
-      }
+  implicit val stepDisplayedCogen: Cogen[StepIdDisplayed] =
+    Cogen[Int].contramap(_.step)
 
   implicit val arbStepsTableFocus: Arbitrary[StepsTableFocus] =
     Arbitrary {
@@ -280,12 +269,12 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
       for {
         i  <- arbitrary[Instrument]
         oi <- arbitrary[Observation.Id]
-        sd <- arbitrary[Int]
+        sd <- arbitrary[StepIdDisplayed]
       } yield PreviewPage(i, oi, sd)
     }
 
   implicit val previewPageCogen: Cogen[PreviewPage] =
-    Cogen[(Instrument, Observation.Id, Int)]
+    Cogen[(Instrument, Observation.Id, StepIdDisplayed)]
       .contramap(x => (x.instrument, x.obsId, x.step))
 
   implicit val arbSequencePage: Arbitrary[SequencePage] =
@@ -293,12 +282,12 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
       for {
         i  <- arbitrary[Instrument]
         oi <- arbitrary[Observation.Id]
-        sd <- arbitrary[Int]
+        sd <- arbitrary[StepIdDisplayed]
       } yield SequencePage(i, oi, sd)
     }
 
   implicit val sequencePageCogen: Cogen[SequencePage] =
-    Cogen[(Instrument, Observation.Id, Int)]
+    Cogen[(Instrument, Observation.Id, StepIdDisplayed)]
       .contramap(x => (x.instrument, x.obsId, x.step))
 
   implicit val arbPreviewConfigPage: Arbitrary[PreviewConfigPage] =
@@ -342,7 +331,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     }
 
   implicit val seqexecPageCogen: Cogen[SeqexecPages] =
-    Cogen[Option[Option[Option[Either[(Instrument, Observation.Id, Int), Either[(Instrument, Observation.Id, Int), Either[(Instrument, Observation.Id, Int), (Instrument, Observation.Id, Int)]]]]]]].contramap {
+    Cogen[Option[Option[Option[Either[(Instrument, Observation.Id, StepIdDisplayed), Either[(Instrument, Observation.Id, StepIdDisplayed), Either[(Instrument, Observation.Id, Int), (Instrument, Observation.Id, Int)]]]]]]].contramap {
       case Root                        => None
       case SoundTest                   => Some(None)
       case EmptyPreviewPage            => Some(Some(None))

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -386,7 +386,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val stepsTableColumnCogen: Cogen[StepsTable.TableColumn] =
     Cogen[String].contramap(_.productPrefix)
 
-
   implicit val arbSeqexecUIModel: Arbitrary[SeqexecUIModel] =
     Arbitrary {
       for {
@@ -441,6 +440,20 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         clientId <- arbitrary[Option[ClientID]]
         uiModel  <- arbitrary[SeqexecUIModel]
       } yield SeqexecAppRootModel(ws, site, clientId, uiModel)
+    }
+
+  implicit val arbTableStates: Arbitrary[TableStates] =
+    Arbitrary {
+      for {
+        qt <- arbitrary[TableState[QueueTableBody.TableColumn]]
+        ct <- arbitrary[TableState[StepConfigTable.TableColumn]]
+        st <- arbitrary[Map[Observation.Id, TableState[StepsTable.TableColumn]]]
+      } yield TableStates(qt, ct, st)
+    }
+
+  implicit val tableStatesCogen: Cogen[TableStates] =
+    Cogen[(TableState[QueueTableBody.TableColumn], TableState[StepConfigTable.TableColumn], List[(Observation.Id, TableState[StepsTable.TableColumn])])].contramap {
+      x => (x.queueTable, x.stepConfigTable, x.stepsTables.toList)
     }
 
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
@@ -22,6 +22,7 @@ final class CircuitReaderSpec extends CatsSuite with PropertyChecks with Arbitra
   // checkAll("sodLocationFocusL", LensTests(SODLocationFocus.sodLocationFocusL))
   // checkAll("initialSyncFocusL", LensTests(InitialSyncFocus.initialSyncFocusL))
   checkAll("clientStatusFocusL", LensTests(ClientStatus.clientStatusFocusL))
+  // checkAll("tableStateL", LensTests(TableStates.tableStateL))
 
   test("maintain reference equality for constant readers") {
       (webSocketFocusRW === webSocketFocusRW.value) should be(true)

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/PagesSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/PagesSpec.scala
@@ -15,6 +15,7 @@ final class PagesSpec extends CatsSuite with ArbitrariesWebClient {
 
   checkAll("Eq[SeqexecPages]", EqTests[SeqexecPages].eqv)
   checkAll("Eq[StepIdDisplayed]", EqTests[StepIdDisplayed].eqv)
+  checkAll("Monoid[StepIdDisplayed]", MonoidTests[StepIdDisplayed].monoid)
 
   // lenses
   // checkAll("Prism[Action, SeqexecPages]", PrismTests(PageActionP))

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/PagesSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/PagesSpec.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client
+
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+// import monocle.law.discipline.PrismTests
+import seqexec.web.client.model.Pages._
+
+/**
+  * Tests Client typeclasses
+  */
+final class PagesSpec extends CatsSuite with ArbitrariesWebClient {
+
+  checkAll("Eq[SeqexecPages]", EqTests[SeqexecPages].eqv)
+  checkAll("Eq[StepDisplayed]", EqTests[StepDisplayed].eqv)
+
+  // lenses
+  // checkAll("Prism[Action, SeqexecPages]", PrismTests(PageActionP))
+}

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/PagesSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/PagesSpec.scala
@@ -14,7 +14,7 @@ import seqexec.web.client.model.Pages._
 final class PagesSpec extends CatsSuite with ArbitrariesWebClient {
 
   checkAll("Eq[SeqexecPages]", EqTests[SeqexecPages].eqv)
-  checkAll("Eq[StepDisplayed]", EqTests[StepDisplayed].eqv)
+  checkAll("Eq[StepIdDisplayed]", EqTests[StepIdDisplayed].eqv)
 
   // lenses
   // checkAll("Prism[Action, SeqexecPages]", PrismTests(PageActionP))

--- a/modules/shared/web/client/src/main/scala/web/client/utils.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/utils.scala
@@ -3,6 +3,8 @@
 
 package web.client
 
+import cats.Eq
+import cats.implicits._
 import japgolly.scalajs.react.raw.JsNumber
 import org.scalajs.dom
 import org.scalajs.dom.html
@@ -25,6 +27,14 @@ trait utils {
 }
 
 object utils extends utils {
+  implicit val eq: Eq[JsNumber] = Eq.instance { (d, e) => (d: Any, e: Any) match {
+    case (a: Float, b : Float)  => a === b
+    case (a: Double, b: Double) => a === b
+    case (a: Byte, b  : Byte)   => a === b
+    case (a: Short, b : Short)  => a === b
+    case (a: Int, b   : Int)    => a === b
+    case _                      => false
+  } }
 
   implicit class JsNumberOps(val d: JsNumber) extends AnyVal {
 


### PR DESCRIPTION
One annoying thing on the main steps tables is the tendency to go to step 0 after switching tabs or running a step. This PR is an improvement. When a sequence is loaded or previewed it will jump to the next step to run and will remember if the user scrolls

![seqexec - gs-2018b-q-0-19 2018-09-06 18-03-43](https://user-images.githubusercontent.com/3615303/45185089-655a6580-b1ff-11e8-9b03-5fd833112d98.png)
