### PR TITLE
SEQNG-735: Store the state of the cal tables at the root model

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -13,8 +13,9 @@ import seqexec.model.enum._
 import seqexec.model.events._
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
-import seqexec.web.client.components.SessionQueueTableBody
 import seqexec.web.client.components.sequence.steps.StepsTable
+import seqexec.web.client.components.SessionQueueTableBody
+import seqexec.web.client.components.queue.CalQueueTable
 import org.scalajs.dom.WebSocket
 import web.client.table._
 
@@ -120,6 +121,9 @@ object actions {
       extends Action
   final case class UpdateStepTableState(id: Observation.Id,
                                         s:  TableState[StepsTable.TableColumn])
+      extends Action
+  final case class UpdateCalTableState(id: QueueId,
+                                        s:  TableState[CalQueueTable.TableColumn])
       extends Action
   final case class LoadSequence(observer: Observer,
                                 i:        Instrument,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/AppTableStates.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/AppTableStates.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.implicits._
+import gem.Observation
+import monocle.Lens
+import monocle.macros.Lenses
+import monocle.function.At._
+import seqexec.model._
+import seqexec.web.client.model._
+import seqexec.web.client.components.sequence.steps.StepConfigTable
+import seqexec.web.client.components.sequence.steps.StepsTable
+import seqexec.web.client.components.SessionQueueTableBody
+import seqexec.web.client.components.queue.CalQueueTable
+import web.client.table._
+
+@Lenses
+final case class AppTableStates(
+  queueTable:      TableState[SessionQueueTableBody.TableColumn],
+  stepConfigTable: TableState[StepConfigTable.TableColumn],
+  stepsTables:     Map[Observation.Id, TableState[StepsTable.TableColumn]],
+  queueTables:     Map[QueueId, TableState[CalQueueTable.TableColumn]])
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object AppTableStates {
+  implicit val eq: Eq[AppTableStates] =
+    Eq.by(x => (x.queueTable, x.stepConfigTable, x.stepsTables))
+
+  val tableStateL: Lens[SeqexecUIModel, AppTableStates] =
+    Lens[SeqexecUIModel, AppTableStates](
+      m =>
+        AppTableStates(m.queueTableState,
+                       m.configTableState,
+                       m.sequencesOnDisplay.stepsTables,
+                       m.queues.queueTables))(
+      v =>
+        m =>
+          m.copy(
+            queueTableState  = v.queueTable,
+            configTableState = v.stepConfigTable,
+            sequencesOnDisplay = m.sequencesOnDisplay
+              .updateTableStates(v.stepsTables),
+            queues = m.queues
+              .updateTableStates(v.queueTables)
+      ))
+
+  def stepTableAtL(id: Observation.Id): Lens[AppTableStates, Option[TableState[StepsTable.TableColumn]]] =
+    AppTableStates.stepsTables ^|-> at(id)
+
+  def queueTableAtL(id: QueueId): Lens[AppTableStates, Option[TableState[CalQueueTable.TableColumn]]] =
+    AppTableStates.queueTables ^|-> at(id)
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/CalQueueControlFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/CalQueueControlFocus.scala
@@ -25,9 +25,10 @@ object CalQueueControlFocus {
   def optQueue(id: QueueId): Optional[SeqexecAppRootModel, QueueOperations] =
     SeqexecAppRootModel.uiModel ^|->
     SeqexecUIModel.queues       ^|->
-    CalibrationQueues.ops       ^|->
+    CalibrationQueues.queues    ^|->
     at(id)                      ^<-?
-    std.option.some
+    std.option.some             ^|->
+    CalQueueState.ops
 
   def queueControlG(id: QueueId): Getter[SeqexecAppRootModel, Option[CalQueueControlFocus]] = {
     ClientStatus.canOperateG.zip(Getter(optQueue(id).getOption)) >>> {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/CalQueueFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/CalQueueFocus.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.implicits._
 import gem.Observation
 import monocle.Getter
+import monocle.Lens
 import monocle.Traversal
 import monocle.macros.Lenses
 import monocle.function.Each.each
@@ -17,14 +18,19 @@ import seqexec.model.ExecutionQueue
 import seqexec.model.QueueId
 import seqexec.model.SequencesQueue
 import seqexec.web.client.model._
+import seqexec.web.client.components.queue.CalQueueTable
+import web.client.table.TableState
 
 @Lenses
-final case class CalQueueFocus(canOperate: Boolean, seqs: List[CalQueueSeq])
+final case class CalQueueFocus(
+  canOperate: Boolean,
+  seqs:       List[CalQueueSeq],
+  tableState: TableState[CalQueueTable.TableColumn])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object CalQueueFocus {
   implicit val eq: Eq[CalQueueFocus] =
-    Eq.by(x => (x.canOperate, x.seqs))
+    Eq.by(x => (x.canOperate, x.seqs, x.tableState))
 
   // A fairly complicated getter
   def calQueueG(id: QueueId): Getter[SeqexecAppRootModel, Option[CalQueueFocus]] = {
@@ -33,20 +39,27 @@ object CalQueueFocus {
       SeqexecAppRootModel.sequences               ^|->
         SequencesQueue.queues                     ^|->>
         filterIndex((qid: QueueId) => qid === id) ^|->
-        ExecutionQueue.queue ^|->>
+        ExecutionQueue.queue                      ^|->>
         each
 
     // All metadata of the given obs
     def calSeq(id: Observation.Id): Getter[SeqexecAppRootModel, Option[CalQueueSeq]] =
       SeqexecAppRootModel.sequences.composeGetter(CalQueueSeq.calQueueSeqG(id))
 
+    def calTS(id: QueueId): Lens[SeqexecAppRootModel, Option[TableState[CalQueueTable.TableColumn]]] =
+      SeqexecAppRootModel.uiModel  ^|->
+        AppTableStates.tableStateL ^|->
+        AppTableStates.queueTableAtL(id)
+
     // combine
     val calQueueSeqG = (s: SeqexecAppRootModel) =>
       ids.getAll(s).map(i => calSeq(i).get(s))
 
-    ClientStatus.canOperateG.zip(Getter(calQueueSeqG)) >>> {
-      case (status, ids) =>
-        CalQueueFocus(status, ids.collect { case Some(x) => x }).some
+    ClientStatus.canOperateG.zip(Getter(calQueueSeqG).zip(calTS(id).asGetter)) >>> {
+      case (status, (ids, ts)) =>
+        CalQueueFocus(status,
+                      ids.collect { case Some(x) => x },
+                      ts.getOrElse(CalQueueTable.State.InitialTableState)).some
       case _ =>
         none
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -13,7 +13,6 @@ import gem.enum.Site
 import monocle.Getter
 import monocle.Lens
 import monocle.macros.Lenses
-import monocle.function.At._
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.web.client.lenses.firstScienceStepTargetNameT
@@ -372,32 +371,6 @@ package circuit {
         case _ => none
       }
     }
-  }
-
-  @Lenses
-  final case class AppTableStates(
-    queueTable:      TableState[SessionQueueTableBody.TableColumn],
-    stepConfigTable: TableState[StepConfigTable.TableColumn],
-    stepsTables:     Map[Observation.Id, TableState[StepsTable.TableColumn]])
-      extends UseValueEq
-
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  object AppTableStates {
-    implicit val eq: Eq[AppTableStates] =
-      Eq.by(x => (x.queueTable, x.stepConfigTable, x.stepsTables))
-
-    val tableStateL: Lens[SeqexecUIModel, AppTableStates] =
-      Lens[SeqexecUIModel, AppTableStates](
-        m => AppTableStates(m.queueTableState,
-                         m.configTableState,
-                         m.sequencesOnDisplay.stepsTables))(
-        v => m => m.copy(queueTableState  = v.queueTable,
-                         configTableState = v.stepConfigTable,
-                         sequencesOnDisplay = m.sequencesOnDisplay
-                           .updateTableStates(v.stepsTables)))
-
-    def stepTableAt(id: Observation.Id): Lens[AppTableStates, Option[TableState[StepsTable.TableColumn]]] =
-      AppTableStates.stepsTables ^|-> at(id)
   }
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
@@ -18,6 +18,7 @@ import seqexec.web.client.actions.RequestAllDayCal
 import seqexec.web.client.model.CalibrationQueues
 import seqexec.web.client.model.QueueOperations
 import seqexec.web.client.model.AddDayCalOperation
+import seqexec.web.client.model.CalQueueState
 import seqexec.web.client.model.ClearAllCalOperation
 import seqexec.web.client.actions._
 
@@ -28,11 +29,17 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     extends ActionHandler(modelRW)
     with Handlers[M, CalibrationQueues] {
 
+  private def calQueueStateL(qid: QueueId) =
+    CalibrationQueues.queues ^|->
+      at(qid)                ^<-?
+      std.option.some        ^|->
+      CalQueueState.ops
+
   private def addDayCalL(qid: QueueId) =
-    CalibrationQueues.ops ^|-> at(qid) ^<-? std.option.some ^|-> QueueOperations.addDayCalRequested
+    calQueueStateL(qid) ^|-> QueueOperations.addDayCalRequested
 
   private def clearAllCalL(qid: QueueId) =
-    CalibrationQueues.ops ^|-> at(qid) ^<-? std.option.some ^|-> QueueOperations.clearAllCalRequested
+    calQueueStateL(qid) ^|-> QueueOperations.clearAllCalRequested
 
   def handleAddAllDayCal: PartialFunction[Any, ActionResult[M]] = {
     case RequestAllDayCal(qid) =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/TableStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/TableStateHandler.scala
@@ -23,6 +23,9 @@ class TableStateHandler[M](modelRW: ModelRW[M, AppTableStates])
       updatedSilentL(AppTableStates.queueTable.set(state)) // We should only do silent updates as these change too quickly
 
     case UpdateStepTableState(id, state) =>
-      updatedSilentL(AppTableStates.stepTableAt(id).set(Some(state))) // We should only do silent updates as these change too quickly
+      updatedSilentL(AppTableStates.stepTableAtL(id).set(Some(state))) // We should only do silent updates as these change too quickly
+
+    case UpdateCalTableState(id, state) =>
+      updatedSilentL(AppTableStates.queueTableAtL(id).set(Some(state))) // We should only do silent updates as these change too quickly
   }
 }


### PR DESCRIPTION
The state of the column's widths and scroll location of the cal table should be stored in the model to preserve it when doing changes.
This PR does exactly that.