### PR TITLE
Refactoring of sequence extracting lenses

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTableContainer.scala
@@ -5,7 +5,9 @@ package seqexec.web.client.components.sequence.steps
 
 import diode.react.ReactConnectProxy
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{ CallbackTo, CatsReact, ScalaComponent }
+import japgolly.scalajs.react.CallbackTo
+import japgolly.scalajs.react.CatsReact
+import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
@@ -34,10 +36,10 @@ object StepsTableContainer {
     ST.set(State(step)).liftCB
 
   def toolbar(p: Props): VdomElement = {
-    val loggedIn            = p.statusAndStep.isLogged
+    val canOperate          = p.statusAndStep.canOperate
     val stepConfigDisplayed = p.statusAndStep.stepConfigDisplayed.isDefined
     val isPreview           = p.statusAndStep.isPreview
-    val showDefault         = loggedIn && !stepConfigDisplayed && !isPreview
+    val showDefault         = canOperate && !stepConfigDisplayed && !isPreview
 
     <.div(
       SequenceDefaultToolbar(
@@ -51,7 +53,8 @@ object StepsTableContainer {
                                     s,
                                     p.statusAndStep.totalSteps,
                                     isPreview)).when(stepConfigDisplayed)
-        }.getOrElse(TagMod.empty)
+        }
+        .getOrElse(TagMod.empty)
     )
   }
 
@@ -62,12 +65,13 @@ object StepsTableContainer {
       <.div(
         ^.height := "100%",
         toolbar(p),
-        p.stepsConnect(r =>
-          StepsTable(
-            StepsTable.Props(p.router,
-                             p.statusAndStep.isLogged,
-                             r(),
-                             x => $.runState(updateStepToRun(x)))))
+        p.stepsConnect(
+          r =>
+            StepsTable(
+              StepsTable.Props(p.router,
+                               p.statusAndStep.canOperate,
+                               r(),
+                               x => $.runState(updateStepToRun(x)))))
       )
     }
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -3,7 +3,6 @@
 
 package seqexec.web.client.components.sequence.toolbars
 
-import diode.react.ModelProxy
 import diode.react.ReactConnectProxy
 import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -247,8 +246,8 @@ object SequenceControl {
       }
       .build
 
-  def apply(p: ModelProxy[SequenceControlFocus]): Unmounted[Props, State, Unit] =
-    component(Props(p()))
+  def apply(p: Props): Unmounted[Props, State, Unit] =
+    component(p)
 }
 
 /**
@@ -256,9 +255,9 @@ object SequenceControl {
   */
 object SequenceDefaultToolbar {
   final case class Props(id: Observation.Id) {
-    val observerReader: ReactConnectProxy[SequenceInfoFocus] =
+    val observerReader: ReactConnectProxy[Option[SequenceInfoFocus]] =
       SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(id))
-    val controlReader: ReactConnectProxy[SequenceControlFocus] =
+    val controlReader: ReactConnectProxy[Option[SequenceControlFocus]] =
       SeqexecCircuit.connect(SeqexecCircuit.sequenceControlReader(id))
   }
 
@@ -273,12 +272,19 @@ object SequenceDefaultToolbar {
           SeqexecStyles.shorterRow,
           <.div(
             ^.cls := "ui left floated column eight wide computer eight wide tablet only",
-            p.controlReader(SequenceControl.apply)
+            p.controlReader(_() match {
+                case Some(c) => SequenceControl(SequenceControl.Props(c))
+                case _       => ReactFragment()
+              }
+            )
           ),
           <.div(
             ^.cls := "ui right floated column",
             SeqexecStyles.infoOnControl,
-            p.observerReader(p => SequenceInfo(SequenceInfo.Props(p)))
+            p.observerReader(_() match {
+              case Some(p) => SequenceInfo(SequenceInfo.Props(p))
+              case _       => ReactFragment()
+            })
           )
         )
     ))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
@@ -8,48 +8,61 @@ import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.semanticui.elements.label.Label
 import seqexec.web.client.semanticui.elements.icon.Icon.IconCheckmark
 import seqexec.web.client.semanticui.Size
-import seqexec.model.{ SequenceState, DaytimeCalibrationTargetName }
+import seqexec.model.SequenceState
+import seqexec.model.DaytimeCalibrationTargetName
 import web.client.style._
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import diode.react.ModelProxy
 import cats.implicits._
 
 /**
   * Display the name of the sequence and the observer
   */
 object SequenceInfo {
-  final case class Props(p: ModelProxy[SequenceInfoFocus])
+  final case class Props(p: SequenceInfoFocus)
 
-  private def component = ScalaComponent.builder[Props]("SequenceInfo")
-    .stateless
-    .render_P { p =>
-      val SequenceInfoFocus(isLogged, oName, status, tName) = p.p()
-      val obsName = oName.filter(_.nonEmpty).getOrElse("Unknown.")
-      val daytimeCalibrationTargetName: TagMod =
-        Label(Label.Props(DaytimeCalibrationTargetName, basic = true, extraStyles = List(SeqexecStyles.daytimeCal)))
-      val targetName = tName.filter(_.nonEmpty).fold(daytimeCalibrationTargetName)(t => Label(Label.Props(t, basic = true)))
-      <.div(
-        ^.cls := "ui form",
+  private def component =
+    ScalaComponent
+      .builder[Props]("SequenceInfo")
+      .stateless
+      .render_P { p =>
+        val SequenceInfoFocus(isLogged, oName, status, tName) = p.p
+        val obsName                                           = oName.filter(_.nonEmpty).getOrElse("Unknown.")
+        val daytimeCalibrationTargetName: TagMod =
+          Label(
+            Label.Props(DaytimeCalibrationTargetName,
+                        basic       = true,
+                        extraStyles = List(SeqexecStyles.daytimeCal)))
+        val targetName = tName
+          .filter(_.nonEmpty)
+          .fold(daytimeCalibrationTargetName)(t =>
+            Label(Label.Props(t, basic = true)))
         <.div(
-          ^.cls := "fields",
-          SeqexecStyles.fieldsNoBottom,
+          ^.cls := "ui form",
           <.div(
-            ^.cls := "field",
-            Label(Label.Props("Sequence Complete", color = "green".some, icon = IconCheckmark.some, size = Size.Big))
-          ).when(status.forall(_ === SequenceState.Completed)),
-          <.div(
-            ^.cls := "field",
-            Label(Label.Props(obsName, basic = true))
-          ).when(isLogged),
-          <.div(
-            ^.cls := "field",
-            targetName
-          ).when(isLogged)
+            ^.cls := "fields",
+            SeqexecStyles.fieldsNoBottom,
+            <.div(
+              ^.cls := "field",
+              Label(
+                Label.Props("Sequence Complete",
+                            color = "green".some,
+                            icon  = IconCheckmark.some,
+                            size  = Size.Big))
+            ).when(status.forall(_ === SequenceState.Completed)),
+            <.div(
+              ^.cls := "field",
+              Label(Label.Props(obsName, basic = true))
+            ).when(isLogged),
+            <.div(
+              ^.cls := "field",
+              targetName
+            ).when(isLogged)
+          )
         )
-      )
-    }.build
+      }
+      .build
 
   def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -13,12 +13,14 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import seqexec.model.enum.Instrument
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.model.RunningStep
-import seqexec.web.client.circuit.{ SeqexecCircuit, SequenceInfoFocus }
+import seqexec.web.client.circuit.SeqexecCircuit
+import seqexec.web.client.circuit.SequenceInfoFocus
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.semanticui.elements.button.ButtonGroup
 import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.button.Button._
-import seqexec.web.client.semanticui.elements.icon.Icon.{IconChevronLeft, IconChevronRight}
+import seqexec.web.client.semanticui.elements.icon.Icon.IconChevronLeft
+import seqexec.web.client.semanticui.elements.icon.Icon.IconChevronRight
 import seqexec.web.client.semanticui.elements.label.Label
 import seqexec.web.client.semanticui.Size
 import web.client.style._
@@ -28,12 +30,18 @@ import mouse.boolean._
   * Toolbar when displaying a step configuration
   */
 object StepConfigToolbar {
-  final case class Props(router: RouterCtl[SeqexecPages], instrument: Instrument, id: Observation.Id, step: Int, total: Int, isPreview: Boolean) {
-    val sequenceConnect: ReactConnectProxy[SequenceInfoFocus] =
+  final case class Props(router:     RouterCtl[SeqexecPages],
+                         instrument: Instrument,
+                         id:         Observation.Id,
+                         step:       Int,
+                         total:      Int,
+                         isPreview:  Boolean) {
+    val sequenceConnect: ReactConnectProxy[Option[SequenceInfoFocus]] =
       SeqexecCircuit.connect(SeqexecCircuit.sequenceObserverReader(id))
   }
 
-  private val component = ScalaComponent.builder[Props]("StepConfigToolbar")
+  private val component = ScalaComponent
+    .builder[Props]("StepConfigToolbar")
     .stateless
     .render_P { p =>
       val sequencePage = if (p.isPreview) {
@@ -54,40 +62,56 @@ object StepConfigToolbar {
 
       <.div(
         ^.cls := "ui grid",
-      <.div(
-        ^.cls := "ui row three column",
-        SeqexecStyles.shorterRow,
         <.div(
-          ^.cls := "ui left floated two wide column",
-          SeqexecStyles.shorterFields,
-          // Back to sequence button
-          p.router.link(sequencePage)
-            (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = p.router.setUrlAndDispatchCB(sequencePage)), "Back"))
-        ),
-        <.div(
-          ^.cls := "left floated six wide column bottom aligned computer only",
-          p.sequenceConnect(p => SequenceInfo(SequenceInfo.Props(p)))
-        ),
-        <.div(
-          ^.cls := "ui right floated eight wide column",
-          SeqexecStyles.shorterFields,
-          ButtonGroup(
-            ButtonGroup.Props(List(GStyle.fromString("right floated"))),
-            // Previous step button
-            (p.step > 0).option(p.router.link(prevStepPage)
-              (Button(Button.Props(icon = Some(IconChevronLeft), labeled = LeftLabeled, onClick = p.router.setUrlAndDispatchCB(prevStepPage)), "Prev"))),
-            Label(Label.Props(
-              RunningStep(p.step, p.total).show,
-              size = Size.Large,
-              extraStyles = List(SeqexecStyles.labelAsButton))),
-            // Next step button
-            (p.step < p.total - 1).option(p.router.link(nextStepPage)
-              (Button(Button.Props(icon = Some(IconChevronRight), labeled = RightLabeled, onClick = p.router.setUrlAndDispatchCB(nextStepPage)), "Next")))
+          ^.cls := "ui row three column",
+          SeqexecStyles.shorterRow,
+          <.div(
+            ^.cls := "ui left floated two wide column",
+            SeqexecStyles.shorterFields,
+            // Back to sequence button
+            p.router.link(sequencePage)(
+              Button(Button.Props(icon    = Some(IconChevronLeft),
+                                  labeled = LeftLabeled,
+                                  onClick =
+                                    p.router.setUrlAndDispatchCB(sequencePage)),
+                     "Back"))
+          ),
+          <.div(
+            ^.cls := "left floated six wide column bottom aligned computer only",
+            p.sequenceConnect(_() match {
+              case Some(p) => SequenceInfo(SequenceInfo.Props(p))
+              case _       => ReactFragment()
+            })
+          ),
+          <.div(
+            ^.cls := "ui right floated eight wide column",
+            SeqexecStyles.shorterFields,
+            ButtonGroup(
+              ButtonGroup.Props(List(GStyle.fromString("right floated"))),
+              // Previous step button
+              (p.step > 0).option(
+                p.router.link(prevStepPage)(
+                  Button(Button.Props(icon    = Some(IconChevronLeft),
+                                      labeled = LeftLabeled,
+                                      onClick = p.router.setUrlAndDispatchCB(
+                                        prevStepPage)), "Prev"))),
+              Label(
+                Label.Props(RunningStep(p.step, p.total).show,
+                            size        = Size.Large,
+                            extraStyles = List(SeqexecStyles.labelAsButton))),
+              // Next step button
+              (p.step < p.total - 1).option(
+                p.router.link(nextStepPage)(
+                  Button(Button.Props(icon    = Some(IconChevronRight),
+                                      labeled = RightLabeled,
+                                      onClick = p.router.setUrlAndDispatchCB(
+                                        nextStepPage)), "Next")))
             )
           )
         )
       )
-    }.build
+    }
+    .build
 
   def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -395,17 +395,13 @@ object SequencesOnDisplay {
   def loadingL(id: Observation.Id): Traversal[SequencesOnDisplay, Boolean] =
     SequencesOnDisplay.previewTabById(id) ^|-> PreviewSequenceTab.isLoading
 
-  def tabG(id: Observation.Id): Getter[SequencesOnDisplay, SeqexecTabActive] =
+  def tabG(id: Observation.Id): Getter[SequencesOnDisplay, Option[SeqexecTabActive]] =
     SequencesOnDisplay.tabs.asGetter >>> {
-      _.withFocus.toList
-        .collect {
-          case (i: SequenceTab, a) if i.obsId.exists(_ === id) =>
-            val selected =
-              if (a) TabSelected.Selected else TabSelected.Background
-            SeqexecTabActive(i, selected)
-        }
-        .headOption
-        // Returning the getOrElse part shouldn't happen but it simplifies the model not carrying the Option up
-        .getOrElse(SeqexecTabActive.Empty)
+      _.withFocus.toList.collect {
+        case (i: SequenceTab, a) if i.obsId.exists(_ === id) =>
+          val selected =
+            if (a) TabSelected.Selected else TabSelected.Background
+          SeqexecTabActive(i, selected)
+      }.headOption
     }
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -146,17 +146,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
       (x.currentSequence, x.stepConfig, x.tableState, x.tabOperations)
     }
 
-  implicit val arbEmptySequenceTab: Arbitrary[EmptySequenceTab.type] =
-    Arbitrary {
-      Gen.const(EmptySequenceTab)
-    }
-
-  implicit val estCogen: Cogen[EmptySequenceTab.type] =
-    Cogen[Boolean].contramap {
-      case _: EmptySequenceTab.type => true
-      case _                        => false
-    }
-
   implicit val arbSeqexecTab: Arbitrary[SeqexecTab] = Arbitrary {
     Gen.frequency(10 -> arbitrary[InstrumentSequenceTab],
                   1 -> arbitrary[PreviewSequenceTab],
@@ -165,13 +154,11 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
 
   implicit val sxCogen: Cogen[SeqexecTab] =
     Cogen[Either[CalibrationQueueTab,
-                 Either[PreviewSequenceTab,
-                        Either[InstrumentSequenceTab, EmptySequenceTab.type]]]]
+                 Either[PreviewSequenceTab, InstrumentSequenceTab]]]
       .contramap {
         case a: CalibrationQueueTab   => Left(a)
         case a: PreviewSequenceTab    => Right(Left(a))
-        case a: InstrumentSequenceTab => Right(Right(Left(a)))
-        case a: EmptySequenceTab.type => Right(Right(Right(a)))
+        case a: InstrumentSequenceTab => Right(Right(a))
       }
 
   implicit val arbSequenceTab: Arbitrary[SequenceTab] = Arbitrary {
@@ -180,12 +167,10 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   }
 
   implicit val stCogen: Cogen[SequenceTab] =
-    Cogen[Either[PreviewSequenceTab,
-                 Either[InstrumentSequenceTab, EmptySequenceTab.type]]]
+    Cogen[Either[PreviewSequenceTab, InstrumentSequenceTab]]
       .contramap {
         case a: PreviewSequenceTab    => Left(a)
-        case a: InstrumentSequenceTab => Right(Left(a))
-        case a: EmptySequenceTab.type => Right(Right(a))
+        case a: InstrumentSequenceTab => Right(a)
       }
 
   implicit val arbSequenceOnDisplay: Arbitrary[SequencesOnDisplay] =
@@ -265,8 +250,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     Arbitrary {
       for {
         ws <- arbitrary[Pot[WebSocket]]
-        a <- arbitrary[Int]
-        r <- arbitrary[Boolean]
+        a  <- arbitrary[Int]
+        r  <- arbitrary[Boolean]
       } yield WebSocketConnection(ws, a, r)
     }
 
@@ -452,7 +437,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val sifCogen: Cogen[SequenceInfoFocus] =
     Cogen[(Boolean, Option[String], Option[SequenceState], Option[TargetName])]
       .contramap { x =>
-        (x.isLogged, x.obsName, x.status, x.targetName)
+        (x.canOperate, x.obsName, x.status, x.targetName)
       }
 
   implicit val arbPreviewPage: Arbitrary[PreviewPage] =


### PR DESCRIPTION
I've been trying to simplify the client side model removing some shorcuts and relying more on lenses as possible

This in one of those refactorings to remove a kludge to avoid `Option` in certain cases, but it was kind of cheating