### PR TITLE
SEQNG-701: Fixed giapi channel to set the GPI prism

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
@@ -178,7 +178,7 @@ final case class GPIController[F[_]: Sync](gpiClient: GPIClient[F],
         Configuration.single("gpi:selectSource.sourceIr",
                              (config.asu.ir === LegacyArtificialSource.ON)
                                .fold(1, 0)) |+|
-        Configuration.single("gpi:selectSource.deploy",
+        Configuration.single("gpi:configPolarizer.deploy",
                              (config.disperser === LegacyDisperser.WOLLASTON)
                                .fold(1, 0)) |+|
         Configuration.single("gpi:configPolarizer.angle", config.disperserAngle)


### PR DESCRIPTION
Tested with the instrument

![seqexec - gs-2018b-q-0-22 2018-09-07 10-23-52](https://user-images.githubusercontent.com/3615303/45221761-d3973a80-b288-11e8-96c8-445ae476bfa5.png)
