### PR TITLE
Fixed some issues with calibration queue status

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -310,7 +310,7 @@ class Engine[D, U](stateL: Lens[D, Engine.State]) {
   private def inspect[A](f: D => A): HandleType[A] =
     Handle.inspect(f)
 
-  private def modify(f: D => D): HandleType[Unit] =
+  def modify(f: D => D): HandleType[Unit] =
     Handle.modify(f)
 
   private def getS(id: Observation.Id): HandleType[Option[Sequence.State]] = get.map(stateL.get(_).sequences.get(id))

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/BatchCommandState.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/BatchCommandState.scala
@@ -6,16 +6,13 @@ package seqexec.model.enum
 import cats.Eq
 import seqexec.model.{ClientId, Observer, UserDetails}
 
-sealed trait BatchCommandState extends Product with Serializable {
-  def running: Boolean = this match {
-    case BatchCommandState.Idle | BatchCommandState.Stop => false
-    case BatchCommandState.Run(_, _, _)                  => true
-  }
-}
+sealed trait BatchCommandState extends Product with Serializable
 
 object BatchCommandState {
   case object Idle extends BatchCommandState
-  final case class Run(observer: Observer, user: UserDetails, clientId: ClientId) extends BatchCommandState
+  final case class Run(observer: Observer,
+                       user: UserDetails,
+                       clientId: ClientId) extends BatchCommandState
   case object Stop extends BatchCommandState
 
   implicit val equal: Eq[BatchCommandState] = Eq.fromUniversalEquals

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/BatchExecState.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/BatchExecState.scala
@@ -6,7 +6,13 @@ package seqexec.model.enum
 import cats.Eq
 import cats.Show
 
-sealed trait BatchExecState extends Product with Serializable
+sealed trait BatchExecState extends Product with Serializable {
+  def running: Boolean = this match {
+    case BatchExecState.Running |
+         BatchExecState.Waiting => true
+    case _                      => false
+  }
+}
 
 object BatchExecState {
   case object Idle extends BatchExecState // Queue is not running, and has unfinished sequences.

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -450,7 +450,8 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
             st
           } else {
             (EngineState.sequences.modify(ss => ss - seqId) >>>
-             EngineState.selected.modify(ss => ss.toList.filter{case (_, x) => x =!= seqId}.toMap))(st)
+             EngineState.selected.modify(ss => ss.toList.filter{case (_, x) => x =!= seqId}.toMap) >>>
+             EngineState.queues.modify(_.mapValues(ExecutionQueue.queue.modify(_.filterNot(_ === seqId)))))(st)
           }
       } withEvent UnloadSequence(seqId)).toHandle
     )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -249,34 +249,38 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
   def cmdStateO(qid: QueueId): Optional[EngineState, BatchCommandState] =
     queueO(qid) ^|-> ExecutionQueue.cmdState
 
-  private def addSeqs(qid: QueueId, seqIds: List[Observation.Id]): Endo[EngineState] = st => (
-    for {
-      q    <- st.queues.get(qid)
-      seqs <- seqIds.filter(sid => st.executionState.sequences.get(sid).map(seq => !seq.status.isRunning && !seq.status.isCompleted && !q.queue.contains(sid)).getOrElse(false)).some.filter(_.nonEmpty)
-      if (q.status(st) =!= BatchExecState.Running)
-    } yield queueO(qid).modify(_.addSeqs(seqs))(st)
-  ).getOrElse(st)
+  private def addSeqs(qid: QueueId, seqIds: List[Observation.Id]): executeEngine.HandleType[Unit] =
+    executeEngine.get.flatMap{ st => (
+      for {
+        q <- st.queues.get(qid)
+        seqs <- seqIds.filter(sid => st.executionState.sequences.get(sid)
+          .map(seq => !seq.status.isRunning && !seq.status.isCompleted && !q.queue.contains(sid))
+          .getOrElse(false)).some.filter(_.nonEmpty)
+        if (!seqs.isEmpty)
+      } yield executeEngine.modify(queueO(qid).modify(_.addSeqs(seqs))) *>
+        ((q.cmdState, q.status(st)) match {
+        case (_, BatchExecState.Completed)       => ((EngineState.queues ^|-? index(qid) ^|-> ExecutionQueue.cmdState)
+          .set(BatchCommandState.Idle) >>> {(_, ())}).toHandle
+        case (BatchCommandState.Run(o, u, c), _) => runQueue(qid, o, u, c)
+        case _                                   => executeEngine.unit
+      })
+    ).getOrElse(executeEngine.unit)}
 
-  def addSequencesToQueue(q: EventQueue, qid: QueueId, seqIds: List[Observation.Id]): IO[Either[SeqexecFailure, Unit]] = q.enqueue1(
-    Event.modifyState[executeEngine.ConcreteTypes]((addSeqs(qid, seqIds) withEvent UpdateQueueAdd(qid, seqIds)).toHandle)
+  def addSequencesToQueue(q: EventQueue, qid: QueueId, seqIds: List[Observation.Id])
+  : IO[Either[SeqexecFailure, Unit]] = q.enqueue1(
+    Event.modifyState[executeEngine.ConcreteTypes](addSeqs(qid, seqIds)
+      .map[executeEngine.ConcreteTypes#EventData](_ => UpdateQueueAdd(qid, seqIds)))
   ).map(_.asRight)
 
-  private def addSeq(qid: QueueId, seqId: Observation.Id): Endo[EngineState] = st => (
-    for {
-      q   <- st.queues.get(qid)
-      seq <- st.executionState.sequences.get(seqId)
-      if (q.status(st) =!= BatchExecState.Running && !seq.status.isRunning && !seq.status.isCompleted && !q.queue.contains(seqId))
-    } yield queueO(qid).modify(_.addSeq(seqId))(st)
-  ).getOrElse(st)
-
-  def addSequenceToQueue(q: EventQueue, qid: QueueId, seqId: Observation.Id): IO[Either[SeqexecFailure, Unit]] = q.enqueue1(
-    Event.modifyState[executeEngine.ConcreteTypes]((addSeq(qid, seqId) withEvent UpdateQueueAdd(qid, List(seqId))).toHandle)
-  ).map(_.asRight)
+  def addSequenceToQueue(q: EventQueue, qid: QueueId, seqId: Observation.Id): IO[Either[SeqexecFailure, Unit]] =
+    addSequencesToQueue(q, qid, List(seqId))
 
   private def removeSeq(qid: QueueId, seqId: Observation.Id): Endo[EngineState] = st => (
     for {
       q <- st.queues.get(qid)
-      if (q.status(st) =!= BatchExecState.Running && q.queue.contains(seqId))
+      if (q.queue.contains(seqId))
+      if (q.status(st) =!= BatchExecState.Running || st.executionState.sequences.get(seqId)
+        .map(seq => !seq.status.isRunning && !seq.status.isCompleted).getOrElse(true))
     } yield queueO(qid).modify(_.removeSeq(seqId))(st)
   ).getOrElse(st)
 
@@ -287,7 +291,7 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
   private def moveSeq(qid: QueueId, seqId: Observation.Id, d: Int): Endo[EngineState] = st => (
     for {
       q <- st.queues.get(qid)
-      if (q.status(st) =!= BatchExecState.Running && q.queue.contains(seqId))
+      if (q.queue.contains(seqId))
     } yield queueO(qid).modify(_.moveSeq(seqId, d))(st)
   ).getOrElse(st)
 
@@ -328,10 +332,12 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
 
   def startQueue(q: EventQueue, qid: QueueId, observer: Observer, user: UserDetails, clientId: ClientId): IO[Either[SeqexecFailure, Unit]] = q.enqueue1(
     Event.modifyState[executeEngine.ConcreteTypes](executeEngine.get.flatMap{ st => {
-      queueO(qid).getOption(st).map {
+      queueO(qid).getOption(st).filter(!_.queue.isEmpty).map {
         _.status(st) match {
-          case BatchExecState.Idle     => ((EngineState.queues ^|-? index(qid) ^|-> ExecutionQueue.cmdState).set(BatchCommandState.Run(observer, user, clientId)) >>> {(_, ())}).toHandle *> runQueue(qid, observer, user, clientId)
-          case BatchExecState.Stopping => ((EngineState.queues ^|-? index(qid) ^|-> ExecutionQueue.cmdState).set(BatchCommandState.Run(observer, user, clientId)) >>> {(_, ())}).toHandle
+          case BatchExecState.Idle |
+               BatchExecState.Stopping => ((EngineState.queues ^|-? index(qid) ^|-> ExecutionQueue.cmdState)
+            .set(BatchCommandState.Run(observer, user, clientId)) >>> {(_, ())}).toHandle *>
+            runQueue(qid, observer, user, clientId)
           case _                       => executeEngine.unit
         }
       }.getOrElse(executeEngine.unit)
@@ -349,7 +355,8 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
     Event.modifyState[executeEngine.ConcreteTypes](executeEngine.get.flatMap{ st =>
       queueO(qid).getOption(st).map {
         _.status(st) match {
-          case BatchExecState.Running => (cmdStateO(qid).set(BatchCommandState.Stop) >>> {(_, ())}).toHandle *> stopSequencesInQueue(qid)
+          case BatchExecState.Running => (cmdStateO(qid).set(BatchCommandState.Stop) >>> {(_, ())}).toHandle *>
+            stopSequencesInQueue(qid)
           case BatchExecState.Waiting => (cmdStateO(qid).set(BatchCommandState.Stop) >>> {(_, ())}).toHandle
           case _                      => executeEngine.unit
         }
@@ -609,7 +616,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     val seqInfos = st.sequences.map { case (id, ObserverSequence(_, seq)) => id -> ((seq.resources, st.executionState.sequences.get(id))) }.collect { case (id, (res, Some(s))) => id -> ((res, s.status)) }
     // Set of resources used by all running sequences
     val used = seqInfos.collect { case (_, (res, status)) if (status.isRunning) => res }.foldRight(Set[Resource]())(_.union(_))
-    // For each observations in the queue that is not yet run, retrieve the required resources
+    // For each observation in the queue that is not yet run, retrieve the required resources
     val obs = st.queues.get(qid).map(_.queue.fproduct(seqInfos.get).collect {
       case (id, Some((res, status))) if (!status.isRunning && !status.isCompleted) => id -> res
     }).orEmpty

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -156,11 +156,12 @@ package object server {
       val statuses: Seq[SequenceState] = q.queue.map(st.executionState.sequences.get(_).map(_.status))
         .collect{ case Some(x) => x }
 
-      if(statuses.forall(_.isCompleted)) BatchExecState.Completed
-      else q.cmdState match {
+
+      q.cmdState match {
         case BatchCommandState.Idle         => BatchExecState.Idle
-        case BatchCommandState.Run(_, _, _) => if(statuses.exists(_.isRunning)) BatchExecState.Running
-                                               else BatchExecState.Waiting
+        case BatchCommandState.Run(_, _, _) => if(statuses.forall(_.isCompleted)) BatchExecState.Completed
+                                               else if(statuses.exists(_.isRunning)) BatchExecState.Running
+                                                    else BatchExecState.Waiting
         case BatchCommandState.Stop         => if(statuses.exists(_.isRunning)) BatchExecState.Stopping
                                                else BatchExecState.Idle
       }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -347,7 +347,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     }).unsafeRunSync
   }
 
-  it should "not remove sequence id if queue is running" in {
+  it should "not remove sequence id if sequence is running" in {
     val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
       SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).modify(_ ++ List(seqObsId1, seqObsId2)) >>>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueToolbar.scala
@@ -53,7 +53,7 @@ object CalQueueToolbar {
     val anyRunning: Boolean =
       clearCalRunning || addDayCalRunning || runRunning || stopRunning
 
-    val queueRunning: Boolean = control.state.running
+    val queueRunning: Boolean = control.execState.running
   }
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]


### PR DESCRIPTION
* Calibration queue status is Completed as long has it has run at least once, and there are no unrun sequences in the queue.
* It goes back to Idle if it is Completed, but a new sequence is added.
* Now it is possible to add or remove sequences to the Calibration queue while it is running.
* It now attempts to start a new added sequence, if the queue is running.
* Fixed bug where sequences removed from the Session queue were not removed from the calibration queue.