### PR TITLE
SEQNG-778: GPI configuration not being picked up

### DIFF
--- a/modules/giapi/src/main/scala/giapi/client/gpi/GPIClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GPIClient.scala
@@ -139,7 +139,7 @@ object GPIExample extends App {
             _ <- client.calExitShutter(true) // Open the shutter
             - <- client.observingMode("Y_coron") // Change observing mode
             _ <- client.ifsConfigure(1.5, 1, 4) // Configure the IFS
-            f <- client.observe("TEST_S20180509", 5.seconds) // observe
+            f <- client.observe("TEST_S20180509", 30.seconds) // observe
             _ <- client.park // Park at the end
           } yield f
         Stream.eval(r.map(println)) // scalastyle:ignore

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -24,7 +24,7 @@ import seqexec.model.enum.{Instrument, Resource}
 import seqexec.model.{ActionType, StepState}
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.SeqTranslate.{Settings, Systems}
+import seqexec.server.SeqTranslate.Systems
 import seqexec.server.SeqexecFailure.{Unexpected, UnrecognizedInstrument}
 import seqexec.server.InstrumentSystem._
 import seqexec.server.flamingos2.{Flamingos2, Flamingos2Controller, Flamingos2Header}
@@ -39,7 +39,7 @@ import seqexec.server.tcs.TcsController.ScienceFoldPosition
 import seqexec.server.gnirs._
 import squants.Time
 
-class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
+class SeqTranslate(site: Site, systems: Systems, settings: TranslateSettings) {
   private val Log = getLogger
 
   implicit val show: Show[InstrumentSystem[IO]] = Show.show(_.resource.show)
@@ -437,7 +437,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: Settings) {
 }
 
 object SeqTranslate {
-  def apply(site: Site, systems: Systems, settings: Settings): SeqTranslate = new SeqTranslate(site, systems, settings)
+  def apply(site: Site, systems: Systems, settings: TranslateSettings): SeqTranslate = new SeqTranslate(site, systems, settings)
 
   final case class Systems(
                       odb: ODBProxy,
@@ -451,16 +451,6 @@ object SeqTranslate {
                       gpi: GPIController[IO],
                       ghost: GHOSTController[IO]
                     )
-
-  final case class Settings(
-                      tcsKeywords: Boolean,
-                      f2Keywords: Boolean,
-                      gwsKeywords: Boolean,
-                      gcalKeywords: Boolean,
-                      gmosKeywords: Boolean,
-                      gnirsKeywords: Boolean
-                     )
-
 
   private sealed trait StepType {
     val instrument: Instrument

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -49,6 +49,8 @@ import mouse.all._
 import scala.collection.immutable.SortedMap
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import shapeless.tag.@@
+import shapeless.tag
 
 class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecMetrics) {
   import SeqexecEngine._
@@ -646,18 +648,18 @@ object SeqexecEngine extends SeqexecConfiguration {
 
   // TODO: Initialization is a bit of a mess, with a mix of effectful and effectless code, and values
   // that should go from one to the other. This should be improved.
-  def giapiConnection(controlName: String, urlName: String): Kleisli[IO, Config, Giapi[IO]] = Kleisli { cfg: Config =>
+  def giapiConnection[T](controlName: String, urlName: String): Kleisli[IO, Config, Giapi[IO] @@ T] = Kleisli { cfg: Config =>
     val control = cfg.require[ControlStrategy](controlName)
     val url  = cfg.require[String](urlName)
-    if (control.command) {
+    (if (control.command) {
       Giapi.giapiConnection[IO](url, scala.concurrent.ExecutionContext.Implicits.global).connect
     } else {
       Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect
-    }
+    }).map(tag[T][Giapi[IO]](_)) // Tag the connection
   }
 
   // scalastyle:off
-  def seqexecConfiguration(gpiGiapi: Giapi[IO], ghostGiapi: Giapi[IO]): Kleisli[IO, Config, Settings[IO]] = Kleisli { cfg: Config =>
+  def seqexecConfiguration(gpiGiapi: Giapi[IO] @@ GpiSettings, ghostGiapi: Giapi[IO] @@ GhostSettings): Kleisli[IO, Config, Settings[IO]] = Kleisli { cfg: Config =>
     val site                    = cfg.require[Site]("seqexec-engine.site")
     val odbHost                 = cfg.require[String]("seqexec-engine.odb")
     val dhsServer               = cfg.require[String]("seqexec-engine.dhsServer")
@@ -676,8 +678,8 @@ object SeqexecEngine extends SeqexecConfiguration {
     val niriControl             = cfg.require[ControlStrategy]("seqexec-engine.systemControl.niri")
     val tcsControl              = cfg.require[ControlStrategy]("seqexec-engine.systemControl.tcs")
     val odbNotifications        = cfg.require[Boolean]("seqexec-engine.odbNotifications")
-    val gpiGDS                  = cfg.require[Uri]("seqexec-engine.gpiGDS")
-    val ghostGDS                = cfg.require[Uri]("seqexec-engine.ghostGDS")
+    val gpiGDS                  = tag[GpiSettings][Uri](cfg.require[Uri]("seqexec-engine.gpiGDS"))
+    val ghostGDS                = tag[GhostSettings][Uri](cfg.require[Uri]("seqexec-engine.ghostGDS"))
     val instForceError          = cfg.require[Boolean]("seqexec-engine.instForceError")
     val failAt                  = cfg.require[Int]("seqexec-engine.failAt")
     val odbQueuePollingInterval = cfg.require[Duration]("seqexec-engine.odbQueuePollingInterval")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import gem.enum.Site
+import giapi.client.Giapi
+import java.time.LocalDate
+import org.http4s.Uri
+import scala.concurrent.duration.Duration
+
+final case class Settings[F[_]](site:                    Site,
+                                odbHost:                 String,
+                                date:                    LocalDate,
+                                dhsURI:                  String,
+                                dhsControl:              ControlStrategy,
+                                f2Control:               ControlStrategy,
+                                gcalControl:             ControlStrategy,
+                                ghostControl:            ControlStrategy,
+                                gmosControl:             ControlStrategy,
+                                gnirsControl:            ControlStrategy,
+                                gpiControl:              ControlStrategy,
+                                gpiGdsControl:           ControlStrategy,
+                                ghostGdsControl:         ControlStrategy,
+                                gsaoiControl:            ControlStrategy,
+                                gwsControl:              ControlStrategy,
+                                nifsControl:             ControlStrategy,
+                                niriControl:             ControlStrategy,
+                                tcsControl:              ControlStrategy,
+                                odbNotifications:        Boolean,
+                                instForceError:          Boolean,
+                                failAt:                  Int,
+                                odbQueuePollingInterval: Duration,
+                                gpiGiapi:                Giapi[F],
+                                ghostGiapi:              Giapi[F],
+                                gpiGDS:                  Uri,
+                                ghostGDS:                Uri)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
@@ -8,6 +8,10 @@ import giapi.client.Giapi
 import java.time.LocalDate
 import org.http4s.Uri
 import scala.concurrent.duration.Duration
+import shapeless.tag.@@
+
+trait GpiSettings
+trait GhostSettings
 
 final case class Settings[F[_]](site:                    Site,
                                 odbHost:                 String,
@@ -31,7 +35,7 @@ final case class Settings[F[_]](site:                    Site,
                                 instForceError:          Boolean,
                                 failAt:                  Int,
                                 odbQueuePollingInterval: Duration,
-                                gpiGiapi:                Giapi[F],
-                                ghostGiapi:              Giapi[F],
-                                gpiGDS:                  Uri,
-                                ghostGDS:                Uri)
+                                gpiGiapi:                Giapi[F] @@ GpiSettings,
+                                ghostGiapi:              Giapi[F] @@ GhostSettings,
+                                gpiGDS:                  Uri @@ GpiSettings,
+                                ghostGDS:                Uri @@ GhostSettings)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/TranslateSettings.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/TranslateSettings.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+final case class TranslateSettings(
+  tcsKeywords:   Boolean,
+  f2Keywords:    Boolean,
+  gwsKeywords:   Boolean,
+  gcalKeywords:  Boolean,
+  gmosKeywords:  Boolean,
+  gnirsKeywords: Boolean
+)

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -86,7 +86,7 @@ class SeqTranslateSpec extends FlatSpec {
     new GDSClient(GDSClient.alwaysOkClient, uri("hhttp://localhost:8888/xmlrpc")))
   )
 
-  private val translatorSettings = SeqTranslate.Settings(tcsKeywords = false, f2Keywords = false, gwsKeywords = false,
+  private val translatorSettings = TranslateSettings(tcsKeywords = false, f2Keywords = false, gwsKeywords = false,
     gcalKeywords = false, gmosKeywords = false, gnirsKeywords = false)
 
   private val translator = SeqTranslate(Site.GS, systems, translatorSettings)

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -12,23 +12,22 @@ import giapi.client.Giapi
 import io.prometheus.client._
 import java.time.LocalDate
 import java.util.UUID
-
 import org.scalatest.Inside.inside
 import org.scalatest.{FlatSpec, Matchers, NonImplicitAssertions}
 import org.http4s.Uri._
-
+import org.http4s.Uri
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import seqexec.engine
 import seqexec.engine.Result.PauseContext
 import seqexec.engine._
-import seqexec.server.SeqexecEngine.Settings
 import seqexec.server.keywords.GDSClient
 import seqexec.model.{ActionType, CalibrationQueueId, ClientId, Conditions, Observer, Operator, SequenceState, UserDetails}
 import seqexec.model.enum._
 import seqexec.model.enum.Resource.TCS
 import monocle.Monocle._
 import seqexec.model.enum.BatchCommandState
+import shapeless.tag
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 @SuppressWarnings(Array("org.wartremover.warts.Throw"))
@@ -55,10 +54,10 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     instForceError = false,
     failAt = 0,
     10.seconds,
-    Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync,
-    Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync,
-    uri("http://localhost:8888/xmlrpc"),
-    uri("http://localhost:8888/xmlrpc")
+    tag[GpiSettings][Giapi[IO]](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
+    tag[GhostSettings][Giapi[IO]](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
+    tag[GpiSettings][Uri](uri("http://localhost:8888/xmlrpc")),
+    tag[GhostSettings][Uri](uri("http://localhost:8888/xmlrpc"))
   )
 
   def configureIO(resource: Resource): IO[Result] = IO.apply(Result.OK(Result.Configured(resource)))

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -29,6 +29,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import seqexec.model.events._
 import seqexec.server
 import seqexec.server.{SeqexecMetrics, SeqexecConfiguration, SeqexecEngine, executeEngine}
+import seqexec.server.GpiSettings
+import seqexec.server.GhostSettings
 import seqexec.web.server.OcsBuildInfo
 import seqexec.web.server.logging.AppenderForClients
 import seqexec.web.server.security.{AuthenticationConfig, AuthenticationService, LDAPConfig}
@@ -179,9 +181,9 @@ object WebServerLauncher extends StreamApp[IO] with LogInitialization with Seqex
         _          <- configLog // Initialize log before the engine is setup
         c          <- config
         site       <- IO.pure(c.require[Site]("seqexec-engine.site"))
-        giapiGPI   <- SeqexecEngine.giapiConnection("seqexec-engine.systemControl.gpi",
+        giapiGPI   <- SeqexecEngine.giapiConnection[GpiSettings]("seqexec-engine.systemControl.gpi",
                                                     "seqexec-engine.gpiUrl").run(c)
-        giapiGHOST <- SeqexecEngine.giapiConnection("seqexec-engine.systemControl.ghost",
+        giapiGHOST <- SeqexecEngine.giapiConnection[GhostSettings]("seqexec-engine.systemControl.ghost",
                                                     "seqexec-engine.ghostUrl").run(c)
         seqc       <- SeqexecEngine.seqexecConfiguration(giapiGPI, giapiGHOST).run(c)
         met        <- SeqexecMetrics.build[IO](site, collector)


### PR DESCRIPTION
There is a serious bug on the current seqexec which doesn't let GPI to run as the configuration of GHOST is passed instead

This is an easy mistake to make, so besides a fix I added tagged types to ensure the correct type is passed

Also we have `SeqexecServer.Settings` and `SeqTranslate.Settings` which is quite confusing. I moved both to their own classes and renamed the latter to `TranslateSettings`