### PR TITLE
SEQNG-768: Do not remove the last executed sequence

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
@@ -12,7 +12,8 @@ import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages.SeqexecPages
-import seqexec.web.client.model.{ SectionClosed, SectionOpen }
+import seqexec.web.client.model.SectionClosed
+import seqexec.web.client.model.SectionOpen
 import seqexec.web.client.model.TabSelected
 import seqexec.web.client.semanticui._
 import seqexec.web.client.semanticui.elements.message.IconMessage
@@ -47,6 +48,7 @@ object SequenceTabContent {
     .render_P { p =>
       val SequenceTabContentFocus(isLogged,
                                   instrument,
+                                  _,
                                   _,
                                   active,
                                   logDisplayed) = p.p

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbars.scala
@@ -273,7 +273,7 @@ object SequenceDefaultToolbar {
             ^.cls := "ui left floated column eight wide computer eight wide tablet only",
             p.controlReader(_() match {
               case Some(c) => SequenceControl(SequenceControl.Props(c))
-              case _       => ReactFragment()
+              case _       => <.div()
             })
           ),
           <.div(
@@ -281,7 +281,7 @@ object SequenceDefaultToolbar {
             SeqexecStyles.infoOnControl,
             p.observerReader(_() match {
               case Some(p) => SequenceInfo(SequenceInfo.Props(p))
-              case _       => ReactFragment()
+              case _       => <.div()
             })
           )
         )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -99,8 +99,6 @@ object actions {
   final case class RemoveSeqCalCompleted(qid: QueueId) extends Action
   final case class RemoveSeqCalFailed(qid:    QueueId, id: Observation.Id) extends Action
 
-  final case class RememberCompleted(s: SequenceView) extends Action
-
   final case class AppendToLog(l: ServerLogMessage) extends Action
   final case object ToggleLogArea extends Action
 
@@ -164,8 +162,6 @@ object actions {
              .collect(standardStep)))
       val dayCalQueue = view.queues.values.map(x => s"${x.execState} ${x.queue}").mkString(",")
       s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, dayCal: '${dayCalQueue}', loaded: '${view.loaded.mkString(",")}', $someSteps)"
-    case s @ RememberCompleted(view)                    =>
-      s"${s.getClass.getSimpleName}(${view.id})"
     case a                                              =>
       s"$a"
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
@@ -123,6 +123,7 @@ object SeqexecCircuit
           SequenceTabContentFocus(o,
                                   tab.instrument,
                                   tab.sequence.map(_.id),
+                                  tab.isComplete,
                                   TabSelected.fromBoolean(active),
                                   log)
         case (_: CalibrationQueueTab, active) =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/SeqexecCircuit.scala
@@ -114,25 +114,8 @@ object SeqexecCircuit
     this.zoomG(constructor)
   }
 
-  val seqexecTabs: ModelR[SeqexecAppRootModel, NonEmptyList[TabContentFocus]] = {
-    val getter = SeqexecAppRootModel.logDisplayL.asGetter.zip(SeqexecAppRootModel.sequencesOnDisplayL.asGetter)
-    val constructor = ClientStatus.canOperateG.zip(getter) >>> { p =>
-      val (o, (log, SequencesOnDisplay(tabs))) = p
-      NonEmptyList.fromListUnsafe(tabs.withFocus.toList.collect {
-        case (tab: SequenceTab, active) =>
-          SequenceTabContentFocus(o,
-                                  tab.instrument,
-                                  tab.sequence.map(_.id),
-                                  tab.isComplete,
-                                  TabSelected.fromBoolean(active),
-                                  log)
-        case (_: CalibrationQueueTab, active) =>
-          CalQueueTabContentFocus(o, TabSelected.fromBoolean(active), log)
-      })
-    }
-
-    this.zoomG(constructor)
-  }
+  val seqexecTabs: ModelR[SeqexecAppRootModel, NonEmptyList[TabContentFocus]] =
+    this.zoomG(TabContentFocus.tabContentFocusG)
 
   val sequencesOnDisplayRW: ModelRW[SeqexecAppRootModel, SequencesOnDisplay] =
     this.zoomRWL(SeqexecAppRootModel.sequencesOnDisplayL)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/TabContentFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/TabContentFocus.scala
@@ -1,0 +1,71 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.implicits._
+import cats.data.NonEmptyList
+import gem.Observation
+import monocle.Getter
+import seqexec.model.enum._
+import seqexec.web.client.model._
+
+sealed trait TabContentFocus extends Product with Serializable {
+  val canOperate: Boolean
+  val logDisplayed: SectionVisibilityState
+  val active: TabSelected
+}
+
+object TabContentFocus {
+  implicit val eq: Eq[TabContentFocus] =
+    Eq.instance {
+      case (a: SequenceTabContentFocus, b: SequenceTabContentFocus) => a === b
+      case (a: CalQueueTabContentFocus, b: CalQueueTabContentFocus) => a === b
+      case _                                                        => false
+    }
+
+  val tabContentFocusG
+    : Getter[SeqexecAppRootModel, NonEmptyList[TabContentFocus]] = {
+    val getter = SeqexecAppRootModel.logDisplayL.asGetter
+      .zip(SeqexecAppRootModel.sequencesOnDisplayL.asGetter)
+    ClientStatus.canOperateG.zip(getter) >>> { p =>
+      val (o, (log, SequencesOnDisplay(tabs))) = p
+      NonEmptyList.fromListUnsafe(tabs.withFocus.toList.collect {
+        case (tab: SequenceTab, active) =>
+          SequenceTabContentFocus(o,
+                                  tab.instrument,
+                                  tab.sequence.map(_.id),
+                                  tab.isComplete,
+                                  TabSelected.fromBoolean(active),
+                                  log)
+        case (_: CalibrationQueueTab, active) =>
+          CalQueueTabContentFocus(o, TabSelected.fromBoolean(active), log)
+      })
+    }
+  }
+}
+
+final case class SequenceTabContentFocus(canOperate:   Boolean,
+                                         instrument:   Option[Instrument],
+                                         id:           Option[Observation.Id],
+                                         completed:    Boolean,
+                                         active:       TabSelected,
+                                         logDisplayed: SectionVisibilityState)
+    extends TabContentFocus
+
+object SequenceTabContentFocus {
+  implicit val eq: Eq[SequenceTabContentFocus] =
+    Eq.by(x =>
+      (x.canOperate, x.instrument, x.id, x.completed, x.active, x.logDisplayed))
+}
+
+final case class CalQueueTabContentFocus(canOperate:   Boolean,
+                                         active:       TabSelected,
+                                         logDisplayed: SectionVisibilityState)
+    extends TabContentFocus
+
+object CalQueueTabContentFocus {
+  implicit val eq: Eq[CalQueueTabContentFocus] =
+    Eq.by(x => (x.canOperate, x.active, x.logDisplayed))
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -156,51 +156,6 @@ package circuit {
       Eq.by(x => (x.canOperate, x.tabs, x.defaultObserver))
   }
 
-  sealed trait TabContentFocus extends Product with Serializable {
-    val canOperate: Boolean
-    val logDisplayed: SectionVisibilityState
-    val active: TabSelected
-  }
-
-  object TabContentFocus {
-    implicit val eq: Eq[TabContentFocus] =
-      Eq.instance {
-        case (a: SequenceTabContentFocus, b: SequenceTabContentFocus) => a === b
-        case (a: CalQueueTabContentFocus, b: CalQueueTabContentFocus) => a === b
-        case _                                                        => false
-      }
-  }
-
-  final case class SequenceTabContentFocus(canOperate:   Boolean,
-                                           instrument:   Option[Instrument],
-                                           id:           Option[Observation.Id],
-                                           completed:    Boolean,
-                                           active:       TabSelected,
-                                           logDisplayed: SectionVisibilityState)
-      extends TabContentFocus
-
-  object SequenceTabContentFocus {
-    implicit val eq: Eq[SequenceTabContentFocus] =
-      Eq.by(
-        x =>
-          (x.canOperate,
-           x.instrument,
-           x.id,
-           x.completed,
-           x.active,
-           x.logDisplayed))
-  }
-
-  final case class CalQueueTabContentFocus(canOperate:   Boolean,
-                                           active:       TabSelected,
-                                           logDisplayed: SectionVisibilityState)
-      extends TabContentFocus
-
-  object CalQueueTabContentFocus {
-    implicit val eq: Eq[CalQueueTabContentFocus] =
-      Eq.by(x => (x.canOperate, x.active, x.logDisplayed))
-  }
-
   final case class SequenceInfoFocus(canOperate: Boolean,
                                      obsName:    Option[String],
                                      status:     Option[SequenceState],
@@ -211,8 +166,9 @@ package circuit {
     implicit val eq: Eq[SequenceInfoFocus] =
       Eq.by(x => (x.canOperate, x.obsName, x.status, x.targetName))
 
-    def sequenceInfoG(id: Observation.Id)
-      : Getter[SeqexecAppRootModel, Option[SequenceInfoFocus]] = {
+    def sequenceInfoG(
+      id: Observation.Id
+    ): Getter[SeqexecAppRootModel, Option[SequenceInfoFocus]] = {
       val getter =
         SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
           SequencesOnDisplay.tabG(id))
@@ -247,8 +203,9 @@ package circuit {
            x.totalSteps,
            x.isPreview))
 
-    def statusAndStepG(id: Observation.Id)
-      : Getter[SeqexecAppRootModel, Option[StatusAndStepFocus]] = {
+    def statusAndStepG(
+      id: Observation.Id
+    ): Getter[SeqexecAppRootModel, Option[StatusAndStepFocus]] = {
       val getter =
         SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
           SequencesOnDisplay.tabG(id))
@@ -292,8 +249,9 @@ package circuit {
            x.isPreview,
            x.tableState))
 
-    def stepsTableG(id: Observation.Id)
-      : Getter[SeqexecAppRootModel, Option[StepsTableFocus]] =
+    def stepsTableG(
+      id: Observation.Id
+    ): Getter[SeqexecAppRootModel, Option[StepsTableFocus]] =
       SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
         SequencesOnDisplay.tabG(id)) >>> {
         _.flatMap {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/circuit/package.scala
@@ -174,13 +174,21 @@ package circuit {
   final case class SequenceTabContentFocus(canOperate:   Boolean,
                                            instrument:   Option[Instrument],
                                            id:           Option[Observation.Id],
+                                           completed:    Boolean,
                                            active:       TabSelected,
                                            logDisplayed: SectionVisibilityState)
       extends TabContentFocus
 
   object SequenceTabContentFocus {
     implicit val eq: Eq[SequenceTabContentFocus] =
-      Eq.by(x => (x.canOperate, x.instrument, x.id, x.active, x.logDisplayed))
+      Eq.by(
+        x =>
+          (x.canOperate,
+           x.instrument,
+           x.id,
+           x.completed,
+           x.active,
+           x.logDisplayed))
   }
 
   final case class CalQueueTabContentFocus(canOperate:   Boolean,
@@ -203,7 +211,8 @@ package circuit {
     implicit val eq: Eq[SequenceInfoFocus] =
       Eq.by(x => (x.canOperate, x.obsName, x.status, x.targetName))
 
-    def sequenceInfoG(id: Observation.Id): Getter[SeqexecAppRootModel, Option[SequenceInfoFocus]] = {
+    def sequenceInfoG(id: Observation.Id)
+      : Getter[SeqexecAppRootModel, Option[SequenceInfoFocus]] = {
       val getter =
         SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
           SequencesOnDisplay.tabG(id))
@@ -238,7 +247,8 @@ package circuit {
            x.totalSteps,
            x.isPreview))
 
-    def statusAndStepG(id: Observation.Id): Getter[SeqexecAppRootModel, Option[StatusAndStepFocus]] = {
+    def statusAndStepG(id: Observation.Id)
+      : Getter[SeqexecAppRootModel, Option[StatusAndStepFocus]] = {
       val getter =
         SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
           SequencesOnDisplay.tabG(id))
@@ -282,7 +292,8 @@ package circuit {
            x.isPreview,
            x.tableState))
 
-    def stepsTableG(id: Observation.Id): Getter[SeqexecAppRootModel, Option[StepsTableFocus]] =
+    def stepsTableG(id: Observation.Id)
+      : Getter[SeqexecAppRootModel, Option[StepsTableFocus]] =
       SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
         SequencesOnDisplay.tabG(id)) >>> {
         _.flatMap {
@@ -340,7 +351,8 @@ package circuit {
     implicit val eq: Eq[SequenceControlFocus] =
       Eq.by(x => (x.canOperate, x.control))
 
-    def seqControlG(id: Observation.Id): Getter[SeqexecAppRootModel, Option[SequenceControlFocus]] = {
+    def seqControlG(id: Observation.Id)
+      : Getter[SeqexecAppRootModel, Option[SequenceControlFocus]] = {
       val getter = SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
         SequencesOnDisplay.tabG(id))
       ClientStatus.canOperateG.zip(getter) >>> {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/LoadedSequencesHandler.scala
@@ -45,6 +45,7 @@ class LoadedSequencesHandler[M](modelRW: ModelRW[M, SODLocationFocus])
       updatedL(upSelected >>> upLocation)
 
     case ServerMessage(SequenceCompleted(sv)) =>
+      // When a a sequence completes we keep the state client side
       sv.sessionQueue
         .find(_.status === SequenceState.Completed)
         .map { k =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/SequenceDisplayHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/SequenceDisplayHandler.scala
@@ -67,11 +67,6 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus])
 
   }
 
-  def handleRememberCompleted: PartialFunction[Any, ActionResult[M]] = {
-    case RememberCompleted(s) =>
-      updatedL(SequencesFocus.sod.modify(_.markCompleted(s)))
-  }
-
   def handleClean: PartialFunction[Any, ActionResult[M]] = {
     case CleanSequences =>
       updatedL(SequencesFocus.sod.modify(_.cleanAll))
@@ -79,13 +74,12 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus])
 
   def handleLoadFailed: PartialFunction[Any, ActionResult[M]] = {
     case SequenceLoadFailed(id) =>
-      updatedL(SequencesFocus.sod.modify(_.loadingComplete(id)))
+      updatedL(SequencesFocus.sod.modify(_.loadingFailed(id)))
   }
 
   override def handle: PartialFunction[Any, ActionResult[M]] =
     List(handleSelectSequenceDisplay,
          handleShowHideStep,
          handleLoadFailed,
-         handleCalTabObserver,
-         handleRememberCompleted).combineAll
+         handleCalTabObserver).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -147,6 +147,11 @@ sealed trait SequenceTab extends SeqexecTab {
     case _                        => true
   }
 
+  def isComplete: Boolean = this match {
+    case InstrumentSequenceTab(_, _, Some(_), _, _, _) => true
+    case _                                             => false
+  }
+
   def runningStep: Option[RunningStep] = this match {
     case _: InstrumentSequenceTab => sequence.flatMap(_.runningStep)
     case _                        => none

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -147,9 +147,11 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     }
 
   implicit val cqtCogen: Cogen[CalibrationQueueTab] =
-    Cogen[(TableState[StepsTable.TableColumn], BatchExecState, Option[Observer])].contramap { x =>
-      (x.tableState, x.state, x.observer)
-    }
+    Cogen[
+      (TableState[StepsTable.TableColumn], BatchExecState, Option[Observer])]
+      .contramap { x =>
+        (x.tableState, x.state, x.observer)
+      }
 
   implicit val arbQueueSeqOperations: Arbitrary[QueueSeqOperations] =
     Arbitrary {
@@ -160,7 +162,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
 
   implicit val sopCogen: Cogen[QueueSeqOperations] =
     Cogen[RemoveSeqQueue].contramap(x => x.removeSeqQueue)
-
 
   implicit val arbInstrumentSequenceTab: Arbitrary[InstrumentSequenceTab] =
     Arbitrary {
@@ -362,9 +363,10 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         g <- arbitrary[Boolean]
         i <- arbitrary[Option[Instrument]]
         d <- arbitrary[Option[Observation.Id]]
+        c <- arbitrary[Boolean]
         s <- arbitrary[TabSelected]
         l <- arbitrary[SectionVisibilityState]
-      } yield SequenceTabContentFocus(g, i, d, s, l)
+      } yield SequenceTabContentFocus(g, i, d, c, s, l)
     }
 
   implicit val stcfCogen: Cogen[SequenceTabContentFocus] =


### PR DESCRIPTION
When a sequence completes we want to still display it though it has been removed from the server side model. Thus we copy the state, however there were some bugs on the process

This PR fixes that and it also fixes a small bug leading to SEQNG-765

![seqexec - gs 2018-10-16 16-22-04](https://user-images.githubusercontent.com/3615303/47042094-d9721c80-d160-11e8-8a09-576008741893.png)
