### PR TITLE
SEQNG-690: Change control column name

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -313,7 +313,7 @@ object StepsTable {
           Column.propsNoFlex(
             controlWidth,
             "state",
-            label = "Control",
+            label = "Execution Progress",
             className = SeqexecStyles.paddedStepRow.htmlClass,
             cellRenderer = stepProgressRenderer(i, p))))
 


### PR DESCRIPTION
As per SEQNG-690, there was some confusion in the sequence table  due to the repetition of a "Control" column. (The first column with the icon had the tooltip "Control", and the second had the name "Control.")

As per the recommendation in the task, I changed the column name to Execution Progress.

Here is a snippet showing this. Please let me know if this is what was expected :-).

![screen shot 2018-09-26 at 3 18 42 pm](https://user-images.githubusercontent.com/8795653/46100510-f2aa2d80-c19f-11e8-83d7-774e4ff8fbe7.png)
