### PR TITLE
SEQNG-682: GHOST UI changes, round 1.

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -110,6 +110,8 @@ object StepsTable {
     val rowCount         : Int                             = stepsList.length
     val nextStepToRun    : Int                             = steps.foldMap(_.nextStepToRun).getOrElse(0)
     val showDisperser    : Boolean                         = showProp(InstrumentProperties.Disperser)
+    val showExposure     : Boolean                         = showProp(InstrumentProperties.Exposure)
+    val showFilter       : Boolean                         = showProp(InstrumentProperties.Filter)
     val showFPU          : Boolean                         = showProp(InstrumentProperties.FPU)
     val isPreview        : Boolean                         = steps.map(_.isPreview).getOrElse(false)
     val canSetBreakpoint : Boolean                         = canOperate && !isPreview
@@ -381,6 +383,7 @@ object StepsTable {
                     className = SeqexecStyles.centeredCell.htmlClass,
                     cellRenderer = stepExposureRenderer(i.instrument)
                   )))
+      if p.showExposure
       if exposureVisible
     } yield col
 
@@ -416,17 +419,20 @@ object StepsTable {
 
   def filterColumn(p: Props,
                    filterVisible: Boolean): Option[Table.ColumnArg] =
-    p.steps
-      .map(
-        i =>
-          Column(Column.propsNoFlex(
-            ColWidths.FilterWidth,
-            "filter",
-            label = "Filter",
-            className = SeqexecStyles.centeredCell.htmlClass,
-            cellRenderer = stepFilterRenderer(i.instrument)
-          )))
-      .filter(_ => filterVisible)
+    for {
+      col <- p.steps.map(
+              i =>
+                Column(
+                  Column.propsNoFlex(
+                    ColWidths.FilterWidth,
+                    "filter",
+                     label = "Filter",
+                     className = SeqexecStyles.centeredCell.htmlClass,
+                     cellRenderer = stepFilterRenderer(i.instrument)
+      )))
+      if p.showFilter
+      if filterVisible
+    } yield col
 
   def typeColumn(p: Props, objectSize: SSize): Option[Table.ColumnArg] =
     p.steps.map(

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -118,6 +118,8 @@ object ModelOps {
   sealed trait InstrumentProperties
 
   object InstrumentProperties {
+    case object Exposure      extends InstrumentProperties
+    case object Filter        extends InstrumentProperties
     case object Disperser     extends InstrumentProperties
     case object Offsets       extends InstrumentProperties
     case object FPU           extends InstrumentProperties
@@ -128,23 +130,39 @@ object ModelOps {
 
     def displayItems: Set[InstrumentProperties] = i match {
       case Instrument.F2 =>
-        Set(InstrumentProperties.Offsets, InstrumentProperties.FPU)
+        Set(InstrumentProperties.Exposure,
+            InstrumentProperties.Filter,
+            InstrumentProperties.Offsets,
+            InstrumentProperties.FPU)
       case Instrument.GmosS =>
-        Set(InstrumentProperties.Offsets,
+        Set(InstrumentProperties.Exposure,
+            InstrumentProperties.Filter,
+            InstrumentProperties.Offsets,
             InstrumentProperties.Disperser,
             InstrumentProperties.FPU)
       case Instrument.GmosN =>
-        Set(InstrumentProperties.Offsets,
+        Set(InstrumentProperties.Exposure,
+            InstrumentProperties.Filter,
+            InstrumentProperties.Offsets,
             InstrumentProperties.Disperser,
             InstrumentProperties.FPU)
       case Instrument.GNIRS =>
-        Set(InstrumentProperties.Offsets,
+        Set(InstrumentProperties.Exposure,
+            InstrumentProperties.Filter,
+            InstrumentProperties.Offsets,
             InstrumentProperties.Disperser,
             InstrumentProperties.FPU)
       case Instrument.GPI =>
-        Set(InstrumentProperties.ObservingMode, InstrumentProperties.Disperser)
+        Set(InstrumentProperties.Exposure,
+            InstrumentProperties.Filter,
+            InstrumentProperties.ObservingMode,
+            InstrumentProperties.Disperser)
       case Instrument.GHOST => Set.empty
-      case _                => Set(InstrumentProperties.Offsets, InstrumentProperties.FPU)
+      case _                =>
+        Set(InstrumentProperties.Exposure,
+            InstrumentProperties.Filter,
+            InstrumentProperties.Offsets,
+            InstrumentProperties.FPU)
     }
   }
 


### PR DESCRIPTION
This change makes the Exposure and Filter columns optional in the StepsTable, since GHOST does not yet currently have these properties and we hence don't want these columns to be displayed when a GHOST observation is selected.

Here is the result for GHOST:
![screen shot 2018-11-08 at 11 21 20 am](https://user-images.githubusercontent.com/8795653/48204631-07561580-e349-11e8-9f7f-ca84a54b0768.png)

Here is the result for GMOS, appearing the same as before:
![screen shot 2018-11-08 at 11 21 08 am](https://user-images.githubusercontent.com/8795653/48204647-150b9b00-e349-11e8-8f24-be28014462b3.png)
