### PR TITLE
SEQNG-564: Add button to send day cal sequences to the calibration queue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -376,6 +376,7 @@ lazy val web_client_common = project
       ScalaJSDom.value,
       JQuery.value,
       ScalaJSReactVirtualized.value,
+      ScalaJSReactSortable.value,
       ScalaJSReactDraggable.value) ++ ReactScalaJS.value ++ Monocle.value
   )
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/package.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/package.scala
@@ -21,4 +21,8 @@ package object model {
   implicit val stEq: Eq[StepConfig]     = Eq.fromUniversalEquals
   implicit val clientIdEq: Eq[ClientID] = Eq.fromUniversalEquals
   val DaytimeCalibrationTargetName      = "Daytime calibration"
+
+  val CalibrationQueueName: String = "Calibration Queue"
+  val CalibrationQueueId: ClientID = UUID.fromString("7156fa7e-48a6-49d1-a267-dbf3bbaa7577")
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -15,7 +15,6 @@ import edu.gemini.spModel.`type`.SequenceableSpType
 import edu.gemini.spModel.guide.StandardGuideOptions
 import fs2.async.mutable.Queue
 import gem.Observation
-import java.util.UUID
 import monocle.macros.Lenses
 import monocle.Lens
 import monocle.macros.GenLens
@@ -23,6 +22,8 @@ import monocle.function.At.at
 import monocle.function.At.atMap
 import seqexec.engine.Engine
 import seqexec.model.ClientID
+import seqexec.model.CalibrationQueueId
+import seqexec.model.CalibrationQueueName
 import seqexec.model.ExecutionQueue
 import seqexec.model.QueueId
 import seqexec.model.Conditions
@@ -98,9 +99,6 @@ package object server {
 
   implicit val sgoEq: Eq[StandardGuideOptions.Value] =
     Eq[Int].contramap(_.ordinal())
-
-  val CalibrationQueueName: String = "Calibration Queue"
-  val CalibrationQueueId: UUID = UUID.fromString("7156fa7e-48a6-49d1-a267-dbf3bbaa7577")
 
   type TrySeq[A] = Either[SeqexecFailure, A]
   type ApplicativeErrorSeq[F[_]] = ApplicativeError[F, SeqexecFailure]

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -25,6 +25,7 @@ import seqexec.engine._
 import seqexec.server.SeqexecEngine.Settings
 import seqexec.server.keywords.GDSClient
 import seqexec.model.{Conditions, ExecutionQueue, Observer, Operator, SequenceState}
+import seqexec.model.CalibrationQueueId
 import seqexec.model.enum.{ActionStatus, CloudCover, ImageQuality, Instrument, Resource, SkyBackground, WaterVapor}
 import seqexec.model.{ActionType, UserDetails}
 import seqexec.model.enum.Resource.TCS

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/QueueTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/QueueTabContent.scala
@@ -10,8 +10,10 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import seqexec.web.client.semanticui._
 import seqexec.web.client.semanticui.elements.message.IconMessage
 import seqexec.web.client.semanticui.elements.icon.Icon.IconInbox
-import seqexec.web.client.model.{ SectionClosed, SectionOpen }
-import seqexec.web.client.model.{ SectionVisibilityState, TabSelected }
+import seqexec.web.client.model.SectionClosed
+import seqexec.web.client.model.SectionOpen
+import seqexec.web.client.model.SectionVisibilityState
+import seqexec.web.client.model.TabSelected
 import seqexec.web.client.components.SeqexecStyles
 import web.client.style._
 
@@ -30,18 +32,25 @@ object QueueTabContent {
     .builder[Props]("QueueTabContent")
     .stateless
     .render_P { p =>
-      <.div(
-        ^.cls := "ui attached secondary segment tab",
-        ^.classSet(
-          "active" -> (p.active === TabSelected.Selected)
-        ),
-        dataTab := "daycal",
-        SeqexecStyles.emptyInstrumentTab,
-        SeqexecStyles.emptyInstrumentTabLogShown
-          .when(p.logDisplayed =!= SectionOpen),
-        SeqexecStyles.emptyInstrumentTabLogHidden
-          .when(p.logDisplayed =!= SectionClosed),
-        defaultContent
+      ReactFragment(
+        // <.div(
+        //   ^.height := "100%",
+        <.div(
+          ^.cls := "ui attached secondary segment tab",
+          ^.classSet(
+            "active" -> (p.active === TabSelected.Selected)
+          ),
+          dataTab := "daycal",
+          SeqexecStyles.emptyInstrumentTab,
+          SeqexecStyles.emptyInstrumentTabLogShown
+            .when(p.logDisplayed =!= SectionOpen),
+          SeqexecStyles.emptyInstrumentTabLogHidden
+            .when(p.logDisplayed =!= SectionClosed),
+          <.div(
+            QueueToolbar.Props().cmp,
+            defaultContent
+          )
+        )
       )
     }
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/QueueToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/QueueToolbar.scala
@@ -3,50 +3,65 @@
 
 package seqexec.web.client.components.queue
 
-// import diode.react.ReactConnectProxy
-// import cats.implicits._
+import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
-// import japgolly.scalajs.react.CallbackTo
+import japgolly.scalajs.react.CallbackTo
 import japgolly.scalajs.react.ScalaComponent
-// import japgolly.scalajs.react.CatsReact
-// import japgolly.scalajs.react.CatsReact._
+import japgolly.scalajs.react.CatsReact
+import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.component.Scala.Unmounted
-// import japgolly.scalajs.react.extra.Reusability
-// import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
-// import gem.Observation
-// import mouse.all._
-// import seqexec.model.SequenceState
-// import seqexec.web.client.circuit._
-// import seqexec.web.client.actions.RequestCancelPause
-// import seqexec.web.client.actions.RequestPause
-// import seqexec.web.client.actions.RequestSync
-// import seqexec.web.client.actions.RequestRun
-// import seqexec.web.client.model.RunOperation
-// import seqexec.web.client.model.PauseOperation
-// import seqexec.web.client.model.SyncOperation
+import japgolly.scalajs.react.extra.Reusability
+import monocle.macros.Lenses
+import seqexec.model.QueueId
+import seqexec.web.client.circuit._
+import seqexec.web.client.actions.RequestAllDayCal
+import seqexec.web.client.model.AddDayCalOperation
+import seqexec.web.client.model.QueueOperations
 import seqexec.web.client.components.SeqexecStyles
-// import seqexec.web.client.semanticui.elements.icon.Icon
-// import seqexec.web.client.semanticui.elements.icon.Icon.IconRefresh
+import seqexec.web.client.semanticui.elements.icon.Icon.IconRefresh
 import seqexec.web.client.semanticui.elements.icon.Icon.IconCloneOutline
 import seqexec.web.client.semanticui.controlButton
-// import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
-// import seqexec.web.client.semanticui.elements.icon.Icon.IconBan
-// import seqexec.web.client.reusability._
+import seqexec.web.client.reusability._
 import web.client.style._
 
 /**
   * Toolbar for logged in users
   */
 object QueueToolbar {
-  final case class Props() {
-    def cmp: Unmounted[Props, Unit, Unit] = component(this)
+  final case class Props(queueId: QueueId, control: QueueControlFocus) {
+    def cmp: Unmounted[Props, State, Unit] = component(this)
   }
+
+  @Lenses
+  final case class State(ops: QueueOperations) {
+    def requestAddDayCal: State =
+      (State.ops ^|-> QueueOperations.addDayCalRequested)
+        .set(AddDayCalOperation.AddDayCalInFlight)(this)
+
+    val addDayCalRunning: Boolean =
+      ops.addDayCalRequested === AddDayCalOperation.AddDayCalInFlight
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object State {
+    val Zero: State = State(ops = QueueOperations.Default)
+  }
+
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+  implicit val stateReuse: Reusability[State] = Reusability.derive[State]
+
+  private val ST = ReactS.Fix[State]
+
+  def allDayCal(id: QueueId): CatsReact.ReactST[CallbackTo, State, Unit] =
+    ST.retM(SeqexecCircuit.dispatchCB(RequestAllDayCal(id))) >>
+      ST.mod(_.requestAddDayCal).liftCB
 
   private val component = ScalaComponent
     .builder[Props]("QueueToolbar")
-    .stateless
-    .render_P(p =>
+    .initialState(State.Zero)
+    .renderPS{(b, p, s) =>
+      val canOperate = p.control.canOperate
       <.div(
         ^.cls := "ui grid",
         <.div(
@@ -55,16 +70,24 @@ object QueueToolbar {
           <.div(
             ^.cls := "ui left floated column",
             controlButton(
-              icon     = IconCloneOutline,
+              icon =
+                if (s.addDayCalRunning) IconRefresh.copyIcon(loading = true)
+                else IconCloneOutline,
               color    = "blue",
-              onClick  = Callback.empty,
-              disabled = false,
+              onClick  = b.runState(allDayCal(p.queueId)),
+              disabled = !canOperate || s.addDayCalRunning,
               tooltip  = "Add all daytime calibrations on the session queue",
               text     = "Add all day cal"
             )
           )
         )
-    ))
+    )}
+    .componentWillReceiveProps { f =>
+      // Update state of operations
+      Callback.when(f.nextProps.control.ops =!= f.state.ops)(
+        f.modState(_.copy(ops = f.nextProps.control.ops)))
+    }
+    .configure(Reusability.shouldComponentUpdate)
     .build
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/QueueToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/QueueToolbar.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components.queue
+
+// import diode.react.ReactConnectProxy
+// import cats.implicits._
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.Callback
+// import japgolly.scalajs.react.CallbackTo
+import japgolly.scalajs.react.ScalaComponent
+// import japgolly.scalajs.react.CatsReact
+// import japgolly.scalajs.react.CatsReact._
+import japgolly.scalajs.react.component.Scala.Unmounted
+// import japgolly.scalajs.react.extra.Reusability
+// import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
+// import gem.Observation
+// import mouse.all._
+// import seqexec.model.SequenceState
+// import seqexec.web.client.circuit._
+// import seqexec.web.client.actions.RequestCancelPause
+// import seqexec.web.client.actions.RequestPause
+// import seqexec.web.client.actions.RequestSync
+// import seqexec.web.client.actions.RequestRun
+// import seqexec.web.client.model.RunOperation
+// import seqexec.web.client.model.PauseOperation
+// import seqexec.web.client.model.SyncOperation
+import seqexec.web.client.components.SeqexecStyles
+// import seqexec.web.client.semanticui.elements.icon.Icon
+// import seqexec.web.client.semanticui.elements.icon.Icon.IconRefresh
+import seqexec.web.client.semanticui.elements.icon.Icon.IconCloneOutline
+import seqexec.web.client.semanticui.controlButton
+// import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
+// import seqexec.web.client.semanticui.elements.icon.Icon.IconBan
+// import seqexec.web.client.reusability._
+import web.client.style._
+
+/**
+  * Toolbar for logged in users
+  */
+object QueueToolbar {
+  final case class Props() {
+    def cmp: Unmounted[Props, Unit, Unit] = component(this)
+  }
+
+  private val component = ScalaComponent
+    .builder[Props]("QueueToolbar")
+    .stateless
+    .render_P(p =>
+      <.div(
+        ^.cls := "ui grid",
+        <.div(
+          ^.cls := "row",
+          SeqexecStyles.shorterRow,
+          <.div(
+            ^.cls := "ui left floated column",
+            controlButton(
+              icon     = IconCloneOutline,
+              color    = "blue",
+              onClick  = Callback.empty,
+              disabled = false,
+              tooltip  = "Add all daytime calibrations on the session queue",
+              text     = "Add all day cal"
+            )
+          )
+        )
+    ))
+    .build
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/reusability.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/reusability.scala
@@ -15,7 +15,9 @@ import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.SectionVisibilityState
 import seqexec.web.client.model.UserNotificationState
 import seqexec.web.client.model.WebSocketConnection
+import seqexec.web.client.model.AddDayCalOperation
 import seqexec.web.client.model.PauseOperation
+import seqexec.web.client.model.QueueOperations
 import seqexec.web.client.model.RunOperation
 import seqexec.web.client.model.SyncOperation
 import seqexec.web.client.model.TabSelected
@@ -49,4 +51,7 @@ package object reusability {
   implicit val availableTabsReuse: Reusability[AvailableTab]   = Reusability.byEq
   implicit val userDetailsReuse: Reusability[UserDetails]      = Reusability.byEq
   implicit val usrNotReuse: Reusability[UserNotificationState] = Reusability.byEq
+  implicit val dcAddReuse: Reusability[AddDayCalOperation]     = Reusability.byRef
+  implicit val qoReuse: Reusability[QueueOperations]           = Reusability.byEq
+  implicit val qfReuse: Reusability[QueueControlFocus]         = Reusability.byEq
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -26,10 +26,7 @@ import seqexec.web.client.model.RunOperation
 import seqexec.web.client.model.PauseOperation
 import seqexec.web.client.model.SyncOperation
 import seqexec.web.client.components.SeqexecStyles
-import seqexec.web.client.semanticui.elements.button.Button
-import seqexec.web.client.semanticui.elements.button.Button.LeftLabeled
-import seqexec.web.client.semanticui.elements.popup.Popup
-import seqexec.web.client.semanticui.elements.icon.Icon
+import seqexec.web.client.semanticui.controlButton
 import seqexec.web.client.semanticui.elements.icon.Icon.IconRefresh
 import seqexec.web.client.semanticui.elements.icon.Icon.IconPlay
 import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
@@ -128,26 +125,13 @@ object SequenceControl {
     ST.retM(SeqexecCircuit.dispatchCB(RequestCancelPause(s))) >>
       ST.mod(_.requestCancelPause).liftCB
 
-  private def controlButton(icon:     Icon,
-                            color:    String,
-                            onClick:  Callback,
-                            disabled: Boolean,
-                            tooltip:  String,
-                            text:     String) =
-    Popup(Popup.Props("button", tooltip),
-          Button(
-            Button.Props(icon     = Some(icon),
-                         labeled  = LeftLabeled,
-                         onClick  = onClick,
-                         color    = Some(color),
-                         disabled = disabled),
-            text
-          ))
-
   def stateFromProps(p: Props): State =
     State.Zero.copy(runRequested = p.runRequested)
 
-  private def syncButton(b: Backend, id: Observation.Id, canOperate: Boolean, canSync: Boolean) =
+  private def syncButton(b:          Backend,
+                         id:         Observation.Id,
+                         canOperate: Boolean,
+                         canSync:    Boolean) =
     controlButton(icon     = IconRefresh,
                   color    = "purple",
                   onClick  = b.runState(requestSync(id)),
@@ -155,7 +139,12 @@ object SequenceControl {
                   tooltip  = "Sync sequence",
                   text     = "Sync")
 
-  private def runButton(b: Backend, id: Observation.Id, isPartiallyExecuted: Boolean, nextStepToRun: Int, canOperate: Boolean, canRun: Boolean) = {
+  private def runButton(b:                   Backend,
+                        id:                  Observation.Id,
+                        isPartiallyExecuted: Boolean,
+                        nextStepToRun:       Int,
+                        canOperate:          Boolean,
+                        canRun:              Boolean) = {
     val runContinueTooltip =
       s"${isPartiallyExecuted.fold("Continue", "Run")} the sequence from the step $nextStepToRun"
     val runContinueButton =
@@ -168,7 +157,10 @@ object SequenceControl {
                   text     = runContinueButton)
   }
 
-  private def cancelPauseButton(b: Backend, id: Observation.Id, canOperate: Boolean, canCancelPause: Boolean) =
+  private def cancelPauseButton(b:              Backend,
+                                id:             Observation.Id,
+                                canOperate:     Boolean,
+                                canCancelPause: Boolean) =
     controlButton(
       icon     = IconBan,
       color    = "brown",
@@ -178,7 +170,10 @@ object SequenceControl {
       text     = "Cancel Pause"
     )
 
-  private def pauseButton(b: Backend, id: Observation.Id, canOperate: Boolean, canPause: Boolean) =
+  private def pauseButton(b:          Backend,
+                          id:         Observation.Id,
+                          canOperate: Boolean,
+                          canPause:   Boolean) =
     controlButton(
       icon     = IconPause,
       color    = "teal",
@@ -188,7 +183,11 @@ object SequenceControl {
       text     = "Pause"
     )
 
-  private def resumeButton(b: Backend, id: Observation.Id, nextStepToRun: Int, canOperate: Boolean, canResume: Boolean) =
+  private def resumeButton(b:             Backend,
+                           id:            Observation.Id,
+                           nextStepToRun: Int,
+                           canOperate:    Boolean,
+                           canResume:     Boolean) =
     controlButton(
       icon     = IconPlay,
       color    = "teal",
@@ -273,10 +272,9 @@ object SequenceDefaultToolbar {
           <.div(
             ^.cls := "ui left floated column eight wide computer eight wide tablet only",
             p.controlReader(_() match {
-                case Some(c) => SequenceControl(SequenceControl.Props(c))
-                case _       => ReactFragment()
-              }
-            )
+              case Some(c) => SequenceControl(SequenceControl.Props(c))
+              case _       => ReactFragment()
+            })
           ),
           <.div(
             ^.cls := "ui right floated column",

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/CalibrationQueues.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/CalibrationQueues.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.model
+
+import cats._
+import cats.implicits._
+import monocle.macros.Lenses
+import seqexec.model.CalibrationQueueId
+import seqexec.model.QueueId
+
+@Lenses
+final case class CalibrationQueues(ops: Map[QueueId, QueueOperations])
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object CalibrationQueues {
+  implicit val eq: Eq[CalibrationQueues] =
+    Eq.by(x => (x.ops))
+
+  val Default: CalibrationQueues =
+    CalibrationQueues(Map(CalibrationQueueId -> QueueOperations.Default))
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/QueueOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/QueueOperations.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.model
+
+import cats.Eq
+import monocle.macros.Lenses
+
+sealed trait AddDayCalOperation extends Product with Serializable
+object AddDayCalOperation {
+  case object AddDayCalInFlight extends AddDayCalOperation
+  case object AddDayCalIdle extends AddDayCalOperation
+
+  implicit val eq: Eq[AddDayCalOperation] =
+    Eq.fromUniversalEquals
+
+}
+
+/**
+  * Hold transient states while excuting an operation on the queue
+  */
+@Lenses
+final case class QueueOperations(addDayCalRequested: AddDayCalOperation)
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object QueueOperations {
+  implicit val eq: Eq[QueueOperations] =
+    Eq.by(x => (x.addDayCalRequested))
+
+  val Default: QueueOperations =
+    QueueOperations(AddDayCalOperation.AddDayCalIdle)
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -27,6 +27,7 @@ final case class SeqexecUIModel(
   queueTableState:    TableState[QueueTableBody.TableColumn],
   defaultObserver:    Observer,
   notification:       UserNotificationState,
+  queues:             CalibrationQueues,
   firstLoad:          Boolean)
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
@@ -41,6 +42,7 @@ object SeqexecUIModel {
     QueueTableBody.InitialTableState.tableState,
     Observer(""),
     UserNotificationState.Empty,
+    CalibrationQueues.Default,
     firstLoad = true
   )
 
@@ -55,6 +57,8 @@ object SeqexecUIModel {
          x.configTableState,
          x.queueTableState,
          x.defaultObserver,
+         x.notification,
+         x.queues,
          x.firstLoad))
 
   val defaultObserverG = SeqexecUIModel.defaultObserver.asGetter

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -80,6 +80,11 @@ object actions {
   final case class RunObsPauseFailed(s:    Observation.Id) extends Action
   final case class RunObsResumeFailed(s:   Observation.Id) extends Action
 
+  // Queue actions
+  final case class RequestAllDayCal(qid:   QueueId) extends Action
+  final case class AllDayCalCompleted(qid: QueueId) extends Action
+  final case class AllDayCalFailed(qid:    QueueId) extends Action
+
   final case class RememberCompleted(s: SequenceView) extends Action
 
   final case class AppendToLog(l: ServerLogMessage) extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/QueueControlFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/QueueControlFocus.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.implicits._
+import monocle.Getter
+import monocle.macros.Lenses
+import monocle.std
+import monocle.function.At.at
+import monocle.function.At.atMap
+import seqexec.model.QueueId
+import seqexec.web.client.model._
+
+@Lenses
+final case class QueueControlFocus(canOperate: Boolean, ops: QueueOperations)
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object QueueControlFocus {
+  implicit val eq: Eq[QueueControlFocus] =
+    Eq.by(x => (x.canOperate, x.ops))
+
+  def queueControlG(id: QueueId): Getter[SeqexecAppRootModel, Option[QueueControlFocus]] = {
+    val optQueue =
+      SeqexecAppRootModel.uiModel ^|->
+      SeqexecUIModel.queues       ^|->
+      CalibrationQueues.ops       ^|->
+      at(id)                      ^<-?
+      std.option.some
+
+    ClientStatus.canOperateG.zip(Getter(optQueue.getOption)) >>> {
+      case (status, Some(c)) =>
+        QueueControlFocus(status, c).some
+      case _ =>
+        none
+    }
+  }
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -364,6 +364,14 @@ package circuit {
     implicit val eq: Eq[SequenceControlFocus] =
       Eq.by(x => (x.canOperate, x.control))
 
+    def seqControlG(id: Observation.Id): Getter[SeqexecAppRootModel, Option[SequenceControlFocus]] = {
+      val getter = SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(SequencesOnDisplay.tabG(id))
+      ClientStatus.canOperateG.zip(getter) >>> {
+        case (status, Some(SeqexecTabActive(tab, _))) =>
+          SequenceControlFocus(status, ControlModel.controlModelG.get(tab)).some
+        case _ => none
+      }
+    }
   }
 
   @Lenses

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.handlers
+
+import cats.implicits._
+import diode.ActionHandler
+import diode.ActionResult
+import diode.Effect
+import diode.ModelRW
+import monocle.function.At.at
+import monocle.std
+import scala.concurrent.Future
+import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+import seqexec.model.RequestFailed
+import seqexec.model.QueueId
+import seqexec.web.client.actions.RequestAllDayCal
+import seqexec.web.client.model.CalibrationQueues
+import seqexec.web.client.model.QueueOperations
+import seqexec.web.client.model.AddDayCalOperation
+import seqexec.web.client.actions._
+
+/**
+  * Updates the state of the tabs when requests are executed
+  */
+class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
+    extends ActionHandler(modelRW)
+    with Handlers[M, CalibrationQueues] {
+  private def addDayCalL(qid: QueueId) =
+    CalibrationQueues.ops ^|-> at(qid) ^<-? std.option.some ^|-> QueueOperations.addDayCalRequested
+  def handleAddAllDayCal: PartialFunction[Any, ActionResult[M]] = {
+    case RequestAllDayCal(qid) =>
+      updatedL(addDayCalL(qid).set(AddDayCalOperation.AddDayCalInFlight))
+
+  }
+
+  def handleRequestResultOk: PartialFunction[Any, ActionResult[M]] = {
+    case AllDayCalCompleted(qid) =>
+      updatedL(addDayCalL(qid).set(AddDayCalOperation.AddDayCalIdle))
+  }
+
+  def handleRequestResultFailed: PartialFunction[Any, ActionResult[M]] = {
+    case AllDayCalFailed(qid) =>
+      val msg = s"Failed to add all day cal sequences"
+      val notification = Effect(
+        Future(RequestFailedNotification(RequestFailed(msg))))
+      updatedLE(addDayCalL(qid).set(AddDayCalOperation.AddDayCalIdle),
+                notification)
+  }
+  override def handle: PartialFunction[Any, ActionResult[M]] =
+    List(handleAddAllDayCal, handleRequestResultOk, handleRequestResultFailed).combineAll
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueRequestsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueRequestsHandler.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.handlers
+
+import cats.implicits._
+import diode.ActionHandler
+import diode.ActionResult
+import diode.ModelRW
+import seqexec.model.SequencesQueue
+import seqexec.model.SequenceView
+import seqexec.web.client.actions._
+import seqexec.web.client.services.SeqexecWebClient
+
+/**
+  * Handles actions sending requests to the backend
+  */
+class QueueRequestsHandler[M](modelRW: ModelRW[M, SequencesQueue[SequenceView]])
+    extends ActionHandler(modelRW)
+    with Handlers[M, SequencesQueue[SequenceView]] {
+
+  def handleAddAllDayCal: PartialFunction[Any, ActionResult[M]] = {
+    case RequestAllDayCal(qid) =>
+      val ids = value.sessionQueue.map(_.id)
+      effectOnly(
+        requestEffect(qid,
+                      SeqexecWebClient.addSequencesToQueue(ids),
+                      AllDayCalCompleted.apply,
+                      AllDayCalFailed.apply))
+  }
+
+  override def handle: PartialFunction[Any, ActionResult[M]] =
+    List(handleAddAllDayCal).combineAll
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/RemoteRequestsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/RemoteRequestsHandler.scala
@@ -4,7 +4,6 @@
 package seqexec.web.client.handlers
 
 import cats.implicits._
-import diode.Action
 import diode.ActionHandler
 import diode.ActionResult
 import diode.Effect
@@ -12,7 +11,6 @@ import diode.ModelRW
 import seqexec.model.ClientID
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
-import scala.concurrent.Future
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 /**
@@ -37,19 +35,6 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientID]])
         .getOrElse(VoidEffect)
       effectOnly(effect)
   }
-
-  private def requestEffect[A, B <: Action, C <: Action](
-      a: A,
-      f: A => Future[Unit],
-      m: A => B,
-      r: A => C): Effect =
-    Effect(
-      f(a)
-        .map(_ => m(a))
-        .recover {
-          case _ => r(a)
-        }
-    )
 
   def handlePause: PartialFunction[Any, ActionResult[M]] = {
     case RequestPause(id) =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/package.scala
@@ -4,7 +4,11 @@
 package seqexec.web.client
 
 import cats.Monoid
-import diode.{Action, ActionHandler, ActionResult, Effect, NoAction}
+import diode.Action
+import diode.ActionHandler
+import diode.ActionResult
+import diode.Effect
+import diode.NoAction
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -23,6 +27,19 @@ package handlers {
 
     def updatedLE(lens: T => T, effect: Effect): ActionResult[M] =
       updated(lens(value), effect)
+
+    def requestEffect[A, B <: Action, C <: Action](a: A,
+                                                   f: A => Future[Unit],
+                                                   m: A => B,
+                                                   r: A => C): Effect =
+      Effect(
+        f(a)
+          .map(_ => m(a))
+          .recover {
+            case _ => r(a)
+          }
+      )
+
   }
 }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/icon/Icon.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/icon/Icon.scala
@@ -6,7 +6,8 @@ package seqexec.web.client.semanticui.elements.icon
 import cats.Eq
 import seqexec.web.client.semanticui.Size
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{Callback, ScalaComponent}
+import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.extra.Reusability
 import cats.implicits._
 import web.client.style._
@@ -93,41 +94,43 @@ final case class Icon(p: Icon.Props, children: Seq[VdomNode]) {
 }
 
 object Icon {
-  implicit val iconProps: Reusability[Icon.Props] = Reusability.caseClassExcept[Icon.Props]('onClick, 'onMouseEnter, 'onMouseLeave)
+  implicit val iconProps: Reusability[Icon.Props] = Reusability
+    .caseClassExcept[Icon.Props]('onClick, 'onMouseEnter, 'onMouseLeave)
   implicit val reuse: Reusability[Icon] = Reusability.by(_.p)
-  val IconBrowser: Icon           = Icon("browser")
-  val IconDropdown: Icon          = Icon("dropdown")
-  val IconInbox: Icon             = Icon("inbox")
-  val IconSettings: Icon          = Icon("settings")
-  val IconBan: Icon               = Icon("ban")
-  val IconLock: Icon              = Icon("lock")
-  val IconRefresh: Icon           = Icon("refresh")
-  val IconReply: Icon             = Icon("reply")
-  val IconSignIn: Icon            = Icon("sign in")
-  val IconSignOut: Icon           = Icon("sign out")
-  val IconUpload: Icon            = Icon("upload")
-  val IconUser: Icon              = Icon("user")
-  val IconCircleNotched: Icon     = Icon("circle notched")
-  val IconCrosshairs: Icon        = Icon("crosshairs")
-  val IconCheckmark: Icon         = Icon("checkmark")
-  val IconMinusCircle: Icon       = Icon("minus circle")
-  val IconPlusSquareOutline: Icon = Icon("plus square outline")
-  val IconRemove: Icon            = Icon("remove")
-  val IconSelectedRadio: Icon     = Icon("dot circle outline")
-  val IconAngleDoubleDown: Icon   = Icon("angle double down")
-  val IconAngleDoubleUp: Icon     = Icon("angle double up")
-  val IconCaretDown: Icon         = Icon("caret down")
-  val IconCaretRight: Icon        = Icon("caret right")
-  val IconChevronLeft: Icon       = Icon("chevron left")
-  val IconChevronRight: Icon      = Icon("chevron right")
-  val IconTrash: Icon             = Icon("trash")
-  val IconPause: Icon             = Icon("pause")
-  val IconPlay: Icon              = Icon("play")
-  val IconStop: Icon              = Icon("stop")
-  val IconStopCircle: Icon        = Icon("stop circle")
-  val IconCopy: Icon              = Icon("copy outline")
-  val IconAttention: Icon         = Icon("attention")
-  val IconClose: Icon             = Icon("close")
+  val IconBrowser: Icon                 = Icon("browser")
+  val IconDropdown: Icon                = Icon("dropdown")
+  val IconInbox: Icon                   = Icon("inbox")
+  val IconSettings: Icon                = Icon("settings")
+  val IconBan: Icon                     = Icon("ban")
+  val IconLock: Icon                    = Icon("lock")
+  val IconRefresh: Icon                 = Icon("refresh")
+  val IconReply: Icon                   = Icon("reply")
+  val IconSignIn: Icon                  = Icon("sign in")
+  val IconSignOut: Icon                 = Icon("sign out")
+  val IconUpload: Icon                  = Icon("upload")
+  val IconUser: Icon                    = Icon("user")
+  val IconCircleNotched: Icon           = Icon("circle notched")
+  val IconCrosshairs: Icon              = Icon("crosshairs")
+  val IconCheckmark: Icon               = Icon("checkmark")
+  val IconMinusCircle: Icon             = Icon("minus circle")
+  val IconPlusSquareOutline: Icon       = Icon("plus square outline")
+  val IconRemove: Icon                  = Icon("remove")
+  val IconSelectedRadio: Icon           = Icon("dot circle outline")
+  val IconAngleDoubleDown: Icon         = Icon("angle double down")
+  val IconAngleDoubleUp: Icon           = Icon("angle double up")
+  val IconCaretDown: Icon               = Icon("caret down")
+  val IconCaretRight: Icon              = Icon("caret right")
+  val IconChevronLeft: Icon             = Icon("chevron left")
+  val IconChevronRight: Icon            = Icon("chevron right")
+  val IconTrash: Icon                   = Icon("trash")
+  val IconPause: Icon                   = Icon("pause")
+  val IconPlay: Icon                    = Icon("play")
+  val IconStop: Icon                    = Icon("stop")
+  val IconStopCircle: Icon              = Icon("stop circle")
+  val IconCopy: Icon                    = Icon("copy outline")
+  val IconAttention: Icon               = Icon("attention")
+  val IconClose: Icon                   = Icon("close")
+  val IconCloneOutline: Icon            = Icon("clone outline")
 
   sealed trait Flipped
 
@@ -136,7 +139,7 @@ object Icon {
     case object Horizontally extends Flipped
     case object Vertically extends Flipped
 
-    implicit val equal: Eq[Flipped] = Eq.fromUniversalEquals
+    implicit val equal: Eq[Flipped]          = Eq.fromUniversalEquals
     implicit val reuse: Reusability[Flipped] = Reusability.byRef[Flipped]
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/package.scala
@@ -3,15 +3,38 @@
 
 package seqexec.web.client
 
-import japgolly.scalajs.react.vdom.html_<^.VdomAttr
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react.component.Scala.Unmounted
+import seqexec.web.client.semanticui.elements.button.Button
+import seqexec.web.client.semanticui.elements.button.Button.LeftLabeled
+import seqexec.web.client.semanticui.elements.popup.Popup
+import seqexec.web.client.semanticui.elements.icon.Icon
 
 package object semanticui {
 
   // Custom attributes used by SemanticUI
-  val dataTab: VdomAttr[String]     = VdomAttr("data-tab")
-  val dataTooltip: VdomAttr[String] = VdomAttr("data-tooltip")
-  val dataContent: VdomAttr[String] = VdomAttr("data-content")
+  val dataTab: VdomAttr[String]      = VdomAttr("data-tab")
+  val dataTooltip: VdomAttr[String]  = VdomAttr("data-tooltip")
+  val dataContent: VdomAttr[String]  = VdomAttr("data-content")
   val dataPosition: VdomAttr[String] = VdomAttr("data-position")
   val dataInverted: VdomAttr[String] = VdomAttr("data-inverted")
-  val formId: VdomAttr[String]      = VdomAttr("form")
+  val formId: VdomAttr[String]       = VdomAttr("form")
+
+  def controlButton(icon:     Icon,
+                    color:    String,
+                    onClick:  Callback,
+                    disabled: Boolean,
+                    tooltip:  String,
+                    text:     String): Unmounted[Popup.Props, Unit, Unit] =
+    Popup(Popup.Props("button", tooltip),
+          Button(
+            Button.Props(icon     = Some(icon),
+                         labeled  = LeftLabeled,
+                         onClick  = onClick,
+                         color    = Some(color),
+                         disabled = disabled),
+            text
+          ))
+
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -335,11 +335,10 @@ object SeqexecWebClient extends ModelBooPicklers {
   /**
     * Add a sequence from a queue
     */
-  def addSequencesToQueue(queueId: QueueId,
-                          ids:     List[Observation.Id]): Future[Unit] =
+  def addSequencesToQueue(ids: List[Observation.Id])(qid: QueueId): Future[Unit] =
     Ajax
       .post(
-        url          = s"$baseUrl/queue/${encodeURI(queueId.show)}/add",
+        url          = s"$baseUrl/commands/queue/${encodeURI(qid.show)}/add",
         responseType = "arraybuffer",
         data         = Pickle.intoBytes(ids)
       )

--- a/modules/shared/web/client/src/main/scala/web/client/table/SortableRow.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/SortableRow.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package web.client.table
+
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.{CtorType, ScalaComponent}
+import japgolly.scalajs.react.component.Scala.Component
+import react.virtualized._
+
+object SortableRow {
+  final case class Props(p: react.virtualized.raw.RawRowRendererParameter)
+
+  val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent.builder[Props]("SortableRow")
+    .render_P{ p =>
+      <.div(
+        // ^.className := "sortable-hoc-item sortable-hoc-stylizedItem",
+        // SortableView.handl
+        raw.defaultRowRenderer(p.p)
+      )
+    }
+    .build
+
+}

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -11,9 +11,12 @@ import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.Callback
 import org.scalajs.dom.MouseEvent
 import scala.scalajs.js
+import js.JSConverters._
 import monocle.Lens
 import mouse.boolean._
 import react.virtualized._
+import react.virtualized.raw
+import react.sortable._
 import react.draggable._
 import web.client.utils._
 
@@ -230,4 +233,38 @@ package object table {
           <.span(^.cls := "DragHandleIcon", "⋮")
         )
     )
+
+  def sortableRowRenderer[C <: js.Object]: RowRenderer[C] =
+    (className: String,
+     columns: Array[VdomNode],
+     index: Int,
+     isScrolling: Boolean,
+     key: String,
+     rowData: C,
+     onRowClick: Option[OnRowClick],
+     onRowDoubleClick: Option[OnRowClick],
+     onRowMouseOut: Option[OnRowClick],
+     onRowMouseOver: Option[OnRowClick],
+     onRowRightClick: Option[OnRowClick],
+     style: Style) => {
+      val sortableItem = SortableElement.wrap(SortableRow.component)
+      sortableItem(
+        SortableElement.Props(index = index))(SortableRow.Props(
+          raw.RawRowRendererParameter(
+            className,
+            columns.map(_.rawNode).toJSArray,
+            index,
+            isScrolling,
+            key,
+            rowData,
+            onRowClick.map(_.toJsCallback).orUndefined,
+            onRowDoubleClick.map(_.toJsCallback).orUndefined,
+            onRowMouseOut.map(_.toJsCallback).orUndefined,
+            onRowMouseOver.map(_.toJsCallback).orUndefined,
+            onRowRightClick.map(_.toJsCallback).orUndefined,
+            Style.toJsObject(style)
+          ))
+        )
+
+    }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -224,15 +224,15 @@ object Settings {
       "io.suzaku" %%% "diode"       % LibraryVersions.diode,
       "io.suzaku" %%% "diode-react" % LibraryVersions.diodeReact
     ))
-    val ScalaJSDom              = Def.setting("org.scala-js"      %%% "scalajs-dom"               % LibraryVersions.scalaDom)
-    val ScalaJSReactVirtualized = Def.setting("io.github.cquiroz" %%% "scalajs-react-virtualized" % LibraryVersions.scalaJSReactVirtualized)
-    val ScalaJSReactDraggable   = Def.setting("io.github.cquiroz" %%% "scalajs-react-draggable"   % LibraryVersions.scalaJSReactDraggable)
-    val ScalaJSReactSortable    = Def.setting("io.github.cquiroz" %%% "scalajs-react-sortable-hoc"    % LibraryVersions.scalaJSReactSortable)
-    val ScalaJSReactClipboard   = Def.setting("io.github.cquiroz" %%% "scalajs-react-clipboard"   % LibraryVersions.scalaJSReactClipboard)
-    val JQuery                  = Def.setting("org.querki"        %%% "jquery-facade"             % LibraryVersions.scalaJQuery)
-    val BooPickle               = Def.setting("io.suzaku"         %%% "boopickle"                 % LibraryVersions.booPickle)
-    val JavaTimeJS              = Def.setting("io.github.cquiroz" %%% "scala-java-time"           % LibraryVersions.javaTimeJS)
-    val JavaLogJS               = Def.setting("org.scala-js"      %%% "scalajs-java-logging"      % LibraryVersions.javaLogJS)
+    val ScalaJSDom              = Def.setting("org.scala-js"      %%% "scalajs-dom"                % LibraryVersions.scalaDom)
+    val ScalaJSReactVirtualized = Def.setting("io.github.cquiroz" %%% "scalajs-react-virtualized"  % LibraryVersions.scalaJSReactVirtualized)
+    val ScalaJSReactDraggable   = Def.setting("io.github.cquiroz" %%% "scalajs-react-draggable"    % LibraryVersions.scalaJSReactDraggable)
+    val ScalaJSReactSortable    = Def.setting("io.github.cquiroz" %%% "scalajs-react-sortable-hoc" % LibraryVersions.scalaJSReactSortable)
+    val ScalaJSReactClipboard   = Def.setting("io.github.cquiroz" %%% "scalajs-react-clipboard"    % LibraryVersions.scalaJSReactClipboard)
+    val JQuery                  = Def.setting("org.querki"        %%% "jquery-facade"              % LibraryVersions.scalaJQuery)
+    val BooPickle               = Def.setting("io.suzaku"         %%% "boopickle"                  % LibraryVersions.booPickle)
+    val JavaTimeJS              = Def.setting("io.github.cquiroz" %%% "scala-java-time"            % LibraryVersions.javaTimeJS)
+    val JavaLogJS               = Def.setting("org.scala-js"      %%% "scalajs-java-logging"       % LibraryVersions.javaLogJS)
 
     // OCS Libraries, these should become modules in the future
     val SpModelCore = "edu.gemini.ocs"    %% "edu-gemini-spmodel-core"        % LibraryVersions.ocsVersion

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,12 +1,13 @@
 import sbt._
-import java.lang.{Runtime => JRuntime}
+import java.lang.{ Runtime => JRuntime }
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 /**
- * Application settings and dependencies
- */
+  * Application settings and dependencies
+  */
 object Settings {
   object Definitions {
+
     /** The name of the application */
     val name = "ocs3"
 
@@ -74,9 +75,10 @@ object Settings {
     val javaTimeJS              = "2.0.0-M13"
     val javaLogJS               = "0.1.5"
     val scalaJQuery             = "1.2"
-    val scalaJSReactVirtualized = "0.3.4"
+    val scalaJSReactVirtualized = "0.3.5"
     val scalaJSReactClipboard   = "0.4.0"
     val scalaJSReactDraggable   = "0.1.1"
+    val scalaJSReactSortable    = "0.0.1"
 
     // Scala libraries
     val catsEffectVersion       = "0.10.1"
@@ -86,7 +88,7 @@ object Settings {
     val shapelessVersion        = "2.3.3"
     val attoVersion             = "0.6.3"
     val scalaParsersVersion     = "1.1.1"
-    val scalaXmlVerson          = "1.1.0"
+    val scalaXmlVerson          = "1.1.1"
 
     val http4sVersion           = "0.18.19"
     val squants                 = "1.3.0"
@@ -225,6 +227,7 @@ object Settings {
     val ScalaJSDom              = Def.setting("org.scala-js"      %%% "scalajs-dom"               % LibraryVersions.scalaDom)
     val ScalaJSReactVirtualized = Def.setting("io.github.cquiroz" %%% "scalajs-react-virtualized" % LibraryVersions.scalaJSReactVirtualized)
     val ScalaJSReactDraggable   = Def.setting("io.github.cquiroz" %%% "scalajs-react-draggable"   % LibraryVersions.scalaJSReactDraggable)
+    val ScalaJSReactSortable    = Def.setting("io.github.cquiroz" %%% "scalajs-react-sortable-hoc"    % LibraryVersions.scalaJSReactSortable)
     val ScalaJSReactClipboard   = Def.setting("io.github.cquiroz" %%% "scalajs-react-clipboard"   % LibraryVersions.scalaJSReactClipboard)
     val JQuery                  = Def.setting("org.querki"        %%% "jquery-facade"             % LibraryVersions.scalaJQuery)
     val BooPickle               = Def.setting("io.suzaku"         %%% "boopickle"                 % LibraryVersions.booPickle)


### PR DESCRIPTION
This PR adds all daycal calibrations to the queue. It doesn't do much of practical value beyond exercising the model but this PR also adds a substantial amount of infrastructure and it is getting large already

![seqexec - daycal queue 2018-10-02 17-39-09](https://user-images.githubusercontent.com/3615303/46375695-79607e00-c66a-11e8-9090-831ae8b3b1b9.png)

I'm also adding an extra dependency to support resorting the quee table