### PR TITLE
SEQNG-794: Fix bad navigation when on config page

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StatusAndLoadedSequencesFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StatusAndLoadedSequencesFocus.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.Order
+import cats.implicits._
+import diode._
+import gem.Observation
+import seqexec.model._
+import seqexec.model.enum._
+import seqexec.web.client.model._
+import seqexec.web.client.components.SessionQueueTableBody
+import web.client.table._
+
+final case class SequenceInSessionQueue(id:            Observation.Id,
+                                        status:        SequenceState,
+                                        instrument:    Instrument,
+                                        active:        Boolean,
+                                        loaded:        Boolean,
+                                        name:          String,
+                                        targetName:    Option[TargetName],
+                                        runningStep:   Option[RunningStep],
+                                        nextStepToRun: Option[Int])
+
+object SequenceInSessionQueue {
+  implicit val order: Order[SequenceInSessionQueue] = Order.by(_.id)
+  implicit val ordering: scala.math.Ordering[SequenceInSessionQueue] =
+    order.toOrdering
+}
+
+final case class StatusAndLoadedSequencesFocus(
+  status:     ClientStatus,
+  sequences:  List[SequenceInSessionQueue],
+  tableState: TableState[SessionQueueTableBody.TableColumn])
+    extends UseValueEq
+
+object StatusAndLoadedSequencesFocus {
+  implicit val eq: Eq[StatusAndLoadedSequencesFocus] =
+    Eq.by(x => (x.status, x.sequences, x.tableState))
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/TabFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/TabFocus.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.implicits._
+import cats.data.NonEmptyList
+import monocle.Getter
+import seqexec.model._
+import seqexec.web.client.model._
+
+final case class TabFocus(
+  canOperate:      Boolean,
+  tabs:            NonEmptyList[Either[CalibrationQueueTabActive, AvailableTab]],
+  defaultObserver: Observer)
+
+object TabFocus {
+  implicit val eq: Eq[TabFocus] =
+    Eq.by(x => (x.canOperate, x.tabs, x.defaultObserver))
+
+  val tabFocusG: Getter[SeqexecAppRootModel, TabFocus] = {
+    val getter = SeqexecAppRootModel.uiModel.composeGetter(
+      (SeqexecUIModel.sequencesOnDisplay
+        .composeGetter(SequencesOnDisplay.availableTabsG))
+        .zip(SeqexecUIModel.defaultObserverG))
+    ClientStatus.canOperateG.zip(getter) >>> {
+      case (o, (t, ob)) =>
+        TabFocus(o, t, ob)
+    }
+  }
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/package.scala
@@ -4,7 +4,6 @@
 package seqexec.web.client
 
 import cats.Eq
-import cats.Order
 import cats.implicits._
 import cats.data.NonEmptyList
 import diode._
@@ -18,7 +17,6 @@ import seqexec.web.client.model.lenses.firstScienceStepTargetNameT
 import seqexec.web.client.model._
 import seqexec.web.client.model.ModelOps._
 import seqexec.web.client.components.sequence.steps.StepsTable
-import seqexec.web.client.components.SessionQueueTableBody
 import web.client.table._
 
 package object circuit {
@@ -116,45 +114,12 @@ package circuit {
                    firstLoad          = v.firstLoad))
   }
 
-  final case class SequenceInSessionQueue(id:            Observation.Id,
-                                          status:        SequenceState,
-                                          instrument:    Instrument,
-                                          active:        Boolean,
-                                          loaded:        Boolean,
-                                          name:          String,
-                                          targetName:    Option[TargetName],
-                                          runningStep:   Option[RunningStep],
-                                          nextStepToRun: Option[Int])
-      extends UseValueEq
-
-  object SequenceInSessionQueue {
-    implicit val order: Order[SequenceInSessionQueue] = Order.by(_.id)
-    implicit val ordering: scala.math.Ordering[SequenceInSessionQueue] =
-      order.toOrdering
-  }
-
-  final case class StatusAndLoadedSequencesFocus(
-    status:     ClientStatus,
-    sequences:  List[SequenceInSessionQueue],
-    tableState: TableState[SessionQueueTableBody.TableColumn])
-      extends UseValueEq
-
   final case class InstrumentStatusFocus(
     instrument:  Instrument,
     active:      Boolean,
     idState:     Option[(Observation.Id, SequenceState)],
     runningStep: Option[RunningStep])
       extends UseValueEq
-
-  final case class TabFocus(
-    canOperate:      Boolean,
-    tabs:            NonEmptyList[Either[CalibrationQueueTabActive, AvailableTab]],
-    defaultObserver: Observer)
-
-  object TabFocus {
-    implicit val eq: Eq[TabFocus] =
-      Eq.by(x => (x.canOperate, x.tabs, x.defaultObserver))
-  }
 
   final case class SequenceInfoFocus(canOperate: Boolean,
                                      obsName:    Option[String],

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/WebSocketHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/WebSocketHandler.scala
@@ -6,15 +6,24 @@ package seqexec.web.client.handlers
 import boopickle.DefaultBasic._
 import cats.implicits._
 import diode.util.RunAfterJS
-import diode.{ Action, ActionHandler, ActionResult, Effect, ModelRW, NoAction }
-import diode.data.{ Pending, Pot, Ready }
-import java.util.logging.{ Level, Logger }
+import diode.Action
+import diode.ActionHandler
+import diode.ActionResult
+import diode.Effect
+import diode.ModelRW
+import diode.NoAction
+import diode.data.Pending
+import diode.data.Pot
+import diode.data.Ready
+import java.util.logging.Level
+import java.util.logging.Logger
 import java.time.Instant
 import mouse.all._
 import org.scalajs.dom._
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.scalajs.js.typedarray.{ ArrayBuffer, TypedArrayBuffer }
+import scala.scalajs.js.typedarray.ArrayBuffer
+import scala.scalajs.js.typedarray.TypedArrayBuffer
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 import seqexec.model.enum.ServerLogLevel
 import seqexec.model.events._
@@ -28,10 +37,13 @@ import seqexec.web.model.boopickle.ModelBooPicklers
   * Handles the WebSocket connection and performs reconnection if needed
   */
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends ActionHandler(modelRW) with Handlers[M, WebSocketConnection] with ModelBooPicklers {
+class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection])
+    extends ActionHandler(modelRW)
+    with Handlers[M, WebSocketConnection]
+    with ModelBooPicklers {
 
   private implicit val runner = new RunAfterJS
-  private val logger = Logger.getLogger(this.getClass.getSimpleName)
+  private val logger          = Logger.getLogger(this.getClass.getSimpleName)
   // Reconfigure to avoid sending ajax events in this logger
   logger.setUseParentHandlers(false)
   logger.addHandler(new ConsoleHandler(Level.FINE))
@@ -88,10 +100,11 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
     case WSConnect(d) =>
       effectOnly(Effect(webSocket).after(d.millis))
 
-    case Reconnect   =>
+    case Reconnect =>
       // Capture the WS, or it maybe invalid during the Future
       val ws = value.ws
-      val closeCurrent = Effect(Future(ws.foreach(_.close())).map(_ => NoAction))
+      val closeCurrent = Effect(
+        Future(ws.foreach(_.close())).map(_ => NoAction))
       val reConnect = Effect(webSocket)
       updated(value.copy(ws = Pot.empty[WebSocket], nextAttempt = 0, autoReconnect = false), closeCurrent >> reConnect)
   }
@@ -130,9 +143,9 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection]) extends Acti
   // can reconnect if needed
   override def handle: PartialFunction[Any, ActionResult[M]] =
     List(connectHandler,
-      connectingHandler,
-      connectedHandler,
-      connectionErrorHandler,
-      connectedCloseHandler,
-      connectionClosedHandler).combineAll
+         connectingHandler,
+         connectedHandler,
+         connectionErrorHandler,
+         connectedCloseHandler,
+         connectionClosedHandler).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -128,10 +128,11 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
           .getOrElse(StepsTable.State.InitialTableState)
         val completed = tab
           .flatMap(_.completedSequence)
+        val stepConfig = tab.flatMap(_.stepConfig)
         InstrumentSequenceTab(x.metadata.instrument,
                               x.some,
                               completed,
-                              None,
+                              stepConfig,
                               curTableState,
                               TabOperations.Default).some
     }
@@ -169,9 +170,10 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     // Replace the sequence for the instrument or the completed sequence and reset displaying a step
     val seq = if (s.metadata.instrument === i && !isLoaded) {
       val newPreview = SequencesOnDisplay.previewTabById(obsId).isEmpty(this)
-      val tsUpd = (ts: TableState[StepsTable.TableColumn]) => if (newPreview) StepsTable.State.InitialTableState else ts
+      val tsUpd = (ts: TableState[StepsTable.TableColumn]) =>
+        if (newPreview) StepsTable.State.InitialTableState else ts
       val update =
-          PreviewSequenceTab.tableState.modify(tsUpd) >>>
+        PreviewSequenceTab.tableState.modify(tsUpd) >>>
           PreviewSequenceTab.currentSequence.set(s) >>>
           PreviewSequenceTab.stepConfig.set(None)
       val q = withPreviewTab(s).tabs


### PR DESCRIPTION
While testing i noted a small bug where if you are on a config page of seq X and the seq is updated, e.g. when running the view will jump back to the main table

This PR fixes this and do some refactoring