### PR TITLE
Make all BooPicklers explicit

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/authentication.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/authentication.scala
@@ -7,6 +7,11 @@ import cats.Eq
 
 // Shared classes used for authentication
 final case class UserLoginRequest(username: String, password: String)
+
+object UserLoginRequest {
+  implicit val eq: Eq[UserLoginRequest] = Eq.fromUniversalEquals
+}
+
 final case class UserDetails(username: String, displayName: String)
 
 object UserDetails {

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
@@ -66,4 +66,7 @@ object Instrument {
   val all: NonEmptyList[Instrument] =
     gsInstruments.concatNel(gnInstruments)
 
+  val allResources: NonEmptyList[Resource] =
+    NonEmptyList.of(Resource.P1, Resource.OI, Resource.TCS, Resource.Gcal, Resource.Gems, Resource.Altair) ::: Instrument.all
+
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -462,6 +462,18 @@ trait SeqexecModelArbitraries extends ArbObservation {
            List[Observation.Id])]
       .contramap(x => (x.id, x.name, x.cmdState, x.execState, x.queue))
 
+  implicit val arbUserLoginRequest: Arbitrary[UserLoginRequest] =
+    Arbitrary {
+      for {
+        u <- arbitrary[String]
+        p <- arbitrary[String]
+      } yield UserLoginRequest(u, p)
+    }
+
+  implicit val userLoginRequestCogen: Cogen[UserLoginRequest] =
+    Cogen[(String, String)].contramap(x =>
+      (x.username, x.password))
+
 }
 
 object SeqexecModelArbitraries extends SeqexecModelArbitraries

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/GemModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/GemModelBooPicklers.scala
@@ -3,7 +3,7 @@
 
 package seqexec.model.boopickle
 
-import boopickle.Default._
+import boopickle.DefaultBasic._
 import gem.{ProgramId, Observation}
 import gem.math.Index
 import java.time.{LocalDate, Year}

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -3,7 +3,8 @@
 
 package seqexec.model.boopickle
 
-import boopickle.Default._
+import boopickle.DefaultBasic._
+import cats.implicits._
 import gem.Observation
 import java.time.Instant
 
@@ -30,13 +31,28 @@ trait ModelBooPicklers extends GemModelBooPicklers {
   // IMPORTANT The order of the picklers is very relevant to the generated size
   // add them with care
   //**********************
-  implicit val instrumentPickler = generatePickler[Instrument]
+  implicit val instrumentPickler = transformPickler(
+    (t: Int) =>
+      Instrument.all
+        .find(_.ordinal === t)
+        .getOrElse(throw new RuntimeException("Failed to decode instrument")))(
+    _.ordinal)
 
-  implicit val resourcePickler = generatePickler[Resource]
+  implicit val resourcePickler = transformPickler(
+    (t: Int) =>
+      Instrument.allResources
+        .find(_.ordinal === t)
+        .getOrElse(throw new RuntimeException("Failed to decode resource")))(
+    _.ordinal)
 
   implicit val operatorPickler = generatePickler[Operator]
 
-  implicit val systemNamePickler = generatePickler[SystemName]
+  implicit val systemNamePickler = transformPickler(
+    (t: String) =>
+      SystemName.all
+        .find(_.system === t)
+        .getOrElse(throw new RuntimeException("Failed to decode system name")))(
+    _.system)
 
   implicit val observerPickler = generatePickler[Observer]
 
@@ -45,32 +61,44 @@ trait ModelBooPicklers extends GemModelBooPicklers {
   implicit val instantPickler =
     transformPickler((t: Long) => Instant.ofEpochMilli(t))(_.toEpochMilli)
 
-  implicit val cloudCoverPickler = compositePickler[CloudCover]
-    .addConcreteType[CloudCover.Any.type]
-    .addConcreteType[CloudCover.Percent50.type]
-    .addConcreteType[CloudCover.Percent70.type]
-    .addConcreteType[CloudCover.Percent80.type]
+  implicit val cloudCoverPickler = transformPickler(
+    (t: Int) =>
+      CloudCover.all
+        .find(_.toInt === t)
+        .getOrElse(throw new RuntimeException("Failed to decode cloud cover")))(
+    _.toInt)
 
-  implicit val imageQualityPickler = compositePickler[ImageQuality]
-    .addConcreteType[ImageQuality.Any.type]
-    .addConcreteType[ImageQuality.Percent20.type]
-    .addConcreteType[ImageQuality.Percent70.type]
-    .addConcreteType[ImageQuality.Percent85.type]
+  implicit val imageQualityPickler = transformPickler((t: Int) =>
+    ImageQuality.all
+      .find(_.toInt === t)
+      .getOrElse(throw new RuntimeException("Failed to decode image quality")))(
+    _.toInt)
 
-  implicit val skyBackgroundPickler = compositePickler[SkyBackground]
-    .addConcreteType[SkyBackground.Any.type]
-    .addConcreteType[SkyBackground.Percent20.type]
-    .addConcreteType[SkyBackground.Percent50.type]
-    .addConcreteType[SkyBackground.Percent80.type]
+  implicit val skyBackgroundPickler = transformPickler(
+    (t: Int) =>
+      SkyBackground.all
+        .find(_.toInt === t)
+        .getOrElse(throw new RuntimeException(
+          "Failed to decode sky background")))(_.toInt)
 
-  implicit val waterVaporPickler = compositePickler[WaterVapor]
-    .addConcreteType[WaterVapor.Any.type]
-    .addConcreteType[WaterVapor.Percent20.type]
-    .addConcreteType[WaterVapor.Percent50.type]
-    .addConcreteType[WaterVapor.Percent80.type]
+  implicit val waterVaporPickler = transformPickler(
+    (t: Int) =>
+      WaterVapor.all
+        .find(_.toInt === t)
+        .getOrElse(throw new RuntimeException("Failed to decode water vapor")))(
+    _.toInt)
 
-  // Composite pickler for the seqexec event hierarchy
-  // It is not strictly need but reduces the size of the js
+  implicit val sequenceStateCompletedPickler =
+    generatePickler[SequenceState.Completed.type]
+  implicit val sequenceStateIdlePickler =
+    generatePickler[SequenceState.Idle.type]
+  implicit val sequenceStateStoppedPickler =
+    generatePickler[SequenceState.Stopped.type]
+  implicit val sequenceStateRunningPickler =
+    generatePickler[SequenceState.Running]
+  implicit val sequenceStateFailedPickler =
+    generatePickler[SequenceState.Failed]
+
   implicit val sequenceStatePickler = compositePickler[SequenceState]
     .addConcreteType[SequenceState.Completed.type]
     .addConcreteType[SequenceState.Running]
@@ -78,12 +106,28 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     .addConcreteType[SequenceState.Stopped.type]
     .addConcreteType[SequenceState.Idle.type]
 
-  implicit val actionStatusPickler = compositePickler[ActionStatus]
-    .addConcreteType[ActionStatus.Pending.type]
-    .addConcreteType[ActionStatus.Completed.type]
-    .addConcreteType[ActionStatus.Running.type]
-    .addConcreteType[ActionStatus.Paused.type]
-    .addConcreteType[ActionStatus.Failed.type]
+  private val actionStatusIdx = Map((0 -> ActionStatus.Pending),
+                                    (1 -> ActionStatus.Completed),
+                                    (2 -> ActionStatus.Running),
+                                    (3 -> ActionStatus.Paused),
+                                    (4 -> ActionStatus.Failed))
+
+  implicit val actionStatusPickler =
+    transformPickler(
+      (t: Int) =>
+        actionStatusIdx
+          .get(t)
+          .getOrElse(
+            throw new RuntimeException("Falied to decode action status")))(t =>
+      actionStatusIdx.find { case (_, v) => v === t }.map(_._1).getOrElse(-1))
+
+  implicit val stepStatePendingPickler = generatePickler[StepState.Pending.type]
+  implicit val stepStateCompletedPickler =
+    generatePickler[StepState.Completed.type]
+  implicit val stepStateSkippedPickler = generatePickler[StepState.Skipped.type]
+  implicit val stepStateFailedPickler  = generatePickler[StepState.Failed]
+  implicit val stepStateRunningPickler = generatePickler[StepState.Running.type]
+  implicit val stepStatePausedPickler  = generatePickler[StepState.Paused.type]
 
   implicit val stepStatePickler = compositePickler[StepState]
     .addConcreteType[StepState.Pending.type]
@@ -93,12 +137,26 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     .addConcreteType[StepState.Running.type]
     .addConcreteType[StepState.Paused.type]
 
+  implicit val standardStepPickler = generatePickler[StandardStep]
+
   implicit val stepPickler = compositePickler[Step]
     .addConcreteType[StandardStep]
 
   implicit val sequenceMetadataPickler = generatePickler[SequenceMetadata]
 
   implicit val stepConfigPickler = generatePickler[SequenceView]
+
+  implicit val queueIdPickler      = generatePickler[QueueId]
+  implicit val queueOpMovedPickler = generatePickler[QueueManipulationOp.Moved]
+  implicit val queueOpStartedPickler =
+    generatePickler[QueueManipulationOp.Started]
+  implicit val queueOpStoppedPickler =
+    generatePickler[QueueManipulationOp.Stopped]
+  implicit val queueOpClearPickler = generatePickler[QueueManipulationOp.Clear]
+  implicit val queueOpAddedSeqsPickler =
+    generatePickler[QueueManipulationOp.AddedSeqs]
+  implicit val queueOpRemovedSeqsPickler =
+    generatePickler[QueueManipulationOp.RemovedSeqs]
 
   implicit val queueOpPickler = compositePickler[QueueManipulationOp]
     .addConcreteType[QueueManipulationOp.Clear]
@@ -108,30 +166,95 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     .addConcreteType[QueueManipulationOp.AddedSeqs]
     .addConcreteType[QueueManipulationOp.RemovedSeqs]
 
-  implicit val serverLogLevelPickler = compositePickler[ServerLogLevel]
-    .addConcreteType[ServerLogLevel.INFO.type]
-    .addConcreteType[ServerLogLevel.WARN.type]
-    .addConcreteType[ServerLogLevel.ERROR.type]
+  private val serverLogIdx = Map((0 -> ServerLogLevel.INFO),
+                                 (1 -> ServerLogLevel.WARN),
+                                 (2 -> ServerLogLevel.ERROR))
+
+  implicit val serverLogLevelPickler =
+    transformPickler(
+      (t: Int) =>
+        serverLogIdx
+          .get(t)
+          .getOrElse(
+            throw new RuntimeException("Falied to decode server log level")))(
+      t => serverLogIdx.find { case (_, v) => v === t }.map(_._1).getOrElse(-1))
+
+  implicit val clientIdPickler = generatePickler[ClientId]
+  implicit val batchCommandStateIdlePickler =
+    generatePickler[BatchCommandState.Idle.type]
+  implicit val batchCommandStateRun = generatePickler[BatchCommandState.Run]
+  implicit val batchCommandStateStopPickler =
+    generatePickler[BatchCommandState.Stop.type]
 
   implicit val batchCommandPickler = compositePickler[BatchCommandState]
     .addConcreteType[BatchCommandState.Idle.type]
     .addConcreteType[BatchCommandState.Run]
     .addConcreteType[BatchCommandState.Stop.type]
 
-  implicit val batchExecStatePickler = compositePickler[BatchExecState]
-    .addConcreteType[BatchExecState.Idle.type]
-    .addConcreteType[BatchExecState.Waiting.type]
-    .addConcreteType[BatchExecState.Running.type]
-    .addConcreteType[BatchExecState.Stopping.type]
-    .addConcreteType[BatchExecState.Completed.type]
+  private val batchExecStateIdx = Map((0 -> BatchExecState.Idle),
+                                      (1 -> BatchExecState.Running),
+                                      (2 -> BatchExecState.Waiting),
+                                      (3 -> BatchExecState.Stopping),
+                                      (4 -> BatchExecState.Completed))
+
+  implicit val batchExecStatePickler =
+    transformPickler(
+      (t: Int) =>
+        batchExecStateIdx
+          .get(t)
+          .getOrElse(throw new RuntimeException(
+            "Falied to decode batch exec state")))(t =>
+      batchExecStateIdx.find { case (_, v) => v === t }.map(_._1).getOrElse(-1))
 
   implicit val executionQueuePickler = generatePickler[ExecutionQueueView]
+
+  implicit val conditionsPickler = generatePickler[Conditions]
 
   implicit val sequenceQueueIdPickler =
     generatePickler[SequencesQueue[Observation.Id]]
 
   implicit val sequenceQueueViewPickler =
     generatePickler[SequencesQueue[SequenceView]]
+
+  implicit val resourceConflictPickler = generatePickler[ResourceConflict]
+  implicit val instrumentInUsePickler  = generatePickler[InstrumentInUse]
+  implicit val requestFailedPickler    = generatePickler[RequestFailed]
+  implicit val notificatonPickler: Pickler[Notification] =
+    compositePickler[Notification]
+      .addConcreteType[ResourceConflict]
+      .addConcreteType[InstrumentInUse]
+      .addConcreteType[RequestFailed]
+
+  implicit val connectionOpenEventPickler = generatePickler[ConnectionOpenEvent]
+  implicit val sequenceStartPickler       = generatePickler[SequenceStart]
+  implicit val stepExecutedPickler        = generatePickler[StepExecuted]
+  implicit val fileIdStepExecutedPickler  = generatePickler[FileIdStepExecuted]
+  implicit val sequenceCompletedPickler   = generatePickler[SequenceCompleted]
+  implicit val sequenceLoadedPickler      = generatePickler[SequenceLoaded]
+  implicit val sequenceUnloadedPickler    = generatePickler[SequenceUnloaded]
+  implicit val stepBreakpointChangedPickler =
+    generatePickler[StepBreakpointChanged]
+  implicit val operatorUpdatedPickler     = generatePickler[OperatorUpdated]
+  implicit val observerUpdatedPickler     = generatePickler[ObserverUpdated]
+  implicit val conditionsUpdatedPickler   = generatePickler[ConditionsUpdated]
+  implicit val loadSequenceUpdatedPickler = generatePickler[LoadSequenceUpdated]
+  implicit val clearLoadedSequencesUpdatedPickler =
+    generatePickler[ClearLoadedSequencesUpdated]
+  implicit val stepSkipMarkChangedPickler = generatePickler[StepSkipMarkChanged]
+  implicit val sequencePauseRequestedPickler =
+    generatePickler[SequencePauseRequested]
+  implicit val sequencePauseCanceledPickler =
+    generatePickler[SequencePauseCanceled]
+  implicit val sequenceRefreshedPickler   = generatePickler[SequenceRefreshed]
+  implicit val actionStopRequestedPickler = generatePickler[ActionStopRequested]
+  implicit val sequenceUpdatedPickler     = generatePickler[SequenceUpdated]
+  implicit val sequenceErrorPickler       = generatePickler[SequenceError]
+  implicit val sequencePausedPickler      = generatePickler[SequencePaused]
+  implicit val exposurePausedPickler      = generatePickler[ExposurePaused]
+  implicit val serverLogMessagePickler    = generatePickler[ServerLogMessage]
+  implicit val userNotificationPickler    = generatePickler[UserNotification]
+  implicit val queueUpdatedPickler        = generatePickler[QueueUpdated]
+  implicit val nullEventPickler           = generatePickler[NullEvent.type]
 
   // Composite pickler for the seqexec event hierarchy
   // It is not strictly need but reduces the size of the js
@@ -162,5 +285,7 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     .addConcreteType[UserNotification]
     .addConcreteType[QueueUpdated]
     .addConcreteType[NullEvent.type]
+
+  implicit val userLoginPickler = generatePickler[UserLoginRequest]
 
 }

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/GemModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/GemModelBooPicklersSpec.scala
@@ -3,7 +3,7 @@
 
 package seqexec.model.boopickle
 
-import boopickle.Default._
+import boopickle.DefaultBasic._
 import cats.Eq
 import cats.tests.CatsSuite
 import gem.{ProgramId, Observation}

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
@@ -7,7 +7,7 @@ import seqexec.model.enum._
 import seqexec.model._
 import seqexec.model.events._
 import cats.tests.CatsSuite
-import _root_.boopickle.Default._
+import _root_.boopickle.DefaultBasic._
 import org.scalacheck.Arbitrary._
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.SequenceEventsArbitraries._
@@ -66,5 +66,15 @@ final class BoopicklingSpec extends CatsSuite with ModelBooPicklers {
   checkAll("Pickler[SkyBackground]", PicklerTests[SkyBackground].pickler)
   checkAll("Pickler[CloudCover]", PicklerTests[CloudCover].pickler)
   checkAll("Pickler[Conditions]", PicklerTests[Conditions].pickler)
+  checkAll("Pickler[Notification]", PicklerTests[Notification].pickler)
   checkAll("Pickler[UserNotification]", PicklerTests[UserNotification].pickler)
+  checkAll("Pickler[UserLoginRequest]", PicklerTests[UserLoginRequest].pickler)
+  checkAll("Pickler[Instrument]", PicklerTests[Instrument].pickler)
+  checkAll("Pickler[Resource]", PicklerTests[Resource].pickler)
+  checkAll("Pickler[SystemName]", PicklerTests[SystemName].pickler)
+  checkAll("Pickler[SequenceState]", PicklerTests[SequenceState].pickler)
+  checkAll("Pickler[StepState]", PicklerTests[StepState].pickler)
+  checkAll("Pickler[ActionStatus]", PicklerTests[ActionStatus].pickler)
+  checkAll("Pickler[StandardStep]", PicklerTests[StandardStep].pickler)
+  checkAll("Pickler[QueueId]", PicklerTests[QueueId].pickler)
 }


### PR DESCRIPTION
I've noted we don't always explicitly define all boo picklers leading to bigger size. From now on this should fail to compile rather than use the auto generated pickler via macros