### PR TITLE
SEQNG-796 Merged engine and server sequence data in a single Map.

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
@@ -247,7 +247,7 @@ object Sequence {
     /**
       * Rebuilds the state of a sequence with a new steps definition, but preserving breakpoints and skip marks
       * The sequence must not be running.
-      * @param q New sequence definition
+      * @param steps New sequence definition
       * @param st Old sequence state
       * @return The new sequence state
       */

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/EngineSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/EngineSpec.scala
@@ -11,12 +11,13 @@ import gem.arb.ArbObservation
 import monocle.law.discipline.OptionalTests
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Arbitrary._
+import seqexec.engine.TestUtil.TestState
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.SequenceState
 
 final class EngineSpec extends CatsSuite with ArbObservation {
   implicit val seqstateEq: Eq[Sequence.State[IO]] = Eq.fromUniversalEquals
-  implicit val execstateEq: Eq[Engine.State] = Eq.by(x => x.sequences)
+  implicit val execstateEq: Eq[TestState] = Eq.by(x => x.sequences)
 
   implicit val sequenceArb: Arbitrary[Sequence[IO]] = Arbitrary{
     for{
@@ -33,13 +34,14 @@ final class EngineSpec extends CatsSuite with ArbObservation {
 
   implicit val sequenceStateCogen: Cogen[Sequence.State[IO]] = Cogen[Observation.Id].contramap(_.toSequence.id)
 
-  implicit val engineStateArb: Arbitrary[Engine.State] = Arbitrary {
+  implicit val engineStateArb: Arbitrary[TestState] = Arbitrary {
     for {
       q <- arbitrary[Map[Observation.Id, Sequence.State[IO]]]
-    } yield Engine.State(q)
+    } yield TestState(q)
   }
 
   checkAll("sequence optional",
-           OptionalTests[Engine.State, Sequence.State[IO], Observation.Id](Engine.State.sequenceState))
+           OptionalTests[TestState, Sequence.State[IO], Observation.Id](TestState
+             .sequenceStateIndex))
 
 }

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/TestUtil.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/TestUtil.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.engine
+
+import cats.effect.IO
+import gem.Observation
+import monocle.Optional
+import monocle.macros.Lenses
+import monocle.function.Index._
+
+object TestUtil {
+  @Lenses
+  final case class TestState(sequences: Map[Observation.Id, Sequence.State[IO]])
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object TestState extends Engine.State[TestState] {
+    override def sequenceStateIndex(sid: Observation.Id): Optional[TestState, Sequence
+    .State[IO]] =
+      TestState.sequences ^|-? index(sid)
+
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -236,9 +236,9 @@ class SeqTranslate(site: Site, systems: Systems, settings: TranslateSettings) {
       }
 
     for {
-      seqg <- st.sequences.seq.get(seqId)
-      seq  <- st.executionState.sequences.get(seqId)
-      r    <- seqCmd(seq, seqg.seq.instrument)
+      seqg   <- st.sequences.seq.get(seqId)
+      obsseq <- st.sequences.get(seqId)
+      r      <- seqCmd(obsseq.seq, seqg.seqGen.instrument)
     } yield r
 
   }
@@ -320,9 +320,9 @@ class SeqTranslate(site: Site, systems: Systems, settings: TranslateSettings) {
     }
 
     for {
-      seqg <- st.sequences.seq.get(seqId)
-      seq  <- st.executionState.sequences.get(seqId)
-      r    <- seqCmd(seq, seqg.seq.instrument)
+      seqg   <- st.sequences.seq.get(seqId)
+      obsseq <- st.sequences.get(seqId)
+      r      <- seqCmd(obsseq.seq, seqg.seqGen.instrument)
     } yield r
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -16,10 +16,10 @@ import edu.gemini.spModel.guide.StandardGuideOptions
 import fs2.async.mutable.Queue
 import gem.Observation
 import monocle.macros.Lenses
-import monocle.Lens
+import monocle.{Lens, Optional}
 import monocle.macros.GenLens
-import monocle.function.At.at
-import monocle.function.At.atMap
+import monocle.function.Index._
+import monocle.function.At._
 import seqexec.engine.Engine
 import seqexec.engine.Result.{PartialVal, RetVal}
 import seqexec.model.ClientId
@@ -36,22 +36,32 @@ import seqexec.model.UserDetails
 import seqexec.model.dhs.ImageFileId
 
 package server {
+  import seqexec.engine.Sequence
 
   import squants.Time
 
   @Lenses
-  final case class ObserverSequence(observer: Option[Observer], seq: SequenceGen)
+  final case class SequenceData(observer: Option[Observer],
+                                seqGen: SequenceGen,
+                                seq: Sequence.State[IO])
+
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  object ObserverSequence
+  object SequenceData
 
   @Lenses
-  final case class EngineState(queues: ExecutionQueues, selected: Map[Instrument, Observation.Id], conditions: Conditions, operator: Option[Operator], sequences: Map[Observation.Id, ObserverSequence], executionState: Engine.State)
+  final case class EngineState(queues: ExecutionQueues, selected: Map[Instrument, Observation.Id], conditions: Conditions, operator: Option[Operator], sequences: Map[Observation.Id, SequenceData])
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  object EngineState {
-    val default: EngineState = EngineState(Map(CalibrationQueueId -> ExecutionQueue.init(CalibrationQueueName)), Map.empty, Conditions.Default, None, Map.empty, Engine.State.empty)
+  object EngineState extends Engine.State[EngineState]{
+    val default: EngineState = EngineState(Map(CalibrationQueueId -> ExecutionQueue.init(CalibrationQueueName)), Map.empty, Conditions.Default, None, Map.empty)
 
     def instrumentLoadedL(instrument: Instrument): Lens[EngineState, Option[Observation.Id]] = GenLens[EngineState](_.selected) ^|-> at(instrument)
 
+    def atSequence(sid:Observation.Id): Optional[EngineState, SequenceData] =
+      EngineState.sequences ^|-? index(sid)
+
+    override def sequenceStateIndex(sid: Observation.Id)
+    : Optional[EngineState, Sequence.State[IO]] =
+      atSequence(sid) ^|-> SequenceData.seq
   }
 
   sealed trait SeqEvent
@@ -139,7 +149,7 @@ package object server {
 
   type ExecutionQueues = Map[QueueId, ExecutionQueue]
 
-  val executeEngine: Engine[EngineState, SeqEvent] = new Engine[EngineState, SeqEvent](EngineState.executionState)
+  val executeEngine: Engine[EngineState, SeqEvent] = new Engine[EngineState, SeqEvent](EngineState)
 
   type EventQueue = Queue[IO, executeEngine.EventType]
 
@@ -175,9 +185,9 @@ package object server {
 
   implicit class ExecutionQueueOps(val q: ExecutionQueue) extends AnyVal {
     def status(st: EngineState): BatchExecState = {
-      val statuses: Seq[SequenceState] = q.queue.map(st.executionState.sequences.get(_).map(_.status))
+      val statuses: Seq[SequenceState] = q.queue.map(sid => st.sequences.get(sid))
         .collect{ case Some(x) => x }
-
+        .map(_.seq.status)
 
       q.cmdState match {
         case BatchCommandState.Idle         => BatchExecState.Idle

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerLensesSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerLensesSpec.scala
@@ -28,13 +28,13 @@ final class SeqexecServerLensesSpec extends CatsSuite with ArbObservation {
     case (a:PendingStepGen, b:PendingStepGen)     => a === b
     case (a:SkippedStepGen, b:SkippedStepGen)     => a === b
     case (a:CompletedStepGen, b:CompletedStepGen) => a === b
-    case _                                  => false
+    case _                                        => false
   }
   implicit val seqgEq: Eq[SequenceGen] = Eq.by(x => (x.id, x.title, x.instrument, x.steps))
-  implicit val obsseqEq: Eq[ObserverSequence] = Eq.by(x => (x.observer, x.seq))
+  implicit val obsseqEq: Eq[SequenceData] = Eq.by(x => (x.observer, x.seqGen))
   implicit val seqstateEq: Eq[engine.Sequence.State[IO]] = Eq.fromUniversalEquals
-  implicit val execstateEq: Eq[engine.Engine.State] = Eq.by(x => x.sequences)
-  implicit val stateEq: Eq[EngineState] = Eq.by(x => (x.queues, x.selected, x.conditions, x.operator, x.sequences, x.executionState))
+  implicit val stateEq: Eq[EngineState] = Eq.by(x =>
+    (x.queues, x.selected, x.conditions, x.operator, x.sequences))
 
   checkAll("selected optional",
            LensTests(EngineState.instrumentLoadedL(Instrument.GPI)))


### PR DESCRIPTION
The sequence data used by the execution engine and the sequence data used by the seqexec server (the upper level) are kept in separate Maps. This PR uses Lenses magic join those Maps in a single one, while keeping the execution engine agnostic of the extra data required by upper level.