### PR TITLE
SEQNG-561: Add calibration queue to the global state for the client

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/ExecutionQueue.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ExecutionQueue.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package seqexec.server
+package seqexec.model
 
 import cats.Eq
 import cats.implicits._

--- a/modules/seqexec/model/src/main/scala/seqexec/model/ExecutionQueue.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ExecutionQueue.scala
@@ -10,11 +10,15 @@ import monocle.macros.Lenses
 import seqexec.model.enum.BatchCommandState
 
 @Lenses
-final case class ExecutionQueue(name: String, cmdState: BatchCommandState, queue: List[Observation.Id])
+final case class ExecutionQueue(name:     String,
+                                cmdState: BatchCommandState,
+                                queue:    List[Observation.Id])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object ExecutionQueue {
-  def init(name: String): ExecutionQueue = ExecutionQueue(name, BatchCommandState.Idle, List())
+  def init(name: String): ExecutionQueue =
+    ExecutionQueue(name, BatchCommandState.Idle, List())
 
-  implicit val eq: Eq[ExecutionQueue] = Eq.by(x => (x.name, x.cmdState, x.queue))
+  implicit val eq: Eq[ExecutionQueue] =
+    Eq.by(x => (x.name, x.cmdState, x.queue))
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
@@ -6,10 +6,15 @@ package seqexec.model
 import seqexec.model.enum._
 import seqexec.model.events._
 
-import monocle.{Lens, Optional, Prism, Traversal}
-import monocle.macros.{GenLens, GenPrism}
-import monocle.function.At.{at, atMap}
-import monocle.function.FilterIndex.{filterIndex}
+import monocle.Lens
+import monocle.Optional
+import monocle.Prism
+import monocle.Traversal
+import monocle.macros.GenLens
+import monocle.macros.GenPrism
+import monocle.function.At.at
+import monocle.function.At.atMap
+import monocle.function.FilterIndex.filterIndex
 import monocle.unsafe.MapTraversal._
 import monocle.std.option.some
 import monocle.Iso
@@ -19,18 +24,24 @@ import cats.implicits._
 import mouse.all._
 
 trait ModelLenses {
-    // Some useful Monocle lenses
-  val obsNameL: Lens[SequenceView, String] = GenLens[SequenceView](_.metadata.name)
+  // Some useful Monocle lenses
+  val obsNameL: Lens[SequenceView, String] =
+    GenLens[SequenceView](_.metadata.name)
   // From step to standard step
   val standardStepP: Prism[Step, StandardStep] = GenPrism[Step, StandardStep]
-  val eachStepT: Traversal[List[Step], Step] = Traversal.fromTraverse[List, Step]
+  val eachStepT: Traversal[List[Step], Step] =
+    Traversal.fromTraverse[List, Step]
   val obsStepsL: Lens[SequenceView, List[Step]] = GenLens[SequenceView](_.steps)
-  val eachViewT: Traversal[List[SequenceView], SequenceView] = Traversal.fromTraverse[List, SequenceView]
-  val sequencesQueueL: Lens[SequencesQueue[SequenceView], List[SequenceView]] = GenLens[SequencesQueue[SequenceView]](_.queue)
+  val eachViewT: Traversal[List[SequenceView], SequenceView] =
+    Traversal.fromTraverse[List, SequenceView]
+  val sessionQueueL: Lens[SequencesQueue[SequenceView], List[SequenceView]] =
+    GenLens[SequencesQueue[SequenceView]](_.sessionQueue)
   // from standard step to config
-  val stepConfigL: Lens[StandardStep, StepConfig] = GenLens[StandardStep](_.config)
+  val stepConfigL: Lens[StandardStep, StepConfig] =
+    GenLens[StandardStep](_.config)
   // Prism to focus on only the SeqexecEvents that have a queue
-  val sequenceEventsP: Prism[SeqexecEvent, SeqexecModelUpdate] = GenPrism[SeqexecEvent, SeqexecModelUpdate]
+  val sequenceEventsP: Prism[SeqexecEvent, SeqexecModelUpdate] =
+    GenPrism[SeqexecEvent, SeqexecModelUpdate]
   // Required for type correctness
   val stepConfigRoot: Iso[Map[SystemName, Parameters], Map[SystemName, Parameters]] = Iso.id[Map[SystemName, Parameters]]
   val parametersRoot: Iso[Map[ParamName, ParamValue], Map[ParamName, ParamValue]] = Iso.id[Map[ParamName, ParamValue]]
@@ -81,12 +92,11 @@ trait ModelLenses {
       case e @ LoadSequenceUpdated(_, _, _, _) => e.copy(view = q)
       case e @ ClearLoadedSequencesUpdated(_)  => e.copy(view = q)
       case e                                   => e
-    }
-  )
+    })
 
   val sequenceViewT: Traversal[SeqexecModelUpdate, SequenceView] =
     sequenceQueueViewL ^|->  // Find the sequence view
-    sequencesQueueL    ^|->> // Find the queue
+    sessionQueueL      ^|->> // Find the queue
     eachViewT                // each sequence on the queue
 
   val sequenceStepT: Traversal[SequenceView, StandardStep] =
@@ -98,7 +108,7 @@ trait ModelLenses {
   val sequenceNameT: Traversal[SeqexecEvent, ObservationName] =
     sequenceEventsP    ^|->  // Events with model updates
     sequenceQueueViewL ^|->  // Find the sequence view
-    sequencesQueueL    ^|->> // Find the queue
+    sessionQueueL      ^|->> // Find the queue
     eachViewT          ^|->  // each sequence on the queue
     obsNameL              // sequence's observation name
 
@@ -106,7 +116,7 @@ trait ModelLenses {
   val sequenceConfigT: Traversal[SeqexecEvent, StepConfig] =
     sequenceEventsP    ^|->  // Events with model updates
     sequenceQueueViewL ^|->  // Find the sequence view
-    sequencesQueueL    ^|->> // Find the queue
+    sessionQueueL      ^|->> // Find the queue
     eachViewT          ^|->  // each sequence on the queue
     obsStepsL          ^|->> // sequence steps
     eachStepT          ^<-?  // each step
@@ -114,11 +124,14 @@ trait ModelLenses {
     stepConfigL             // configuration of the step
 
   def filterEntry[K, V](predicate: (K, V) => Boolean): Traversal[Map[K, V], V] =
-    new Traversal[Map[K, V], V]{
+    new Traversal[Map[K, V], V] {
       def modifyF[F[_]: Applicative](f: V => F[V])(s: Map[K, V]): F[Map[K, V]] =
-        s.toList.traverse{ case (k, v) =>
-          (if(predicate(k, v)) f(v) else v.pure[F]).tupleLeft(k)
-        }.map(kvs => kvs.toMap)
+        s.toList
+          .traverse {
+            case (k, v) =>
+              (if (predicate(k, v)) f(v) else v.pure[F]).tupleLeft(k)
+          }
+          .map(kvs => kvs.toMap)
     }
 
   // Find the Parameters of the steps containing science steps
@@ -158,7 +171,8 @@ trait ModelLenses {
   val observeCoaddsO: Optional[Step, Int] =
     stepObserveOptional(SystemName.Observe, "coadds", stringToIntP)
 
-  val stringToFPUModeP: Prism[String, FPUMode] = Prism(FPUMode.fromString)(_.show)
+  val stringToFPUModeP: Prism[String, FPUMode] =
+    Prism(FPUMode.fromString)(_.show)
   // Composite lens to find the instrument fpu model
   val instrumentFPUModeO: Optional[Step, FPUMode] =
     stepObserveOptional(SystemName.Instrument, "fpuMode", stringToFPUModeP)
@@ -169,7 +183,9 @@ trait ModelLenses {
 
   // Composite lens to find the instrument fpu custom mask
   val instrumentFPUCustomMaskO: Optional[Step, String] =
-    stepObserveOptional(SystemName.Instrument, "fpuCustomMask", Iso.id[String].asPrism)
+    stepObserveOptional(SystemName.Instrument,
+                        "fpuCustomMask",
+                        Iso.id[String].asPrism)
 
   // Composite lens to find the instrument filter
   val instrumentFilterO: Optional[Step, String] =
@@ -177,24 +193,33 @@ trait ModelLenses {
 
   // Composite lens to find the instrument disperser for GMOS
   val instrumentDisperserO: Optional[Step, String] =
-    stepObserveOptional(SystemName.Instrument, "disperser", Iso.id[String].asPrism)
+    stepObserveOptional(SystemName.Instrument,
+                        "disperser",
+                        Iso.id[String].asPrism)
 
   // Composite lens to find the instrument observing mode on GPI
   val instrumentObservingModeO: Optional[Step, String] =
-    stepObserveOptional(SystemName.Instrument, "observingMode", Iso.id[String].asPrism)
+    stepObserveOptional(SystemName.Instrument,
+                        "observingMode",
+                        Iso.id[String].asPrism)
 
   // Composite lens to find the central wavelength for a disperser
   val instrumentDisperserLambdaO: Optional[Step, Double] =
-    stepObserveOptional(SystemName.Instrument, "disperserLambda", stringToDoubleP)
+    stepObserveOptional(SystemName.Instrument,
+                        "disperserLambda",
+                        stringToDoubleP)
 
   // Lens to find p offset
   def telescopeOffsetO(x: OffsetAxis): Optional[Step, Double] =
     stepObserveOptional(SystemName.Telescope, x.configItem, stringToDoubleP)
 
-  val telescopeOffsetPO: Optional[Step, TelescopeOffset.P] = telescopeOffsetO(OffsetAxis.AxisP) ^<-> telescopeOffsetPI
-  val telescopeOffsetQO: Optional[Step, TelescopeOffset.Q] = telescopeOffsetO(OffsetAxis.AxisQ) ^<-> telescopeOffsetQI
+  val telescopeOffsetPO: Optional[Step, TelescopeOffset.P] = telescopeOffsetO(
+    OffsetAxis.AxisP) ^<-> telescopeOffsetPI
+  val telescopeOffsetQO: Optional[Step, TelescopeOffset.Q] = telescopeOffsetO(
+    OffsetAxis.AxisQ) ^<-> telescopeOffsetQI
 
-  val stringToGuidingP: Prism[String, Guiding] = Prism(Guiding.fromString)(_.configValue)
+  val stringToGuidingP: Prism[String, Guiding] =
+    Prism(Guiding.fromString)(_.configValue)
 
   // Lens to find guidingWith configurations
   val telescopeGuidingWithT: Traversal[Step, Guiding] =

--- a/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
@@ -43,8 +43,10 @@ trait ModelLenses {
   val sequenceEventsP: Prism[SeqexecEvent, SeqexecModelUpdate] =
     GenPrism[SeqexecEvent, SeqexecModelUpdate]
   // Required for type correctness
-  val stepConfigRoot: Iso[Map[SystemName, Parameters], Map[SystemName, Parameters]] = Iso.id[Map[SystemName, Parameters]]
-  val parametersRoot: Iso[Map[ParamName, ParamValue], Map[ParamName, ParamValue]] = Iso.id[Map[ParamName, ParamValue]]
+  val stepConfigRoot: Iso[Map[SystemName, Parameters], Map[SystemName, Parameters]] =
+    Iso.id[Map[SystemName, Parameters]]
+  val parametersRoot: Iso[Map[ParamName, ParamValue], Map[ParamName, ParamValue]] =
+    Iso.id[Map[ParamName, ParamValue]]
 
   // Focus on a param value
   def paramValueL(param: ParamName): Lens[Parameters, Option[String]] =
@@ -135,21 +137,29 @@ trait ModelLenses {
     }
 
   // Find the Parameters of the steps containing science steps
-  val scienceStepT: Traversal[StepConfig, Parameters] = filterEntry[SystemName, Parameters] {
-    case (s, p) => s === SystemName.Observe && p.exists {
-      case (k, v) => k === SystemName.Observe.withParam("observeType") && v === "OBJECT"
+  val scienceStepT: Traversal[StepConfig, Parameters] =
+    filterEntry[SystemName, Parameters] {
+      case (s, p) =>
+        s === SystemName.Observe && p.exists {
+          case (k, v) =>
+            k === SystemName.Observe.withParam("observeType") && v === "OBJECT"
+        }
     }
-  }
 
   val scienceTargetNameO: Optional[Parameters, TargetName] =
     paramValueL(SystemName.Observe.withParam("object")) ^<-? // find the target name
     some                                                     // focus on the option
 
-  val stringToStepTypeP: Prism[String, StepType] = Prism(StepType.fromString)(_.show)
-  private[model] def telescopeOffsetPI: Iso[Double, TelescopeOffset.P] = Iso(TelescopeOffset.P.apply)(_.value)
-  private[model] def telescopeOffsetQI: Iso[Double, TelescopeOffset.Q] = Iso(TelescopeOffset.Q.apply)(_.value)
-  val stringToDoubleP: Prism[String, Double] = Prism((x: String) => x.parseDouble.toOption)(_.show)
-  val stringToIntP: Prism[String, Int] = Prism((x: String) => x.parseInt.toOption)(_.show)
+  val stringToStepTypeP: Prism[String, StepType] =
+    Prism(StepType.fromString)(_.show)
+  private[model] def telescopeOffsetPI: Iso[Double, TelescopeOffset.P] =
+    Iso(TelescopeOffset.P.apply)(_.value)
+  private[model] def telescopeOffsetQI: Iso[Double, TelescopeOffset.Q] =
+    Iso(TelescopeOffset.Q.apply)(_.value)
+  val stringToDoubleP: Prism[String, Double] =
+    Prism((x: String) => x.parseDouble.toOption)(_.show)
+  val stringToIntP: Prism[String, Int] =
+    Prism((x: String) => x.parseInt.toOption)(_.show)
 
   def stepObserveOptional[A](systemName: SystemName, param: String, prism: Prism[String, A]): Optional[Step, A] =
     standardStepP                            ^|-> // which is a standard step

--- a/modules/seqexec/model/src/main/scala/seqexec/model/SequencesQueue.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/SequencesQueue.scala
@@ -16,18 +16,19 @@ import seqexec.model.enum.Instrument
   */
 @Lenses
 final case class SequencesQueue[T](
-  loaded:     Map[Instrument, Observation.Id],
-  conditions: Conditions,
-  operator:   Option[Operator],
-  queue:      List[T]
+  loaded:       Map[Instrument, Observation.Id],
+  conditions:   Conditions,
+  operator:     Option[Operator],
+  sessionQueue: List[T]
 )
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SequencesQueue {
 
   implicit def equal[T: Eq]: Eq[SequencesQueue[T]] =
-    Eq.by(x => (x.loaded, x.conditions, x.operator, x.queue))
+    Eq.by(x => (x.loaded, x.conditions, x.operator, x.sessionQueue))
 
-  def queueItemG[T](predicate: T => Boolean): Getter[SequencesQueue[T], Option[T]] =
-    SequencesQueue.queue composeGetter Getter[List[T], Option[T]] { _.find(predicate) }
+  def queueItemG[T](pred: T => Boolean): Getter[SequencesQueue[T], Option[T]] =
+    SequencesQueue.sessionQueue
+      .composeGetter(Getter[List[T], Option[T]](_.find(pred)))
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/SequencesQueue.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/SequencesQueue.scala
@@ -19,6 +19,7 @@ final case class SequencesQueue[T](
   loaded:       Map[Instrument, Observation.Id],
   conditions:   Conditions,
   operator:     Option[Operator],
+  queues:       Map[QueueId, ExecutionQueue],
   sessionQueue: List[T]
 )
 
@@ -26,7 +27,7 @@ final case class SequencesQueue[T](
 object SequencesQueue {
 
   implicit def equal[T: Eq]: Eq[SequencesQueue[T]] =
-    Eq.by(x => (x.loaded, x.conditions, x.operator, x.sessionQueue))
+    Eq.by(x => (x.loaded, x.conditions, x.operator, x.queues, x.sessionQueue))
 
   def queueItemG[T](pred: T => Boolean): Getter[SequencesQueue[T], Option[T]] =
     SequencesQueue.sessionQueue

--- a/modules/seqexec/model/src/main/scala/seqexec/model/package.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/package.scala
@@ -4,18 +4,21 @@
 package seqexec
 
 import cats._
+import java.util.UUID
 import seqexec.model.enum._
 
 package object model {
-  type ParamName = String
-  type ParamValue = String
-  type Parameters = Map[ParamName, ParamValue]
-  type StepConfig = Map[SystemName, Parameters]
-  implicit val stEq: Eq[StepConfig] = Eq.fromUniversalEquals
-  type StepId = Int
+  type ParamName       = String
+  type ParamValue      = String
+  type Parameters      = Map[ParamName, ParamValue]
+  type StepConfig      = Map[SystemName, Parameters]
+  type StepId          = Int
   type ObservationName = String
-  type TargetName = String
-  type ClientID = java.util.UUID
+  type TargetName      = String
+  type ClientID        = UUID
+  type QueueId         = UUID
+
+  implicit val stEq: Eq[StepConfig]     = Eq.fromUniversalEquals
   implicit val clientIdEq: Eq[ClientID] = Eq.fromUniversalEquals
-  val DaytimeCalibrationTargetName = "Daytime calibration"
+  val DaytimeCalibrationTargetName      = "Daytime calibration"
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ExecutionQueueSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ExecutionQueueSpec.scala
@@ -1,11 +1,10 @@
 // Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package seqexec.server
+package seqexec.model
 
 import cats.tests.CatsSuite
 import monocle.law.discipline.LensTests
-import seqexec.server.SeqexecServerArbitraries._
 import seqexec.model.SeqexecModelArbitraries._
 
 final class ExecutionQueueSpec extends CatsSuite {

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ExecutionQueueSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ExecutionQueueSpec.scala
@@ -9,6 +9,7 @@ import seqexec.model.SeqexecModelArbitraries._
 
 final class ExecutionQueueSpec extends CatsSuite {
   checkAll("ExecutedQueue name lens", LensTests(ExecutionQueue.name))
-  checkAll("ExecutedQueue command state lens", LensTests(ExecutionQueue.cmdState))
+  checkAll("ExecutedQueue command state lens",
+           LensTests(ExecutionQueue.cmdState))
   checkAll("ExecutedQueue queue lens", LensTests(ExecutionQueue.queue))
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelLensesSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelLensesSpec.scala
@@ -4,7 +4,11 @@
 package seqexec.model
 
 import cats.tests.CatsSuite
-import monocle.law.discipline.{IsoTests, LensTests, OptionalTests, PrismTests, TraversalTests}
+import monocle.law.discipline.IsoTests
+import monocle.law.discipline.LensTests
+import monocle.law.discipline.OptionalTests
+import monocle.law.discipline.PrismTests
+import monocle.law.discipline.TraversalTests
 import org.scalacheck.Arbitrary._
 import seqexec.model.enum._
 import seqexec.model.SeqexecModelArbitraries._
@@ -16,37 +20,47 @@ final class ModelLensesSpec extends CatsSuite with ModelLenses {
   checkAll("each step traversal", TraversalTests(eachStepT))
   checkAll("observation steps lens", LensTests(obsStepsL))
   checkAll("each view traversal", TraversalTests(eachViewT))
-  checkAll("sequence queue lens", LensTests(sequencesQueueL))
+  checkAll("sequence queue lens", LensTests(sessionQueueL))
   checkAll("standard step config lens", LensTests(stepConfigL))
   checkAll("events prism", PrismTests(sequenceEventsP))
   checkAll("param value lens", LensTests(paramValueL("object")))
-  checkAll("system parameters lens", LensTests(systemConfigL(SystemName.Observe)))
-  checkAll("config param value optional", OptionalTests(configParamValueO(SystemName.Observe, "object")))
+  checkAll("system parameters lens",
+           LensTests(systemConfigL(SystemName.Observe)))
+  checkAll("config param value optional",
+           OptionalTests(configParamValueO(SystemName.Observe, "object")))
   checkAll("sequence view Lens", LensTests(sequenceQueueViewL))
   checkAll("sequencename traversal", TraversalTests(sequenceNameT))
   checkAll("sequence config traversal", TraversalTests(sequenceConfigT))
   checkAll("science step traversal", TraversalTests(scienceStepT))
   checkAll("science target name optional", OptionalTests(scienceTargetNameO))
   checkAll("step type optional", OptionalTests(stepTypeO))
-  checkAll("first science target name traversal", TraversalTests(firstScienceTargetNameT))
+  checkAll("first science target name traversal",
+           TraversalTests(firstScienceTargetNameT))
   checkAll("observe targetname traversal", TraversalTests(observeTargetNameT))
-  checkAll("telescope targetname traversal", TraversalTests(telescopeTargetNameT))
-  checkAll("first science step target name traversal", TraversalTests(firstScienceTargetNameT))
+  checkAll("telescope targetname traversal",
+           TraversalTests(telescopeTargetNameT))
+  checkAll("first science step target name traversal",
+           TraversalTests(firstScienceTargetNameT))
   checkAll("step type prism", PrismTests(stringToStepTypeP))
   checkAll("step step type optional", OptionalTests(stepTypeO))
   checkAll("telescope p offset iso", IsoTests(telescopeOffsetPI))
   checkAll("telescope q offset iso", IsoTests(telescopeOffsetQI))
-  checkAll("telescope offset optional", OptionalTests(telescopeOffsetO(OffsetAxis.AxisP)))
+  checkAll("telescope offset optional",
+           OptionalTests(telescopeOffsetO(OffsetAxis.AxisP)))
   checkAll("step double prism", PrismTests(stringToDoubleP))
   checkAll("param guiding prism", PrismTests(stringToGuidingP))
   checkAll("telescope guiding traversal", TraversalTests(telescopeGuidingWithT))
-  checkAll("observe exposure time Optional", OptionalTests(observeExposureTimeO))
+  checkAll("observe exposure time Optional",
+           OptionalTests(observeExposureTimeO))
   checkAll("observe coadds Optional", OptionalTests(observeCoaddsO))
   checkAll("instrument fpu Optional", OptionalTests(instrumentFPUO))
   checkAll("instrument fpu mode Optional", OptionalTests(instrumentFPUModeO))
-  checkAll("instrument fpu custom mask Optional", OptionalTests(instrumentFPUCustomMaskO))
+  checkAll("instrument fpu custom mask Optional",
+           OptionalTests(instrumentFPUCustomMaskO))
   checkAll("instrument filter Optional", OptionalTests(instrumentFilterO))
   checkAll("instrument disperser Optional", OptionalTests(instrumentDisperserO))
-  checkAll("instrument disperser lambda Optional", OptionalTests(instrumentDisperserLambdaO))
-  checkAll("instrument observing mode Optional", OptionalTests(instrumentObservingModeO))
+  checkAll("instrument disperser lambda Optional",
+           OptionalTests(instrumentDisperserLambdaO))
+  checkAll("instrument observing mode Optional",
+           OptionalTests(instrumentObservingModeO))
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -30,7 +30,8 @@ final class ModelSpec extends CatsSuite {
   checkAll("Eq[ActionType]", EqTests[ActionType].eqv)
   checkAll("Eq[SequenceMetadata]", EqTests[SequenceMetadata].eqv)
   checkAll("Eq[SequenceView]", EqTests[SequenceView].eqv)
-  checkAll("Eq[SequencesQueue[SequenceView]]", EqTests[SequencesQueue[SequenceView]].eqv)
+  checkAll("Eq[SequencesQueue[SequenceView]]",
+           EqTests[SequencesQueue[SequenceView]].eqv)
   checkAll("Eq[StepType]", EqTests[StepType].eqv)
   checkAll("Order[TelescopeOffset.P]", OrderTests[TelescopeOffset.P].order)
   checkAll("Order[TelescopeOffset.Q]", OrderTests[TelescopeOffset.Q].order)

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -47,4 +47,5 @@ final class ModelSpec extends CatsSuite {
   checkAll("Eq[ResourceConflict]", EqTests[ResourceConflict].eqv)
   checkAll("Eq[InstrumentInUse]", EqTests[InstrumentInUse].eqv)
   checkAll("Eq[Notification]", EqTests[Notification].eqv)
+  checkAll("Eq[ExecutionQueue]", EqTests[ExecutionQueue].eqv)
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -29,9 +29,34 @@ trait SeqexecModelArbitraries extends ArbObservation {
 
   implicit val clientIdArb: Arbitrary[ClientID] = Arbitrary(Gen.uuid)
 
-  implicit val levArb = Arbitrary[ServerLogLevel](Gen.oneOf(ServerLogLevel.INFO, ServerLogLevel.WARN, ServerLogLevel.ERROR))
-  implicit val resArb = Arbitrary[Resource](Gen.oneOf(Resource.P1, Resource.OI, Resource.TCS, Resource.Gcal, Resource.Gems, Resource.Altair, Instrument.F2, Instrument.GmosS, Instrument.GmosN, Instrument.GPI, Instrument.GSAOI, Instrument.GNIRS, Instrument.NIRI, Instrument.NIFS))
-  implicit val insArb = Arbitrary[Instrument](Gen.oneOf(Instrument.F2, Instrument.GmosS, Instrument.GmosN, Instrument.GPI, Instrument.GSAOI, Instrument.GNIRS, Instrument.NIRI, Instrument.NIFS))
+  implicit val levArb = Arbitrary[ServerLogLevel](
+    Gen.oneOf(ServerLogLevel.INFO, ServerLogLevel.WARN, ServerLogLevel.ERROR))
+  implicit val resArb = Arbitrary[Resource](
+    Gen.oneOf(
+      Resource.P1,
+      Resource.OI,
+      Resource.TCS,
+      Resource.Gcal,
+      Resource.Gems,
+      Resource.Altair,
+      Instrument.F2,
+      Instrument.GmosS,
+      Instrument.GmosN,
+      Instrument.GPI,
+      Instrument.GSAOI,
+      Instrument.GNIRS,
+      Instrument.NIRI,
+      Instrument.NIFS
+    ))
+  implicit val insArb = Arbitrary[Instrument](
+    Gen.oneOf(Instrument.F2,
+              Instrument.GmosS,
+              Instrument.GmosN,
+              Instrument.GPI,
+              Instrument.GSAOI,
+              Instrument.GNIRS,
+              Instrument.NIRI,
+              Instrument.NIFS))
 
   implicit val executionQueueArb: Arbitrary[ExecutionQueue] = Arbitrary {
     for {
@@ -49,15 +74,15 @@ trait SeqexecModelArbitraries extends ArbObservation {
     } yield b
   }
 
-  implicit val udArb  = Arbitrary[UserDetails] {
+  implicit val udArb = Arbitrary[UserDetails] {
     for {
       u <- arbitrary[String]
       n <- arbitrary[String]
     } yield UserDetails(u, n)
   }
 
-  implicit val obArb  = Arbitrary[Observer] { Gen.alphaStr.map(Observer.apply) }
-  implicit val smArb  = Arbitrary[SequenceMetadata] {
+  implicit val obArb = Arbitrary[Observer] { Gen.alphaStr.map(Observer.apply) }
+  implicit val smArb = Arbitrary[SequenceMetadata] {
     for {
       i <- arbitrary[Instrument]
       o <- arbitrary[Option[Observer]]
@@ -65,16 +90,25 @@ trait SeqexecModelArbitraries extends ArbObservation {
     } yield SequenceMetadata(i, o, n)
   }
 
-  implicit val opArb  = Arbitrary[Operator] { Gen.alphaStr.map(Operator.apply) }
+  implicit val opArb = Arbitrary[Operator] { Gen.alphaStr.map(Operator.apply) }
   implicit val spsArb = Arbitrary[StepState] {
     for {
-      v1 <- Gen.oneOf(StepState.Pending, StepState.Completed, StepState.Skipped, StepState.Running, StepState.Paused)
+      v1 <- Gen.oneOf(StepState.Pending,
+                      StepState.Completed,
+                      StepState.Skipped,
+                      StepState.Running,
+                      StepState.Paused)
       v2 <- Gen.alphaStr.map(StepState.Failed.apply)
       r  <- Gen.oneOf(v1, v2)
     } yield r
   }
 
-  implicit val acsArb = Arbitrary[ActionStatus](Gen.oneOf(ActionStatus.Pending, ActionStatus.Completed, ActionStatus.Running, ActionStatus.Paused, ActionStatus.Failed))
+  implicit val acsArb = Arbitrary[ActionStatus](
+    Gen.oneOf(ActionStatus.Pending,
+              ActionStatus.Completed,
+              ActionStatus.Running,
+              ActionStatus.Paused,
+              ActionStatus.Failed))
 
   implicit val sqrArb = Arbitrary[SequenceState.Running] {
     for {
@@ -85,16 +119,18 @@ trait SeqexecModelArbitraries extends ArbObservation {
 
   implicit val sqsArb = Arbitrary[SequenceState] {
     for {
-      f <- Gen.oneOf(SequenceState.Completed, SequenceState.Idle, SequenceState.Stopped)
+      f <- Gen.oneOf(SequenceState.Completed,
+                     SequenceState.Idle,
+                     SequenceState.Stopped)
       r <- arbitrary[SequenceState.Running]
       a <- arbitrary[String].map(SequenceState.Failed.apply)
       s <- Gen.oneOf(f, r, a)
     } yield s
   }
-  implicit val ccArb  = Arbitrary[CloudCover](Gen.oneOf(CloudCover.all))
-  implicit val wvArb  = Arbitrary[WaterVapor](Gen.oneOf(WaterVapor.all))
-  implicit val sbArb  = Arbitrary[SkyBackground](Gen.oneOf(SkyBackground.all))
-  implicit val iqArb  = Arbitrary[ImageQuality](Gen.oneOf(ImageQuality.all))
+  implicit val ccArb = Arbitrary[CloudCover](Gen.oneOf(CloudCover.all))
+  implicit val wvArb = Arbitrary[WaterVapor](Gen.oneOf(WaterVapor.all))
+  implicit val sbArb = Arbitrary[SkyBackground](Gen.oneOf(SkyBackground.all))
+  implicit val iqArb = Arbitrary[ImageQuality](Gen.oneOf(ImageQuality.all))
 
   implicit val conArb = Arbitrary[Conditions] {
     for {
@@ -105,7 +141,7 @@ trait SeqexecModelArbitraries extends ArbObservation {
     } yield Conditions(cc, iq, sb, wv)
   }
 
-  implicit val snArb  = Arbitrary(Gen.oneOf(SystemName.all))
+  implicit val snArb = Arbitrary(Gen.oneOf(SystemName.all))
 
   def asciiStr: Gen[String] =
     Gen.listOf(Gen.alphaChar).map(_.mkString)
@@ -116,7 +152,8 @@ trait SeqexecModelArbitraries extends ArbObservation {
       b <- asciiStr
     } yield (a, b)
 
-  val parametersGen: Gen[Parameters] = Gen.chooseNum(0, 10).flatMap(s => Gen.mapOfN[String, String](s, stepItemG))
+  val parametersGen: Gen[Parameters] =
+    Gen.chooseNum(0, 10).flatMap(s => Gen.mapOfN[String, String](s, stepItemG))
 
   val stepConfigG: Gen[(SystemName, Parameters)] =
     for {
@@ -124,16 +161,26 @@ trait SeqexecModelArbitraries extends ArbObservation {
       b <- parametersGen
     } yield (a, b)
 
-  val stepConfigGen: Gen[StepConfig] = Gen.chooseNum(0, 3).flatMap(s => Gen.mapOfN[SystemName, Parameters](s, stepConfigG))
+  val stepConfigGen: Gen[StepConfig] = Gen
+    .chooseNum(0, 3)
+    .flatMap(s => Gen.mapOfN[SystemName, Parameters](s, stepConfigG))
   implicit val steArb = Arbitrary[Step] {
     for {
       id <- arbitrary[StepId]
-      c  <- stepConfigGen
-      s  <- arbitrary[StepState]
-      b  <- arbitrary[Boolean]
-      k  <- arbitrary[Boolean]
-      f  <- arbitrary[Option[dhs.ImageFileId]]
-    } yield new StandardStep(id = id, config = c, status = s, breakpoint = b, skip = k, fileId = f, configStatus = Nil, observeStatus = ActionStatus.Pending)
+      c <- stepConfigGen
+      s <- arbitrary[StepState]
+      b <- arbitrary[Boolean]
+      k <- arbitrary[Boolean]
+      f <- arbitrary[Option[dhs.ImageFileId]]
+    } yield
+      new StandardStep(id            = id,
+                       config        = c,
+                       status        = s,
+                       breakpoint    = b,
+                       skip          = k,
+                       fileId        = f,
+                       configStatus  = Nil,
+                       observeStatus = ActionStatus.Pending)
   }
 
   implicit val stsArb = Arbitrary[StandardStep] {
@@ -146,12 +193,22 @@ trait SeqexecModelArbitraries extends ArbObservation {
       f  <- arbitrary[Option[dhs.ImageFileId]]
       cs <- arbitrary[List[(Resource, ActionStatus)]]
       os <- arbitrary[ActionStatus]
-    } yield new StandardStep(id = id, config = c, status = s, breakpoint = b, skip = k, fileId = f, configStatus = cs, observeStatus = os)
+    } yield
+      new StandardStep(id            = id,
+                       config        = c,
+                       status        = s,
+                       breakpoint    = b,
+                       skip          = k,
+                       fileId        = f,
+                       configStatus  = cs,
+                       observeStatus = os)
   }
 
   implicit val styArb = Arbitrary(Gen.oneOf(StepType.all))
-  implicit val guiArb = Arbitrary[Guiding](Gen.oneOf(Guiding.Park, Guiding.Guide, Guiding.Freeze))
-  implicit val fpmArb = Arbitrary[FPUMode](Gen.oneOf(FPUMode.BuiltIn, FPUMode.Custom))
+  implicit val guiArb =
+    Arbitrary[Guiding](Gen.oneOf(Guiding.Park, Guiding.Guide, Guiding.Freeze))
+  implicit val fpmArb =
+    Arbitrary[FPUMode](Gen.oneOf(FPUMode.BuiltIn, FPUMode.Custom))
   implicit val telOffPArb = Arbitrary[TelescopeOffset.P] {
     for {
       d <- Gen.choose(-999.0, 999.0)
@@ -168,7 +225,7 @@ trait SeqexecModelArbitraries extends ArbObservation {
       q <- arbitrary[TelescopeOffset.Q]
     } yield TelescopeOffset(p, q)
   }
-  implicit val svArb  = Arbitrary[SequenceView] {
+  implicit val svArb = Arbitrary[SequenceView] {
     for {
       id <- arbitrary[Observation.Id]
       m  <- arbitrary[SequenceMetadata]
@@ -207,10 +264,33 @@ trait SeqexecModelArbitraries extends ArbObservation {
     Cogen[String].contramap(_.productPrefix)
 
   implicit val stepCogen: Cogen[Step] =
-    Cogen[(StepId, Map[SystemName, Map[String, String]], StepState, Boolean, Boolean, Option[dhs.ImageFileId])].contramap(s => (s.id, s.config, s.status, s.breakpoint, s.skip, s.fileId))
+    Cogen[(StepId,
+           Map[SystemName, Map[String, String]],
+           StepState,
+           Boolean,
+           Boolean,
+           Option[dhs.ImageFileId])].contramap(s =>
+      (s.id, s.config, s.status, s.breakpoint, s.skip, s.fileId))
 
   implicit val standardStepCogen: Cogen[StandardStep] =
-    Cogen[(StepId, Map[SystemName, Map[String, String]], StepState, Boolean, Boolean, Option[dhs.ImageFileId], List[(Resource, ActionStatus)], ActionStatus)].contramap(s => (s.id, s.config, s.status, s.breakpoint, s.skip, s.fileId, s.configStatus, s.observeStatus))
+    Cogen[
+      (StepId,
+       Map[SystemName, Map[String, String]],
+       StepState,
+       Boolean,
+       Boolean,
+       Option[dhs.ImageFileId],
+       List[(Resource, ActionStatus)],
+       ActionStatus)].contramap(
+      s =>
+        (s.id,
+         s.config,
+         s.status,
+         s.breakpoint,
+         s.skip,
+         s.fileId,
+         s.configStatus,
+         s.observeStatus))
 
   implicit val sqsCogen: Cogen[SequenceState] =
     Cogen[String].contramap(_.productPrefix)
@@ -222,13 +302,20 @@ trait SeqexecModelArbitraries extends ArbObservation {
     Cogen[(String, String)].contramap(u => (u.username, u.displayName))
 
   implicit val smCogen: Cogen[SequenceMetadata] =
-    Cogen[(Instrument, Option[Observer], String)].contramap(s => (s.instrument, s.observer, s.name))
+    Cogen[(Instrument, Option[Observer], String)].contramap(s =>
+      (s.instrument, s.observer, s.name))
 
   implicit val svCogen: Cogen[SequenceView] =
-    Cogen[(Observation.Id, SequenceMetadata, SequenceState, List[Step], Option[Int])].contramap(s => (s.id, s.metadata, s.status, s.steps, s.willStopIn))
+    Cogen[(Observation.Id,
+           SequenceMetadata,
+           SequenceState,
+           List[Step],
+           Option[Int])].contramap(s =>
+      (s.id, s.metadata, s.status, s.steps, s.willStopIn))
 
   implicit def sqCogen[A: Cogen]: Cogen[SequencesQueue[A]] =
-    Cogen[(Conditions, Option[Operator], List[A])].contramap(s => (s.conditions, s.operator, s.sessionQueue))
+    Cogen[(Conditions, Option[Operator], List[A])].contramap(s =>
+      (s.conditions, s.operator, s.sessionQueue))
 
   implicit val offPCogen: Cogen[TelescopeOffset.P] =
     Cogen[Double].contramap(_.value)
@@ -258,7 +345,8 @@ trait SeqexecModelArbitraries extends ArbObservation {
     Cogen[String].contramap(_.productPrefix)
 
   implicit val conCogen: Cogen[Conditions] =
-    Cogen[(CloudCover, ImageQuality, SkyBackground, WaterVapor)].contramap(c => (c.cc, c.iq, c.sb, c.wv))
+    Cogen[(CloudCover, ImageQuality, SkyBackground, WaterVapor)].contramap(c =>
+      (c.cc, c.iq, c.sb, c.wv))
 
   implicit val cidCogen: Cogen[ClientID] =
     Cogen[String].contramap(_.toString)
@@ -266,7 +354,7 @@ trait SeqexecModelArbitraries extends ArbObservation {
   implicit val levCogen: Cogen[ServerLogLevel] =
     Cogen[String].contramap(_.productPrefix)
 
-  implicit val rcArb  = Arbitrary[ResourceConflict] {
+  implicit val rcArb = Arbitrary[ResourceConflict] {
     for {
       id <- arbitrary[Observation.Id]
     } yield ResourceConflict(id)
@@ -275,7 +363,7 @@ trait SeqexecModelArbitraries extends ArbObservation {
   implicit val rcCogen: Cogen[ResourceConflict] =
     Cogen[Observation.Id].contramap(_.sid)
 
-  implicit val inArb  = Arbitrary[InstrumentInUse] {
+  implicit val inArb = Arbitrary[InstrumentInUse] {
     for {
       id <- arbitrary[Observation.Id]
       i  <- arbitrary[Instrument]
@@ -285,7 +373,7 @@ trait SeqexecModelArbitraries extends ArbObservation {
   implicit val inCogen: Cogen[InstrumentInUse] =
     Cogen[(Observation.Id, Instrument)].contramap(x => (x.sid, x.ins))
 
-  implicit val notArb  = Arbitrary[Notification] {
+  implicit val notArb = Arbitrary[Notification] {
     for {
       r <- arbitrary[ResourceConflict]
       a <- arbitrary[InstrumentInUse]
@@ -300,7 +388,9 @@ trait SeqexecModelArbitraries extends ArbObservation {
     }
 
   implicit val seqBatchCmdStateArb: Arbitrary[BatchCommandState] = Arbitrary(
-    Gen.oneOf(BatchCommandState.Idle, BatchCommandState.Run, BatchCommandState.Stop)
+    Gen.oneOf(BatchCommandState.Idle,
+              BatchCommandState.Run,
+              BatchCommandState.Stop)
   )
 
   implicit val seqBatchCmdStateCogen: Cogen[BatchCommandState] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -190,6 +190,7 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
               EngineState.selected.get(qState),
               EngineState.conditions.get(qState),
               EngineState.operator.get(qState),
+              Map.empty,
               sequences
             )
           )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -190,7 +190,7 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
               EngineState.selected.get(qState),
               EngineState.conditions.get(qState),
               EngineState.operator.get(qState),
-              Map.empty,
+              EngineState.queues.get(qState),
               sequences
             )
           )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -3,8 +3,6 @@
 
 package seqexec
 
-import java.util.UUID
-
 import cats.data._
 import cats.effect.{IO, Sync}
 import cats.implicits._
@@ -13,13 +11,14 @@ import edu.gemini.spModel.`type`.SequenceableSpType
 import edu.gemini.spModel.guide.StandardGuideOptions
 import fs2.async.mutable.Queue
 import gem.Observation
+import java.util.UUID
 import monocle.macros.Lenses
 import monocle.Lens
 import monocle.macros.GenLens
 import monocle.function.At.at
 import monocle.function.At.atMap
 import seqexec.engine.Engine
-import seqexec.model.{ClientID, Conditions, Observer, Operator, SequenceState}
+import seqexec.model.{ClientID, ExecutionQueue, QueueId, Conditions, Observer, Operator, SequenceState}
 import seqexec.model.enum._
 import seqexec.model.{Notification, UserDetails}
 
@@ -103,7 +102,6 @@ package object server {
   type SeqObserve[A, B] = Reader[A, SeqAction[B]]
   type SeqObserveF[F[_], A, B] = Reader[A, SeqActionF[F, B]]
 
-  type QueueId = UUID
   type ExecutionQueues = Map[QueueId, ExecutionQueue]
 
   val executeEngine: Engine[EngineState, SeqEvent] = new Engine[EngineState, SeqEvent](EngineState.executionState)

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -24,7 +24,7 @@ import seqexec.engine.Result.PauseContext
 import seqexec.engine._
 import seqexec.server.SeqexecEngine.Settings
 import seqexec.server.keywords.GDSClient
-import seqexec.model.{Conditions, Observer, Operator, SequenceState}
+import seqexec.model.{ExecutionQueue, Conditions, Observer, Operator, SequenceState}
 import seqexec.model.enum.{ActionStatus, CloudCover, ImageQuality, Instrument, Resource, SkyBackground, WaterVapor}
 import seqexec.model.{ActionType, UserDetails}
 import seqexec.model.enum.Resource.TCS

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
@@ -20,7 +20,7 @@ import seqexec.server.gcal.GcalController
 import seqexec.server.gcal.GcalController._
 import seqexec.server.tcs.{CRFollow, TcsController, TcsControllerEpics}
 import seqexec.server.keywords._
-import seqexec.model.enum.{BatchCommandState, Instrument}
+import seqexec.model.enum.Instrument
 import seqexec.model.{Conditions, Operator}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams
@@ -148,13 +148,6 @@ object SeqexecServerArbitraries extends ArbTime {
 
   implicit val selectedCoGen: Cogen[Map[Instrument, Observation.Id]] =
     Cogen[List[(Instrument, Observation.Id)]].contramap(_.toList)
-  implicit val executionQueueArb: Arbitrary[ExecutionQueue] = Arbitrary {
-    for {
-      n <- arbitrary[String]
-      s <- arbitrary[BatchCommandState]
-      q <- arbitrary[List[Observation.Id]]
-    } yield ExecutionQueue(n, s, q)
-  }
   implicit val engineStateArb: Arbitrary[EngineState] = Arbitrary {
     for {
       q <- arbitrary[ExecutionQueues]

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -6,32 +6,41 @@ package seqexec.web.client.model
 import cats._
 import cats.implicits._
 import gem.enum.Site
+import monocle.Lens
 import monocle.macros.Lenses
+import seqexec.model.Conditions
+import seqexec.model.SequenceView
+import seqexec.model.SequencesQueue
 import seqexec.model.ClientID
 
 /**
   * Root of the UI Model of the application
   */
 @Lenses
-final case class SeqexecAppRootModel(ws:       WebSocketConnection,
-                                     site:     Option[Site],
-                                     clientId: Option[ClientID],
-                                     uiModel:  SeqexecUIModel)
+final case class SeqexecAppRootModel(sequences: SequencesQueue[SequenceView],
+                                     ws:        WebSocketConnection,
+                                     site:      Option[Site],
+                                     clientId:  Option[ClientID],
+                                     uiModel:   SeqexecUIModel)
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SeqexecAppRootModel {
+  private val NoSequencesLoaded: SequencesQueue[SequenceView] =
+    SequencesQueue[SequenceView](Map.empty, Conditions.Default, None, Nil)
+
   val Initial: SeqexecAppRootModel = SeqexecAppRootModel(
+    NoSequencesLoaded,
     WebSocketConnection.Empty,
     None,
     None,
     SeqexecUIModel.Initial)
 
-  val logDisplayL =
+  val logDisplayL: Lens[SeqexecAppRootModel, SectionVisibilityState] =
     SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.globalLog ^|-> GlobalLog.display
 
-  val sequencesOnDisplayL =
+  val sequencesOnDisplayL: Lens[SeqexecAppRootModel, SequencesOnDisplay] =
     SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.sequencesOnDisplay
 
   implicit val eq: Eq[SeqexecAppRootModel] =
-    Eq.by(x => (x.ws, x.site, x.clientId, x.uiModel))
+    Eq.by(x => (x.sequences, x.ws, x.site, x.clientId, x.uiModel))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -25,8 +25,8 @@ final case class SeqexecAppRootModel(sequences: SequencesQueue[SequenceView],
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SeqexecAppRootModel {
-  private val NoSequencesLoaded: SequencesQueue[SequenceView] =
-    SequencesQueue[SequenceView](Map.empty, Conditions.Default, None, Nil)
+  val NoSequencesLoaded: SequencesQueue[SequenceView] =
+    SequencesQueue[SequenceView](Map.empty, Conditions.Default, None, Map.empty, Nil)
 
   val Initial: SeqexecAppRootModel = SeqexecAppRootModel(
     NoSequencesLoaded,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -26,7 +26,11 @@ final case class SeqexecAppRootModel(sequences: SequencesQueue[SequenceView],
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SeqexecAppRootModel {
   val NoSequencesLoaded: SequencesQueue[SequenceView] =
-    SequencesQueue[SequenceView](Map.empty, Conditions.Default, None, Map.empty, Nil)
+    SequencesQueue[SequenceView](Map.empty,
+                                 Conditions.Default,
+                                 None,
+                                 Map.empty,
+                                 Nil)
 
   val Initial: SeqexecAppRootModel = SeqexecAppRootModel(
     NoSequencesLoaded,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -6,8 +6,8 @@ package seqexec.web.client.model
 import cats.Eq
 import cats.implicits._
 import monocle.macros.Lenses
-import seqexec.model.{ Conditions, Observer, SequenceView }
-import seqexec.model.{ SequencesQueue, UserDetails }
+import seqexec.model.Observer
+import seqexec.model.UserDetails
 import seqexec.web.common.FixedLengthBuffer
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.QueueTableBody
@@ -18,27 +18,23 @@ import web.client.table._
   */
 @Lenses
 final case class SeqexecUIModel(
-    navLocation:        Pages.SeqexecPages,
-    user:               Option[UserDetails],
-    sequences:          SequencesQueue[SequenceView],
-    loginBox:           SectionVisibilityState,
-    globalLog:          GlobalLog,
-    sequencesOnDisplay: SequencesOnDisplay,
-    syncInProgress:     Boolean,
-    configTableState:   TableState[StepConfigTable.TableColumn],
-    queueTableState:    TableState[QueueTableBody.TableColumn],
-    defaultObserver:    Observer,
-    notification:       UserNotificationState,
-    firstLoad:          Boolean)
+  navLocation:        Pages.SeqexecPages,
+  user:               Option[UserDetails],
+  loginBox:           SectionVisibilityState,
+  globalLog:          GlobalLog,
+  sequencesOnDisplay: SequencesOnDisplay,
+  syncInProgress:     Boolean,
+  configTableState:   TableState[StepConfigTable.TableColumn],
+  queueTableState:    TableState[QueueTableBody.TableColumn],
+  defaultObserver:    Observer,
+  notification:       UserNotificationState,
+  firstLoad:          Boolean)
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SeqexecUIModel {
-  val noSequencesLoaded: SequencesQueue[SequenceView] =
-    SequencesQueue[SequenceView](Map.empty, Conditions.Default, None, Nil)
   val Initial: SeqexecUIModel = SeqexecUIModel(
     Pages.Root,
     None,
-    noSequencesLoaded,
     SectionClosed,
     GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
     SequencesOnDisplay.Empty,
@@ -55,7 +51,6 @@ object SeqexecUIModel {
       x =>
         (x.navLocation,
          x.user,
-         x.sequences,
          x.loginBox,
          x.globalLog,
          x.sequencesOnDisplay,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -59,10 +59,10 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     */
   def updateFromQueue(s: SequencesQueue[SequenceView]): SequencesOnDisplay = {
     val updated = updateLoaded(s.loaded.values.toList.map { id =>
-      s.queue.find(_.id === id)
+      s.sessionQueue.find(_.id === id)
     }).tabs.map {
       case p @ PreviewSequenceTab(curr, r, _, t, o) =>
-        s.queue
+        s.sessionQueue
           .find(_.id === curr.id)
           .map(s => PreviewSequenceTab(s, r, false, t, o))
           .getOrElse(p)
@@ -295,7 +295,7 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
       }
       .toMap
 
-  def updateStepsTableStates(stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]]): SequencesOnDisplay =
+  def updateTableStates(stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]]): SequencesOnDisplay =
     copy(tabs = tabs.map {
       case i @ InstrumentSequenceTab(_, Some(curr), _, _, _, _) =>
         stepsTables

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -7,9 +7,12 @@ import cats.Eq
 import cats.implicits._
 import cats.data.NonEmptyList
 import gem.Observation
-import monocle.{ Getter, Optional, Traversal }
+import monocle.Getter
+import monocle.Optional
+import monocle.Traversal
 import monocle.macros.Lenses
-import seqexec.model.{ SequenceView, SequencesQueue }
+import seqexec.model.SequenceView
+import seqexec.model.SequencesQueue
 import seqexec.model.enum._
 import seqexec.web.common.Zipper
 import seqexec.web.client.circuit.SequenceObserverFocus
@@ -125,8 +128,8 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     val seq = if (s.metadata.instrument === i && !isLoaded) {
       val update =
         PreviewSequenceTab.tableState.set(StepsTable.State.InitialTableState) >>>
-        PreviewSequenceTab.currentSequence.set(s) >>>
-        PreviewSequenceTab.stepConfig.set(None)
+          PreviewSequenceTab.currentSequence.set(s) >>>
+          PreviewSequenceTab.stepConfig.set(None)
       val q = withPreviewTab(s).tabs
         .findFocus(_.isPreview)
         .map(_.modify(SeqexecTab.previewTab.modify(update)))
@@ -324,7 +327,8 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
 object SequencesOnDisplay {
   // We need to initialize the model with something so we use preview
   val Empty: SequencesOnDisplay =
-    SequencesOnDisplay(Zipper.fromNel[SeqexecTab](NonEmptyList.of(CalibrationQueueTab.Empty)))
+    SequencesOnDisplay(
+      Zipper.fromNel[SeqexecTab](NonEmptyList.of(CalibrationQueueTab.Empty)))
 
   implicit val eq: Eq[SequencesOnDisplay] =
     Eq.by(_.tabs)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -130,8 +130,14 @@ object actions {
 
   implicit val show: Show[Action] = Show.show {
     case s @ ServerMessage(u @ SeqexecModelUpdate(view)) =>
-      val someSteps = view.sessionQueue.map(s =>
-        (s"id: ${s.id.format}", s"steps: ${s.steps.length}", s.steps.filter(_.status === StepState.Running).slice(0, scala.math.min(s.steps.length, 20)).collect(standardStep)))
+      val someSteps = view.sessionQueue.map(
+        s =>
+          (s"id: ${s.id.format}",
+           s"steps: ${s.steps.length}",
+           s.steps
+             .filter(_.status === StepState.Running)
+             .slice(0, scala.math.min(s.steps.length, 20))
+             .collect(standardStep)))
       val dayCalQueue = view.queues.values.map(_.queue).mkString(",")
       s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, dayCal: '${dayCalQueue}', loaded: '${view.loaded.mkString(",")}', $someSteps)"
     case s @ RememberCompleted(view)                    =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -130,7 +130,7 @@ object actions {
 
   implicit val show: Show[Action] = Show.show {
     case s @ ServerMessage(u @ SeqexecModelUpdate(view)) =>
-      val someSteps = view.queue.map(s =>
+      val someSteps = view.sessionQueue.map(s =>
         (s"id: ${s.id.format}", s"steps: ${s.steps.length}", s.steps.filter(_.status === StepState.Running).slice(0, scala.math.min(s.steps.length, 20)).collect(standardStep)))
       s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, loaded: '${view.loaded.mkString(",")}', $someSteps)"
     case s @ RememberCompleted(view)                    =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -132,7 +132,8 @@ object actions {
     case s @ ServerMessage(u @ SeqexecModelUpdate(view)) =>
       val someSteps = view.sessionQueue.map(s =>
         (s"id: ${s.id.format}", s"steps: ${s.steps.length}", s.steps.filter(_.status === StepState.Running).slice(0, scala.math.min(s.steps.length, 20)).collect(standardStep)))
-      s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, loaded: '${view.loaded.mkString(",")}', $someSteps)"
+      val dayCalQueue = view.queues.values.map(_.queue).mkString(",")
+      s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, dayCal: '${dayCalQueue}', loaded: '${view.loaded.mkString(",")}', $someSteps)"
     case s @ RememberCompleted(view)                    =>
       s"${s.getClass.getSimpleName}(${view.id})"
     case a                                              =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -3,13 +3,15 @@
 
 package seqexec.web.client
 
-import cats.{ Eq, Order }
+import cats.Eq
+import cats.Order
 import cats.implicits._
 import cats.data.NonEmptyList
 import diode._
 import gem.Observation
 import gem.enum.Site
-import monocle.{ Getter, Lens }
+import monocle.Getter
+import monocle.Lens
 import monocle.macros.Lenses
 import monocle.function.At._
 import seqexec.model._
@@ -134,9 +136,9 @@ package circuit {
   }
 
   final case class StatusAndLoadedSequencesFocus(
-      status:     ClientStatus,
-      sequences:  List[SequenceInQueue],
-      tableState: TableState[QueueTableBody.TableColumn])
+    status:     ClientStatus,
+    sequences:  List[SequenceInQueue],
+    tableState: TableState[QueueTableBody.TableColumn])
       extends UseValueEq
 
   final case class SequenceObserverFocus(instrument: Instrument,
@@ -146,23 +148,23 @@ package circuit {
       extends UseValueEq
 
   final case class HeaderSideBarFocus(
-      status:     ClientStatus,
-      conditions: Conditions,
-      operator:   Option[Operator],
-      observer:   Either[Observer, SequenceObserverFocus])
+    status:     ClientStatus,
+    conditions: Conditions,
+    operator:   Option[Operator],
+    observer:   Either[Observer, SequenceObserverFocus])
       extends UseValueEq
 
   final case class InstrumentStatusFocus(
-      instrument:  Instrument,
-      active:      Boolean,
-      idState:     Option[(Observation.Id, SequenceState)],
-      runningStep: Option[RunningStep])
+    instrument:  Instrument,
+    active:      Boolean,
+    idState:     Option[(Observation.Id, SequenceState)],
+    runningStep: Option[RunningStep])
       extends UseValueEq
 
   final case class TabFocus(
-      canOperate:      Boolean,
-      tabs:            NonEmptyList[Either[CalibrationQueueTabActive, AvailableTab]],
-      defaultObserver: Observer)
+    canOperate:      Boolean,
+    tabs:            NonEmptyList[Either[CalibrationQueueTabActive, AvailableTab]],
+    defaultObserver: Observer)
 
   object TabFocus {
     implicit val eq: Eq[TabFocus] =
@@ -237,14 +239,14 @@ package circuit {
   }
 
   final case class StepsTableFocus(
-      id:                  Observation.Id,
-      instrument:          Instrument,
-      state:               SequenceState,
-      steps:               List[Step],
-      stepConfigDisplayed: Option[Int],
-      nextStepToRun:       Option[Int],
-      isPreview:           Boolean,
-      tableState:          TableState[StepsTable.TableColumn])
+    id:                  Observation.Id,
+    instrument:          Instrument,
+    state:               SequenceState,
+    steps:               List[Step],
+    stepConfigDisplayed: Option[Int],
+    nextStepToRun:       Option[Int],
+    isPreview:           Boolean,
+    tableState:          TableState[StepsTable.TableColumn])
 
   object StepsTableFocus {
     implicit val eq: Eq[StepsTableFocus] =
@@ -261,9 +263,9 @@ package circuit {
   }
 
   final case class StepsTableAndStatusFocus(
-      status:           ClientStatus,
-      stepsTable:       Option[StepsTableFocus],
-      configTableState: TableState[StepConfigTable.TableColumn])
+    status:           ClientStatus,
+    stepsTable:       Option[StepsTableFocus],
+    configTableState: TableState[StepConfigTable.TableColumn])
 
   object StepsTableAndStatusFocus {
     implicit val eq: Eq[StepsTableAndStatusFocus] =
@@ -308,9 +310,9 @@ package circuit {
 
   @Lenses
   final case class AppTableStates(
-      queueTable:      TableState[QueueTableBody.TableColumn],
-      stepConfigTable: TableState[StepConfigTable.TableColumn],
-      stepsTables:     Map[Observation.Id, TableState[StepsTable.TableColumn]])
+    queueTable:      TableState[QueueTableBody.TableColumn],
+    stepConfigTable: TableState[StepConfigTable.TableColumn],
+    stepsTables:     Map[Observation.Id, TableState[StepsTable.TableColumn]])
       extends UseValueEq
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -71,10 +71,11 @@ package circuit {
     implicit val eq: Eq[SequencesFocus] =
       Eq.by(x => (x.sequences, x.sod))
 
-    val sequencesFocusL: Lens[SeqexecUIModel, SequencesFocus] =
-      Lens[SeqexecUIModel, SequencesFocus](m =>
-        SequencesFocus(m.sequences, m.sequencesOnDisplay))(v => m =>
-          m.copy(sequences = v.sequences, sequencesOnDisplay = v.sod))
+    val sequencesFocusL: Lens[SeqexecAppRootModel, SequencesFocus] =
+      Lens[SeqexecAppRootModel, SequencesFocus](m =>
+        SequencesFocus(m.sequences, m.uiModel.sequencesOnDisplay))(v => m =>
+          m.copy(sequences = v.sequences, uiModel = m.uiModel.copy(sequencesOnDisplay = v.sod)))
+
   }
 
   @Lenses
@@ -192,8 +193,7 @@ package circuit {
 
   object SequenceTabContentFocus {
     implicit val eq: Eq[SequenceTabContentFocus] =
-      Eq.by(x =>
-        (x.canOperate, x.instrument, x.id, x.active, x.logDisplayed))
+      Eq.by(x => (x.canOperate, x.instrument, x.id, x.active, x.logDisplayed))
   }
 
   final case class QueueTabContentFocus(canOperate:   Boolean,
@@ -307,29 +307,29 @@ package circuit {
   }
 
   @Lenses
-  final case class TableStates(
+  final case class AppTableStates(
       queueTable:      TableState[QueueTableBody.TableColumn],
       stepConfigTable: TableState[StepConfigTable.TableColumn],
       stepsTables:     Map[Observation.Id, TableState[StepsTable.TableColumn]])
       extends UseValueEq
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  object TableStates {
-    implicit val eq: Eq[TableStates] =
+  object AppTableStates {
+    implicit val eq: Eq[AppTableStates] =
       Eq.by(x => (x.queueTable, x.stepConfigTable, x.stepsTables))
 
-    val tableStateL: Lens[SeqexecUIModel, TableStates] =
-      Lens[SeqexecUIModel, TableStates](
-        m => TableStates(m.queueTableState,
+    val tableStateL: Lens[SeqexecUIModel, AppTableStates] =
+      Lens[SeqexecUIModel, AppTableStates](
+        m => AppTableStates(m.queueTableState,
                          m.configTableState,
                          m.sequencesOnDisplay.stepsTables))(
         v => m => m.copy(queueTableState  = v.queueTable,
                          configTableState = v.stepConfigTable,
                          sequencesOnDisplay = m.sequencesOnDisplay
-                           .updateStepsTableStates(v.stepsTables)))
+                           .updateTableStates(v.stepsTables)))
 
-    def stepTableAt(id: Observation.Id): Lens[TableStates, Option[TableState[StepsTable.TableColumn]]] =
-      TableStates.stepsTables ^|-> at(id)
+    def stepTableAt(id: Observation.Id): Lens[AppTableStates, Option[TableState[StepsTable.TableColumn]]] =
+      AppTableStates.stepsTables ^|-> at(id)
   }
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
@@ -4,7 +4,11 @@
 package seqexec.web.client.handlers
 
 import cats.implicits._
-import diode.{ActionHandler, ActionResult, Effect, ModelRW, NoAction}
+import diode.ActionHandler
+import diode.ActionResult
+import diode.Effect
+import diode.ModelRW
+import diode.NoAction
 import seqexec.model.events._
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.ModelOps._
@@ -14,20 +18,29 @@ import seqexec.web.client.circuit.SODLocationFocus
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 /**
- * Handles updates to the selected sequences set
- */
-class LoadedSequencesHandler[M](modelRW: ModelRW[M, SODLocationFocus]) extends ActionHandler(modelRW) with Handlers[M, SODLocationFocus] {
+  * Handles updates to the selected sequences set
+  */
+class LoadedSequencesHandler[M](modelRW: ModelRW[M, SODLocationFocus])
+    extends ActionHandler(modelRW)
+    with Handlers[M, SODLocationFocus] {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(LoadSequenceUpdated(i, sid, view, cid)) =>
       // Update selected and the page
       val upSelected = if (value.clientId.exists(_ === cid)) {
         // if I requested the load also focus on it
-        SODLocationFocus.sod.modify(_.updateFromQueue(view).loadingComplete(sid).unsetPreviewOn(sid).focusOnSequence(i, sid))
+        SODLocationFocus.sod.modify(
+          _.updateFromQueue(view)
+            .loadingComplete(sid)
+            .unsetPreviewOn(sid)
+            .focusOnSequence(i, sid))
       } else {
-        SODLocationFocus.sod.modify(_.updateFromQueue(view).loadingComplete(sid).unsetPreviewOn(sid))
+        SODLocationFocus.sod.modify(
+          _.updateFromQueue(view).loadingComplete(sid).unsetPreviewOn(sid))
       }
-      val nextStepToRun = view.sessionQueue.find(_.id === sid).foldMap(_.nextStepToRun)
-      val upLocation = SODLocationFocus.location.set(SequencePage(i, sid, nextStepToRun.foldMap(StepIdDisplayed.apply)))
+      val nextStepToRun =
+        view.sessionQueue.find(_.id === sid).foldMap(_.nextStepToRun)
+      val upLocation = SODLocationFocus.location.set(
+        SequencePage(i, sid, nextStepToRun.foldMap(StepIdDisplayed.apply)))
       updatedL(upSelected >>> upLocation)
 
     case ServerMessage(s: SeqexecModelUpdate) =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
@@ -26,7 +26,7 @@ class LoadedSequencesHandler[M](modelRW: ModelRW[M, SODLocationFocus]) extends A
       } else {
         SODLocationFocus.sod.modify(_.updateFromQueue(view).loadingComplete(sid).unsetPreviewOn(sid))
       }
-      val nextStepToRun = view.queue.find(_.id === sid).foldMap(_.nextStepToRun)
+      val nextStepToRun = view.sessionQueue.find(_.id === sid).foldMap(_.nextStepToRun)
       val upLocation = SODLocationFocus.location.set(SequencePage(i, sid, nextStepToRun.foldMap(StepIdDisplayed.apply)))
       updatedL(upSelected >>> upLocation)
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/ServerMessagesHandler.scala
@@ -32,7 +32,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus]) extends Act
   // It is legal do put sequences of the other sites on the queue
   // but we don't know how to display them, so let's filter them out
   private def filterSequences(sequences: SequencesQueue[SequenceView]): SequencesQueue[SequenceView] =
-    sequences.copy(queue = sequences.queue.filter {
+    sequences.copy(sessionQueue = sequences.sessionQueue.filter {
       case SequenceView(_, metadata, _, _, _) => value.site.map(_.instruments.toList.contains(metadata.instrument)).getOrElse(false)
     })
 
@@ -73,12 +73,12 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus]) extends Act
     case ServerMessage(SequenceCompleted(sv)) =>
       // Play audio when the sequence completes
       val audioEffect = Effect(Future(SequenceCompleteAudio.play()).map(_ => NoAction))
-      val rememberCompleted = Effect(Future(sv.queue.find(_.status === SequenceState.Completed).fold(NoAction: Action)(RememberCompleted.apply)))
+      val rememberCompleted = Effect(Future(sv.sessionQueue.find(_.status === SequenceState.Completed).fold(NoAction: Action)(RememberCompleted.apply)))
       updated(value.copy(sequences = filterSequences(sv)), audioEffect + rememberCompleted)
   }
 
   val sequenceUnloadedMessage: PartialFunction[Any, ActionResult[M]] = {
-    case ServerMessage(SequenceUnloaded(id, sv)) if value.sequences.queue.map(_.id).contains(id) =>
+    case ServerMessage(SequenceUnloaded(id, sv)) if value.sequences.sessionQueue.map(_.id).contains(id) =>
       updated(value.copy(sequences = filterSequences(sv)), Effect(Future(NavigateTo(Root))))
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/ServerMessagesHandler.scala
@@ -4,15 +4,26 @@
 package seqexec.web.client.handlers
 
 import cats.implicits._
-import diode.{Action, ActionHandler, ActionResult, Effect, ModelRW, NoAction}
-import seqexec.model.enum.{ ActionStatus }
-import seqexec.model.{ Observer, SequencesQueue, SequenceView, StepState, SequenceState }
+import diode.Action
+import diode.ActionHandler
+import diode.ActionResult
+import diode.Effect
+import diode.ModelRW
+import diode.NoAction
+import seqexec.model.enum.ActionStatus
+import seqexec.model.Observer
+import seqexec.model.SequencesQueue
+import seqexec.model.SequenceView
+import seqexec.model.StepState
+import seqexec.model.SequenceState
 import seqexec.model.events._
-import seqexec.web.client.lenses.{sequenceStepT, sequenceViewT}
+import seqexec.web.client.lenses.sequenceStepT
+import seqexec.web.client.lenses.sequenceViewT
 import seqexec.web.client.ModelOps._
 import seqexec.web.client.actions._
 import seqexec.web.client.circuit._
-import seqexec.web.client.services.{Audio, SeqexecWebClient}
+import seqexec.web.client.services.Audio
+import seqexec.web.client.services.SeqexecWebClient
 import seqexec.web.client.services.WebpackResources._
 import seqexec.web.client.model.Pages.Root
 import scala.concurrent.Future
@@ -21,7 +32,9 @@ import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 /**
   * Handles messages received over the WS channel
   */
-class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus]) extends ActionHandler(modelRW) with Handlers[M, WebSocketsFocus] {
+class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
+    extends ActionHandler(modelRW)
+    with Handlers[M, WebSocketsFocus] {
   // Global references to audio files
   private val SequencePausedAudio = new Audio(SequencePausedResource.resource)
   private val ExposurePausedAudio = new Audio(ExposurePausedResource.resource)
@@ -33,7 +46,10 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus]) extends Act
   // but we don't know how to display them, so let's filter them out
   private def filterSequences(sequences: SequencesQueue[SequenceView]): SequencesQueue[SequenceView] =
     sequences.copy(sessionQueue = sequences.sessionQueue.filter {
-      case SequenceView(_, metadata, _, _, _) => value.site.map(_.instruments.toList.contains(metadata.instrument)).getOrElse(false)
+      case SequenceView(_, metadata, _, _, _) =>
+        value.site
+          .map(_.instruments.toList.contains(metadata.instrument))
+          .getOrElse(false)
     })
 
   val soundCheck: PartialFunction[Any, ActionResult[M]] = {
@@ -130,7 +146,8 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus]) extends Act
   }
 
   override def handle: PartialFunction[Any, ActionResult[M]] =
-    List(soundCheck,
+    List(
+      soundCheck,
       logMessage,
       stepCompletedMessage,
       connectionOpenMessage,
@@ -143,5 +160,6 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus]) extends Act
       sequenceLoadedMessage,
       sequenceUnloadedMessage,
       modelUpdateMessage,
-      defaultMessage).combineAll
+      defaultMessage
+    ).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/TableStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/TableStateHandler.scala
@@ -3,14 +3,18 @@
 
 package seqexec.web.client.handlers
 
-import diode.{ ActionHandler, ActionResult, ModelRW }
+import diode.ActionHandler
+import diode.ActionResult
+import diode.ModelRW
 import seqexec.web.client.actions._
 import seqexec.web.client.circuit._
 
 /**
   * Handle to preserve the steps table state
   */
-class TableStateHandler[M](modelRW: ModelRW[M, AppTableStates]) extends ActionHandler(modelRW) with Handlers[M, AppTableStates] {
+class TableStateHandler[M](modelRW: ModelRW[M, AppTableStates])
+    extends ActionHandler(modelRW)
+    with Handlers[M, AppTableStates] {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateStepsConfigTableState(state) =>
       updatedSilentL(AppTableStates.stepConfigTable.set(state)) // We should only do silent updates as these change too quickly

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/TableStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/TableStateHandler.scala
@@ -10,15 +10,15 @@ import seqexec.web.client.circuit._
 /**
   * Handle to preserve the steps table state
   */
-class TableStateHandler[M](modelRW: ModelRW[M, TableStates]) extends ActionHandler(modelRW) with Handlers[M, TableStates] {
+class TableStateHandler[M](modelRW: ModelRW[M, AppTableStates]) extends ActionHandler(modelRW) with Handlers[M, AppTableStates] {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateStepsConfigTableState(state) =>
-      updatedSilentL(TableStates.stepConfigTable.set(state)) // We should only do silent updates as these change too quickly
+      updatedSilentL(AppTableStates.stepConfigTable.set(state)) // We should only do silent updates as these change too quickly
 
     case UpdateQueueTableState(state) =>
-      updatedSilentL(TableStates.queueTable.set(state)) // We should only do silent updates as these change too quickly
+      updatedSilentL(AppTableStates.queueTable.set(state)) // We should only do silent updates as these change too quickly
 
     case UpdateStepTableState(id, state) =>
-      updatedSilentL(TableStates.stepTableAt(id).set(Some(state))) // We should only do silent updates as these change too quickly
+      updatedSilentL(AppTableStates.stepTableAt(id).set(Some(state))) // We should only do silent updates as these change too quickly
   }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/handlers.scala
@@ -28,7 +28,7 @@ class SyncRequestsHandler[M](modelRW: ModelRW[M, Boolean])
     with Handlers[M, Boolean] {
   def handleSyncRequestOperation: PartialFunction[Any, ActionResult[M]] = {
     case RequestSync(s) =>
-      updated(true, Effect(SeqexecWebClient.sync(s).map(r => if (r.sessionQueue.isEmpty) RunSyncFailed(s) else RunSync(s))))
+      updated(true, Effect(SeqexecWebClient.sync(s).map(r => RunSync(s))))
   }
 
   def handleSyncResult: PartialFunction[Any, ActionResult[M]] = {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/handlers.scala
@@ -4,9 +4,16 @@
 package seqexec.web.client.handlers
 
 import cats.implicits._
-import diode.{ ActionHandler, ActionResult, Effect, ModelRW, NoAction }
+import diode.ActionHandler
+import diode.ActionResult
+import diode.Effect
+import diode.ModelRW
+import diode.NoAction
 import gem.enum.Site
-import seqexec.model.{ Observer, Operator, SequencesQueue, SequenceView }
+import seqexec.model.Observer
+import seqexec.model.Operator
+import seqexec.model.SequencesQueue
+import seqexec.model.SequenceView
 import seqexec.web.client.model._
 import seqexec.web.client.ModelOps._
 import seqexec.web.client.actions._
@@ -14,9 +21,11 @@ import seqexec.web.client.services.SeqexecWebClient
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 /**
-* Handles actions requesting sync
-*/
-class SyncRequestsHandler[M](modelRW: ModelRW[M, Boolean]) extends ActionHandler(modelRW) with Handlers[M, Boolean] {
+  * Handles actions requesting sync
+  */
+class SyncRequestsHandler[M](modelRW: ModelRW[M, Boolean])
+    extends ActionHandler(modelRW)
+    with Handlers[M, Boolean] {
   def handleSyncRequestOperation: PartialFunction[Any, ActionResult[M]] = {
     case RequestSync(s) =>
       updated(true, Effect(SeqexecWebClient.sync(s).map(r => if (r.sessionQueue.isEmpty) RunSyncFailed(s) else RunSync(s))))
@@ -31,14 +40,16 @@ class SyncRequestsHandler[M](modelRW: ModelRW[M, Boolean]) extends ActionHandler
   }
 
   override def handle: PartialFunction[Any, ActionResult[M]] =
-    List(handleSyncRequestOperation,
-      handleSyncResult).combineAll
+    List(handleSyncRequestOperation, handleSyncResult).combineAll
 }
 
 /**
   * Handles sequence execution actions
   */
-class SequenceExecutionHandler[M](modelRW: ModelRW[M, SequencesQueue[SequenceView]]) extends ActionHandler(modelRW) with Handlers[M, SequencesQueue[SequenceView]] {
+class SequenceExecutionHandler[M](
+  modelRW: ModelRW[M, SequencesQueue[SequenceView]])
+    extends ActionHandler(modelRW)
+    with Handlers[M, SequencesQueue[SequenceView]] {
   def handleUpdateObserver: PartialFunction[Any, ActionResult[M]] = {
     case UpdateObserver(sequenceId, name) =>
       val updateObserverE = Effect(SeqexecWebClient.setObserver(sequenceId, name.value).map(_ => NoAction))
@@ -71,9 +82,11 @@ class SequenceExecutionHandler[M](modelRW: ModelRW[M, SequencesQueue[SequenceVie
 }
 
 /**
- * Handles updates to the operator
- */
-class OperatorHandler[M](modelRW: ModelRW[M, Option[Operator]]) extends ActionHandler(modelRW) with Handlers[M, Option[Operator]] {
+  * Handles updates to the operator
+  */
+class OperatorHandler[M](modelRW: ModelRW[M, Option[Operator]])
+    extends ActionHandler(modelRW)
+    with Handlers[M, Option[Operator]] {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateOperator(name) =>
       val updateOperatorE = Effect(SeqexecWebClient.setOperator(name).map(_ => NoAction))
@@ -82,9 +95,11 @@ class OperatorHandler[M](modelRW: ModelRW[M, Option[Operator]]) extends ActionHa
 }
 
 /**
- * Handles setting the site
- */
-class SiteHandler[M](modelRW: ModelRW[M, Option[Site]]) extends ActionHandler(modelRW) with Handlers[M, Option[Site]] {
+  * Handles setting the site
+  */
+class SiteHandler[M](modelRW: ModelRW[M, Option[Site]])
+    extends ActionHandler(modelRW)
+    with Handlers[M, Option[Site]] {
 
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case Initialize(site) =>
@@ -95,7 +110,9 @@ class SiteHandler[M](modelRW: ModelRW[M, Option[Site]]) extends ActionHandler(mo
 /**
   * Handles updates to the log
   */
-class GlobalLogHandler[M](modelRW: ModelRW[M, GlobalLog]) extends ActionHandler(modelRW) with Handlers[M, GlobalLog] {
+class GlobalLogHandler[M](modelRW: ModelRW[M, GlobalLog])
+    extends ActionHandler(modelRW)
+    with Handlers[M, GlobalLog] {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case AppendToLog(s) =>
       updated(value.copy(log = value.log.append(s)))
@@ -108,7 +125,9 @@ class GlobalLogHandler[M](modelRW: ModelRW[M, GlobalLog]) extends ActionHandler(
 /**
   * Handles updates to the defaultObserver
   */
-class DefaultObserverHandler[M](modelRW: ModelRW[M, Observer]) extends ActionHandler(modelRW) with Handlers[M, Observer] {
+class DefaultObserverHandler[M](modelRW: ModelRW[M, Observer])
+    extends ActionHandler(modelRW)
+    with Handlers[M, Observer] {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateDefaultObserver(o) =>
       updated(o)
@@ -118,7 +137,9 @@ class DefaultObserverHandler[M](modelRW: ModelRW[M, Observer]) extends ActionHan
 /**
   * Handle for UI debugging events
   */
-class DebuggingHandler[M](modelRW: ModelRW[M, SequencesQueue[SequenceView]]) extends ActionHandler(modelRW) with Handlers[M, SequencesQueue[SequenceView]] {
+class DebuggingHandler[M](modelRW: ModelRW[M, SequencesQueue[SequenceView]])
+    extends ActionHandler(modelRW)
+    with Handlers[M, SequencesQueue[SequenceView]] {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case MarkStepAsRunning(obsId, step) =>
       updated(value.copy(sessionQueue = value.sessionQueue.collect {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -9,20 +9,39 @@ import gem.Observation
 import java.util.logging.LogRecord
 import org.scalajs.dom.ext.Ajax
 import org.scalajs.dom.XMLHttpRequest
-import seqexec.model.{ ClientID, Conditions, UserDetails, UserLoginRequest, Observer, Operator, SequencesQueue, Step }
+import seqexec.model.ClientID
+import seqexec.model.Conditions
+import seqexec.model.UserDetails
+import seqexec.model.UserLoginRequest
+import seqexec.model.Observer
+import seqexec.model.Operator
+import seqexec.model.Step
 import seqexec.model.boopickle._
-import seqexec.model.enum.{ CloudCover, Instrument, ImageQuality, SkyBackground, WaterVapor}
-import seqexec.web.common.{LogMessage, RegularCommand}
+import seqexec.model.enum.CloudCover
+import seqexec.model.enum.Instrument
+import seqexec.model.enum.ImageQuality
+import seqexec.model.enum.SkyBackground
+import seqexec.model.enum.WaterVapor
+import seqexec.web.common.LogMessage
+import seqexec.web.common.RegularCommand
 import seqexec.web.common.LogMessage._
 import scala.scalajs.js.URIUtils._
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.scalajs.js.typedarray.{ArrayBuffer, TypedArrayBuffer}
+import scala.scalajs.js.typedarray.ArrayBuffer
+import scala.scalajs.js.typedarray.TypedArrayBuffer
 
 /**
   * Encapsulates remote calls to the Seqexec Web API
   */
-@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.OptionPartial", "org.wartremover.warts.Throw"))
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Equals",
+    "org.wartremover.warts.ImplicitParameter",
+    "org.wartremover.warts.NonUnitStatements",
+    "org.wartremover.warts.OptionPartial",
+    "org.wartremover.warts.Throw"
+  ))
 object SeqexecWebClient extends ModelBooPicklers {
   private val baseUrl = "/api/seqexec"
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -52,12 +52,12 @@ object SeqexecWebClient extends ModelBooPicklers {
     Unpickle[A].fromBytes(ab)
   }
 
-  def sync(id: Observation.Id): Future[SequencesQueue[Observation.Id]] =
-    Ajax.get(
+  def sync(id: Observation.Id): Future[String] =
+    Ajax.post(
       url = s"$baseUrl/commands/${encodeURI(id.format)}/sync",
       responseType = "arraybuffer"
     )
-    .map(unpickle[SequencesQueue[Observation.Id]])
+    .map(_ => id.format)
 
   /**
     * Requests the backend to execute a sequence

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -7,12 +7,12 @@ import boopickle.Default._
 import cats.implicits._
 import gem.Observation
 import java.util.logging.LogRecord
-import org.scalajs.dom.ext.{Ajax, AjaxException}
+import org.scalajs.dom.ext.Ajax
 import org.scalajs.dom.XMLHttpRequest
 import seqexec.model.{ ClientID, Conditions, UserDetails, UserLoginRequest, Observer, Operator, SequencesQueue, Step }
 import seqexec.model.boopickle._
 import seqexec.model.enum.{ CloudCover, Instrument, ImageQuality, SkyBackground, WaterVapor}
-import seqexec.web.common.{HttpStatusCodes, LogMessage, RegularCommand}
+import seqexec.web.common.{LogMessage, RegularCommand}
 import seqexec.web.common.LogMessage._
 import scala.scalajs.js.URIUtils._
 import scala.concurrent.Future
@@ -39,11 +39,6 @@ object SeqexecWebClient extends ModelBooPicklers {
       responseType = "arraybuffer"
     )
     .map(unpickle[SequencesQueue[Observation.Id]])
-    .recover {
-      case AjaxException(xhr) if xhr.status == HttpStatusCodes.NotFound  =>
-        // If not found, we'll consider it like an empty response
-        SequencesQueue(Map.empty, Conditions.Default, None, Nil)
-    }
 
   /**
     * Requests the backend to execute a sequence

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -162,11 +162,12 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val arbSequenceOnDisplay: Arbitrary[SequencesOnDisplay] =
     Arbitrary {
       for {
-        s <- Gen.nonEmptyListOf(arbitrary[SeqexecTab])
+        c <- arbitrary[CalibrationQueueTab]
+        l <- Gen.chooseNum(0, 4)
+        s <- Gen.listOfN(l, arbitrary[SeqexecTab])
       } yield {
-        val sequences =
-          NonEmptyList.of(s.headOption.getOrElse(CalibrationQueueTab.Empty),
-                          s.drop(1): _*)
+        val sequences = NonEmptyList.of(c, s: _*)
+        println(s"seq ${sequences.length}")
         SequencesOnDisplay(Zipper.fromNel(sequences))
       }
     }
@@ -561,7 +562,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
       for {
         navLocation        <- arbitrary[Pages.SeqexecPages]
         user               <- arbitrary[Option[UserDetails]]
-        sequences          <- arbitrary[SequencesQueue[SequenceView]]
         loginBox           <- arbitrary[SectionVisibilityState]
         globalLog          <- arbitrary[GlobalLog]
         sequencesOnDisplay <- arbitrary[SequencesOnDisplay]
@@ -575,7 +575,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         SeqexecUIModel(
           navLocation,
           user,
-          sequences,
           loginBox,
           globalLog,
           sequencesOnDisplay,
@@ -592,7 +591,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     Cogen[
       (Pages.SeqexecPages,
        Option[UserDetails],
-       SequencesQueue[SequenceView],
        SectionVisibilityState,
        GlobalLog,
        SequencesOnDisplay,
@@ -606,7 +604,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         x =>
           (x.navLocation,
            x.user,
-           x.sequences,
            x.loginBox,
            x.globalLog,
            x.sequencesOnDisplay,
@@ -646,23 +643,24 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val arbSeqexecAppRootModel: Arbitrary[SeqexecAppRootModel] =
     Arbitrary {
       for {
-        ws       <- arbitrary[WebSocketConnection]
-        site     <- arbitrary[Option[Site]]
-        clientId <- arbitrary[Option[ClientID]]
-        uiModel  <- arbitrary[SeqexecUIModel]
-      } yield SeqexecAppRootModel(ws, site, clientId, uiModel)
+        sequences <- arbitrary[SequencesQueue[SequenceView]]
+        ws        <- arbitrary[WebSocketConnection]
+        site      <- arbitrary[Option[Site]]
+        clientId  <- arbitrary[Option[ClientID]]
+        uiModel   <- arbitrary[SeqexecUIModel]
+      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel)
     }
 
-  implicit val arbTableStates: Arbitrary[TableStates] =
+  implicit val arbAppTableStates: Arbitrary[AppTableStates] =
     Arbitrary {
       for {
         qt <- arbitrary[TableState[QueueTableBody.TableColumn]]
         ct <- arbitrary[TableState[StepConfigTable.TableColumn]]
         st <- arbitrary[Map[Observation.Id, TableState[StepsTable.TableColumn]]]
-      } yield TableStates(qt, ct, st)
+      } yield AppTableStates(qt, ct, st)
     }
 
-  implicit val tableStatesCogen: Cogen[TableStates] =
+  implicit val appTableStatesCogen: Cogen[AppTableStates] =
     Cogen[(TableState[QueueTableBody.TableColumn],
            TableState[StepConfigTable.TableColumn],
            List[(Observation.Id, TableState[StepsTable.TableColumn])])]

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -167,7 +167,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         s <- Gen.listOfN(l, arbitrary[SeqexecTab])
       } yield {
         val sequences = NonEmptyList.of(c, s: _*)
-        println(s"seq ${sequences.length}")
         SequencesOnDisplay(Zipper.fromNel(sequences))
       }
     }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -11,13 +11,21 @@ import gem.arb.ArbEnumerated._
 import gem.Observation
 import gem.enum.Site
 import seqexec.model.enum.Instrument
-import seqexec.model.{ ClientID, Observer, TargetName }
-import seqexec.model.{ SequenceState, SequenceView, SequencesQueue }
-import seqexec.model.{ Notification, Step, UserDetails }
+import seqexec.model.ClientID
+import seqexec.model.Observer
+import seqexec.model.TargetName
+import seqexec.model.SequenceState
+import seqexec.model.SequenceView
+import seqexec.model.SequencesQueue
+import seqexec.model.Notification
+import seqexec.model.Step
+import seqexec.model.UserDetails
 import seqexec.model.events.ServerLogMessage
 import seqexec.model.SeqexecModelArbitraries._
-import seqexec.model.SequenceEventsArbitraries.{ slmArb, slmCogen }
-import seqexec.web.common.{ FixedLengthBuffer, Zipper }
+import seqexec.model.SequenceEventsArbitraries.slmArb
+import seqexec.model.SequenceEventsArbitraries.slmCogen
+import seqexec.web.common.FixedLengthBuffer
+import seqexec.web.common.Zipper
 import seqexec.web.common.ArbitrariesWebCommon._
 import seqexec.web.client.model._
 import seqexec.web.client.model.RunOperation
@@ -28,9 +36,11 @@ import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.components.QueueTableBody
 import org.scalacheck.Arbitrary._
-import org.scalacheck.{ Arbitrary, _ }
+import org.scalacheck.Arbitrary
+import org.scalacheck._
 import org.scalajs.dom.WebSocket
-import web.client.table.{ TableArbitraries, TableState }
+import web.client.table.TableArbitraries
+import web.client.table.TableState
 
 trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
 

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
@@ -6,10 +6,15 @@ package seqexec.web.client
 import cats.tests.CatsSuite
 import gem.Observation
 import seqexec.model.enum.Instrument
-import seqexec.model.{ SequenceMetadata, SequenceView, SequencesQueue }
-import seqexec.model.{ Conditions, SequenceState }
-import seqexec.web.client.model.{ PreviewSequenceTab, SequencesOnDisplay }
-import seqexec.web.client.model.{ CalibrationQueueTab, InstrumentSequenceTab }
+import seqexec.model.SequenceMetadata
+import seqexec.model.SequenceView
+import seqexec.model.SequencesQueue
+import seqexec.model.Conditions
+import seqexec.model.SequenceState
+import seqexec.web.client.model.PreviewSequenceTab
+import seqexec.web.client.model.SequencesOnDisplay
+import seqexec.web.client.model.CalibrationQueueTab
+import seqexec.web.client.model.InstrumentSequenceTab
 
 /**
   * Tests Sequences on display class

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
@@ -81,7 +81,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     val queue  = List(s)
     val loaded = Map((Instrument.GPI: Instrument) -> obsId)
     val sod = SequencesOnDisplay.Empty.updateFromQueue(
-      SequencesQueue(loaded, Conditions.Default, None, queue))
+      SequencesQueue(loaded, Conditions.Default, None, Map.empty, queue))
     sod.tabs.length should be(2)
     sod.tabs.toList.lift(1) should matchPattern {
       case Some(InstrumentSequenceTab(_, s, _, _, _, _))
@@ -95,7 +95,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     val queue  = List(s)
     val loaded = Map((Instrument.GPI: Instrument) -> obsId)
     val sod = SequencesOnDisplay.Empty.updateFromQueue(
-      SequencesQueue(loaded, Conditions.Default, None, queue))
+      SequencesQueue(loaded, Conditions.Default, None, Map.empty, queue))
 
     val obs2 = Observation.Id.unsafeFromString("GS-2018A-Q-0-2")
     val s2   = SequenceView(obs2, m, SequenceState.Idle, Nil, None)

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -4,7 +4,6 @@
 package seqexec.web.server.http4s
 
 import cats.effect.IO
-import gem.Observation
 import seqexec.server.Commands
 import seqexec.server.SeqexecEngine
 import seqexec.server
@@ -61,8 +60,7 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: server.Event
     case GET -> Root / ObsIdVar(obsId) / "sync" as _ =>
       for {
         u     <- se.load(inputQueue, obsId)
-        resp  <- u.fold(_ => NotFound(s"Not found sequence $obsId"), _ =>
-          Ok(SequencesQueue[Observation.Id](Map.empty, Conditions.Default, None, List(obsId))))
+        resp  <- u.fold(_ => NotFound(s"Not found sequence $obsId"), _ => Ok("Sync requested"))
       } yield resp
 
    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "skip" / bp as user =>

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -57,10 +57,10 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: server.Event
        resp   <- Ok(s"Set breakpoint in step $stepId of sequence $obsId")
      } yield resp
 
-    case GET -> Root / ObsIdVar(obsId) / "sync" as _ =>
+    case POST -> Root / ObsIdVar(obsId) / "sync" as _ =>
       for {
         u     <- se.load(inputQueue, obsId)
-        resp  <- u.fold(_ => NotFound(s"Not found sequence $obsId"), _ => Ok("Sync requested"))
+        resp  <- u.fold(_ => NotFound(s"Not found sequence $obsId"), _ => Ok(s"Sync requested for ${obsId.format}"))
       } yield resp
 
    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "skip" / bp as user =>
@@ -68,7 +68,6 @@ class SeqexecCommandRoutes(auth: AuthenticationService, inputQueue: server.Event
        newVal <- IO.fromEither(Either.catchNonFatal(bp.toBoolean))
        _      <- se.setSkipMark(inputQueue, obsId, user, stepId, newVal)
        resp   <- Ok(s"Set skip mark in step $stepId of sequence $obsId")
-
      } yield resp
 
    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "stop" as _ =>

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -15,7 +15,15 @@ import seqexec.model.events._
   * Boopickle can auto derived encoders but it is preferred to make
   * them explicitly
   */
-@SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.PublicInference", "org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Throw", "org.wartremover.warts.OptionPartial"))
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Equals",
+    "org.wartremover.warts.PublicInference",
+    "org.wartremover.warts.ImplicitParameter",
+    "org.wartremover.warts.NonUnitStatements",
+    "org.wartremover.warts.Throw",
+    "org.wartremover.warts.OptionPartial"
+  ))
 trait ModelBooPicklers extends GemModelBooPicklers {
   //**********************
   // IMPORTANT The order of the picklers is very relevant to the generated size
@@ -33,7 +41,8 @@ trait ModelBooPicklers extends GemModelBooPicklers {
 
   implicit val userDetailsPickler = generatePickler[UserDetails]
 
-  implicit val instantPickler = transformPickler((t: Long) => Instant.ofEpochMilli(t))(_.toEpochMilli)
+  implicit val instantPickler =
+    transformPickler((t: Long) => Instant.ofEpochMilli(t))(_.toEpochMilli)
 
   implicit val cloudCoverPickler = compositePickler[CloudCover]
     .addConcreteType[CloudCover.Any.type]
@@ -102,9 +111,11 @@ trait ModelBooPicklers extends GemModelBooPicklers {
 
   implicit val executionQueuePickler = generatePickler[ExecutionQueue]
 
-  implicit val sequenceQueueIdPickler = generatePickler[SequencesQueue[Observation.Id]]
+  implicit val sequenceQueueIdPickler =
+    generatePickler[SequencesQueue[Observation.Id]]
 
-  implicit val sequenceQueueViewPickler = generatePickler[SequencesQueue[SequenceView]]
+  implicit val sequenceQueueViewPickler =
+    generatePickler[SequencesQueue[SequenceView]]
 
   // Composite pickler for the seqexec event hierarchy
   // It is not strictly need but reduces the size of the js

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -95,6 +95,13 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     .addConcreteType[ServerLogLevel.WARN.type]
     .addConcreteType[ServerLogLevel.ERROR.type]
 
+  implicit val batchCommandPickler = compositePickler[BatchCommandState]
+    .addConcreteType[BatchCommandState.Idle.type]
+    .addConcreteType[BatchCommandState.Run.type]
+    .addConcreteType[BatchCommandState.Stop.type]
+
+  implicit val executionQueuePickler = generatePickler[ExecutionQueue]
+
   implicit val sequenceQueueIdPickler = generatePickler[SequencesQueue[Observation.Id]]
 
   implicit val sequenceQueueViewPickler = generatePickler[SequencesQueue[SequenceView]]

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
@@ -54,6 +54,8 @@ final class BoopicklingSpec extends CatsSuite with ModelBooPicklers {
   checkAll("Pickler[SequenceError]", PicklerTests[SequenceError].pickler)
   checkAll("Pickler[SequencePaused]", PicklerTests[SequencePaused].pickler)
   checkAll("Pickler[ExposurePaused]", PicklerTests[ExposurePaused].pickler)
+  checkAll("Pickler[BatchCommandState]", PicklerTests[BatchCommandState].pickler)
+  checkAll("Pickler[ExecutionQueue]", PicklerTests[ExecutionQueue].pickler)
   checkAll("Pickler[SequencesQueue[Observation.Id]]",
            PicklerTests[SequencesQueue[Observation.Id]].pickler)
   checkAll("Pickler[ImageQuality]", PicklerTests[ImageQuality].pickler)

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
@@ -54,7 +54,8 @@ final class BoopicklingSpec extends CatsSuite with ModelBooPicklers {
   checkAll("Pickler[SequenceError]", PicklerTests[SequenceError].pickler)
   checkAll("Pickler[SequencePaused]", PicklerTests[SequencePaused].pickler)
   checkAll("Pickler[ExposurePaused]", PicklerTests[ExposurePaused].pickler)
-  checkAll("Pickler[BatchCommandState]", PicklerTests[BatchCommandState].pickler)
+  checkAll("Pickler[BatchCommandState]",
+           PicklerTests[BatchCommandState].pickler)
   checkAll("Pickler[ExecutionQueue]", PicklerTests[ExecutionQueue].pickler)
   checkAll("Pickler[SequencesQueue[Observation.Id]]",
            PicklerTests[SequencesQueue[Observation.Id]].pickler)


### PR DESCRIPTION
This updates the client model to carry the calibration queue to the client. I also did some work on tests to make them faster and did some formatting