### PR TITLE
Pause operation

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/reusability.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/reusability.scala
@@ -15,6 +15,7 @@ import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.SectionVisibilityState
 import seqexec.web.client.model.UserNotificationState
 import seqexec.web.client.model.WebSocketConnection
+import seqexec.web.client.model.PauseOperation
 import seqexec.web.client.model.RunOperation
 import seqexec.web.client.model.SyncOperation
 import seqexec.web.client.model.TabSelected
@@ -44,6 +45,7 @@ package object reusability {
   implicit val webSCeuse: Reusability[WebSocketConnection]     = Reusability.by(_.ws.state)
   implicit val runOperationReuse: Reusability[RunOperation]    = Reusability.byRef
   implicit val syncOperationReuse: Reusability[SyncOperation]  = Reusability.byRef
+  implicit val psOperationReuse: Reusability[PauseOperation]   = Reusability.byRef
   implicit val availableTabsReuse: Reusability[AvailableTab]   = Reusability.byEq
   implicit val userDetailsReuse: Reusability[UserDetails]      = Reusability.byEq
   implicit val usrNotReuse: Reusability[UserNotificationState] = Reusability.byEq

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
@@ -27,18 +27,31 @@ object SyncOperation {
 
 }
 
+sealed trait PauseOperation extends Product with Serializable
+object PauseOperation {
+  case object PauseInFlight extends PauseOperation
+  case object PauseIdle extends PauseOperation
+
+  implicit val eq: Eq[PauseOperation] =
+    Eq.fromUniversalEquals
+
+}
+
 /**
   * Hold transient states while excuting an operation
   */
 @Lenses
-final case class TabOperations(runRequested:  RunOperation,
-                               syncRequested: SyncOperation)
+final case class TabOperations(runRequested:   RunOperation,
+                               syncRequested:  SyncOperation,
+                               pauseRequested: PauseOperation)
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object TabOperations {
   implicit val eq: Eq[TabOperations] =
-    Eq.by(x => (x.runRequested, x.syncRequested))
+    Eq.by(x => (x.runRequested, x.syncRequested, x.pauseRequested))
 
   val Default: TabOperations =
-    TabOperations(RunOperation.RunIdle, SyncOperation.SyncIdle)
+    TabOperations(RunOperation.RunIdle,
+                  SyncOperation.SyncIdle,
+                  PauseOperation.PauseIdle)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -272,12 +272,14 @@ package circuit {
       Eq.by(x => (x.status, x.stepsTable, x.configTableState))
   }
 
+  @Lenses
   final case class ControlModel(id:                  Observation.Id,
                                 isPartiallyExecuted: Boolean,
                                 nextStepToRun:       Option[Int],
                                 status:              SequenceState,
                                 tabOperations:       TabOperations)
 
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object ControlModel {
     implicit val eq: Eq[ControlModel] =
       Eq.by(
@@ -298,9 +300,11 @@ package circuit {
                            t.tabOperations)))
   }
 
+  @Lenses
   final case class SequenceControlFocus(canOperate: Boolean,
                                         control:    Option[ControlModel])
 
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object SequenceControlFocus {
     implicit val eq: Eq[SequenceControlFocus] =
       Eq.by(x => (x.canOperate, x.control))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/OperationsStateHandler.scala
@@ -11,6 +11,7 @@ import diode.ModelRW
 import scala.concurrent.Future
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 import seqexec.model.RequestFailed
+import seqexec.web.client.model.PauseOperation
 import seqexec.web.client.model.SyncOperation
 import seqexec.web.client.model.RunOperation
 import seqexec.web.client.model.SequencesOnDisplay
@@ -35,6 +36,12 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
         value.markOperations(
           id,
           TabOperations.syncRequested.set(SyncOperation.SyncInFlight)))
+
+    case RequestPause(id) =>
+      updated(
+        value.markOperations(
+          id,
+          TabOperations.pauseRequested.set(PauseOperation.PauseInFlight)))
   }
 
   def handleOperationResult: PartialFunction[Any, ActionResult[M]] = {
@@ -54,6 +61,15 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
       updated(value.markOperations(
                 id,
                 TabOperations.syncRequested.set(SyncOperation.SyncIdle)),
+              notification)
+
+    case RunPauseFailed(id) =>
+      val msg = s"Failed to pause sequence ${id.format}"
+      val notification = Effect(
+        Future(RequestFailedNotification(RequestFailed(msg))))
+      updated(value.markOperations(
+                id,
+                TabOperations.pauseRequested.set(PauseOperation.PauseIdle)),
               notification)
   }
 

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -62,17 +62,24 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val soCogen: Cogen[SyncOperation] =
     Cogen[String].contramap(_.productPrefix)
 
+  implicit val arbPauseOperation: Arbitrary[PauseOperation] =
+    Arbitrary(Gen.oneOf(PauseOperation.PauseIdle, PauseOperation.PauseInFlight))
+
+  implicit val poCogen: Cogen[PauseOperation] =
+    Cogen[String].contramap(_.productPrefix)
+
   implicit val arbTabOperations: Arbitrary[TabOperations] =
     Arbitrary {
       for {
         r <- arbitrary[RunOperation]
         s <- arbitrary[SyncOperation]
-      } yield TabOperations(r, s)
+        p <- arbitrary[PauseOperation]
+      } yield TabOperations(r, s, p)
     }
 
   implicit val toCogen: Cogen[TabOperations] =
-    Cogen[(RunOperation, SyncOperation)].contramap(x =>
-      (x.runRequested, x.syncRequested))
+    Cogen[(RunOperation, SyncOperation, PauseOperation)].contramap(x =>
+      (x.runRequested, x.syncRequested, x.pauseRequested))
 
   implicit val arbCalibrationQueueTab: Arbitrary[CalibrationQueueTab] =
     Arbitrary {


### PR DESCRIPTION
I've been refactoring the client side handling of remote requests to reduce the reliance on booleans and properly handle remote errors.

This time is pause:
![seqexec - gs-2018b-q-0-13 2018-10-01 12-03-02](https://user-images.githubusercontent.com/3615303/46297016-1390cb00-c572-11e8-9aca-46fc0295edf2.png)
