### PR TITLE
SEQNG-763 Fixed setting the url when removing an item from the queue

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -341,7 +341,7 @@ object SeqexecWebClient extends ModelBooPicklers {
     Ajax
       .post(
         url =
-          s"$baseUrl/commands/queue/${encodeURI(queueId.show)}/remove/${encodeURI(id.format)}",
+          s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/remove/${encodeURI(id.format)}",
         responseType = "arraybuffer"
       )
       .map(_ => ())


### PR DESCRIPTION
Small mistake preventing the removal of indivdual seqs of the cal queue