### PR TITLE
SEQNG-789: Export countdown time on the websocket channel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -543,7 +543,7 @@ lazy val seqexec_model = crossProject(JVMPlatform, JSPlatform)
   .enablePlugins(GitBranchPrompt)
   .settings(
     addCompilerPlugin(Plugins.paradisePlugin),
-    libraryDependencies ++= Seq(Mouse.value, BooPickle.value) ++ Monocle.value
+    libraryDependencies ++= Seq(Squants.value, Mouse.value, BooPickle.value) ++ Monocle.value
   )
   .jvmSettings(
     commonSettings)

--- a/modules/seqexec/model/src/main/scala/seqexec/model/ObservationProgress.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ObservationProgress.scala
@@ -5,16 +5,17 @@ package seqexec.model
 
 import cats.Eq
 import cats.implicits._
+import gem.Observation
 import squants.Time
-import seqexec.model.dhs.ImageFileId
 
-final case class ObservationProgress(fileId:    ImageFileId,
+final case class ObservationProgress(obsId:     Observation.Id,
+                                     step:      Int,
                                      total:     Time,
                                      remaining: Time)
 
 object ObservationProgress {
 
   implicit val equal: Eq[ObservationProgress] =
-    Eq.by(x => (x.fileId, x.total, x.remaining))
+    Eq.by(x => (x.obsId, x.step, x.total, x.remaining))
 
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/ObservationProgress.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ObservationProgress.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model
+
+import cats.Eq
+import cats.implicits._
+import squants.Time
+import seqexec.model.dhs.ImageFileId
+
+final case class ObservationProgress(fileId:    ImageFileId,
+                                     total:     Time,
+                                     remaining: Time)
+
+object ObservationProgress {
+
+  implicit val equal: Eq[ObservationProgress] =
+    Eq.by(x => (x.fileId, x.total, x.remaining))
+
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
@@ -18,6 +18,10 @@ object events {
     def view: SequencesQueue[SequenceView]
   }
 
+  /**
+    * Events implementing ForClient will be delivered only to the given
+    * clientId
+    */
   sealed trait ForClient extends SeqexecEvent {
     def clientId: ClientId
   }
@@ -30,7 +34,17 @@ object events {
     implicit lazy val equal: Eq[NewLogMessage] = Eq.fromUniversalEquals
   }
 
-  final case class ServerLogMessage(level: ServerLogLevel, timestamp: Instant, msg: String) extends SeqexecEvent
+  final case class ObservationProgressEvent(progress: ObservationProgress)
+      extends SeqexecEvent
+
+  object ObservationProgressEvent {
+    implicit lazy val equal: Eq[ObservationProgressEvent] = Eq.by(_.progress)
+  }
+
+  final case class ServerLogMessage(level:     ServerLogLevel,
+                                    timestamp: Instant,
+                                    msg:       String)
+      extends SeqexecEvent
   object ServerLogMessage {
     implicit lazy val equal: Eq[ServerLogMessage] =
       Eq.by(x => (x.level, x.timestamp, x.msg))
@@ -42,7 +56,9 @@ object events {
     case _                      => false
   }
 
-  final case class ConnectionOpenEvent(u: Option[UserDetails], clientId: ClientId) extends SeqexecEvent
+  final case class ConnectionOpenEvent(u:        Option[UserDetails],
+                                       clientId: ClientId)
+      extends SeqexecEvent
 
   object ConnectionOpenEvent {
     implicit lazy val equal: Eq[ConnectionOpenEvent] =
@@ -81,176 +97,214 @@ object events {
       Some(u.view)
   }
 
-  final case class SequenceStart(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequenceStart(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequenceStart {
     implicit lazy val equal: Eq[SequenceStart] =
       Eq.by(_.view)
   }
 
-  final case class StepExecuted(obsId: Observation.Id, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class StepExecuted(obsId: Observation.Id,
+                                view:  SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object StepExecuted {
     implicit lazy val equal: Eq[StepExecuted] =
       Eq.by(x => (x.obsId, x.view))
   }
 
-  final case class FileIdStepExecuted(fileId: ImageFileId, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class FileIdStepExecuted(fileId: ImageFileId,
+                                      view:   SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
-  object FileIdStepExecuted{
+  object FileIdStepExecuted {
     implicit lazy val equal: Eq[FileIdStepExecuted] =
       Eq.by(x => (x.fileId, x.view))
   }
 
-  final case class SequenceCompleted(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequenceCompleted(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequenceCompleted {
     implicit lazy val equal: Eq[SequenceCompleted] =
       Eq.by(_.view)
   }
 
-  final case class SequenceLoaded(obsId: Observation.Id, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequenceLoaded(obsId: Observation.Id,
+                                  view:  SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequenceLoaded {
     implicit lazy val equal: Eq[SequenceLoaded] =
       Eq.by(x => (x.obsId, x.view))
   }
 
-  final case class SequenceUnloaded(obsId: Observation.Id, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequenceUnloaded(obsId: Observation.Id,
+                                    view:  SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequenceUnloaded {
     implicit lazy val equal: Eq[SequenceUnloaded] =
       Eq.by(x => (x.obsId, x.view))
   }
 
-  final case class StepBreakpointChanged(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class StepBreakpointChanged(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object StepBreakpointChanged {
     implicit lazy val equal: Eq[StepBreakpointChanged] =
       Eq.by(_.view)
   }
 
-  final case class OperatorUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class OperatorUpdated(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object OperatorUpdated {
     implicit lazy val equal: Eq[OperatorUpdated] =
       Eq.by(_.view)
   }
 
-  final case class QueueUpdated(op: QueueManipulationOp, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class QueueUpdated(op:   QueueManipulationOp,
+                                view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object QueueUpdated {
     implicit lazy val equal: Eq[QueueUpdated] =
       Eq.by(x => (x.op, x.view))
   }
 
-  final case class LoadSequenceUpdated(i: Instrument, sid: Observation.Id, view: SequencesQueue[SequenceView], clientId: ClientId) extends SeqexecModelUpdate
+  final case class LoadSequenceUpdated(i:        Instrument,
+                                       sid:      Observation.Id,
+                                       view:     SequencesQueue[SequenceView],
+                                       clientId: ClientId)
+      extends SeqexecModelUpdate
 
   object LoadSequenceUpdated {
     implicit lazy val equal: Eq[LoadSequenceUpdated] =
       Eq.by(x => (x.i, x.sid, x.view, x.clientId))
   }
 
-  final case class ClearLoadedSequencesUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class ClearLoadedSequencesUpdated(
+    view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object ClearLoadedSequencesUpdated {
     implicit lazy val clsEqual: Eq[ClearLoadedSequencesUpdated] =
       Eq.by(_.view)
   }
 
-  final case class ObserverUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class ObserverUpdated(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object ObserverUpdated {
     implicit lazy val equal: Eq[ObserverUpdated] =
       Eq.by(_.view)
   }
 
-  final case class ConditionsUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class ConditionsUpdated(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object ConditionsUpdated {
     implicit lazy val equal: Eq[ConditionsUpdated] =
       Eq.by(_.view)
   }
 
-  final case class StepSkipMarkChanged(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class StepSkipMarkChanged(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object StepSkipMarkChanged {
     implicit lazy val equal: Eq[StepSkipMarkChanged] =
       Eq.by(_.view)
   }
 
-  final case class SequencePauseRequested(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequencePauseRequested(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequencePauseRequested {
     implicit lazy val equal: Eq[SequencePauseRequested] =
       Eq.by(_.view)
   }
 
-  final case class SequencePauseCanceled(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequencePauseCanceled(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequencePauseCanceled {
     implicit lazy val equal: Eq[SequencePauseCanceled] =
       Eq.by(_.view)
   }
 
-  final case class SequenceRefreshed(view: SequencesQueue[SequenceView], clientId: ClientId) extends SeqexecModelUpdate with ForClient
+  final case class SequenceRefreshed(view:     SequencesQueue[SequenceView],
+                                     clientId: ClientId)
+      extends SeqexecModelUpdate
+      with ForClient
 
   object SequenceRefreshed {
     implicit lazy val equal: Eq[SequenceRefreshed] =
       Eq.by(x => (x.view, x.clientId))
   }
 
-  final case class ActionStopRequested(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class ActionStopRequested(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object ActionStopRequested {
     implicit lazy val equal: Eq[ActionStopRequested] =
       Eq.by(_.view)
   }
 
-  final case class SequenceUpdated(view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequenceUpdated(view: SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequenceUpdated {
     implicit lazy val equal: Eq[SequenceUpdated] =
       Eq.by(_.view)
   }
 
-  final case class SequencePaused(obsId: Observation.Id, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequencePaused(obsId: Observation.Id,
+                                  view:  SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequencePaused {
     implicit lazy val equal: Eq[SequencePaused] =
       Eq.by(x => (x.obsId, x.view))
   }
 
-  final case class ExposurePaused(obsId: Observation.Id, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class ExposurePaused(obsId: Observation.Id,
+                                  view:  SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object ExposurePaused {
     implicit lazy val equal: Eq[ExposurePaused] =
       Eq.by(x => (x.obsId, x.view))
   }
 
-  final case class SequenceError(obsId: Observation.Id, view: SequencesQueue[SequenceView]) extends SeqexecModelUpdate
+  final case class SequenceError(obsId: Observation.Id,
+                                 view:  SequencesQueue[SequenceView])
+      extends SeqexecModelUpdate
 
   object SequenceError {
     implicit lazy val equal: Eq[SequenceError] =
       Eq.by(x => (x.obsId, x.view))
   }
 
-  final case class UserNotification(memo: Notification, clientId: ClientId) extends ForClient
+  final case class UserNotification(memo: Notification, clientId: ClientId)
+      extends ForClient
 
-  object UserNotification{
+  object UserNotification {
     implicit lazy val equal: Eq[UserNotification] =
       Eq.by(x => (x.memo, x.clientId))
   }
 
   implicit val equal: Eq[SeqexecEvent] =
     Eq.instance {
-      case (a: ConnectionOpenEvent, b: ConnectionOpenEvent) => a === b
-      case (a: SeqexecModelUpdate,  b: SeqexecModelUpdate)  => a === b
-      case (a: NewLogMessage,       b: NewLogMessage)       => a === b
-      case (a: ServerLogMessage,    b: ServerLogMessage)    => a === b
-      case (a: UserNotification,    b: UserNotification)    => a === b
-      case (_: NullEvent.type,      _: NullEvent.type)      => true
-      case _                                                => false
+      case (a: ConnectionOpenEvent,      b: ConnectionOpenEvent)      => a === b
+      case (a: SeqexecModelUpdate,       b: SeqexecModelUpdate)       => a === b
+      case (a: NewLogMessage,            b: NewLogMessage)            => a === b
+      case (a: ServerLogMessage,         b: ServerLogMessage)         => a === b
+      case (a: UserNotification,         b: UserNotification)         => a === b
+      case (a: ObservationProgressEvent, b: ObservationProgressEvent) => a === b
+      case (_: NullEvent.type,           _: NullEvent.type)           => true
+      case _                                                          => false
     }
 
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/package.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/package.scala
@@ -6,7 +6,7 @@ package seqexec
 import cats._
 import cats.implicits._
 import java.util.UUID
-import squants.Time
+import squants.time.Time
 import squants.time.TimeUnit
 import seqexec.model.enum._
 
@@ -46,7 +46,8 @@ package object model {
 
   implicit val timeUnit: Eq[TimeUnit] =
     Eq.by(_.symbol)
+
   implicit val timeEq: Eq[Time] =
-    Eq.by(t => (t.value, t.unit))
+    Eq.by(_.toMilliseconds.value)
 
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/package.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/package.scala
@@ -6,10 +6,12 @@ package seqexec
 import cats._
 import cats.implicits._
 import java.util.UUID
+import squants.Time
+import squants.time.TimeUnit
 import seqexec.model.enum._
 
 package model {
-  final case class QueueId(self: UUID) extends AnyVal
+  final case class QueueId(self:  UUID) extends AnyVal
   final case class ClientId(self: UUID) extends AnyVal
 }
 
@@ -22,23 +24,29 @@ package object model {
   type ObservationName = String
   type TargetName      = String
 
-  implicit val queueIdEq: Eq[QueueId] = Eq.by(x => x.self)
+  implicit val queueIdEq: Eq[QueueId]     = Eq.by(x => x.self)
   implicit val queueIdShow: Show[QueueId] = Show.fromToString
   implicit val queueIdOrder: Order[QueueId] =
     Order.by(_.self)
   implicit val queueIdOrdering: scala.math.Ordering[QueueId] =
     queueIdOrder.toOrdering
 
-  implicit val stEq: Eq[StepConfig]     = Eq.fromUniversalEquals
-  implicit val clientIdEq: Eq[ClientId] = Eq.by(x => x.self)
+  implicit val stEq: Eq[StepConfig]         = Eq.fromUniversalEquals
+  implicit val clientIdEq: Eq[ClientId]     = Eq.by(x => x.self)
   implicit val clientIdShow: Show[ClientId] = Show.fromToString
   implicit val clientIdOrder: Order[ClientId] =
     Order.by(_.self)
   implicit val clientIdOrdering: scala.math.Ordering[ClientId] =
     clientIdOrder.toOrdering
-  val DaytimeCalibrationTargetName      = "Daytime calibration"
+  val DaytimeCalibrationTargetName = "Daytime calibration"
 
   val CalibrationQueueName: String = "Calibration Queue"
-  val CalibrationQueueId: QueueId = QueueId(UUID.fromString("7156fa7e-48a6-49d1-a267-dbf3bbaa7577"))
+  val CalibrationQueueId: QueueId =
+    QueueId(UUID.fromString("7156fa7e-48a6-49d1-a267-dbf3bbaa7577"))
+
+  implicit val timeUnit: Eq[TimeUnit] =
+    Eq.by(_.symbol)
+  implicit val timeEq: Eq[Time] =
+    Eq.by(t => (t.value, t.unit))
 
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -7,6 +7,8 @@ import cats.tests.CatsSuite
 import cats.kernel.laws.discipline._
 import seqexec.model.enum._
 import seqexec.model.SeqexecModelArbitraries._
+import squants.time.Time
+import squants.time.TimeUnit
 
 /**
   * Tests Model typeclasses
@@ -52,4 +54,6 @@ final class ModelSpec extends CatsSuite {
   checkAll("Eq[Notification]", EqTests[Notification].eqv)
   checkAll("Eq[ExecutionQueueView]", EqTests[ExecutionQueueView].eqv)
   checkAll("Eq[ObservationProgress]", EqTests[ObservationProgress].eqv)
+  checkAll("Eq[TimeUnit]", EqTests[TimeUnit].eqv)
+  checkAll("Eq[Time]", EqTests[Time].eqv)
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -51,4 +51,5 @@ final class ModelSpec extends CatsSuite {
   checkAll("Eq[InstrumentInUse]", EqTests[InstrumentInUse].eqv)
   checkAll("Eq[Notification]", EqTests[Notification].eqv)
   checkAll("Eq[ExecutionQueueView]", EqTests[ExecutionQueueView].eqv)
+  checkAll("Eq[ObservationProgress]", EqTests[ObservationProgress].eqv)
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecEventSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecEventSpec.scala
@@ -33,4 +33,5 @@ final class SeqexecEventSpec extends CatsSuite with SequenceEventsArbitraries {
   checkAll("Eq[SequenceError]", EqTests[SequenceError].eqv)
   checkAll("Eq[NewLogMessage]", EqTests[NewLogMessage].eqv)
   checkAll("Eq[UserNotification]", EqTests[UserNotification].eqv)
+  checkAll("Eq[ObservationProgressEvent]", EqTests[ObservationProgressEvent].eqv)
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -14,9 +14,8 @@ import org.scalacheck.Gen
 import org.scalacheck.Arbitrary._
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration.Duration
-import squants.time.Time
+import squants.time._
 import seqexec.model.enum._
-import seqexec.model.dhs.ImageFileId
 
 trait SeqexecModelArbitraries extends ArbObservation {
 
@@ -475,8 +474,22 @@ trait SeqexecModelArbitraries extends ArbObservation {
     }
 
   implicit val userLoginRequestCogen: Cogen[UserLoginRequest] =
-    Cogen[(String, String)].contramap(x =>
-      (x.username, x.password))
+    Cogen[(String, String)].contramap(x => (x.username, x.password))
+
+  implicit val arbTimeUnit: Arbitrary[TimeUnit] =
+    Arbitrary {
+      Gen.oneOf(Nanoseconds,
+                Microseconds,
+                Milliseconds,
+                Seconds,
+                Minutes,
+                Hours,
+                Days)
+    }
+
+  implicit val timeUnitCogen: Cogen[TimeUnit] =
+    Cogen[String]
+      .contramap(_.symbol)
 
   implicit val arbTime: Arbitrary[Time] =
     Arbitrary {
@@ -490,15 +503,16 @@ trait SeqexecModelArbitraries extends ArbObservation {
   implicit val arbObservationProgress: Arbitrary[ObservationProgress] =
     Arbitrary {
       for {
-        f <- arbitrary[ImageFileId]
+        o <- arbitrary[Observation.Id]
+        s <- arbitrary[Int]
         t <- arbitrary[Time]
         r <- arbitrary[Time]
-      } yield ObservationProgress(f, t, r)
+      } yield ObservationProgress(o, s, t, r)
     }
 
   implicit val observationInProgressCogen: Cogen[ObservationProgress] =
-    Cogen[(ImageFileId, Time, Time)]
-      .contramap(x => (x.fileId, x.total, x.remaining))
+    Cogen[(Observation.Id, Int, Time, Time)]
+      .contramap(x => (x.obsId, x.step, x.total, x.remaining))
 
 }
 

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -156,6 +156,12 @@ trait SequenceEventsArbitraries extends ArbTime {
     } yield UserNotification(i, c)
   }
 
+  implicit val oprArb = Arbitrary[ObservationProgressEvent] {
+    for {
+      p <- arbitrary[ObservationProgress]
+    } yield ObservationProgressEvent(p)
+  }
+
   implicit val smuArb = Arbitrary[SeqexecModelUpdate] {
     Gen.oneOf[SeqexecModelUpdate](
       arbitrary[SequenceStart],
@@ -189,6 +195,7 @@ trait SequenceEventsArbitraries extends ArbTime {
       arbitrary[NewLogMessage],
       arbitrary[ServerLogMessage],
       arbitrary[UserNotification],
+      arbitrary[ObservationProgressEvent],
       arbitrary[NullEvent.type]
     )
   }
@@ -270,6 +277,9 @@ trait SequenceEventsArbitraries extends ArbTime {
 
   implicit val unCogen: Cogen[UserNotification] =
     Cogen[(Notification, ClientId)].contramap(x => (x.memo, x.clientId))
+
+  implicit val oprCogen: Cogen[ObservationProgressEvent] =
+    Cogen[ObservationProgress].contramap(_.progress)
 }
 
 object SequenceEventsArbitraries extends SequenceEventsArbitraries

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -852,6 +852,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     case engine.SystemUpdate(se, _)             => se match {
       // TODO: Sequence completed event not emited by engine.
       case engine.Completed(_, _, _)                                    => SequenceUpdated(svs)
+      case engine.PartialResult(i, s, Partial(Progress(t, r)))          => ObservationProgressEvent(ObservationProgress(i, s, t, r.self))
       case engine.PartialResult(_, _, Partial(FileIdAllocated(fileId))) => FileIdStepExecuted(fileId, svs)
       case engine.PartialResult(_, _, _)                                => SequenceUpdated(svs)
       case engine.Failed(id, _, _)                                      => SequenceError(id, svs)

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -8,10 +8,10 @@ import cats.Traverse
 import cats.implicits._
 import gem.Observation
 import java.time.Instant
-
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.model.events._
+import squants.time.TimeConversions._
 
 /**
   * Contains boopickle implicit picklers of model objects
@@ -162,7 +162,7 @@ trait ModelBooPicklers extends GemModelBooPicklers {
   implicit val sequenceMetadataPickler = generatePickler[SequenceMetadata]
 
   implicit val stepConfigPickler = generatePickler[SequenceView]
-  implicit val clientIdPickler = generatePickler[ClientId]
+  implicit val clientIdPickler   = generatePickler[ClientId]
 
   implicit val queueIdPickler      = generatePickler[QueueId]
   implicit val queueOpMovedPickler = generatePickler[QueueManipulationOp.Moved]
@@ -269,10 +269,13 @@ trait ModelBooPicklers extends GemModelBooPicklers {
   implicit val serverLogMessagePickler    = generatePickler[ServerLogMessage]
   implicit val userNotificationPickler    = generatePickler[UserNotification]
   implicit val queueUpdatedPickler        = generatePickler[QueueUpdated]
+  implicit val timeProgressPickler =
+    transformPickler((t: Double) => t.milliseconds)(_.toMilliseconds.value)
+  implicit val observationProgressPickler = generatePickler[ObservationProgress]
+  implicit val obsProgressPickler         = generatePickler[ObservationProgressEvent]
   implicit val nullEventPickler           = generatePickler[NullEvent.type]
 
   // Composite pickler for the seqexec event hierarchy
-  // It is not strictly need but reduces the size of the js
   implicit val eventsPickler = compositePickler[SeqexecEvent]
     .addConcreteType[ConnectionOpenEvent]
     .addConcreteType[SequenceStart]
@@ -299,6 +302,7 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     .addConcreteType[ServerLogMessage]
     .addConcreteType[UserNotification]
     .addConcreteType[QueueUpdated]
+    .addConcreteType[ObservationProgressEvent]
     .addConcreteType[NullEvent.type]
 
   implicit val userLoginPickler = generatePickler[UserLoginRequest]

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
@@ -3,15 +3,16 @@
 
 package seqexec.web.model.boopickle
 
+import _root_.boopickle.DefaultBasic._
+import cats.tests.CatsSuite
+import gem.Observation
+import org.scalacheck.Arbitrary._
 import seqexec.model.enum._
 import seqexec.model._
 import seqexec.model.events._
-import cats.tests.CatsSuite
-import _root_.boopickle.DefaultBasic._
-import org.scalacheck.Arbitrary._
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.SequenceEventsArbitraries._
-import gem.Observation
+import squants.time.Time
 
 /**
   * Tests Serialization/Deserialization using BooPickle
@@ -51,14 +52,18 @@ final class BoopicklingSpec extends CatsSuite with ModelBooPicklers {
            PicklerTests[LoadSequenceUpdated].pickler)
   checkAll("Pickler[ClearLoadedSequencesUpdated.type]",
            PicklerTests[ClearLoadedSequencesUpdated].pickler)
-  checkAll("Pickler[QueueManipulationOp]", PicklerTests[QueueManipulationOp].pickler)
+  checkAll("Pickler[QueueManipulationOp]",
+           PicklerTests[QueueManipulationOp].pickler)
+  checkAll("Pickler[ObservationProgressEvent]",
+           PicklerTests[ObservationProgressEvent].pickler)
   checkAll("Pickler[QueueUpdated]", PicklerTests[QueueUpdated].pickler)
   checkAll("Pickler[SequenceError]", PicklerTests[SequenceError].pickler)
   checkAll("Pickler[SequencePaused]", PicklerTests[SequencePaused].pickler)
   checkAll("Pickler[ExposurePaused]", PicklerTests[ExposurePaused].pickler)
   checkAll("Pickler[BatchCommandState]",
            PicklerTests[BatchCommandState].pickler)
-  checkAll("Pickler[ExecutionQueueView]", PicklerTests[ExecutionQueueView].pickler)
+  checkAll("Pickler[ExecutionQueueView]",
+           PicklerTests[ExecutionQueueView].pickler)
   checkAll("Pickler[SequencesQueue[Observation.Id]]",
            PicklerTests[SequencesQueue[Observation.Id]].pickler)
   checkAll("Pickler[ImageQuality]", PicklerTests[ImageQuality].pickler)
@@ -77,4 +82,7 @@ final class BoopicklingSpec extends CatsSuite with ModelBooPicklers {
   checkAll("Pickler[ActionStatus]", PicklerTests[ActionStatus].pickler)
   checkAll("Pickler[StandardStep]", PicklerTests[StandardStep].pickler)
   checkAll("Pickler[QueueId]", PicklerTests[QueueId].pickler)
+  checkAll("Pickler[Time]", PicklerTests[Time].pickler)
+  checkAll("Pickler[ObservationProgress]",
+           PicklerTests[ObservationProgress].pickler)
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -91,7 +91,7 @@ object Settings {
     val scalaXmlVerson          = "1.1.1"
 
     val http4sVersion           = "0.18.21"
-    val squants                 = "1.3.0"
+    val squants                 = "1.4.0"
     val argonaut                = "6.2.2"
     val commonsHttp             = "2.0.2"
     val unboundId               = "3.2.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -83,19 +83,19 @@ object Settings {
     // Scala libraries
     val catsEffectVersion       = "0.10.1"
     val catsVersion             = "1.4.0"
-    val mouseVersion            = "0.18"
+    val mouseVersion            = "0.19"
     val fs2Version              = "0.10.5"
     val shapelessVersion        = "2.3.3"
-    val attoVersion             = "0.6.3"
+    val attoVersion             = "0.6.4"
     val scalaParsersVersion     = "1.1.1"
     val scalaXmlVerson          = "1.1.1"
 
-    val http4sVersion           = "0.18.19"
+    val http4sVersion           = "0.18.21"
     val squants                 = "1.3.0"
     val argonaut                = "6.2.2"
     val commonsHttp             = "2.0.2"
     val unboundId               = "3.2.1"
-    val jwt                     = "0.18.0"
+    val jwt                     = "0.19.0"
     val slf4j                   = "1.7.25"
     val log4s                   = "1.6.1"
     val logback                 = "1.2.3"
@@ -103,7 +103,7 @@ object Settings {
     val logstash                = "5.2"
     val knobs                   = "6.0.33"
     val monocleVersion          = "1.5.1-cats"
-    val circeVersion            = "0.10.0"
+    val circeVersion            = "0.10.1"
     val doobieVersion           = "0.5.3"
     val flywayVersion           = "5.1.4"
     val tucoVersion             = "0.3.1"
@@ -272,7 +272,7 @@ object Settings {
   object PluginVersions {
     // Compiler plugins
     val paradiseVersion    = "2.1.1"
-    val kpVersion          = "0.9.7"
+    val kpVersion          = "0.9.8"
   }
 
   object Plugins {


### PR DESCRIPTION
The seqexec engine is sending countdown time updates as regular global model updates. This changes it by sending a specific `ObservationProgress` event

I also updated several libs to their latest versions