### PR TITLE
SEQNG-738: Support reordering of the queue

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/QueueManipulationOp.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/QueueManipulationOp.scala
@@ -14,7 +14,10 @@ sealed trait QueueManipulationOp extends Product with Serializable {
 }
 
 object QueueManipulationOp {
-  final case class Moved(qid: QueueId, cid: ClientId)
+  final case class Moved(qid: QueueId,
+                         cid: ClientId,
+                         oid: Observation.Id,
+                         pos: Int)
       extends QueueManipulationOp
   final case class Started(qid:   QueueId) extends QueueManipulationOp
   final case class Stopped(qid:   QueueId) extends QueueManipulationOp
@@ -27,7 +30,8 @@ object QueueManipulationOp {
       extends QueueManipulationOp
 
   implicit val equal: Eq[QueueManipulationOp] = Eq.instance {
-    case (Moved(a, c), Moved(b, d))         => a === b && c === d
+    case (Moved(a, c, e, g), Moved(b, d, f, h)) =>
+      a === b && c === d && e === f && g === h
     case (Started(a), Started(b))           => a === b
     case (Stopped(a), Stopped(b))           => a === b
     case (Clear(a), Clear(b))               => a === b

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/QueueManipulationOp.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/QueueManipulationOp.scala
@@ -6,6 +6,7 @@ package seqexec.model.enum
 import cats.Eq
 import cats.implicits._
 import gem.Observation
+import seqexec.model.ClientId
 import seqexec.model.QueueId
 
 sealed trait QueueManipulationOp extends Product with Serializable {
@@ -13,7 +14,8 @@ sealed trait QueueManipulationOp extends Product with Serializable {
 }
 
 object QueueManipulationOp {
-  final case class Moved(qid:     QueueId) extends QueueManipulationOp
+  final case class Moved(qid: QueueId, cid: ClientId)
+      extends QueueManipulationOp
   final case class Started(qid:   QueueId) extends QueueManipulationOp
   final case class Stopped(qid:   QueueId) extends QueueManipulationOp
   final case class Clear(qid:     QueueId) extends QueueManipulationOp
@@ -25,7 +27,7 @@ object QueueManipulationOp {
       extends QueueManipulationOp
 
   implicit val equal: Eq[QueueManipulationOp] = Eq.instance {
-    case (Moved(a), Moved(b))               => a === b
+    case (Moved(a, c), Moved(b, d))         => a === b && c === d
     case (Started(a), Started(b))           => a === b
     case (Stopped(a), Stopped(b))           => a === b
     case (Clear(a), Clear(b))               => a === b

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -94,7 +94,9 @@ trait SequenceEventsArbitraries extends ArbTime {
       i <- arbitrary[List[Observation.Id]]
       r <- arbitrary[List[Int]]
       c <- arbitrary[ClientId]
-      m <- Gen.oneOf(Moved(q, c), Started(q), Stopped(q), Clear(q), AddedSeqs(q, i), RemovedSeqs(q, i, r))
+      o <- arbitrary[Observation.Id]
+      p <- arbitrary[Int]
+      m <- Gen.oneOf(Moved(q, c, o, p), Started(q), Stopped(q), Clear(q), AddedSeqs(q, i), RemovedSeqs(q, i, r))
     } yield m
   }
   implicit val quArb = Arbitrary[QueueUpdated] {

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -93,7 +93,8 @@ trait SequenceEventsArbitraries extends ArbTime {
       q <- arbitrary[QueueId]
       i <- arbitrary[List[Observation.Id]]
       r <- arbitrary[List[Int]]
-      m <- Gen.oneOf(Moved(q), Started(q), Stopped(q), Clear(q), AddedSeqs(q, i), RemovedSeqs(q, i, r))
+      c <- arbitrary[ClientId]
+      m <- Gen.oneOf(Moved(q, c), Started(q), Stopped(q), Clear(q), AddedSeqs(q, i), RemovedSeqs(q, i, r))
     } yield m
   }
   implicit val quArb = Arbitrary[QueueUpdated] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -67,7 +67,7 @@ package server {
   final case class StopQueue(qid: QueueId, clientID: ClientId) extends SeqEvent
   final case class UpdateQueueAdd(qid: QueueId, seqs: List[Observation.Id]) extends SeqEvent
   final case class UpdateQueueRemove(qid: QueueId, seqs: List[Observation.Id], pos: List[Int]) extends SeqEvent
-  final case class UpdateQueueMoved(qid: QueueId, cid: ClientId) extends SeqEvent
+  final case class UpdateQueueMoved(qid: QueueId, cid: ClientId, oid: Observation.Id, pos: Int) extends SeqEvent
   final case class UpdateQueueClear(qid: QueueId) extends SeqEvent
   case object NullSeqEvent extends SeqEvent
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -67,7 +67,7 @@ package server {
   final case class StopQueue(qid: QueueId, clientID: ClientId) extends SeqEvent
   final case class UpdateQueueAdd(qid: QueueId, seqs: List[Observation.Id]) extends SeqEvent
   final case class UpdateQueueRemove(qid: QueueId, seqs: List[Observation.Id], pos: List[Int]) extends SeqEvent
-  final case class UpdateQueueMoved(qid: QueueId) extends SeqEvent
+  final case class UpdateQueueMoved(qid: QueueId, cid: ClientId) extends SeqEvent
   final case class UpdateQueueClear(qid: QueueId) extends SeqEvent
   case object NullSeqEvent extends SeqEvent
 
@@ -141,12 +141,13 @@ package object server {
   }
 
   // This assumes that there is only one instance of e in l
-  private def moveElement[T](l: List[T], e: T, d: Int)(implicit eq: Eq[T]): List[T] = {
+  private def moveElement[T](l: List[T], e: T, delta: Int)(implicit eq: Eq[T]): List[T] = {
     val idx = l.indexOf(e)
 
-    if(d === 0 || idx<0) l
-    else {
-      val (h, t) = l.filterNot(_ === e).splitAt(idx+d)
+    if (delta === 0 || idx < 0) {
+      l
+    } else {
+      val (h, t) = l.filterNot(_ === e).splitAt(idx + delta)
       (h :+ e) ++ t
     }
   }
@@ -170,7 +171,7 @@ package object server {
     def addSeq(sid: Observation.Id): ExecutionQueue = q.copy(queue = q.queue :+ sid)
     def addSeqs(sids: List[Observation.Id]): ExecutionQueue = q.copy(queue = q.queue ++ sids)
     def removeSeq(sid: Observation.Id): ExecutionQueue = q.copy(queue = q.queue.filter(_ =!= sid))
-    def moveSeq(sid:Observation.Id, idx: Int): ExecutionQueue = q.copy(queue = moveElement(q.queue, sid, idx))
+    def moveSeq(sid:Observation.Id, delta: Int): ExecutionQueue = q.copy(queue = moveElement(q.queue, sid, delta))
     def clear: ExecutionQueue = q.copy(queue = List.empty)
   }
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -375,7 +375,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     def testAdvance(obsId: Observation.Id, n: Int): Option[EngineState] =
       (for {
         q <- async.boundedQueue[IO, executeEngine.EventType](10)
-        r <- advanceOne(q, s0, seqexecEngine.moveSequenceInQueue(q, CalibrationQueueId, obsId, n))
+        r <- advanceOne(q, s0, seqexecEngine.moveSequenceInQueue(q, CalibrationQueueId, obsId, n, clientId))
       } yield r).unsafeRunSync
 
     val sf1 = testAdvance(seqObsId2, -1)

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -1052,25 +1052,34 @@ body {
   padding-right: 0 !important;
   padding-left: 0 !important;
 }
+
 .noselect() {
   -moz-user-select: none;
   user-select: none;
 }
+
 .SeqexecStyles-noselect {
   .noselect;
 }
+
 .SeqexecStyles-draggableRow {
   .noselect;
 }
+
 .SeqexecStyles-draggedRowHelper {
   box-shadow: 0 5px 5px -5px rgba(0, 0, 0, 0.2),
     0 -5px 5px -5px rgba(0, 0, 0, 0.2);
   background-color: @selectableInvertedBackground;
+  border-bottom: @border;
+  border-left: @border;
+  border-right: @border;
   cursor: row-resize;
 }
+
 .SeqexecStyles-draggedRowHelper.horizontalItem {
   cursor: col-resize;
 }
+
 .SeqexecStyles-draggedRowHelper.gridItem {
   background-color: transparent;
   white-space: nowrap;

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -1052,6 +1052,34 @@ body {
   padding-right: 0 !important;
   padding-left: 0 !important;
 }
+.noselect() {
+  -moz-user-select: none;
+  user-select: none;
+}
+.SeqexecStyles-noselect {
+  .noselect;
+}
+.SeqexecStyles-draggableRow {
+  .noselect;
+}
+.SeqexecStyles-draggedRowHelper {
+  box-shadow: 0 5px 5px -5px rgba(0, 0, 0, 0.2),
+    0 -5px 5px -5px rgba(0, 0, 0, 0.2);
+  background-color: @selectableInvertedBackground;
+  cursor: row-resize;
+}
+.SeqexecStyles-draggedRowHelper.horizontalItem {
+  cursor: col-resize;
+}
+.SeqexecStyles-draggedRowHelper.gridItem {
+  background-color: transparent;
+  white-space: nowrap;
+  box-shadow: none;
+  .wrapper {
+    background-color: @selectableInvertedBackground;
+    box-shadow: 0 0 7px rgba(0, 0, 0, 0.15);
+  }
+}
 @media only screen and (max-width: 767px) {
   .SeqexecStyles-notInMobile {
     display: none !important;

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -275,4 +275,12 @@ object SeqexecStyles {
   val autoMargin: GStyle = GStyle.fromString("SeqexecStyles-autoMargin")
 
   val deletedRow: GStyle = GStyle.fromString("SeqexecStyles-deletedRow")
+
+  val noselect: GStyle = GStyle.fromString("SeqexecStyles-noselect")
+
+  val draggedRowHelper: GStyle =
+    GStyle.fromString("SeqexecStyles-draggedRowHelper")
+
+  val draggableRow: GStyle =
+    GStyle.fromString("SeqexecStyles-draggableRow")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
@@ -67,7 +67,7 @@ object CalQueueTabContent {
             case Some(x) =>
               <.div(
                 ^.height := "100%",
-                CalQueueTable.Props(CalibrationQueueId, x).cmp
+                CalQueueTable(CalQueueTable.Props(CalibrationQueueId, x))
               )
             case _ => defaultContent
           })

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -29,6 +29,7 @@ import seqexec.web.client.circuit._
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.reusability._
 import seqexec.web.client.actions.RequestRemoveSeqCal
+import seqexec.web.client.actions.RequestMoveCal
 import seqexec.web.client.actions.UpdateCalTableState
 import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.icon.Icon.IconTimes
@@ -334,6 +335,17 @@ object CalQueueTable {
           else ""
       )
 
+    def requestMove(c: IndexChange): Callback =
+      b.props >>= { p =>
+        p.data.seqs
+          .map(_.id)
+          .lift(c.oldIndex)
+          .map(i =>
+            SeqexecCircuit.dispatchCB(
+              RequestMoveCal(p.queueId, i, c.newIndex - c.oldIndex)))
+          .getOrEmpty
+      }
+
     def render(p: Props, s: State): VdomElement =
       <.div(
         SeqexecStyles.stepsListPaneWithControls.when(p.canOperate),
@@ -347,7 +359,7 @@ object CalQueueTable {
 
           // If distance is 0 we can miss some events
           val cp = SortableContainer.Props(
-            onSortEnd = p => Callback.log(s"end $p"),
+            onSortEnd = requestMove,
             helperClass =
               (SeqexecStyles.noselect |+| SeqexecStyles.draggedRowHelper).htmlClass,
             distance = 3)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -135,6 +135,14 @@ object CalQueueTable {
       case _                                              => Nil
     }
 
+    /**
+      * Rows deleted on the last operation
+      */
+    val movedRows: List[Observation.Id] = data.lastOp match {
+      case Some(QueueManipulationOp.Moved(_, _, o, _)) => List(o)
+      case _                                           => Nil
+    }
+
     val afterDeletedRows: List[Int] =
       data.seqs.zipWithIndex
         .find {
@@ -305,6 +313,9 @@ object CalQueueTable {
           SeqexecStyles.headerRowStyle
         case (_, CalQueueRow(i, _))
             if p.addedRows.contains(i) && !s.animationRendered =>
+          SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow |+| SeqexecStyles.calRowBackground
+        case (_, CalQueueRow(i, _))
+            if p.movedRows.contains(i) && !s.animationRendered =>
           SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow |+| SeqexecStyles.calRowBackground
         case (i, CalQueueRow(_, _))
             if p.afterDeletedRows.contains(i) && !s.animationRendered =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -9,6 +9,7 @@ import cats.data.NonEmptyList
 import gem.Observation
 import japgolly.scalajs.react.BackendScope
 import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react.CallbackTo
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
@@ -360,6 +361,7 @@ object CalQueueTable {
           // If distance is 0 we can miss some events
           val cp = SortableContainer.Props(
             onSortEnd = requestMove,
+            shouldCancelStart = _ => CallbackTo(!p.data.canOperate),
             helperClass =
               (SeqexecStyles.noselect |+| SeqexecStyles.draggedRowHelper).htmlClass,
             distance = 3)
@@ -368,8 +370,6 @@ object CalQueueTable {
       )
 
   }
-
-  // type Backend = RenderScope[Props, State, CalQueueTableBackend]
 
   def initialState(p: Props): State =
     if (p.data.loggedIn) {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -378,6 +378,16 @@ object CalQueueTable {
     def resetMoved: Callback =
       b.modState(_.copy(moved = none))
 
+    def updateVisibleCols: Callback =
+      b.props >>= { p =>
+        val cols = if (p.data.loggedIn) {
+          State.DefaultEditable.tableState.columns
+        } else {
+          State.DefaultRO.tableState.columns
+        }
+        b.modState(s => s.copy(tableState = s.tableState.copy(columns = cols)))
+      }
+
     def render(p: Props, s: State): VdomElement =
       <.div(
         SeqexecStyles.stepsListPaneWithControls.when(p.canOperate),
@@ -427,7 +437,8 @@ object CalQueueTable {
       c.backend.allowAnim.when(opChanged) *>
         // And then we reset the state to avoid re running the anim
         c.backend.setTimeout(c.backend.resetAnim, 1.5.second).when(opChanged) *>
-        c.backend.resetMoved
+        c.backend.resetMoved *>
+        c.backend.updateVisibleCols
     }
     .configure(Reusability.shouldComponentUpdate)
     .configure(TimerSupport.install)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -447,7 +447,7 @@ object CalQueueTable {
       val opChanged = c.nextProps.data.lastOp =!= c.currentProps.data.lastOp
       c.backend.allowAnim.when(opChanged) *>
         // And then we reset the state to avoid re running the anim
-        c.backend.setTimeout(c.backend.resetAnim, 1.5.second).when(opChanged) *>
+        c.backend.setTimeout(c.backend.resetAnim, 1.second).when(opChanged) *>
         c.backend.resetMoved *>
         c.backend.updateVisibleCols
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/QueueSeqOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/QueueSeqOperations.scala
@@ -4,6 +4,7 @@
 package seqexec.web.client.model
 
 import cats.Eq
+import cats.implicits._
 import monocle.macros.Lenses
 
 sealed trait RemoveSeqQueue extends Product with Serializable
@@ -16,17 +17,29 @@ object RemoveSeqQueue {
 
 }
 
+sealed trait MoveSeqQueue extends Product with Serializable
+object MoveSeqQueue {
+  case object MoveSeqQueueInFlight extends MoveSeqQueue
+  case object MoveSeqQueueIdle extends MoveSeqQueue
+
+  implicit val eq: Eq[MoveSeqQueue] =
+    Eq.fromUniversalEquals
+
+}
+
 /**
   * Hold transient states while excuting an operation on a queue element
   */
 @Lenses
-final case class QueueSeqOperations(removeSeqQueue: RemoveSeqQueue)
+final case class QueueSeqOperations(removeSeqQueue: RemoveSeqQueue,
+                                    moveSeqQueue:   MoveSeqQueue)
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object QueueSeqOperations {
   implicit val eq: Eq[QueueSeqOperations] =
-    Eq.by(x => (x.removeSeqQueue))
+    Eq.by(x => (x.removeSeqQueue, x.moveSeqQueue))
 
   val Default: QueueSeqOperations =
-    QueueSeqOperations(RemoveSeqQueue.RemoveSeqQueueIdle)
+    QueueSeqOperations(RemoveSeqQueue.RemoveSeqQueueIdle,
+                       MoveSeqQueue.MoveSeqQueueInFlight)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -102,6 +102,7 @@ object actions {
       extends Action
   final case class MoveCalCompleted(qid: QueueId) extends Action
   final case class MoveCalFailed(qid:    QueueId, id: Observation.Id) extends Action
+  final case class ClearLastQueueOp(qid: QueueId) extends Action
 
   final case class AppendToLog(l: ServerLogMessage) extends Action
   final case object ToggleLogArea extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/actions.scala
@@ -98,6 +98,10 @@ object actions {
       extends Action
   final case class RemoveSeqCalCompleted(qid: QueueId) extends Action
   final case class RemoveSeqCalFailed(qid:    QueueId, id: Observation.Id) extends Action
+  final case class RequestMoveCal(qid:  QueueId, id: Observation.Id, pos: Int)
+      extends Action
+  final case class MoveCalCompleted(qid: QueueId) extends Action
+  final case class MoveCalFailed(qid:    QueueId, id: Observation.Id) extends Action
 
   final case class AppendToLog(l: ServerLogMessage) extends Action
   final case object ToggleLogArea extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
@@ -48,7 +48,13 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     case RequestRunCal(qid) =>
       updatedL(
         CalibrationQueues.calLastOpO(qid).set(none) >>>
-        CalibrationQueues.runCalL(qid).set(RunCalOperation.RunCalInFlight))
+          CalibrationQueues.runCalL(qid).set(RunCalOperation.RunCalInFlight))
+
+  }
+
+  def handleClearLastOp: PartialFunction[Any, ActionResult[M]] = {
+    case ClearLastQueueOp(qid) =>
+      updatedL(CalibrationQueues.calLastOpO(qid).set(none))
 
   }
 
@@ -56,7 +62,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     case RequestStopCal(qid) =>
       updatedL(
         CalibrationQueues.calLastOpO(qid).set(none) >>>
-        CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalInFlight))
+          CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalInFlight))
 
   }
 
@@ -64,10 +70,10 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     case RequestRemoveSeqCal(qid, id) =>
       updatedL(
         CalibrationQueues.calLastOpO(qid).set(none) >>>
-        CalibrationQueues.modifyOrAddSeqOps(
-          qid,
-          id,
-          _.copy(removeSeqQueue = RemoveSeqQueue.RemoveSeqQueueInFlight)))
+          CalibrationQueues.modifyOrAddSeqOps(
+            qid,
+            id,
+            _.copy(removeSeqQueue = RemoveSeqQueue.RemoveSeqQueueInFlight)))
 
   }
 
@@ -141,5 +147,6 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
          handleStopCal,
          handleSeqOps,
          handleRequestResultOk,
+         handleClearLastOp,
          handleRequestResultFailed).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueOperationsHandler.scala
@@ -134,7 +134,9 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
       updatedLE(
         CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalIdle),
         notification)
+  }
 
+  def handleSeqRequestResultFailed: PartialFunction[Any, ActionResult[M]] = {
     case RemoveSeqCalFailed(qid, id) =>
       val msg = s"Failed to remove sequence ${id.format} from the queue"
       val notification = Effect(
@@ -164,5 +166,6 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
          handleSeqOps,
          handleRequestResultOk,
          handleClearLastOp,
+         handleSeqRequestResultFailed,
          handleRequestResultFailed).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueRequestsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueRequestsHandler.scala
@@ -82,11 +82,28 @@ class QueueRequestsHandler[M](modelRW: ModelRW[M, QueueRequestsFocus])
         .getOrElse(noChange)
   }
 
+  def handleMoveCal: PartialFunction[Any, ActionResult[M]] = {
+    case RequestMoveCal(qid, oid, i) =>
+      value.clientId
+        .map { cid =>
+          effectOnly(
+            requestEffect2((qid, cid),
+                           SeqexecWebClient.moveSequenceQueue(_: QueueId,
+                                                              oid,
+                                                              i,
+                                                              _: ClientId),
+                           RunCalCompleted.apply,
+                           RunCalFailed.apply))
+        }
+        .getOrElse(noChange)
+  }
+
   override def handle: PartialFunction[Any, ActionResult[M]] =
     List(handleAddAllDayCal,
          handleClearAllCal,
          handleRunCal,
          handleStopCal,
+         handleMoveCal,
          handleRemoveSeqCal).combineAll
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueRequestsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueRequestsHandler.scala
@@ -92,8 +92,8 @@ class QueueRequestsHandler[M](modelRW: ModelRW[M, QueueRequestsFocus])
                                                               oid,
                                                               i,
                                                               _: ClientId),
-                           RunCalCompleted.apply,
-                           RunCalFailed.apply))
+                           MoveCalCompleted.apply,
+                           MoveCalFailed.apply(_: QueueId, oid)))
         }
         .getOrElse(noChange)
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/handlers/QueueStateHandler.scala
@@ -32,10 +32,15 @@ class QueueStateHandler[M](modelRW: ModelRW[M, CalibrationQueues])
         CalibrationQueues.calLastOpO(qid).set(m.some) >>>
           CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalIdle))
 
-    case ServerMessage(QueueUpdated(m @ QueueManipulationOp.AddedSeqs(qid, _), _)) =>
+    case ServerMessage(
+        QueueUpdated(m @ QueueManipulationOp.AddedSeqs(qid, _), _)) =>
       updatedL(CalibrationQueues.calLastOpO(qid).set(m.some))
 
     case ServerMessage(QueueUpdated(m @ QueueManipulationOp.Clear(qid), _)) =>
+      updatedL(CalibrationQueues.calLastOpO(qid).set(m.some))
+
+    case ServerMessage(
+        QueueUpdated(m @ QueueManipulationOp.Moved(qid, _, _, _), _)) =>
       updatedL(CalibrationQueues.calLastOpO(qid).set(m.some))
 
     case ServerMessage(

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -324,18 +324,6 @@ object SeqexecWebClient extends ModelBooPicklers {
   /**
     * Add a sequence from a queue
     */
-  def addSequenceToQueue(queueId: QueueId, id: Observation.Id): Future[Unit] =
-    Ajax
-      .post(
-        url =
-          s"$baseUrl/queue/${encodeURI(queueId.self.show)}/add/${encodeURI(id.format)}",
-        responseType = "arraybuffer"
-      )
-      .map(_ => ())
-
-  /**
-    * Add a sequence from a queue
-    */
   def removeSequenceFromQueue(queueId: QueueId,
                               id:      Observation.Id): Future[Unit] =
     Ajax
@@ -397,12 +385,13 @@ object SeqexecWebClient extends ModelBooPicklers {
       .map(_ => ())
 
   /**
-    * Remove a sequence from a queue
+    * Stops a queue
     */
-  def removeSequenceToQueue(queueId: QueueId, id: Observation.Id): Future[Unit] =
+  def moveSequenceQueue(queueId: QueueId, obsId: Observation.Id, pos: Int, clientId: ClientId): Future[Unit] =
     Ajax
       .post(
-        url          = s"$baseUrl/queue/${encodeURI(queueId.self.show)}/remove/${encodeURI(id.format)}",
+        url =
+          s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/move/${encodeURI(obsId.self.format)}/$pos/${encodeURI(clientId.self.show)}",
         responseType = "arraybuffer"
       )
       .map(_ => ())

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -139,6 +139,15 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val rsqCogen: Cogen[RemoveSeqQueue] =
     Cogen[String].contramap(_.productPrefix)
 
+  implicit val arbMoveSeqQueue: Arbitrary[MoveSeqQueue] =
+    Arbitrary {
+      Gen.oneOf(MoveSeqQueue.MoveSeqQueueIdle,
+                MoveSeqQueue.MoveSeqQueueInFlight)
+    }
+
+  implicit val msqCogen: Cogen[MoveSeqQueue] =
+    Cogen[String].contramap(_.productPrefix)
+
   implicit val arbCalibrationQueueTab: Arbitrary[CalibrationQueueTab] =
     Arbitrary {
       for {
@@ -159,11 +168,13 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     Arbitrary {
       for {
         r <- arbitrary[RemoveSeqQueue]
-      } yield QueueSeqOperations(r)
+        m <- arbitrary[MoveSeqQueue]
+      } yield QueueSeqOperations(r, m)
     }
 
   implicit val sopCogen: Cogen[QueueSeqOperations] =
-    Cogen[RemoveSeqQueue].contramap(x => x.removeSeqQueue)
+    Cogen[(RemoveSeqQueue, MoveSeqQueue)]
+      .contramap(x => (x.removeSeqQueue, x.moveSeqQueue))
 
   implicit val arbInstrumentSequenceTab: Arbitrary[InstrumentSequenceTab] =
     Arbitrary {

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -154,9 +154,9 @@ class SeqexecCommandRoutes(auth:       AuthenticationService,
       se.removeSequenceFromQueue(inputQueue, qid, obsId) *>
         Ok(s"${obsId.format} removed from queue $qid")
 
-    case POST -> Root / "queue" / QueueIdVar(qid) / "move" / ObsIdVar(obsId) / IntVar(mv) as _ =>
-      se.moveSequenceInQueue(inputQueue, qid, obsId, mv) *>
-        Ok(s"{obsId.format} moved $mv positions inside queue $qid")
+    case POST -> Root / "queue" / QueueIdVar(qid) / "move" / ObsIdVar(obsId) / IntVar(delta) / ClientIDVar(clientId) as _ =>
+      se.moveSequenceInQueue(inputQueue, qid, obsId, delta, clientId) *>
+        Ok(s"${obsId.format} moved $delta positions in queue $qid")
 
     case POST -> Root / "queue" / QueueIdVar(qid) / "clear" as _ =>
       se.clearQueue(inputQueue, qid) *>

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -162,6 +162,7 @@ trait ModelBooPicklers extends GemModelBooPicklers {
   implicit val sequenceMetadataPickler = generatePickler[SequenceMetadata]
 
   implicit val stepConfigPickler = generatePickler[SequenceView]
+  implicit val clientIdPickler = generatePickler[ClientId]
 
   implicit val queueIdPickler      = generatePickler[QueueId]
   implicit val queueOpMovedPickler = generatePickler[QueueManipulationOp.Moved]
@@ -195,7 +196,6 @@ trait ModelBooPicklers extends GemModelBooPicklers {
           throw new RuntimeException("Falied to decode server log level")))(t =>
     serverLogIdx.find { case (_, v) => v === t }.map(_._1).getOrElse(-1))
 
-  implicit val clientIdPickler = generatePickler[ClientId]
   implicit val batchCommandStateIdlePickler =
     generatePickler[BatchCommandState.Idle.type]
   implicit val batchCommandStateRun = generatePickler[BatchCommandState.Run]

--- a/modules/shared/web/client/src/main/scala/web/client/style/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/style/package.scala
@@ -8,7 +8,6 @@ import cats.Monoid
 import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.Reusability
-// import react.virtualized._
 
 package style {
   final case class GStyle(htmlClasses: List[String]) {

--- a/modules/shared/web/client/src/main/scala/web/client/style/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/style/package.scala
@@ -3,10 +3,12 @@
 
 package web.client
 
+import cats.Eq
+import cats.Monoid
+import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.Reusability
-import cats.{Eq, Monoid}
-import cats.implicits._
+// import react.virtualized._
 
 package style {
   final case class GStyle(htmlClasses: List[String]) {

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnWidth.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnWidth.scala
@@ -13,12 +13,15 @@ sealed trait ColumnWidth
 sealed abstract class FixedColumnWidth(val width: Double)
     extends ColumnWidth {
   assert(width >= 0)
+
+  override def toString: String = s"Fixed(${width}px)"
 }
 sealed abstract class PercentageColumnWidth(val percentage: Double,
                                             val minWidth:   Double)
     extends ColumnWidth {
   assert(percentage >= 0 && percentage <= 1)
   assert(minWidth >= 0)
+  override def toString: String = s"Percentage(${percentage}%, ${minWidth}px)"
 }
 
 object ColumnWidth {

--- a/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
@@ -1,0 +1,119 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package web.client.table
+
+import cats.Eq
+import cats.data.NonEmptyList
+import cats.implicits._
+import monocle.Lens
+import japgolly.scalajs.react.raw.JsNumber
+import japgolly.scalajs.react.Callback
+import react.virtualized._
+import web.client.utils._
+
+/**
+  * State of a table
+  */
+final case class TableState[A: Eq](userModified:   UserModified,
+                                   scrollPosition: JsNumber,
+                                   columns:        NonEmptyList[ColumnMeta[A]]) {
+
+  // Changes the relative widths when a column is being dragged
+  def applyOffset(column: A, delta: Double, s: Size): TableState[A] = {
+    val indexOf = columns.toList.indexWhere(_.column === column)
+    // Shift the selected column and the next one
+    val result = columns.toList.zipWithIndex.map {
+      case (c @ ColumnMeta(_, _, _, true, PercentageColumnWidth(x, min)), idx) if idx === indexOf     =>
+        val nv = x + delta
+        if (nv >= 0 && nv <= 1) {
+          c.copy(width = PercentageColumnWidth(nv, min))
+        } else {
+          c
+        }
+      case (c @ ColumnMeta(_, _, _, true, PercentageColumnWidth(x, min)), idx) if idx === indexOf + 1 =>
+        val nv = scala.math.max(min / s.width, x - delta)
+        if (nv >= 0 && nv <= 1) {
+          c.copy(width = PercentageColumnWidth(nv, min))
+        } else {
+          c
+        }
+      case (c, _)                                                                                => c
+    }
+    copy(userModified = IsModified,
+         columns      = NonEmptyList.fromListUnsafe(result))
+  }
+
+  // Return the width of a column from the actual column width
+  def widthOf(column: A, s: Size): Double =
+    columns
+      .filter(c => c.column === column && c.visible)
+      .map(_.width)
+      .map {
+        case FixedColumnWidth(w)         => w.toDouble
+        case PercentageColumnWidth(f, m) => scala.math.max(m, f * s.width)
+      }
+      .foldMap(identity)
+
+  // Table can call this to build the columns
+  def columnBuilder(
+    s:  Size,
+    cb: ColumnRenderArgs[A] => Table.ColumnArg): List[Table.ColumnArg] = {
+    val disposableWidth = math.max(0, s.width.toDouble - columns.collect {
+      case ColumnMeta(_, _, _, true, FixedColumnWidth(x)) => x
+    }.sum)
+    normalizeColumnsPercentages(s).columns.toList.zipWithIndex.map {
+      case (m @ ColumnMeta(_, _, _, true, FixedColumnWidth(w)), i) =>
+        cb.apply(ColumnRenderArgs(m, i, w, false))
+      case (m @ ColumnMeta(_, _, _, true, PercentageColumnWidth(p, mw)), i) =>
+        cb.apply(
+          ColumnRenderArgs(m,
+                           i,
+                           scala.math.max(mw, p * disposableWidth),
+                           i < (columns.length - 1)))
+    }
+  }
+
+  // normalize the percentages
+  def normalizeColumnsPercentages(s: Size): TableState[A] = {
+    val percentagesSum = columns.collect {
+      case ColumnMeta(_, _, _, true, PercentageColumnWidth(x, m)) => scala.math.max(x, m / s.width)
+    }.sum
+    TableState
+      .columns[A]
+      .modify(_.map {
+        case c @ ColumnMeta(_, _, _, true, PercentageColumnWidth(x, min)) =>
+          c.copy(width = PercentageColumnWidth(x / percentagesSum, min))
+        case c                                                            =>
+          c
+      })(this)
+  }
+
+  // Tell the model to resize a column
+  def resizeRow(
+    column: A,
+    s:      Size,
+    cb:     TableState[A] => Callback): (String, JsNumber) => Callback =
+    (_, dx) => {
+      val percentDelta = dx.toDouble / s.width.toDouble
+      val st           = applyOffset(column, percentDelta, s)
+      cb(st)
+    }
+}
+
+object TableState {
+  implicit def eqTs[A: Eq]: Eq[TableState[A]] =
+    Eq.by(x => (x.userModified, x.scrollPosition.toDouble, x.columns))
+
+  def userModified[A: Eq]: Lens[TableState[A], UserModified] =
+    Lens[TableState[A], UserModified](_.userModified)(n =>
+      a => a.copy(userModified = n))
+
+  def columns[A: Eq]: Lens[TableState[A], NonEmptyList[ColumnMeta[A]]] =
+    Lens[TableState[A], NonEmptyList[ColumnMeta[A]]](_.columns)(n =>
+      a => a.copy(columns = n))
+
+  def scrollPosition[A: Eq]: Lens[TableState[A], JsNumber] =
+    Lens[TableState[A], JsNumber](_.scrollPosition)(n =>
+      a => a.copy(scrollPosition = n))
+}

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -14,7 +14,6 @@ import japgolly.scalajs.react.extra.Reusability
 import org.scalajs.dom.MouseEvent
 import scala.scalajs.js
 import js.JSConverters._
-import monocle.Lens
 import react.virtualized._
 import react.virtualized.raw
 import react.sortable._
@@ -27,112 +26,6 @@ package table {
                                        index:     Int,
                                        width:     JsNumber,
                                        resizable: Boolean)
-
-  /**
-    * State of a table
-    */
-  final case class TableState[A: Eq](userModified:   UserModified,
-                                     scrollPosition: JsNumber,
-                                     columns:        NonEmptyList[ColumnMeta[A]]) {
-
-    // Changes the relative widths when a column is being dragged
-    def applyOffset(column: A, delta: Double, s: Size): TableState[A] = {
-      val indexOf = columns.toList.indexWhere(_.column === column)
-      // Shift the selected column and the next one
-      val result = columns.toList.zipWithIndex.map {
-        case (c @ ColumnMeta(_, _, _, true, PercentageColumnWidth(x, min)), idx) if idx === indexOf     =>
-          val nv = x + delta
-          if (nv >= 0 && nv <= 1) {
-            c.copy(width = PercentageColumnWidth(nv, min))
-          } else {
-            c
-          }
-        case (c @ ColumnMeta(_, _, _, true, PercentageColumnWidth(x, min)), idx) if idx === indexOf + 1 =>
-          val nv = scala.math.max(min / s.width, x - delta)
-          if (nv >= 0 && nv <= 1) {
-            c.copy(width = PercentageColumnWidth(nv, min))
-          } else {
-            c
-          }
-        case (c, _)                                                                                => c
-      }
-      copy(userModified = IsModified,
-           columns      = NonEmptyList.fromListUnsafe(result))
-    }
-
-    // Return the width of a column from the actual column width
-    def widthOf(column: A, s: Size): Double =
-      columns
-        .filter(c => c.column === column && c.visible)
-        .map(_.width)
-        .map {
-          case FixedColumnWidth(w)         => w.toDouble
-          case PercentageColumnWidth(f, m) => scala.math.max(m, f * s.width)
-        }
-        .foldMap(identity)
-
-    // Table can call this to build the columns
-    def columnBuilder(
-      s:  Size,
-      cb: ColumnRenderArgs[A] => Table.ColumnArg): List[Table.ColumnArg] = {
-      val disposableWidth = math.max(0, s.width.toDouble - columns.collect {
-        case ColumnMeta(_, _, _, true, FixedColumnWidth(x)) => x
-      }.sum)
-      normalizeColumnsPercentages(s).columns.toList.zipWithIndex.map {
-        case (m @ ColumnMeta(_, _, _, true, FixedColumnWidth(w)), i) =>
-          cb.apply(ColumnRenderArgs(m, i, w, false))
-        case (m @ ColumnMeta(_, _, _, true, PercentageColumnWidth(p, mw)), i) =>
-          cb.apply(
-            ColumnRenderArgs(m,
-                             i,
-                             scala.math.max(mw, p * disposableWidth),
-                             i < (columns.length - 1)))
-      }
-    }
-
-    // normalize the percentages
-    def normalizeColumnsPercentages(s: Size): TableState[A] = {
-      val percentagesSum = columns.collect {
-        case ColumnMeta(_, _, _, true, PercentageColumnWidth(x, m)) => scala.math.max(x, m / s.width)
-      }.sum
-      TableState
-        .columns[A]
-        .modify(_.map {
-          case c @ ColumnMeta(_, _, _, true, PercentageColumnWidth(x, min)) =>
-            c.copy(width = PercentageColumnWidth(x / percentagesSum, min))
-          case c                                                            =>
-            c
-        })(this)
-    }
-
-    // Tell the model to resize a column
-    def resizeRow(
-      column: A,
-      s:      Size,
-      cb:     TableState[A] => Callback): (String, JsNumber) => Callback =
-      (_, dx) => {
-        val percentDelta = dx.toDouble / s.width.toDouble
-        val st           = applyOffset(column, percentDelta, s)
-        cb(st)
-      }
-  }
-
-  object TableState {
-    implicit def eqTs[A: Eq]: Eq[TableState[A]] =
-      Eq.by(x => (x.userModified, x.scrollPosition.toDouble, x.columns))
-
-    def userModified[A: Eq]: Lens[TableState[A], UserModified] =
-      Lens[TableState[A], UserModified](_.userModified)(n =>
-        a => a.copy(userModified = n))
-
-    def columns[A: Eq]: Lens[TableState[A], NonEmptyList[ColumnMeta[A]]] =
-      Lens[TableState[A], NonEmptyList[ColumnMeta[A]]](_.columns)(n =>
-        a => a.copy(columns = n))
-
-    def scrollPosition[A: Eq]: Lens[TableState[A], JsNumber] =
-      Lens[TableState[A], JsNumber](_.scrollPosition)(n =>
-        a => a.copy(scrollPosition = n))
-  }
 
   /**
     * Metadata for a column

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -78,7 +78,7 @@ object Settings {
     val scalaJSReactVirtualized = "0.3.5"
     val scalaJSReactClipboard   = "0.4.0"
     val scalaJSReactDraggable   = "0.1.1"
-    val scalaJSReactSortable    = "0.0.2"
+    val scalaJSReactSortable    = "0.0.3"
 
     // Scala libraries
     val catsEffectVersion       = "0.10.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -78,7 +78,7 @@ object Settings {
     val scalaJSReactVirtualized = "0.3.5"
     val scalaJSReactClipboard   = "0.4.0"
     val scalaJSReactDraggable   = "0.1.1"
-    val scalaJSReactSortable    = "0.0.4-SNAPSHOT"
+    val scalaJSReactSortable    = "0.0.4"
 
     // Scala libraries
     val catsEffectVersion       = "0.10.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -78,7 +78,7 @@ object Settings {
     val scalaJSReactVirtualized = "0.3.5"
     val scalaJSReactClipboard   = "0.4.0"
     val scalaJSReactDraggable   = "0.1.1"
-    val scalaJSReactSortable    = "0.0.3"
+    val scalaJSReactSortable    = "0.0.4-SNAPSHOT"
 
     // Scala libraries
     val catsEffectVersion       = "0.10.1"


### PR DESCRIPTION
This is a relatively large change to support reordering of the elements on the cal queue:

https://monosnap.com/file/aVgw2RtxrzbxRnnLJ6dePVpCyx7T61#

The change produced several regressions on animation, and updates, they should be fixed by the most part but some may have escaped