### PR TITLE
SEQNG-700 Force AC park if instrument is in port 1.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -353,10 +353,10 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
     case Instrument.NIRI  => true
     case Instrument.GPI   => true
     case Instrument.GHOST => false
-    case _                      => false
+    case _                => false
   }
 
-  private def flatOrArcTcsSubsystems(inst: Instrument): NonEmptyList[TcsController.Subsystem] = NonEmptyList.of(ScienceFold, (if (hasOI(inst)) List(OIWFS) else List.empty): _*)
+  private def flatOrArcTcsSubsystems(inst: Instrument): NonEmptyList[TcsController.Subsystem] = NonEmptyList.of(AGUnit, (if (hasOI(inst)) List(OIWFS) else List.empty): _*)
 
   private def calcSystems(stepType: StepType): TrySeq[List[System[IO]]] = {
     stepType match {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/StandardHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/StandardHeader.scala
@@ -96,7 +96,7 @@ class StandardHeader[F[_]](
 
   private def m2TcsKeyword[B](v: SeqAction[B])(implicit d: DefaultHeaderValue[B]) = optTcsKeyword[B](TcsController.Subsystem.M2)(v)(d)
 
-  private def sfTcsKeyword[B](v: SeqAction[B])(implicit d: DefaultHeaderValue[B]) = optTcsKeyword[B](TcsController.Subsystem.ScienceFold)(v)(d)
+  private def sfTcsKeyword[B](v: SeqAction[B])(implicit d: DefaultHeaderValue[B]) = optTcsKeyword[B](TcsController.Subsystem.AGUnit)(v)(d)
 
   private val baseKeywords = List(
     buildString(SeqAction(OcsBuildInfo.version), KeywordName.SEQEXVER),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
@@ -57,21 +57,20 @@ final case class Tcs(tcsController: TcsController, subsystems: NonEmptyList[Subs
 
   // Helper function to output the part of the TCS configuration that is actually applied.
   private def subsystemConfig(tcs: TcsConfig, subsystem: Subsystem): List[AnyRef] = subsystem match {
-    case Subsystem.M1          => List(tcs.gc.m1Guide.show)
-    case Subsystem.M2          => List(tcs.gc.m2Guide.show)
-    case Subsystem.OIWFS       => List(tcs.gtc.oiwfs.show, tcs.ge.oiwfs.show)
-    case Subsystem.P1WFS       => List(tcs.gtc.pwfs1.show, tcs.ge.pwfs1.show)
-    case Subsystem.P2WFS       => List(tcs.gtc.pwfs2.show, tcs.ge.pwfs2.show)
-    case Subsystem.Mount       => List(tcs.tc.show)
-    case Subsystem.HRProbe     => List(tcs.agc.hrwfsPos.show)
-    case Subsystem.ScienceFold => List(tcs.agc.sfPos.show)
+    case Subsystem.M1     => List(tcs.gc.m1Guide.show)
+    case Subsystem.M2     => List(tcs.gc.m2Guide.show)
+    case Subsystem.OIWFS  => List(tcs.gtc.oiwfs.show, tcs.ge.oiwfs.show)
+    case Subsystem.P1WFS  => List(tcs.gtc.pwfs1.show, tcs.ge.pwfs1.show)
+    case Subsystem.P2WFS  => List(tcs.gtc.pwfs2.show, tcs.ge.pwfs2.show)
+    case Subsystem.Mount  => List(tcs.tc.show)
+    case Subsystem.AGUnit => List(tcs.agc.sfPos.show, tcs.agc.hrwfs.show)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   private def configure(config: Config, tcsState: TcsConfig): SeqAction[ConfigResult[IO]] = {
     val configFromSequence = fromSequenceConfig(config, subsystems)(tcsState)
     //The desired science fold position is passed as a class parameter
-    val tcsConfig = configFromSequence.copy(agc = configFromSequence.agc.copy(sfPos = scienceFoldPosition.some))
+    val tcsConfig = configFromSequence.copy(agc = AGConfig(scienceFoldPosition.some, HrwfsConfig.Auto.some))
 
     Log.debug(s"Applying TCS configuration: ${subsystems.toList.flatMap(subsystemConfig(tcsConfig, _))}")
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -363,6 +363,7 @@ object TcsController {
     val all: NonEmptyList[Subsystem] = NonEmptyList.of(OIWFS, P1WFS, P2WFS, ScienceFold, HRProbe, Mount, M1, M2)
 
     implicit val show: Show[Subsystem] = Show.show { _.productPrefix }
+    implicit val equal: Eq[Subsystem] = Eq.fromUniversalEquals
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -176,6 +176,13 @@ object TcsController {
     implicit val show: Show[HrwfsPickupPosition] = Show.fromToString
   }
 
+  sealed trait HrwfsConfig
+  object HrwfsConfig {
+    case object Auto                                  extends HrwfsConfig
+    final case class Manual(pos: HrwfsPickupPosition) extends HrwfsConfig
+    implicit val show: Show[HrwfsConfig] = Show.fromToString
+  }
+
   /** Enumerated type for light source. */
   sealed trait LightSource
   object LightSource {
@@ -329,7 +336,7 @@ object TcsController {
     def setOiwfsGuiderSensorOption(v: GuiderSensorOption): GuidersEnabled = this.copy(oiwfs = GuiderSensorOptionOI(v))
   }
 
-  final case class AGConfig(sfPos: Option[ScienceFoldPosition], hrwfsPos: Option[HrwfsPickupPosition])
+  final case class AGConfig(sfPos: Option[ScienceFoldPosition], hrwfs: Option[HrwfsConfig])
 
   final case class InstrumentAlignAngle(self: Angle) extends AnyVal
 
@@ -341,26 +348,32 @@ object TcsController {
     agc: AGConfig,
     iaa: InstrumentAlignAngle
   ) {
-    def setGuideConfig(v: GuideConfig): TcsConfig = TcsConfig(v, tc, gtc, ge, agc, iaa)
-    def setTelescopeConfig(v: TelescopeConfig): TcsConfig = TcsConfig(gc, v, gtc, ge, agc, iaa)
-    def setGuidersTrackingConfig(v: GuidersTrackingConfig): TcsConfig = TcsConfig(gc, tc, v, ge, agc, iaa)
-    def setGuidersEnabled(v: GuidersEnabled): TcsConfig = TcsConfig(gc, tc, gtc, v, agc, iaa)
-    def setAGConfig(v: AGConfig): TcsConfig = TcsConfig(gc, tc, gtc, ge, v, iaa)
-    def setIAA(v: InstrumentAlignAngle): TcsConfig = TcsConfig(gc, tc, gtc, ge, agc, v)
+    def setGuideConfig(v: GuideConfig): TcsConfig = this.copy(gc = v)
+    def setTelescopeConfig(v: TelescopeConfig): TcsConfig = this.copy(tc = v)
+    def setGuidersTrackingConfig(v: GuidersTrackingConfig): TcsConfig = this.copy(gtc = v)
+    def setGuidersEnabled(v: GuidersEnabled): TcsConfig = this.copy(ge = v)
+    def setAGConfig(v: AGConfig): TcsConfig = this.copy(agc = v)
+    def setIAA(v: InstrumentAlignAngle): TcsConfig = this.copy(iaa = v)
   }
 
   sealed trait Subsystem extends Product with Serializable
   object Subsystem {
-    case object OIWFS       extends Subsystem
-    case object P1WFS       extends Subsystem
-    case object P2WFS       extends Subsystem
-    case object ScienceFold extends Subsystem
-    case object HRProbe     extends Subsystem
-    case object Mount       extends Subsystem
-    case object M1          extends Subsystem
-    case object M2          extends Subsystem
+    // Instrument internal WFS
+    case object OIWFS  extends Subsystem
+    // Peripheral WFS 1
+    case object P1WFS  extends Subsystem
+    // Peripheral WFS 2
+    case object P2WFS  extends Subsystem
+    // Internal AG mechanisms (science fold, AC arm)
+    case object AGUnit extends Subsystem
+    // Mount and cass-rotator
+    case object Mount  extends Subsystem
+    // Primary mirror
+    case object M1     extends Subsystem
+    // Secondary mirror
+    case object M2     extends Subsystem
 
-    val all: NonEmptyList[Subsystem] = NonEmptyList.of(OIWFS, P1WFS, P2WFS, ScienceFold, HRProbe, Mount, M1, M2)
+    val all: NonEmptyList[Subsystem] = NonEmptyList.of(OIWFS, P1WFS, P2WFS, AGUnit, Mount, M1, M2)
 
     implicit val show: Show[Subsystem] = Show.show { _.productPrefix }
     implicit val equal: Eq[Subsystem] = Eq.fromUniversalEquals

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
@@ -3,7 +3,7 @@
 
 package seqexec.server.tcs
 
-import seqexec.server.tcs.TcsController._
+import seqexec.server.tcs.TcsController.{HrwfsConfig, _}
 import seqexec.model.enum.Instrument
 import seqexec.server.{EpicsCodex, EpicsCommand, SeqAction, SeqexecFailure, TrySeq}
 import edu.gemini.spModel.core.Wavelength
@@ -252,7 +252,7 @@ object TcsControllerEpics extends TcsController {
   } yield if (hwParked) HrwfsPickupPosition.Parked
     else hwPos
 
-  private def getAGConfig: TrySeq[AGConfig] = TrySeq(AGConfig(getScienceFoldPosition, getHrwfsPickupPosition))
+  private def getAGConfig: TrySeq[AGConfig] = TrySeq(AGConfig(getScienceFoldPosition, getHrwfsPickupPosition.map(HrwfsConfig.Manual)))
 
   private def getIAA: TrySeq[InstrumentAlignAngle] = {
     for {
@@ -340,9 +340,25 @@ object TcsControllerEpics extends TcsController {
     case _ => TcsEpics.instance.hrwfsPosCmd.setHrwfsPos(encode(hrwfsPos))
   }
 
-  private def setScienceFoldPosition(p: Option[ScienceFoldPosition]): SeqAction[Unit] = p.map(setScienceFoldConfig).getOrElse(SeqAction(()))
+  private def setAGUnit(c: AGConfig): SeqAction[Unit] = {
+    val sf = c.sfPos.map(setScienceFoldConfig)
+    val hr = c.hrwfs.flatMap{
+      case HrwfsConfig.Manual(h) => setHRPickupConfig(h).some
+      case HrwfsConfig.Auto      => {
+        c.sfPos.flatMap{
+          case ScienceFoldPosition.Position(_, inst) => getInstPort(inst).map(_ === 1)
+          case _                                     => None
+        }.flatMap(park => if(park) setHRPickupConfig(HrwfsPickupPosition.Parked).some else None)
+      }
+    }
 
-  private def setHrProbePosition(p: Option[HrwfsPickupPosition]): SeqAction[Unit] = p.map(setHRPickupConfig).getOrElse(SeqAction(()))
+    (sf, hr) match {
+      case (Some(a), Some(b)) => a *> b
+      case (Some(a), None)    => a
+      case (None, Some(b))    => b
+      case _                  => SeqAction(())
+    }
+  }
 
   implicit private val encodeMountGuideConfig: EncodeEpicsValue[MountGuideOption, String] = EncodeEpicsValue((op: MountGuideOption)
   => op match {
@@ -373,37 +389,27 @@ object TcsControllerEpics extends TcsController {
 
   override def applyConfig(subsystems: NonEmptyList[Subsystem], tcs: TcsConfig): SeqAction[Unit] = {
     def configSubsystem(subsystem: Subsystem, tcs: TcsConfig): SeqAction[Unit] = subsystem match {
-      case Subsystem.M1          => setM1Guide(tcs.gc.m1Guide)
-      case Subsystem.M2          => setM2Guide(tcs.gc.m2Guide)
-      case Subsystem.OIWFS       =>
+      case Subsystem.M1     => setM1Guide(tcs.gc.m1Guide)
+      case Subsystem.M2     => setM2Guide(tcs.gc.m2Guide)
+      case Subsystem.OIWFS  =>
         setProbeTrackingConfig(TcsEpics.instance.oiwfsProbeGuideCmd, tcs.gtc.oiwfs.self) *>
           setGuiderWfs(TcsEpics.instance.oiwfsObserveCmd, TcsEpics.instance.oiwfsStopObserveCmd, tcs.ge.oiwfs.self)
-      case Subsystem.P1WFS       =>
+      case Subsystem.P1WFS  =>
         setProbeTrackingConfig(TcsEpics.instance.pwfs1ProbeGuideCmd, tcs.gtc.pwfs1.self) *>
           setGuiderWfs(TcsEpics.instance.pwfs1ObserveCmd, TcsEpics.instance.pwfs1StopObserveCmd, tcs.ge.pwfs1.self)
-      case Subsystem.P2WFS       =>
+      case Subsystem.P2WFS  =>
         setProbeTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideCmd, tcs.gtc.pwfs2.self) *>
           setGuiderWfs(TcsEpics.instance.pwfs2ObserveCmd, TcsEpics.instance.pwfs2StopObserveCmd, tcs.ge.pwfs2.self)
-      case Subsystem.Mount       => setTelescopeConfig(tcs.tc)
-      case Subsystem.HRProbe     => setHrProbePosition(tcs.agc.hrwfsPos)
-      case Subsystem.ScienceFold => setScienceFoldPosition(tcs.agc.sfPos)
+      case Subsystem.Mount  => setTelescopeConfig(tcs.tc)
+      case Subsystem.AGUnit => setAGUnit(tcs.agc)
     }
 
-    val overrideHRProbe: Boolean = tcs.agc.sfPos.flatMap{
-      case ScienceFoldPosition.Position(_, inst) => getInstPort(inst).map(_ === 1)
-      case _                                     => None
-    }.getOrElse(false)
-
-    val subsyss = if(overrideHRProbe && !subsystems.exists(_ === Subsystem.HRProbe)) Subsystem.HRProbe :: subsystems
-      else subsystems
-    val cfg = if(overrideHRProbe) tcs.setAGConfig(tcs.agc.copy(hrwfsPos = HrwfsPickupPosition.Parked.some)) else tcs
-
-    subsyss.tail.foldLeft(configSubsystem(subsyss.head, cfg))((b, a) => b *> configSubsystem(a, cfg)) *>
+    subsystems.tail.foldLeft(configSubsystem(subsystems.head, tcs))((b, a) => b *> configSubsystem(a, tcs)) *>
       TcsEpics.instance.post *>
       EitherT.right(IO.apply(Log.debug("TCS configuration command post"))) *>
-      (if(subsyss.toList.contains(Subsystem.Mount))
+      (if(subsystems.toList.contains(Subsystem.Mount))
         TcsEpics.instance.waitInPosition(tcsTimeout) *> EitherT.right(IO.apply(Log.info("TCS inposition")))
-      else if(subsyss.toList.contains(Subsystem.ScienceFold))
+      else if(subsystems.toList.intersect(List(Subsystem.P1WFS, Subsystem.P2WFS, Subsystem.AGUnit)).nonEmpty)
         TcsEpics.instance.waitAGInPosition(agTimeout) *> EitherT.right(IO.apply(Log.debug("AG inposition")))
       else SeqAction.void)
   }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
@@ -39,7 +39,7 @@ object TcsControllerSim extends TcsController {
       GuiderSensorOptionP1(GuiderSensorOff),
       GuiderSensorOptionP2(GuiderSensorOff),
       GuiderSensorOptionOI(GuiderSensorOff)),
-    AGConfig(ScienceFoldPosition.Parked.some, HrwfsPickupPosition.Parked.some),
+    AGConfig(ScienceFoldPosition.Parked.some, HrwfsConfig.Manual(HrwfsPickupPosition.Parked).some),
     InstrumentAlignAngle(Degrees(0.0))
   ))
 


### PR DESCRIPTION
This is a small PR that forces the AC pickup mirror to be parked in the AG unit if the instrument in use is in port 1 (bottom port). It only has an effect if the TCS is configured for that step. That means, it will be used for GCAL calibrations or on sky observations, but ignored for Biases or Darks.