### PR TITLE
SEQNG-783: Switched GPIController to use SeqActionF.apply.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
@@ -195,11 +195,10 @@ final case class GPIController[F[_]: Sync](gpiClient: GPIClient[F],
 
   def applyConfig(config: GPIConfig): SeqActionF[F, Unit] =
     for {
-      _ <- EitherT.liftF(Sync[F].delay(Log.debug("Start GPI configuration")))
-      _ <- EitherT.liftF(Sync[F].delay(Log.debug(s"GPI configuration $config")))
+      _ <- SeqActionF.apply(Log.debug("Start GPI configuration"))
+      _ <- SeqActionF.apply(Log.debug(s"GPI configuration $config"))
       _ <- gpiConfig(config)
-      _ <- EitherT.liftF(
-            Sync[F].delay(Log.debug("Completed GPI configuration")))
+      _ <- SeqActionF.apply(Log.debug("Completed GPI configuration"))
     } yield ()
 
   def observe(fileId: ImageFileId, expTime: Time): SeqActionF[F, ImageFileId] =


### PR DESCRIPTION
When making this PR for GHOST, @tpolecat and @jluhrs had some good comments about how we should be using `SeqActionF.apply` to clean up `EitherT.liftF(Sync[F].delay(...))` code, since it does the same thing and is much less verbose and clearer:

https://github.com/gemini-hlsw/ocs3/pull/711

This is code I grabbed from `GPIController` directly, and just changed the names.

Because of the code reuse, we should consider moving `applyConfig` to a parent class (right now there is no shared parent class), especially  if other GIAPI instruments will be similar. (I see now that the code for the non-GIAPI instruments is quite different and doesn't share this.)