### PR TITLE
Replace diode lenses by Monocle lenses

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -17,6 +17,8 @@ import seqexec.model.QueueId
 import seqexec.model.SequenceView
 import seqexec.model.SequencesQueue
 import seqexec.model.ClientID
+import seqexec.web.client.components.sequence.steps.StepConfigTable
+import web.client.table._
 
 /**
   * Root of the UI Model of the application
@@ -45,14 +47,20 @@ object SeqexecAppRootModel {
     SeqexecUIModel.Initial)
 
   val logDisplayL: Lens[SeqexecAppRootModel, SectionVisibilityState] =
-    SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.globalLog ^|-> GlobalLog.display
+    SeqexecAppRootModel.uiModel ^|->
+      SeqexecUIModel.globalLog  ^|->
+      GlobalLog.display
 
   val sequencesOnDisplayL: Lens[SeqexecAppRootModel, SequencesOnDisplay] =
     SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.sequencesOnDisplay
 
-  def executionQueuesT(id: QueueId): Traversal[SeqexecAppRootModel, ExecutionQueue] =
-    SeqexecAppRootModel.sequences               ^|->
-      SequencesQueue.queues                     ^|->>
+  val configTableStateL: Lens[SeqexecAppRootModel, TableState[StepConfigTable.TableColumn]] =
+    SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.configTableState
+
+  def executionQueuesT(
+    id: QueueId): Traversal[SeqexecAppRootModel, ExecutionQueue] =
+    SeqexecAppRootModel.sequences ^|->
+      SequencesQueue.queues       ^|->>
       filterIndex((qid: QueueId) => qid === id)
 
   implicit val eq: Eq[SeqexecAppRootModel] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/HeaderSideBarFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/HeaderSideBarFocus.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.implicits._
+import gem.Observation
+import monocle.Getter
+import monocle.macros.Lenses
+import seqexec.model._
+import seqexec.model.enum.Instrument
+import seqexec.web.client.model._
+
+final case class SequenceObserverFocus(instrument: Instrument,
+                                       obsId:      Observation.Id,
+                                       completed:  Boolean,
+                                       observer:   Option[Observer])
+
+object SequenceObserverFocus {
+  implicit val eq: Eq[SequenceObserverFocus] =
+    Eq.by(x => (x.instrument, x.obsId, x.completed, x.observer))
+
+}
+
+@Lenses
+final case class HeaderSideBarFocus(
+  status:     ClientStatus,
+  conditions: Conditions,
+  operator:   Option[Operator],
+  observer:   Either[Observer, SequenceObserverFocus])
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object HeaderSideBarFocus {
+  implicit val eq: Eq[HeaderSideBarFocus] =
+    Eq.by(x => (x.status, x.conditions, x.operator, x.observer))
+
+  val headerSideBarG: Getter[SeqexecAppRootModel, HeaderSideBarFocus] =
+    Getter[SeqexecAppRootModel, HeaderSideBarFocus] { c =>
+      val clientStatus = ClientStatus(c.uiModel.user, c.ws)
+      val obs = c.uiModel.sequencesOnDisplay.selectedOperator match {
+        case Some(x) => x.asRight
+        case _       => c.uiModel.defaultObserver.asLeft
+      }
+      HeaderSideBarFocus(clientStatus,
+                         c.sequences.conditions,
+                         c.sequences.operator,
+                         obs)
+    }
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/StepsTableAndStatusFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/StepsTableAndStatusFocus.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.implicits._
+import gem.Observation
+import monocle.Getter
+import seqexec.web.client.model._
+import seqexec.web.client.components.sequence.steps.StepConfigTable
+import web.client.table._
+
+final case class StepsTableAndStatusFocus(
+  status:           ClientStatus,
+  stepsTable:       Option[StepsTableFocus],
+  configTableState: TableState[StepConfigTable.TableColumn])
+
+object StepsTableAndStatusFocus {
+  implicit val eq: Eq[StepsTableAndStatusFocus] =
+    Eq.by(x => (x.status, x.stepsTable, x.configTableState))
+
+  def stepsTableAndStatusFocusG(id: Observation.Id): Getter[SeqexecAppRootModel, StepsTableAndStatusFocus] =
+    ClientStatus.clientStatusFocusL.asGetter
+    .zip(StepsTableFocus
+        .stepsTableG(id)
+        .zip(SeqexecAppRootModel.configTableStateL.asGetter)) >>> {
+      case (s, (f, t)) => StepsTableAndStatusFocus(s, f, t)
+    }
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/WebSocketFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/WebSocketFocus.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.implicits._
+import gem.enum.Site
+import monocle.Lens
+import monocle.macros.Lenses
+import seqexec.model._
+import seqexec.web.client.model.Pages
+import seqexec.web.client.model.SeqexecAppRootModel
+
+@Lenses
+final case class WebSocketsFocus(location:        Pages.SeqexecPages,
+                                 sequences:       SequencesQueue[SequenceView],
+                                 user:            Option[UserDetails],
+                                 defaultObserver: Observer,
+                                 clientId:        Option[ClientID],
+                                 site:            Option[Site])
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object WebSocketsFocus {
+  implicit val eq: Eq[WebSocketsFocus] =
+    Eq.by(x =>
+      (x.location, x.sequences, x.user, x.defaultObserver, x.clientId, x.site))
+
+  val webSocketFocusL: Lens[SeqexecAppRootModel, WebSocketsFocus] =
+    Lens[SeqexecAppRootModel, WebSocketsFocus](
+      m =>
+        WebSocketsFocus(m.uiModel.navLocation,
+                        m.sequences,
+                        m.uiModel.user,
+                        m.uiModel.defaultObserver,
+                        m.clientId,
+                        m.site))(
+      v =>
+        m =>
+          m.copy(sequences = v.sequences,
+                 uiModel = m.uiModel.copy(user = v.user,
+                                          defaultObserver = v.defaultObserver),
+                 clientId = v.clientId,
+                 site     = v.site))
+}

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -714,6 +714,35 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     Cogen[(Pages.SeqexecPages, SequencesOnDisplay, Option[ClientID])]
       .contramap(x => (x.location, x.sod, x.clientId))
 
+  implicit val arbWebSocketsFocus: Arbitrary[WebSocketsFocus] =
+    Arbitrary {
+      for {
+        navLocation <- arbitrary[Pages.SeqexecPages]
+        sequences   <- arbitrary[SequencesQueue[SequenceView]]
+        user        <- arbitrary[Option[UserDetails]]
+        observer    <- arbitrary[Observer]
+        clientId    <- arbitrary[Option[ClientID]]
+        site        <- arbitrary[Option[Site]]
+      } yield
+        WebSocketsFocus(navLocation, sequences, user, observer, clientId, site)
+    }
+
+  implicit val wsfCogen: Cogen[WebSocketsFocus] =
+    Cogen[(Pages.SeqexecPages,
+           SequencesQueue[SequenceView],
+           Option[UserDetails],
+           Observer,
+           Option[ClientID],
+           Option[Site])]
+      .contramap(
+        x =>
+          (x.location,
+           x.sequences,
+           x.user,
+           x.defaultObserver,
+           x.clientId,
+           x.site))
+
   implicit val arbInitialSyncFocus: Arbitrary[InitialSyncFocus] =
     Arbitrary {
       for {

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/CircuitReaderSpec.scala
@@ -32,6 +32,7 @@ final class CircuitReaderSpec
   // checkAll("sodLocationFocusL", LensTests(SODLocationFocus.sodLocationFocusL))
   // checkAll("initialSyncFocusL", LensTests(InitialSyncFocus.initialSyncFocusL))
   checkAll("clientStatusFocusL", LensTests(ClientStatus.clientStatusFocusL))
+  // checkAll("webSocketFocusL", LensTests(WebSocketsFocus.webSocketFocusL))
   // checkAll("tableStateL", LensTests(TableStates.tableStateL))
 
   test("maintain reference equality for constant readers") {
@@ -46,7 +47,6 @@ final class CircuitReaderSpec
     (logDisplayedReader === logDisplayedReader.value) should be(true)
     (tabsReader === tabsReader.value) should be(true)
     (seqexecTabs === seqexecTabs.value) should be(true)
-    (configTableState === configTableState.value) should be(true)
     (queueOperationsRW === queueOperationsRW.value) should be(true)
     (sequencesOnDisplayRW === sequencesOnDisplayRW.value) should be(true)
     (queueFocusRW === queueFocusRW.value) should be(true)


### PR DESCRIPTION
I've been replacing diode lenses by monocle ones. This PR changes a few more and splits the large `circuit` package classes into their own files
There isn't any change on functionality