### PR TITLE
SEQNG-643: Fixing GHOST fromSequenceConfig to always return a GHOSTConfig (for now).

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOST.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOST.scala
@@ -6,7 +6,6 @@ package seqexec.server.ghost
 import cats.data.Reader
 import cats.data.EitherT
 import cats.effect.{IO, Sync}
-import cats.implicits._
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import edu.gemini.spModel.gemini.ghost.Ghost
@@ -63,70 +62,61 @@ object GHOST {
 
   val sfName: String = "GHOST"
 
-  // TODO: I am sure there is a cleaner way to write this without using for, but I'm not sure right
-  // TODO: now what it is.
-//  private def hmsAngle(config: Config, name: String): Either[ExtractFailure, Option[HourAngle]] =
-//    for {
-//      angOptStr <- config.extract(INSTRUMENT_KEY / name).as[Option[String]]
-//      angStr    <- angOptStr
-//      ang       <- HourAngle.fromStringHMS.getOption(angStr)
-//    } yield ang
-//  private def hmsAngle(config: Config, name: String): Either[ExtractFailure, Option[HourAngle]] =
-//    for {
-//      a <- config.extract(INSTRUMENT_KEY / name).as[String]
-//          .map(HourAngle.fromStringHMS.getOption)
-//    } yield a
-//
-//  private def dmsAngle(config: Config, name: String): Either[ExtractFailure, Option[Angle]] =
-//    for {
-//      a <- config.extract(INSTRUMENT_KEY / name).as[String]
-//        .map(Angle.fromStringSignedDMS.getOption)
-//    } yield a
-//
-//
-//  private def targetName(config: Config, name: String): Either[ExtractFailure, Option[String]] =
-//    config.extract(INSTRUMENT_KEY / name).as[Option[String]]
+  private def hmsAngle(config: Config, name: String): Option[HourAngle] =
+    config.extractAs[HourAngle](INSTRUMENT_KEY / name).toOption
 
+  private def dmsAngle(config: Config, name: String): Option[Angle] =
+    config.extractAs[Angle](INSTRUMENT_KEY / name).toOption
 
-  def fromSequenceConfig[F[_]: Sync](
-      config: Config): SeqActionF[F, GHOSTConfig] = {
-    def extractor[A](param: String) =
-      config.extractAs[Option[A]](INSTRUMENT_KEY / param)
+  private def targetName(config: Config, name: String): Option[String] =
+    config.extractAs[String](INSTRUMENT_KEY / name).toOption
 
-    EitherT(
-      Sync[F].delay(
-        (for {
-          baseRAHMS          <- extractor[HourAngle](Ghost.BaseRAHMS)
-          baseDecDMS         <- extractor[Angle    ](Ghost.BaseDecDMS)
-          srifu1Name         <- extractor[String   ](Ghost.SRIFU1Name)
-          srifu1CoordsRAHMS  <- extractor[HourAngle](Ghost.SRIFU1RAHMS)
-          srifu1CoordsDecDMS <- extractor[Angle    ](Ghost.SRIFU1DecDMS)
-          srifu2Name         <- extractor[String   ](Ghost.SRIFU2Name)
-          srifu2CoordsRAHMS  <- extractor[HourAngle](Ghost.SRIFU2RAHMS)
-          srifu2CoordsDecDMS <- extractor[Angle    ](Ghost.SRIFU2DecDMS)
-          hrifu1Name         <- extractor[String   ](Ghost.HRIFU1Name)
-          hrifu1CoordsRAHMS  <- extractor[HourAngle](Ghost.HRIFU1RAHMS)
-          hrifu1CoordsDecDMS <- extractor[Angle    ](Ghost.HRIFU1DecDMS)
-          hrifu2CoordsRAHMS  <- extractor[HourAngle](Ghost.HRIFU2RAHMS)
-          hrifu2CoordsDecDMS <- extractor[Angle    ](Ghost.HRIFU2DecDMS)
-        } yield
-          GHOSTConfig(
-            baseRAHMS,
-            baseDecDMS,
-            1.minute,
-            srifu1Name,
-            srifu1CoordsRAHMS,
-            srifu1CoordsDecDMS,
-            srifu2Name,
-            srifu2CoordsRAHMS,
-            srifu2CoordsDecDMS,
-            hrifu1Name,
-            hrifu1CoordsRAHMS,
-            hrifu1CoordsDecDMS,
-            hrifu2CoordsRAHMS,
-            hrifu2CoordsDecDMS
-          ))
-          .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
-      ))
+  // We always want a GHOSTConfig at this point, so don't use a for comprehension as not all parameters will be
+  // present and we don't want the for to bork prematurely with a missing key error.
+  def fromSequenceConfig[F[_]: Sync](config: Config): SeqActionF[F, GHOSTConfig] = {
+    def extractor[A](name: String): Option[A] =
+      config.extractAs[A](INSTRUMENT_KEY / name).toOption
+
+    EitherT {
+      Sync[F].delay {
+        // This has the shortcoming that a failure in HourAngle or Angle parsing will result in a None instead
+        // of in a SeqexecFailure, but for this preliminary phase, don't worry about it, as this is just for
+        // basic testing.
+        val baseRAHMS          = extractor[HourAngle](Ghost.BaseRAHMS)
+        val baseDecDMS         = extractor[Angle    ](Ghost.BaseDecDMS)
+
+        val srifu1Name         = extractor[String   ](Ghost.SRIFU1Name)
+        val srifu1CoordsRAHMS  = extractor[HourAngle](Ghost.SRIFU1RAHMS)
+        val srifu1CoordsDecDMS = extractor[Angle    ](Ghost.SRIFU1DecDMS)
+
+        val srifu2Name         = extractor[String   ](Ghost.SRIFU2Name)
+        val srifu2CoordsRAHMS  = extractor[HourAngle](Ghost.SRIFU2RAHMS)
+        val srifu2CoordsDecDMS = extractor[Angle    ](Ghost.SRIFU2DecDMS)
+
+        val hrifu1Name         = extractor[String   ](Ghost.HRIFU1Name)
+        val hrifu1CoordsRAHMS  = extractor[HourAngle](Ghost.HRIFU1RAHMS)
+        val hrifu1CoordsDecDMS = extractor[Angle    ](Ghost.HRIFU1DecDMS)
+
+        val hrifu2CoordsRAHMS  = extractor[HourAngle](Ghost.HRIFU2RAHMS)
+        val hrifu2CoordsDecDMS = extractor[Angle    ](Ghost.HRIFU2DecDMS)
+
+        Right(GHOSTConfig(
+          baseRAHMS,
+          baseDecDMS,
+          1.minute,
+          srifu1Name,
+          srifu1CoordsRAHMS,
+          srifu1CoordsDecDMS,
+          srifu2Name,
+          srifu2CoordsRAHMS,
+          srifu2CoordsDecDMS,
+          hrifu1Name,
+          hrifu1CoordsRAHMS,
+          hrifu1CoordsDecDMS,
+          hrifu2CoordsRAHMS,
+          hrifu2CoordsDecDMS
+        )): Either[SeqexecFailure, GHOSTConfig]
+      }
+    }
   }
 }


### PR DESCRIPTION
Right now, we dont want to deal with missing parameters, as in the architecturing of this initial implementation, there will absolutely be missing parameters since not every combination of parameters is compatible. (Enforcing parameter compatibility is someting we will worry about later, as this is just for initial testing and will be thrown away / modified heavily as GHOST moves on.)

Thus, right now, we extract the parameters, populate a `GHOSTConfig` object, and return it as having "succeeded" in the extraction.