### PR TITLE
SEQNG-734: Indicate when the cal queue table changes

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/QueueManipulationOp.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/QueueManipulationOp.scala
@@ -19,16 +19,19 @@ object QueueManipulationOp {
   final case class Clear(qid:     QueueId) extends QueueManipulationOp
   final case class AddedSeqs(qid: QueueId, seqs: List[Observation.Id])
       extends QueueManipulationOp
-  final case class RemovedSeqs(qid: QueueId, seqs: List[Observation.Id])
+  final case class RemovedSeqs(qid:       QueueId,
+                               seqs:      List[Observation.Id],
+                               positions: List[Int])
       extends QueueManipulationOp
 
   implicit val equal: Eq[QueueManipulationOp] = Eq.instance {
-    case (Moved(a), Moved(b))                   => a === b
-    case (Started(a), Started(b))               => a === b
-    case (Stopped(a), Stopped(b))               => a === b
-    case (Clear(a), Clear(b))                   => a === b
-    case (AddedSeqs(a, c), AddedSeqs(b, d))     => a === b && c === d
-    case (RemovedSeqs(a, c), RemovedSeqs(b, d)) => a === b && c === d
-    case _                                      => false
+    case (Moved(a), Moved(b))               => a === b
+    case (Started(a), Started(b))           => a === b
+    case (Stopped(a), Stopped(b))           => a === b
+    case (Clear(a), Clear(b))               => a === b
+    case (AddedSeqs(a, c), AddedSeqs(b, d)) => a === b && c === d
+    case (RemovedSeqs(a, c, e), RemovedSeqs(b, d, f)) =>
+      a === b && c === d && e === f
+    case _ => false
   }
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -92,7 +92,8 @@ trait SequenceEventsArbitraries extends ArbTime {
     for {
       q <- arbitrary[QueueId]
       i <- arbitrary[List[Observation.Id]]
-      m <- Gen.oneOf(Moved(q), Started(q), Stopped(q), Clear(q), AddedSeqs(q, i), RemovedSeqs(q, i))
+      r <- arbitrary[List[Int]]
+      m <- Gen.oneOf(Moved(q), Started(q), Stopped(q), Clear(q), AddedSeqs(q, i), RemovedSeqs(q, i, r))
     } yield m
   }
   implicit val quArb = Arbitrary[QueueUpdated] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -305,8 +305,10 @@ class SeqexecEngine(httpClient: Client[IO], settings: SeqexecEngine.Settings, sm
 
   def removeSequenceFromQueue(q: EventQueue, qid: QueueId, seqId: Observation.Id)
   : IO[Either[SeqexecFailure, Unit]] = q.enqueue1(
-    Event.modifyState[executeEngine.ConcreteTypes](removeSeq(qid, seqId)
-      .map[executeEngine.ConcreteTypes#EventData](_ => UpdateQueueRemove(qid, List(seqId))))
+    Event.modifyState[executeEngine.ConcreteTypes](
+      executeEngine.get.flatMap(st => removeSeq(qid, seqId)
+        .map(_ => UpdateQueueRemove(qid, List(seqId), st.queues.get(qid)
+          .map(_.queue.indexOf(seqId)).toList))))
   ).map(_.asRight)
 
   private def moveSeq(qid: QueueId, seqId: Observation.Id, d: Int): Endo[EngineState] = st => (
@@ -828,7 +830,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     case UnloadSequence(id)            => SequenceUnloaded(id, svs)
     case NotifyUser(m, cid)            => UserNotification(m, cid)
     case UpdateQueueAdd(qid, seqs)     => QueueUpdated(QueueManipulationOp.AddedSeqs(qid, seqs), svs)
-    case UpdateQueueRemove(qid, seqs)  => QueueUpdated(QueueManipulationOp.RemovedSeqs(qid, seqs), svs)
+    case UpdateQueueRemove(qid, s, p)  => QueueUpdated(QueueManipulationOp.RemovedSeqs(qid, s, p), svs)
     case UpdateQueueMoved(qid)         => QueueUpdated(QueueManipulationOp.Moved(qid), svs)
     case UpdateQueueClear(qid)         => QueueUpdated(QueueManipulationOp.Clear(qid), svs)
     case StartQueue(qid, _)            => QueueUpdated(QueueManipulationOp.Started(qid), svs)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -66,7 +66,7 @@ package server {
   final case class StartQueue(qid: QueueId, clientID: ClientId) extends SeqEvent
   final case class StopQueue(qid: QueueId, clientID: ClientId) extends SeqEvent
   final case class UpdateQueueAdd(qid: QueueId, seqs: List[Observation.Id]) extends SeqEvent
-  final case class UpdateQueueRemove(qid: QueueId, seqs: List[Observation.Id]) extends SeqEvent
+  final case class UpdateQueueRemove(qid: QueueId, seqs: List[Observation.Id], pos: List[Int]) extends SeqEvent
   final case class UpdateQueueMoved(qid: QueueId) extends SeqEvent
   final case class UpdateQueueClear(qid: QueueId) extends SeqEvent
   case object NullSeqEvent extends SeqEvent

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -282,20 +282,48 @@ body {
 
 @keyframes calTableFlash {
   0% {
-    box-shadow: 0 0 5px darkcyan;
-  }
-  50% {
     box-shadow: none;
   }
-  100% {
-    box-shadow: 0 0 5px darkcyan;
+  50% {
+    box-shadow: 0 0 8px darken(lightblue, 20%);
+  }
+  0% {
+    box-shadow: none;
   }
 }
 
 .SeqexecStyles-calTableBorder {
   animation-name: calTableFlash;
   animation-duration: 1s;
+  animation-timing-function: linear;
   animation-iteration-count: 2;
+}
+
+@keyframes calRowFlash {
+  0% {
+    background: none;
+    color: inherit;
+  }
+  50% {
+    background: lightblue;
+    color: @white;
+  }
+  100% {
+    background: none;
+    color: inherit;
+  }
+}
+
+.SeqexecStyles-calRowBackground {
+  animation-name: calRowFlash;
+  animation-duration: 0.7s;
+  animation-timing-function: linear;
+  animation-fill-mode: both;
+  animation-iteration-count: 2;
+}
+
+.SeqexecStyles-autoMargin {
+  margin: auto;
 }
 
 .SeqexecStyles-queueAreaRow {

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -481,11 +481,13 @@ body {
   }
 }
 
-.SeqexecStyles-draggableRow {
+.SeqexecStyles-deletedRow {
   animation-name: pullUpRow;
   animation-duration: 0.5s;
   animation-timing-function: linear;
   animation-iteration-count: 1;
+  animation-delay: 0.2s;
+  animation-fill-mode: forwards;
 }
 
 .SeqexecStyles-observeConfig {

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -323,7 +323,7 @@ body {
 }
 
 .SeqexecStyles-autoMargin {
-  margin: auto;
+  margin: auto !important;
 }
 
 .SeqexecStyles-queueAreaRow {
@@ -470,6 +470,10 @@ body {
   overflow: unset !important;
   .borderTop();
   outline: none;
+}
+
+.SeqexecStyles-draggableRow {
+  .borderTop() !important;
 }
 
 .SeqexecStyles-observeConfig {

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -280,6 +280,24 @@ body {
   animation-direction: alternate;
 }
 
+@keyframes calTableFlash {
+  0% {
+    box-shadow: 0 0 5px darkcyan;
+  }
+  50% {
+    box-shadow: none;
+  }
+  100% {
+    box-shadow: 0 0 5px darkcyan;
+  }
+}
+
+.SeqexecStyles-calTableBorder {
+  animation-name: calTableFlash;
+  animation-duration: 1s;
+  animation-iteration-count: 2;
+}
+
 .SeqexecStyles-queueAreaRow {
   .appSegment;
 }

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -301,16 +301,16 @@ body {
 
 @keyframes calRowFlash {
   0% {
-    background: none;
-    color: inherit;
+    background-color: @background;
+    // color: inherit;
   }
   50% {
-    background: lightblue;
-    color: @white;
+    background-color: lightblue;
+    // color: @white;
   }
   100% {
-    background: none;
-    color: inherit;
+    background-color: @background;
+    // color: inherit;
   }
 }
 
@@ -318,7 +318,7 @@ body {
   animation-name: calRowFlash;
   animation-duration: 0.7s;
   animation-timing-function: linear;
-  animation-fill-mode: both;
+  animation-fill-mode: none;
   animation-iteration-count: 2;
 }
 
@@ -472,8 +472,20 @@ body {
   outline: none;
 }
 
+@keyframes pullUpRow {
+  0% {
+    transform: none;
+  }
+  100% {
+    transform: translateY(-100%);
+  }
+}
+
 .SeqexecStyles-draggableRow {
-  .borderTop() !important;
+  animation-name: pullUpRow;
+  animation-duration: 0.5s;
+  animation-timing-function: linear;
+  animation-iteration-count: 1;
 }
 
 .SeqexecStyles-observeConfig {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -268,4 +268,9 @@ object SeqexecStyles {
   val labelAsButton: GStyle = GStyle.fromString("SeqexecStyles-labelAsButton")
 
   val calTableBorder: GStyle = GStyle.fromString("SeqexecStyles-calTableBorder")
+
+  val calRowBackground: GStyle =
+    GStyle.fromString("SeqexecStyles-calRowBackground")
+
+  val autoMargin: GStyle = GStyle.fromString("SeqexecStyles-autoMargin")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -273,4 +273,6 @@ object SeqexecStyles {
     GStyle.fromString("SeqexecStyles-calRowBackground")
 
   val autoMargin: GStyle = GStyle.fromString("SeqexecStyles-autoMargin")
+
+  val draggableRow: GStyle = GStyle.fromString("SeqexecStyles-draggableRow")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -274,5 +274,5 @@ object SeqexecStyles {
 
   val autoMargin: GStyle = GStyle.fromString("SeqexecStyles-autoMargin")
 
-  val draggableRow: GStyle = GStyle.fromString("SeqexecStyles-draggableRow")
+  val deletedRow: GStyle = GStyle.fromString("SeqexecStyles-deletedRow")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -266,4 +266,6 @@ object SeqexecStyles {
     GStyle.fromString("SeqexecStyles-settingsCellRow")
 
   val labelAsButton: GStyle = GStyle.fromString("SeqexecStyles-labelAsButton")
+
+  val calTableBorder: GStyle = GStyle.fromString("SeqexecStyles-calTableBorder")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.extra.Reusability
 import seqexec.model.CalibrationQueueId
 import seqexec.web.client.semanticui._
 import seqexec.web.client.semanticui.elements.message.IconMessage
@@ -17,6 +18,7 @@ import seqexec.web.client.model.SectionOpen
 import seqexec.web.client.model.SectionVisibilityState
 import seqexec.web.client.model.TabSelected
 import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.reusability._
 import web.client.style._
 
 /**
@@ -32,6 +34,8 @@ object CalQueueTabContent {
     protected[queue] val dayCalConnect =
       SeqexecCircuit.connect(SeqexecCircuit.calQueueReader(CalibrationQueueId))
   }
+
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   private val defaultContent = IconMessage(
     IconMessage
@@ -70,6 +74,7 @@ object CalQueueTabContent {
         ).when(p.active === TabSelected.Selected)
       )
     }
+    .configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(p: Props): Unmounted[Props, Unit, Unit] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -45,7 +45,7 @@ object CalQueueTable {
   case object ObsIdColumn extends TableColumn
   case object InstrumentColumn extends TableColumn
 
-  private val RemoveColumnWidth  = 34.0
+  private val RemoveColumnWidth  = 30.0
   private val ObsIdMinWidth      = 66.2167 + SeqexecStyles.TableBorderWidth
   private val InstrumentMinWidth = 90.4333 + SeqexecStyles.TableBorderWidth
 
@@ -162,12 +162,12 @@ object CalQueueTable {
 
   val obsIdRenderer: CellRenderer[js.Object, js.Object, CalQueueRow] =
     (_, _, _, r: CalQueueRow, _) => {
-      <.p(SeqexecStyles.queueTextColumn, r.obsId.format)
+      <.p(SeqexecStyles.queueText, r.obsId.format)
     }
 
   val instrumentRenderer: CellRenderer[js.Object, js.Object, CalQueueRow] =
     (_, _, _, r: CalQueueRow, _) => {
-      <.p(SeqexecStyles.queueTextColumn, r.instrument.show)
+      <.p(SeqexecStyles.queueText, r.instrument.show)
     }
 
   def removeSeqRenderer(
@@ -219,7 +219,7 @@ object CalQueueTable {
             cellRenderer = renderer(c),
             headerRenderer = resizableHeaderRenderer(
               state.tableState.resizeRow(c, size, updateState)),
-            className = SeqexecStyles.paddedStepRow.htmlClass
+            className = SeqexecStyles.queueTextColumn.htmlClass
           ))
       case ColumnRenderArgs(ColumnMeta(c, name, label, _, _),
                             _,
@@ -232,7 +232,7 @@ object CalQueueTable {
                              cellRenderer = renderer(c),
                              className =
                                if (c === InstrumentColumn)
-                                 SeqexecStyles.paddedStepRow.htmlClass
+                                 SeqexecStyles.queueTextColumn.htmlClass
                                else "")
         )
     }
@@ -244,6 +244,10 @@ object CalQueueTable {
         SeqexecStyles.headerRowStyle
       case (_, CalQueueRow(i, _)) if p.addedRows.contains(i) =>
         SeqexecStyles.stepRow |+| SeqexecStyles.calRowBackground
+      case (r, CalQueueRow(i, _)) if p.addedRows.contains(i) && r > 0 =>
+        SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow |+| SeqexecStyles.calRowBackground
+      case (r, _) if r > 0 =>
+        SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow
       case _ =>
         SeqexecStyles.stepRow
     }).htmlClass

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
@@ -29,6 +29,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   def handleAddAllDayCal: PartialFunction[Any, ActionResult[M]] = {
     case RequestAllDayCal(qid) =>
       updatedL(
+        CalibrationQueues.calLastOpO(qid).set(none) >>>
         CalibrationQueues
           .addDayCalL(qid)
           .set(AddDayCalOperation.AddDayCalInFlight))
@@ -38,6 +39,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   def handleClearAllCal: PartialFunction[Any, ActionResult[M]] = {
     case RequestClearAllCal(qid) =>
       updatedL(
+        CalibrationQueues.calLastOpO(qid).set(none) >>>
         CalibrationQueues
           .clearAllCalL(qid)
           .set(ClearAllCalOperation.ClearAllCalInFlight))
@@ -47,6 +49,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   def handleRunCal: PartialFunction[Any, ActionResult[M]] = {
     case RequestRunCal(qid) =>
       updatedL(
+        CalibrationQueues.calLastOpO(qid).set(none) >>>
         CalibrationQueues.runCalL(qid).set(RunCalOperation.RunCalInFlight))
 
   }
@@ -54,6 +57,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   def handleStopCal: PartialFunction[Any, ActionResult[M]] = {
     case RequestStopCal(qid) =>
       updatedL(
+        CalibrationQueues.calLastOpO(qid).set(none) >>>
         CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalInFlight))
 
   }
@@ -61,6 +65,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   def handleSeqOps: PartialFunction[Any, ActionResult[M]] = {
     case RequestRemoveSeqCal(qid, id) =>
       updatedL(
+        CalibrationQueues.calLastOpO(qid).set(none) >>>
         CalibrationQueues.modifyOrAddSeqOps(
           qid,
           id,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
@@ -29,7 +29,6 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   def handleAddAllDayCal: PartialFunction[Any, ActionResult[M]] = {
     case RequestAllDayCal(qid) =>
       updatedL(
-        CalibrationQueues.calLastOpO(qid).set(none) >>>
         CalibrationQueues
           .addDayCalL(qid)
           .set(AddDayCalOperation.AddDayCalInFlight))
@@ -39,7 +38,6 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   def handleClearAllCal: PartialFunction[Any, ActionResult[M]] = {
     case RequestClearAllCal(qid) =>
       updatedL(
-        CalibrationQueues.calLastOpO(qid).set(none) >>>
         CalibrationQueues
           .clearAllCalL(qid)
           .set(ClearAllCalOperation.ClearAllCalInFlight))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueStateHandler.scala
@@ -3,6 +3,7 @@
 
 package seqexec.web.client.handlers
 
+import cats.implicits._
 import diode.ActionHandler
 import diode.ActionResult
 import diode.ModelRW
@@ -21,15 +22,23 @@ class QueueStateHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     with Handlers[M, CalibrationQueues] {
 
   override def handle: PartialFunction[Any, ActionResult[M]] = {
-    case ServerMessage(QueueUpdated(QueueManipulationOp.Started(qid), _)) =>
-      updatedL(CalibrationQueues.runCalL(qid).set(RunCalOperation.RunCalIdle))
-
-    case ServerMessage(QueueUpdated(QueueManipulationOp.Stopped(qid), _)) =>
+    case ServerMessage(QueueUpdated(m @ QueueManipulationOp.Started(qid), _)) =>
       updatedL(
-        CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalIdle))
+        CalibrationQueues.calLastOpO(qid).set(m.some) >>>
+          CalibrationQueues.runCalL(qid).set(RunCalOperation.RunCalIdle))
+
+    case ServerMessage(QueueUpdated(m @ QueueManipulationOp.Stopped(qid), _)) =>
+      updatedL(
+        CalibrationQueues.calLastOpO(qid).set(m.some) >>>
+          CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalIdle))
+
+    case ServerMessage(QueueUpdated(m @ QueueManipulationOp.Clear(qid), _)) =>
+      updatedL(CalibrationQueues.calLastOpO(qid).set(m.some))
 
     case ServerMessage(
-        QueueUpdated(QueueManipulationOp.RemovedSeqs(qid, seqs), _)) =>
-      updatedL(CalibrationQueues.removeSeqOps(qid, seqs))
+        QueueUpdated(m @ QueueManipulationOp.RemovedSeqs(qid, seqs), _)) =>
+      updatedL(
+        CalibrationQueues.calLastOpO(qid).set(m.some) >>> CalibrationQueues
+          .removeSeqOps(qid, seqs))
   }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueStateHandler.scala
@@ -39,7 +39,7 @@ class QueueStateHandler[M](modelRW: ModelRW[M, CalibrationQueues])
       updatedL(CalibrationQueues.calLastOpO(qid).set(m.some))
 
     case ServerMessage(
-        QueueUpdated(m @ QueueManipulationOp.RemovedSeqs(qid, seqs), _)) =>
+        QueueUpdated(m @ QueueManipulationOp.RemovedSeqs(qid, seqs, _), _)) =>
       updatedL(
         CalibrationQueues.calLastOpO(qid).set(m.some) >>> CalibrationQueues
           .removeSeqOps(qid, seqs))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueStateHandler.scala
@@ -32,6 +32,9 @@ class QueueStateHandler[M](modelRW: ModelRW[M, CalibrationQueues])
         CalibrationQueues.calLastOpO(qid).set(m.some) >>>
           CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalIdle))
 
+    case ServerMessage(QueueUpdated(m @ QueueManipulationOp.AddedSeqs(qid, _), _)) =>
+      updatedL(CalibrationQueues.calLastOpO(qid).set(m.some))
+
     case ServerMessage(QueueUpdated(m @ QueueManipulationOp.Clear(qid), _)) =>
       updatedL(CalibrationQueues.calLastOpO(qid).set(m.some))
 

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -13,6 +13,7 @@ import gem.enum.Site
 import scala.collection.immutable.SortedMap
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.BatchExecState
+import seqexec.model.enum.QueueManipulationOp
 import seqexec.model.ClientId
 import seqexec.model.QueueId
 import seqexec.model.Observer
@@ -27,6 +28,7 @@ import seqexec.model.events.ServerLogMessage
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.SequenceEventsArbitraries.slmArb
 import seqexec.model.SequenceEventsArbitraries.slmCogen
+import seqexec.model.SequenceEventsArbitraries.qmArb
 import seqexec.web.common.FixedLengthBuffer
 import seqexec.web.common.Zipper
 import seqexec.web.common.ArbitrariesWebCommon._
@@ -653,7 +655,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         ops <- arbitrary[QueueOperations]
         ts  <- arbitrary[TableState[CalQueueTable.TableColumn]]
         sop <- arbitrary[SortedMap[Observation.Id, QueueSeqOperations]]
-      } yield CalQueueState(ops, ts, sop)
+        lOp <- arbitrary[Option[QueueManipulationOp]]
+      } yield CalQueueState(ops, ts, sop, lOp)
     }
 
   implicit val calQueuesStateCogen: Cogen[CalQueueState] =

--- a/modules/shared/web/client/src/main/scala/web/client/table/SortableRow.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/SortableRow.scala
@@ -4,20 +4,20 @@
 package web.client.table
 
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{CtorType, ScalaComponent}
+import japgolly.scalajs.react.CtorType
+import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Component
 import react.virtualized._
 
 object SortableRow {
   final case class Props(p: react.virtualized.raw.RawRowRendererParameter)
 
-  val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent.builder[Props]("SortableRow")
-    .render_P{ p =>
-      <.div(
-        // ^.className := "sortable-hoc-item sortable-hoc-stylizedItem",
-        // SortableView.handl
-        raw.defaultRowRenderer(p.p)
-      )
+  val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent
+    .builder[Props]("SortableRow")
+    .render_P { p =>
+      // ^.className := "sortable-hoc-item sortable-hoc-stylizedItem",
+      // SortableView.handl
+      raw.defaultRowRenderer(p.p)
     }
     .build
 

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -269,7 +269,7 @@ package object table {
      onRowRightClick:  Option[OnRowClick],
      style:            Style) => {
       val sortableItem = SortableElement.wrap(SortableRow.component)
-      sortableItem(SortableElement.Props(index = index))(
+      sortableItem(SortableElement.Props(index = index, key = key))(
         SortableRow.Props(raw.RawRowRendererParameter(
           className,
           columns.map(_.rawNode).toJSArray,

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -4,6 +4,7 @@
 package web.client
 
 import cats.Eq
+import cats.Monoid
 import cats.data.NonEmptyList
 import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -255,7 +256,14 @@ package object table {
         )
     )
 
-  def sortableRowRenderer[C <: js.Object]: RowRenderer[C] =
+  implicit val styleMonoid: Monoid[Style] = new Monoid[Style] {
+    override val empty: Style = Style(Map.empty)
+    override def combine(a: Style, b: Style): Style =
+      Style(a.styles ++ b.styles)
+  }
+
+  def sortableRowRenderer[C <: js.Object](
+    extraStyle: (Int, Style) => Style): RowRenderer[C] =
     (className:        String,
      columns:          Array[VdomNode],
      index:            Int,
@@ -269,7 +277,9 @@ package object table {
      onRowRightClick:  Option[OnRowClick],
      style:            Style) => {
       val sortableItem = SortableElement.wrap(SortableRow.component)
-      sortableItem(SortableElement.Props(index = index, key = key))(
+      val mergedStyle = Style.toJsObject(style |+| extraStyle(index, style))
+      sortableItem(
+        SortableElement.Props(index = index, key = key, style = mergedStyle))(
         SortableRow.Props(raw.RawRowRendererParameter(
           className,
           columns.map(_.rawNode).toJSArray,
@@ -282,7 +292,7 @@ package object table {
           onRowMouseOut.map(_.toJsCallback).orUndefined,
           onRowMouseOver.map(_.toJsCallback).orUndefined,
           onRowRightClick.map(_.toJsCallback).orUndefined,
-          Style.toJsObject(style)
+          mergedStyle
         )))
 
     }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -78,7 +78,7 @@ object Settings {
     val scalaJSReactVirtualized = "0.3.5"
     val scalaJSReactClipboard   = "0.4.0"
     val scalaJSReactDraggable   = "0.1.1"
-    val scalaJSReactSortable    = "0.0.1"
+    val scalaJSReactSortable    = "0.0.2"
 
     // Scala libraries
     val catsEffectVersion       = "0.10.1"


### PR DESCRIPTION
When a user edits the cal queue the other uses don't have an indication, except when the table changes. This PR is an attempt to improve this using animations. It is also an opportunity for me to learn about animations:

Here are some videos, FF is on the left and the user edits it and Chrome is on the right and the user can see the changes:

Adding sequences:
https://monosnap.com/file/tVTTXDPgxFLcWxd8MmclNcG6yvqaqU#

Clear the queue:
https://monosnap.com/file/9JbApHs4hvEYjgEJYW3OkEdMNTgmvA

Remove elements:
https://monosnap.com/file/liJNeSEc2cU93VBgnsv9GZJe4DnL7q#

Animations are hard 😄 this is as far as I probably want to go with this

The changes were tested in Chrome and FF in OSX

The PR also fixes SEQNG-761