### PR TITLE
Run calibration queue.

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -39,7 +39,7 @@ class Engine[D, U](stateL: Lens[D, Engine.State]) {
   private def switch(id: Observation.Id)(st: SequenceState): HandleType[Unit] =
     modifyS(id)(s => Sequence.State.status.set(st)(s))
 
-  private def start(id: Observation.Id, clientId: ClientID, userCheck: D => Boolean): HandleType[Unit] =
+  def start(id: Observation.Id, clientId: ClientID, userCheck: D => Boolean): HandleType[Unit] =
     getS(id).flatMap {
       case Some(seq) =>
         // No resources being used by other running sequences
@@ -303,11 +303,11 @@ class Engine[D, U](stateL: Lens[D, Engine.State]) {
 
   // Functions for type bureaucracy
 
-  private def pure[A](a: A): HandleType[A] = Applicative[HandleType].pure(a)
+  def pure[A](a: A): HandleType[A] = Applicative[HandleType].pure(a)
 
-  private val unit: HandleType[Unit] = pure(())
+  val unit: HandleType[Unit] = pure(())
 
-  private val get: HandleType[D] =
+  val get: HandleType[D] =
     StateT.get[IO, D].toHandleP
 
   private def inspect[A](f: D => A): HandleType[A] =

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Event.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Event.scala
@@ -26,7 +26,7 @@ object Event {
   def skip[D<:Engine.Types](id: Observation.Id, user: UserDetails, step: Step.Id, v: Boolean): Event[D] = EventUser[D](SkipMark(id, user.some, step, v))
   def poll(clientId: ClientID): Event[Nothing] = EventUser(Poll(clientId))
   def getState[D<:Engine.Types](f: D#StateType => Option[Stream[IO, Event[D]]]): Event[D] = EventUser[D](GetState[D](f))
-  def modifyState[D<:Engine.Types](f: Engine.HandleP[D#StateType, Event[D], D#EventData]): Event[D] = EventUser[D](ModifyState[D](f))
+  def modifyState[D<:Engine.Types](f: Handle[D#StateType, Event[D], D#EventData]): Event[D] = EventUser[D](ModifyState[D](f))
   def actionStop[D<:Engine.Types](id: Observation.Id, f: D#StateType => Option[Stream[IO, Event[D]]]): Event[D] = EventUser[D](ActionStop(id, f))
   def actionResume[D<:Engine.Types](id: Observation.Id, i: Int, c: IO[Result]): Event[D] = EventUser[D](ActionResume(id, i, c))
   def logDebugMsg[D<:Engine.Types](msg: String): Event[D] = EventUser[D](LogDebug(msg))

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Event.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Event.scala
@@ -26,7 +26,7 @@ object Event {
   def skip[D<:Engine.Types](id: Observation.Id, user: UserDetails, step: Step.Id, v: Boolean): Event[D] = EventUser[D](SkipMark(id, user.some, step, v))
   def poll(clientId: ClientID): Event[Nothing] = EventUser(Poll(clientId))
   def getState[D<:Engine.Types](f: D#StateType => Option[Stream[IO, Event[D]]]): Event[D] = EventUser[D](GetState[D](f))
-  def modifyState[D<:Engine.Types](f: D#StateType => (D#StateType, D#EventData)): Event[D] = EventUser[D](ModifyState[D](f))
+  def modifyState[D<:Engine.Types](f: Engine.HandleP[D#StateType, Event[D], D#EventData]): Event[D] = EventUser[D](ModifyState[D](f))
   def actionStop[D<:Engine.Types](id: Observation.Id, f: D#StateType => Option[Stream[IO, Event[D]]]): Event[D] = EventUser[D](ActionStop(id, f))
   def actionResume[D<:Engine.Types](id: Observation.Id, i: Int, c: IO[Result]): Event[D] = EventUser[D](ActionResume(id, i, c))
   def logDebugMsg[D<:Engine.Types](msg: String): Event[D] = EventUser[D](LogDebug(msg))

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Handle.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Handle.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.engine
+
+import cats.{Applicative, Monad}
+import cats.data.StateT
+import cats.effect.IO
+import fs2.Stream
+
+/**
+  * Type constructor where all Seqexec side effect are managed.
+  * Handle is a State machine inside a IO, which can produce Streams as output. It is combined with the
+  * input stream to run seqexec engine.
+  *
+  * Its type parameters are:
+  * A: Type of the output (usually Unit)
+  * V: Type of the events
+  * D: Type of the state machine state.
+  */
+final case class Handle[D, V, A](run: StateT[IO, D, (A, Option[Stream[IO, V]])])
+
+object Handle {
+  def fromStream[D, V](p: Stream[IO, V]): Handle[D, V, Unit] = {
+    Handle[D, V, Unit](Applicative[StateT[IO, D, ?]].pure[(Unit, Option[Stream[IO, V]])](((), Some(p))))
+  }
+
+  implicit def handlePInstances[D, V]: Monad[Handle[D, V, ?]] = new Monad[Handle[D, V, ?]] {
+    private def concatOpP[F[_]](op1: Option[Stream[F, V]],
+                                op2: Option[Stream[F, V]]): Option[Stream[F, V]] = (op1, op2) match {
+      case (None, None) => None
+      case (Some(p1), None) => Some(p1)
+      case (None, Some(p2)) => Some(p2)
+      case (Some(p1), Some(p2)) => Some(p1 ++ p2)
+    }
+
+    override def pure[A](a: A): Handle[D, V, A] = Handle(Applicative[StateT[IO, D, ?]].pure((a, None)))
+
+    override def flatMap[A, B](fa: Handle[D, V, A])(f: A => Handle[D, V, B]): Handle[D, V, B] = Handle[D, V, B](
+      fa.run.flatMap {
+        case (a, op1) => f(a).run.map {
+          case (b, op2) => (b, concatOpP(op1, op2))
+        }
+      }
+    )
+
+    // Kudos to @tpolecat
+    def tailRecM[A, B](a: A)(f: A => Handle[D, V, Either[A, B]]): Handle[D, V, B] = {
+      // We don't really care what this type is
+      type Unused = Option[Stream[IO, V]]
+
+      // Construct a StateT that delegates to IO's tailRecM
+      val st: StateT[IO, D, (B, Unused)] =
+        StateT { s =>
+          Monad[IO].tailRecM[(D, A), (D, (B, Unused))]((s, a)) {
+            case (s, a) =>
+              f(a).run.run(s).map {
+                case (sʹ, (Left(a), _)) => Left((sʹ, a))
+                case (sʹ, (Right(b), u)) => Right((sʹ, (b, u)))
+              }
+          }
+        }
+
+      // Done
+      Handle(st)
+    }
+  }
+
+  implicit class StateToHandle[D, V, A](self: StateT[IO, D, A]) {
+    def toHandle: Handle[D, V, A] = Handle(self.map((_, None)))
+  }
+
+  def unit[D, V]: Handle[D, V, Unit] = Applicative[Handle[D, V, ?]].pure(())
+
+  def get[D, V]: Handle[D, V, D] =
+    StateT.get[IO, D].toHandle
+
+  def inspect[D, V, A](f: D => A): Handle[D, V, A] =
+    StateT.inspect[IO, D, A](f).toHandle
+
+  def modify[D, V](f: D => D): Handle[D, V, Unit] =
+    StateT.modify[IO, D](f).toHandle
+
+}

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/UserEvent.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/UserEvent.scala
@@ -33,7 +33,7 @@ final case class GetState[D<:Engine.Types](f: D#StateType => Option[Stream[IO, E
 }
 // Generic event to put a function in the main Process process, which changes the state
 // depending on the current state
-final case class ModifyState[D<:Engine.Types](f: D#StateType => (D#StateType, D#EventData)) extends UserEvent[D] {
+final case class ModifyState[D<:Engine.Types](f: Engine.HandleP[D#StateType, Event[D], D#EventData]) extends UserEvent[D] {
   val user: Option[UserDetails] = None
 }
 // Calls a user given function in the main Stream process to stop an Action.

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/UserEvent.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/UserEvent.scala
@@ -33,7 +33,7 @@ final case class GetState[D<:Engine.Types](f: D#StateType => Option[Stream[IO, E
 }
 // Generic event to put a function in the main Process process, which changes the state
 // depending on the current state
-final case class ModifyState[D<:Engine.Types](f: Engine.HandleP[D#StateType, Event[D], D#EventData]) extends UserEvent[D] {
+final case class ModifyState[D<:Engine.Types](f: Handle[D#StateType, Event[D], D#EventData]) extends UserEvent[D] {
   val user: Option[UserDetails] = None
 }
 // Calls a user given function in the main Stream process to stop an Action.

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/SequenceSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/SequenceSpec.scala
@@ -77,7 +77,7 @@ class SequenceSpec extends FlatSpec {
   }
 
   def runToCompletion(s0: Engine.State): Option[Engine.State] = {
-    executionEngine.process(Stream.eval(IO.pure(Event.start[executionEngine.ConcreteTypes](seqId, user, UUID.randomUUID, always))))(s0).drop(1).takeThrough(
+    executionEngine.process(PartialFunction.empty)(Stream.eval(IO.pure(Event.start[executionEngine.ConcreteTypes](seqId, user, UUID.randomUUID, always))))(s0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).compile.last.unsafeRunSync.map(_._2)
   }

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/StepSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/StepSpec.scala
@@ -121,13 +121,13 @@ class StepSpec extends FlatSpec {
   }
 
   def runToCompletion(s0: Engine.State): Option[Engine.State] = {
-    executionEngine.process(Stream.eval(IO.pure(Event.start[executionEngine.ConcreteTypes](seqId, user, UUID.randomUUID, always))))(s0).drop(1).takeThrough(
+    executionEngine.process(PartialFunction.empty)(Stream.eval(IO.pure(Event.start[executionEngine.ConcreteTypes](seqId, user, UUID.randomUUID, always))))(s0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).compile.last.unsafeRunSync.map(_._2)
   }
 
   def runToCompletionL(s0: Engine.State): List[Engine.State] = {
-    executionEngine.process(Stream.eval(IO.pure(Event.start[executionEngine.ConcreteTypes](seqId, user, UUID.randomUUID, always))))(s0).drop(1).takeThrough(
+    executionEngine.process(PartialFunction.empty)(Stream.eval(IO.pure(Event.start[executionEngine.ConcreteTypes](seqId, user, UUID.randomUUID, always))))(s0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).compile.toVector.unsafeRunSync.map(_._2).toList
   }
@@ -171,7 +171,7 @@ class StepSpec extends FlatSpec {
       k <- q
       o <- Stream.apply(qs0(k))
       _ <- Stream.eval(k.enqueue1(startEvent))
-      u <- executionEngine.process(k.dequeue)(o).drop(1).takeThrough(notFinished).map(_._2)
+      u <- executionEngine.process(PartialFunction.empty)(k.dequeue)(o).drop(1).takeThrough(notFinished).map(_._2)
     } yield u.sequences(seqId)
 
     inside (m.compile.last.unsafeRunSync()) {
@@ -214,7 +214,7 @@ class StepSpec extends FlatSpec {
 
     val qs1: Stream[IO, Option[Sequence.State]] =
       for {
-        u <- executionEngine.process(Stream.eval(IO.pure(startEvent)))(qs0).take(1)
+        u <- executionEngine.process(PartialFunction.empty)(Stream.eval(IO.pure(startEvent)))(qs0).take(1)
       } yield u._2.sequences.get(seqId)
 
     inside (qs1.compile.last.unsafeRunSync()) {
@@ -254,7 +254,7 @@ class StepSpec extends FlatSpec {
         )
       )
 
-    val qs1 = executionEngine.process(Stream.eval(IO.pure(Event.cancelPause(seqId, user))))(qs0).take(1).compile.last.unsafeRunSync.map(_._2)
+    val qs1 = executionEngine.process(PartialFunction.empty)(Stream.eval(IO.pure(Event.cancelPause(seqId, user))))(qs0).take(1).compile.last.unsafeRunSync.map(_._2)
 
     inside (qs1.flatMap(_.sequences.get(seqId))) {
       case Some(Sequence.State.Zipper(_, status)) =>
@@ -286,7 +286,7 @@ class StepSpec extends FlatSpec {
           )
         )
       )
-    val qss = executionEngine.process(Stream.eval(IO.pure(Event.pause(seqId, user))))(qs0).take(1).compile.last.unsafeRunSync.map(_._2)
+    val qss = executionEngine.process(PartialFunction.empty)(Stream.eval(IO.pure(Event.pause(seqId, user))))(qs0).take(1).compile.last.unsafeRunSync.map(_._2)
 
     inside (qss.flatMap(_.sequences.get(seqId))) {
       case Some(Sequence.State.Zipper(zipper, status)) =>
@@ -325,7 +325,7 @@ class StepSpec extends FlatSpec {
         )
       )
 
-    val qss = q.flatMap { k => k.enqueue1(Event.start(seqId, user, UUID.randomUUID, always)).flatMap(_ => executionEngine.process(k.dequeue)(qs0).drop(1).takeThrough(
+    val qss = q.flatMap { k => k.enqueue1(Event.start(seqId, user, UUID.randomUUID, always)).flatMap(_ => executionEngine.process(PartialFunction.empty)(k.dequeue)(qs0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
     ).compile.toVector)}.unsafeRunSync
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/BatchCommandState.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/BatchCommandState.scala
@@ -4,12 +4,13 @@
 package seqexec.model.enum
 
 import cats.Eq
+import seqexec.model.ClientID
 
 sealed trait BatchCommandState extends Product with Serializable
 
 object BatchCommandState {
   case object Idle extends BatchCommandState
-  case object Run extends BatchCommandState
+  final case class Run(clientId: ClientID) extends BatchCommandState
   case object Stop extends BatchCommandState
 
   implicit val equal: Eq[BatchCommandState] = Eq.fromUniversalEquals

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -397,10 +397,14 @@ trait SeqexecModelArbitraries extends ArbObservation {
         case f: RequestFailed    => Right(Right(f))
       }
 
+  implicit val seqBatchCmdRunArb: Arbitrary[BatchCommandState.Run] =  Arbitrary {
+    for {
+      clid <- arbitrary[ClientID]
+    } yield BatchCommandState.Run(clid)
+  }
+
   implicit val seqBatchCmdStateArb: Arbitrary[BatchCommandState] = Arbitrary(
-    Gen.oneOf(BatchCommandState.Idle,
-              BatchCommandState.Run,
-              BatchCommandState.Stop)
+    Gen.frequency((2, Gen.oneOf(BatchCommandState.Idle, BatchCommandState.Stop)), (1, arbitrary[BatchCommandState.Run]))
   )
 
   implicit val seqBatchCmdStateCogen: Cogen[BatchCommandState] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -20,6 +20,7 @@ import giapi.client.gpi.GPIClient
 import seqexec.engine
 import seqexec.engine.Result.{FileIdAllocated, Partial}
 import seqexec.engine.{Step => _, _}
+import seqexec.engine.Handle
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.model.events._
@@ -198,8 +199,8 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
     }
   }
 
-  private[server] def stream(p: Stream[IO, executeEngine.EventType])(s0: EngineState): Stream[IO, (executeEngine.ResultType, EngineState)] = executeEngine.process(iterateQueues)(p)(s0)
-
+  private[server] def stream(p: Stream[IO, executeEngine.EventType])(s0: EngineState): Stream[IO, (executeEngine.ResultType, EngineState)] =
+    executeEngine.process(iterateQueues)(p)(s0)
 
   def stopObserve(q: EventQueue, seqId: Observation.Id): IO[Unit] = q.enqueue1(
     Event.actionStop[executeEngine.ConcreteTypes](seqId, translator.stopObserve(seqId))
@@ -370,9 +371,9 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
   }
 
   implicit private final class ToHandle[A](f: EngineState => (EngineState, A)) {
-    import Engine.HandleToHandleP
-    def toHandle: Engine.HandleP[EngineState, Event[executeEngine.ConcreteTypes], A] =
-      StateT[IO, EngineState, A]{ st => IO(f(st)) }.toHandleP
+    import Handle.StateToHandle
+    def toHandle: Handle[EngineState, Event[executeEngine.ConcreteTypes], A] =
+      StateT[IO, EngineState, A]{ st => IO(f(st)) }.toHandle
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -253,6 +253,21 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
     Event.modifyState[executeEngine.ConcreteTypes]((moveSeq(qid, seqId, d) withEvent NullSeqEvent).toHandle)
   ).map(_.asRight)
 
+  private def runQueue(qid: QueueId, clientId: ClientID): executeEngine.HandleType[Unit] =
+    executeEngine.get.map(nextRunnableObservations(qid)).flatMap(_.map(executeEngine.start(_, clientId, {_ => true})).fold(executeEngine.unit)(_ *> _))
+
+  def startQueue(q: EventQueue, qid: QueueId, clientId: ClientID): IO[Either[SeqexecFailure, Unit]] = q.enqueue1(
+    Event.modifyState[executeEngine.ConcreteTypes](executeEngine.get.flatMap{ st => {
+      (EngineState.queues ^|-? index(qid)).getOption(st).map {
+        _.status(st) match {
+          case BatchExecState.Idle     => ((EngineState.queues ^|-? index(qid) ^|-> ExecutionQueue.cmdState).set(BatchCommandState.Run) >>> {(_, ())}).toHandle *> runQueue(qid, clientId)
+          case BatchExecState.Stopping => ((EngineState.queues ^|-? index(qid) ^|-> ExecutionQueue.cmdState).set(BatchCommandState.Run) >>> {(_, ())}).toHandle
+          case _                       => executeEngine.unit
+        }
+      }.getOrElse(executeEngine.unit)
+    }}.map(_ => StartQueue(qid, clientId)))
+  ).map(_.asRight)
+
   def notifyODB(i: (executeEngine.ResultType, EngineState)): IO[(executeEngine.ResultType, EngineState)] = {
     (i match {
       case (SystemUpdate(Failed(id, _, e), _), _) => systems.odb.obsAbort(id, e.msg)
@@ -345,10 +360,10 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
     (loads ++ unloads).toList
   }
 
-  implicit private final class ToHandle(f: EngineState => (EngineState, SeqEvent)) {
+  implicit private final class ToHandle[A](f: EngineState => (EngineState, A)) {
     import Engine.HandleToHandleP
-    val toHandle: Engine.HandleP[EngineState, Event[executeEngine.ConcreteTypes], SeqEvent] =
-      StateT[IO, EngineState, SeqEvent]{ st => IO(f(st)) }.toHandleP
+    def toHandle: Engine.HandleP[EngineState, Event[executeEngine.ConcreteTypes], A] =
+      StateT[IO, EngineState, A]{ st => IO(f(st)) }.toHandleP
   }
 
 }
@@ -659,6 +674,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     case LoadSequence(id)              => SequenceLoaded(id, svs)
     case UnloadSequence(id)            => SequenceUnloaded(id, svs)
     case NotifyUser(m, cid)            => UserNotification(m, cid)
+    case StartQueue(_, _)              => NullEvent
   }
 
   def toSeqexecEvent(ev: executeEngine.ResultType)(svs: => SequencesQueue[SequenceView]): SeqexecEvent = ev match {
@@ -694,7 +710,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     }
   }
 
-  implicit private final class WithEvent(f: Endo[EngineState]) {
+  implicit private final class WithEvent(val f: Endo[EngineState]) extends AnyVal {
     def withEvent(ev: SeqEvent): EngineState => (EngineState, SeqEvent) = f >>> {(_, ev)}
   }
   // scalastyle:on

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -145,10 +145,10 @@ package object server {
 
       if(statuses.forall(_.isCompleted)) BatchExecState.Completed
       else q.cmdState match {
-        case BatchCommandState.Idle => BatchExecState.Idle
-        case BatchCommandState.Run  => if(statuses.exists(_.isRunning)) BatchExecState.Running
+        case BatchCommandState.Idle   => BatchExecState.Idle
+        case BatchCommandState.Run(_) => if(statuses.exists(_.isRunning)) BatchExecState.Running
                                   else BatchExecState.Waiting
-        case BatchCommandState.Stop => if(statuses.exists(_.isRunning)) BatchExecState.Stopping
+        case BatchCommandState.Stop   => if(statuses.exists(_.isRunning)) BatchExecState.Stopping
                                   else BatchExecState.Idle
       }
     }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -52,6 +52,7 @@ package server {
   final case class SetSkyBackground(wv: SkyBackground, user: Option[UserDetails]) extends SeqEvent
   final case class SetCloudCover(cc: CloudCover, user: Option[UserDetails]) extends SeqEvent
   final case class NotifyUser(memo: Notification, clientID: ClientID) extends SeqEvent
+  final case class StartQueue(qid: QueueId, clientID: ClientID) extends SeqEvent
   case object NullSeqEvent extends SeqEvent
 
   sealed trait ControlStrategy

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -14,7 +14,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 import org.scalatest.Inside.inside
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers, NonImplicitAssertions}
 import org.http4s.Uri._
 
 import scala.concurrent.duration._
@@ -24,7 +24,7 @@ import seqexec.engine.Result.PauseContext
 import seqexec.engine._
 import seqexec.server.SeqexecEngine.Settings
 import seqexec.server.keywords.GDSClient
-import seqexec.model.{ExecutionQueue, Conditions, Observer, Operator, SequenceState}
+import seqexec.model.{Conditions, ExecutionQueue, Observer, Operator, SequenceState}
 import seqexec.model.enum.{ActionStatus, CloudCover, ImageQuality, Instrument, Resource, SkyBackground, WaterVapor}
 import seqexec.model.{ActionType, UserDetails}
 import seqexec.model.enum.Resource.TCS
@@ -33,7 +33,7 @@ import seqexec.model.enum.BatchCommandState
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-class SeqexecEngineSpec extends FlatSpec with Matchers {
+class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertions {
   private val defaultSettings = Settings(Site.GS,
     odbHost = "localhost",
     date = LocalDate.of(2017, 1, 1),
@@ -178,10 +178,10 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
   private val sm = SeqexecMetrics.build[IO](Site.GS, new CollectorRegistry()).unsafeRunSync
   private val seqexecEngine = SeqexecEngine(GDSClient.alwaysOkClient, defaultSettings, sm)
   private def advanceOne(q: EventQueue, s0: EngineState, put: IO[Either[SeqexecFailure, Unit]]): IO[Option[EngineState]] =
-    (put *> executeEngine.process(PartialFunction.empty)(q.dequeue)(s0).take(1).compile.last).map(_.map(_._2))
+    (put *> seqexecEngine.stream(q.dequeue)(s0).take(1).compile.last).map(_.map(_._2))
 
   private def advanceN(q: EventQueue, s0: EngineState, put: IO[Either[SeqexecFailure, Unit]], n: Long): IO[Option[EngineState]] =
-    (put *> executeEngine.process(PartialFunction.empty)(q.dequeue)(s0).take(n).compile.last).map(_.map(_._2))
+    (put *> seqexecEngine.stream(q.dequeue)(s0).take(n).compile.last).map(_.map(_._2))
 
   private val seqId1 = "GS-2018B-Q-0-1"
   private val seqObsId1 = Observation.Id.unsafeFromString(seqId1)
@@ -371,6 +371,24 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
     val r = SeqexecEngine.nextRunnableObservations(CalibrationQueueId)(s0)
 
     assert(r.isEmpty)
+  }
+
+  "SeqexecEngine startQueue" should "run sequences in queue" in {
+    // seqObsId1 and seqObsId2 can be run immediately, but seqObsId3 must be run after seqObsId1
+    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1, Set(Instrument.F2))) >>>
+          SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2, Set(Instrument.GmosS))) >>>
+          SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3, Set(Instrument.F2))) >>>
+          (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
+
+    def testCompleted(oid: Observation.Id)(st: EngineState): Boolean = st.executionState.sequences.get(oid).map(_.status.isCompleted).getOrElse(false)
+
+    (for {
+      q <- async.boundedQueue[IO, executeEngine.EventType](10)
+      _ <- seqexecEngine.startQueue(q, CalibrationQueueId, UUID.randomUUID)
+      sf <- seqexecEngine.stream(q.dequeue)(s0).map(_._2).takeThrough(_.executionState.sequences.values.exists(_.status.isRunning)).compile.last
+    } yield inside(sf) {
+      case Some(s) => assert(testCompleted(seqObsId1)(s) && testCompleted(seqObsId2)(s) && testCompleted(seqObsId3)(s))
+    } ).unsafeRunSync
   }
 
   "SeqexecEngine setOperator" should "set operator's name" in {

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -178,10 +178,10 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
   private val sm = SeqexecMetrics.build[IO](Site.GS, new CollectorRegistry()).unsafeRunSync
   private val seqexecEngine = SeqexecEngine(GDSClient.alwaysOkClient, defaultSettings, sm)
   private def advanceOne(q: EventQueue, s0: EngineState, put: IO[Either[SeqexecFailure, Unit]]): IO[Option[EngineState]] =
-    (put *> executeEngine.process(q.dequeue)(s0).take(1).compile.last).map(_.map(_._2))
+    (put *> executeEngine.process(PartialFunction.empty)(q.dequeue)(s0).take(1).compile.last).map(_.map(_._2))
 
   private def advanceN(q: EventQueue, s0: EngineState, put: IO[Either[SeqexecFailure, Unit]], n: Long): IO[Option[EngineState]] =
-    (put *> executeEngine.process(q.dequeue)(s0).take(n).compile.last).map(_.map(_._2))
+    (put *> executeEngine.process(PartialFunction.empty)(q.dequeue)(s0).take(n).compile.last).map(_.map(_._2))
 
   private val seqId1 = "GS-2018B-Q-0-1"
   private val seqObsId1 = Observation.Id.unsafeFromString(seqId1)
@@ -282,7 +282,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers {
     val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
       SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).modify(_ ++ List(seqObsId1, seqObsId2)) >>>
-      (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.cmdState).set(BatchCommandState.Run) >>>
+      (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.cmdState).set(BatchCommandState.Run(java.util.UUID.randomUUID())) >>>
       (EngineState.executionState ^|-? Engine.State.sequenceState(seqObsId1) ^|-> Sequence.State.status).set(SequenceState.Running.init))(EngineState.default)
 
     (for {

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -106,7 +106,7 @@ trait ModelBooPicklers extends GemModelBooPicklers {
 
   implicit val batchCommandPickler = compositePickler[BatchCommandState]
     .addConcreteType[BatchCommandState.Idle.type]
-    .addConcreteType[BatchCommandState.Run.type]
+    .addConcreteType[BatchCommandState.Run]
     .addConcreteType[BatchCommandState.Stop.type]
 
   implicit val executionQueuePickler = generatePickler[ExecutionQueue]


### PR DESCRIPTION
Running the calibration queue means that at any point in time after the user commanded to run the queue, if any sequence in the queue can be run, it must be running.
When the command arrives, every sequence in the queue that can be run (minding resource usage) is started. Then, whenever a sequence finishes and frees resources, the check is repeated.