### PR TITLE
SEQNG-793 Improved rendering times on the steps table

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/operations.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/operations.scala
@@ -33,53 +33,77 @@ object operations {
   }
 
   sealed trait SupportedOperations {
-    /**
-     * Sorted list of operations supported at the sequence level
-     */
-    def observationOperations(s: Step): List[ObservationOperations]
 
     /**
-     * Sorted list of operations supported at the observation (row) level
-     */
+      * Sorted list of operations supported at the sequence level
+      */
+    def observationOperations(
+      isObservePaused: Boolean): List[ObservationOperations]
+
+    /**
+      * Sorted list of operations supported at the observation (row) level
+      */
     def sequenceOperations: List[SequenceOperations]
   }
 
   private val F2SupportedOperations = new SupportedOperations {
-    def observationOperations(s: Step): List[ObservationOperations] = Nil
+    def observationOperations(
+      isObservePaused: Boolean): List[ObservationOperations] = Nil
     def sequenceOperations: List[SequenceOperations] = Nil
   }
 
   private val GmosSupportedOperations = new SupportedOperations {
-    def observationOperations(s: Step): List[ObservationOperations] =
-      s.isObservePaused.fold(List(ObservationOperations.ResumeObservation, ObservationOperations.StopObservation, ObservationOperations.AbortObservation), List(ObservationOperations.PauseObservation, ObservationOperations.StopObservation, ObservationOperations.AbortObservation))
+    def observationOperations(
+      isObservePaused: Boolean): List[ObservationOperations] =
+      isObservePaused.fold(
+        List(ObservationOperations.ResumeObservation,
+             ObservationOperations.StopObservation,
+             ObservationOperations.AbortObservation),
+        List(ObservationOperations.PauseObservation,
+             ObservationOperations.StopObservation,
+             ObservationOperations.AbortObservation)
+      )
 
     def sequenceOperations: List[SequenceOperations] = Nil
   }
 
   private val GnirsSupportedOperations = new SupportedOperations {
-    def observationOperations(s: Step): List[ObservationOperations] =
-      s.isObservePaused.fold(List(ObservationOperations.StopObservation, ObservationOperations.AbortObservation), List(ObservationOperations.StopObservation, ObservationOperations.AbortObservation))
+    def observationOperations(
+      isObservePaused: Boolean): List[ObservationOperations] =
+      isObservePaused.fold(
+        List(ObservationOperations.StopObservation,
+             ObservationOperations.AbortObservation),
+        List(ObservationOperations.StopObservation,
+             ObservationOperations.AbortObservation)
+      )
 
     def sequenceOperations: List[SequenceOperations] = Nil
   }
 
   private val NilSupportedOperations = new SupportedOperations {
-    def observationOperations(s: Step): List[ObservationOperations] = Nil
+    def observationOperations(
+      isObservePaused: Boolean): List[ObservationOperations] = Nil
     def sequenceOperations: List[SequenceOperations] = Nil
   }
 
   private val instrumentOperations: Map[Instrument, SupportedOperations] = Map(
-    (F2    -> F2SupportedOperations),
+    (F2 -> F2SupportedOperations),
     (GmosS -> GmosSupportedOperations),
     (GmosN -> GmosSupportedOperations),
     (GNIRS -> GnirsSupportedOperations)
   )
 
-  final implicit class SupportedOperationsOps(val i: Instrument) extends AnyVal {
-    def observationOperations(s: Step): List[ObservationOperations] =
-      instrumentOperations.getOrElse(i, NilSupportedOperations).observationOperations(s)
+  final implicit class SupportedOperationsOps(val i: Instrument)
+      extends AnyVal {
+    def observationOperations(
+      isObservePaused: Boolean): List[ObservationOperations] =
+      instrumentOperations
+        .getOrElse(i, NilSupportedOperations)
+        .observationOperations(isObservePaused)
     def sequenceOperations: List[SequenceOperations] =
-      instrumentOperations.getOrElse(i, NilSupportedOperations).sequenceOperations
+      instrumentOperations
+        .getOrElse(i, NilSupportedOperations)
+        .sequenceOperations
   }
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableAndStatusFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableAndStatusFocus.scala
@@ -20,11 +20,13 @@ object StepsTableAndStatusFocus {
   implicit val eq: Eq[StepsTableAndStatusFocus] =
     Eq.by(x => (x.status, x.stepsTable, x.configTableState))
 
-  def stepsTableAndStatusFocusG(id: Observation.Id): Getter[SeqexecAppRootModel, StepsTableAndStatusFocus] =
+  def stepsTableAndStatusFocusG(
+    id: Observation.Id): Getter[SeqexecAppRootModel, StepsTableAndStatusFocus] =
     ClientStatus.clientStatusFocusL.asGetter
-    .zip(StepsTableFocus
-        .stepsTableG(id)
-        .zip(SeqexecAppRootModel.configTableStateL.asGetter)) >>> {
+      .zip(
+        StepsTableFocus
+          .stepsTableG(id)
+          .zip(SeqexecAppRootModel.configTableStateL.asGetter)) >>> {
       case (s, (f, t)) => StepsTableAndStatusFocus(s, f, t)
     }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.circuit
+
+import cats.Eq
+import cats.implicits._
+import gem.Observation
+import monocle.Getter
+import monocle.macros.Lenses
+import seqexec.model._
+import seqexec.model.enum._
+import seqexec.web.client.model._
+import seqexec.web.client.model.ModelOps._
+import seqexec.web.client.components.sequence.steps.StepsTable
+import web.client.table._
+
+@Lenses
+final case class StepsTableFocus(
+  id:                  Observation.Id,
+  instrument:          Instrument,
+  state:               SequenceState,
+  steps:               List[Step],
+  stepConfigDisplayed: Option[Int],
+  nextStepToRun:       Option[Int],
+  isPreview:           Boolean,
+  tableState:          TableState[StepsTable.TableColumn])
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object StepsTableFocus {
+  implicit val eq: Eq[StepsTableFocus] =
+    Eq.by(
+      x =>
+        (x.id,
+         x.instrument,
+         x.state,
+         x.steps,
+         x.stepConfigDisplayed,
+         x.nextStepToRun,
+         x.isPreview,
+         x.tableState))
+
+  def stepsTableG(
+    id: Observation.Id
+  ): Getter[SeqexecAppRootModel, Option[StepsTableFocus]] =
+    SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
+      SequencesOnDisplay.tabG(id)) >>> {
+      _.flatMap {
+        case SeqexecTabActive(tab, _) =>
+          tab.sequence.map { sequence =>
+            StepsTableFocus(sequence.id,
+                            sequence.metadata.instrument,
+                            sequence.status,
+                            sequence.steps,
+                            tab.stepConfigDisplayed,
+                            sequence.nextStepToRun,
+                            tab.isPreview,
+                            tab.tableState)
+          }
+      }
+    }
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/package.scala
@@ -16,8 +16,6 @@ import seqexec.model.enum._
 import seqexec.web.client.model.lenses.firstScienceStepTargetNameT
 import seqexec.web.client.model._
 import seqexec.web.client.model.ModelOps._
-import seqexec.web.client.components.sequence.steps.StepsTable
-import web.client.table._
 
 package object circuit {
   implicit def CircuitToOps[T <: AnyRef](c: Circuit[T]): CircuitOps[T] =
@@ -181,50 +179,6 @@ package circuit {
           }
       }
     }
-  }
-
-  final case class StepsTableFocus(
-    id:                  Observation.Id,
-    instrument:          Instrument,
-    state:               SequenceState,
-    steps:               List[Step],
-    stepConfigDisplayed: Option[Int],
-    nextStepToRun:       Option[Int],
-    isPreview:           Boolean,
-    tableState:          TableState[StepsTable.TableColumn])
-
-  object StepsTableFocus {
-    implicit val eq: Eq[StepsTableFocus] =
-      Eq.by(
-        x =>
-          (x.id,
-           x.instrument,
-           x.state,
-           x.steps,
-           x.stepConfigDisplayed,
-           x.nextStepToRun,
-           x.isPreview,
-           x.tableState))
-
-    def stepsTableG(
-      id: Observation.Id
-    ): Getter[SeqexecAppRootModel, Option[StepsTableFocus]] =
-      SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
-        SequencesOnDisplay.tabG(id)) >>> {
-        _.flatMap {
-          case SeqexecTabActive(tab, _) =>
-            tab.sequence.map { sequence =>
-              StepsTableFocus(sequence.id,
-                              sequence.metadata.instrument,
-                              sequence.status,
-                              sequence.steps,
-                              tab.stepConfigDisplayed,
-                              sequence.nextStepToRun,
-                              tab.isPreview,
-                              tab.tableState)
-            }
-        }
-      }
   }
 
   @Lenses

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
@@ -11,6 +11,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.extra.TimerSupport
 import java.time.Duration
+import monocle.macros.Lenses
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.ObservationProgress
 import seqexec.web.client.components.SeqexecStyles
@@ -31,8 +32,11 @@ object SmoothProgressBar {
                          total:  Long,
                          value:  Long,
                          paused: Boolean)
-  final case class State(total:  Long, value: Long, skipStep: Boolean)
 
+  @Lenses
+  final case class State(total: Long, value: Long, skipStep: Boolean)
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object State {
     def fromProps(p: Props): State = State(p.total, p.value, false)
   }
@@ -50,9 +54,9 @@ object SmoothProgressBar {
     def tickTotal: Callback = b.props.zip(b.state) >>= {
       case (p, s) =>
         val next = min(s.value + periodUpdate, p.value + remoteUpdatePeriod)
-        b.modState(x => x.copy(value = min(p.total, next)))
+        b.modState(State.value.set(min(p.total, next)))
           .when(!s.skipStep && !p.paused) *>
-          b.modState(x => x.copy(skipStep = false)) *>
+          b.modState(State.skipStep.set(false)) *>
           Callback.empty
     }
   }
@@ -102,9 +106,9 @@ object SmoothProgressBar {
         else s"${p.fileId} - Completing..."
 
       Progress(Progress.Props(
-        label = label,
-        total = p.total,
-        value = s.value,
+        label       = label,
+        total       = p.total,
+        value       = s.value,
         color       = "blue".some,
         progressCls = List(SeqexecStyles.observationProgressBar),
         barCls      = List(SeqexecStyles.observationBar),
@@ -150,8 +154,8 @@ object ObservationProgressBar {
             case _ =>
               Progress(Progress.Props(
                 if (p.paused) s"${p.fileId} - Paused" else p.fileId,
-                total = 100,
-                value = 0,
+                total       = 100,
+                value       = 0,
                 color       = "blue".some,
                 progressCls = List(SeqexecStyles.observationProgressBar),
                 barCls      = List(SeqexecStyles.observationBar),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
@@ -3,13 +3,15 @@
 
 package seqexec.web.client.components.sequence.steps
 
+import gem.Observation
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import seqexec.model.Step
-import seqexec.web.client.actions.{FlipSkipStep, FlipBreakpointStep}
-import seqexec.web.client.circuit.{ SeqexecCircuit, StepsTableFocus }
+import seqexec.web.client.actions.FlipSkipStep
+import seqexec.web.client.actions.FlipBreakpointStep
+import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.semanticui.elements.icon.Icon
@@ -21,33 +23,37 @@ import web.client.style._
   * Component to display an icon for the state
   */
 object StepBreakStopCell {
-  final case class Props(clientStatus: ClientStatus,
-                         focus: StepsTableFocus,
-                         step: Step,
-                         rowHeight: Int,
-                         breakPointEnterCB: Int => Callback,
-                         breakPointLeaveCB: Int => Callback,
-                         heightChangeCB: Int => Callback) {
-    val steps: List[Step] = focus.steps
-  }
+  final case class Props(clientStatus:       ClientStatus,
+                         step:               Step,
+                         rowHeight:          Int,
+                         obsId:              Observation.Id,
+                         firstRunnableIndex: Int,
+                         breakPointEnterCB:  Int => Callback,
+                         breakPointLeaveCB:  Int => Callback,
+                         heightChangeCB:     Int => Callback)
 
-  implicit val propsReuse: Reusability[Props] = Reusability.caseClassExcept[Props]('heightChangeCB, 'breakPointEnterCB, 'breakPointLeaveCB)
+  implicit val propsReuse: Reusability[Props] =
+    Reusability.caseClassExcept[Props]('heightChangeCB,
+                                       'breakPointEnterCB,
+                                       'breakPointLeaveCB)
 
   // Request a to flip the breakpoint
   def flipBreakpoint(p: Props): Callback =
-    Callback.when(p.clientStatus.canOperate)(SeqexecCircuit.dispatchCB(FlipBreakpointStep(p.focus.id, p.step)) >> p.heightChangeCB(p.step.id))
+    Callback.when(p.clientStatus.canOperate)(
+      SeqexecCircuit.dispatchCB(FlipBreakpointStep(p.obsId, p.step)) >> p
+        .heightChangeCB(p.step.id))
 
   // Request a to flip the skip
   def flipSkipped(p: Props): Callback =
-    Callback.when(p.clientStatus.canOperate)(SeqexecCircuit.dispatchCB(FlipSkipStep(p.focus.id, p.step)))
-
-  private def firstRunnableIndex(l: List[Step]): Int = l.zipWithIndex.find(!_._1.isFinished).map(_._2).getOrElse(l.length)
+    Callback.when(p.clientStatus.canOperate)(
+      SeqexecCircuit.dispatchCB(FlipSkipStep(p.obsId, p.step)))
 
   private val component = ScalaComponent
     .builder[Props]("StepIconCell")
     .stateless
     .render_P { p =>
-      val canSetBreakpoint = p.clientStatus.canOperate && p.step.canSetBreakpoint(p.step.id, firstRunnableIndex(p.steps))
+      val canSetBreakpoint = p.clientStatus.canOperate && p.step
+        .canSetBreakpoint(p.step.id, p.firstRunnableIndex)
       val canSetSkipMark = p.clientStatus.canOperate && p.step.canSetSkipmark
       <.div(
         SeqexecStyles.gutterCell,
@@ -57,16 +63,16 @@ object StepBreakStopCell {
           SeqexecStyles.breakPointHandleOn.unless(p.step.breakpoint),
           ^.onClick --> flipBreakpoint(p),
           Icon.IconRemove
-            .copyIcon(fitted = true,
+            .copyIcon(fitted       = true,
                       onMouseEnter = p.breakPointEnterCB(p.step.id),
                       onMouseLeave = p.breakPointLeaveCB(p.step.id),
-                      extraStyles = List(SeqexecStyles.breakPointOffIcon))
+                      extraStyles  = List(SeqexecStyles.breakPointOffIcon))
             .when(p.step.breakpoint),
           Icon.IconCaretDown
-            .copyIcon(fitted = true,
+            .copyIcon(fitted       = true,
                       onMouseEnter = p.breakPointEnterCB(p.step.id),
                       onMouseLeave = p.breakPointLeaveCB(p.step.id),
-                      extraStyles = List(SeqexecStyles.breakPointOnIcon))
+                      extraStyles  = List(SeqexecStyles.breakPointOnIcon))
             .unless(p.step.breakpoint)
         ).when(canSetBreakpoint),
         <.div(
@@ -76,8 +82,8 @@ object StepBreakStopCell {
             .copyIcon(link = true, onClick = flipSkipped(p))
             .when(p.step.skip),
           IconMinusCircle
-            .copyIcon(link = true,
-                      color = Some("orange"),
+            .copyIcon(link    = true,
+                      color   = Some("orange"),
                       onClick = flipSkipped(p))
             .unless(p.step.skip)
         ).when(canSetSkipMark)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -10,102 +10,23 @@ import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import gem.Observation
-import gem.enum.{GpiDisperser, GpiFilter, GpiObservingMode}
-import seqexec.model.enum.{ FPUMode, Instrument, StepType }
-import seqexec.model.{ Step, StepState }
+import gem.enum.GpiDisperser
+import gem.enum.GpiFilter
+import gem.enum.GpiObservingMode
+import seqexec.model.enum.FPUMode
+import seqexec.model.enum.Instrument
+import seqexec.model.enum.StepType
+import seqexec.model.Step
+import seqexec.model.StepState
 import seqexec.model.enumerations
-import seqexec.web.client.circuit.StepsTableFocus
 import seqexec.web.client.components.SeqexecStyles
-import seqexec.web.client.model.{ClientStatus, Pages}
+import seqexec.web.client.model.Pages
 import seqexec.web.client.model.lenses._
 import seqexec.web.client.semanticui.elements.label.Label
-import seqexec.web.client.semanticui.elements.icon.Icon
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.Size
-import seqexec.web.client.services.HtmlConstants.iconEmpty
 import seqexec.web.client.reusability._
 import web.client.style._
-
-/**
-  * Component to display an icon for the state
-  */
-object StepToolsCell {
-  final case class Props(clientStatus: ClientStatus,
-                         focus: StepsTableFocus,
-                         step: Step,
-                         rowHeight: Int,
-                         breakPointEnterCB: Int => Callback,
-                         breakPointLeaveCB: Int => Callback,
-                         heightChangeCB: Int => Callback)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.caseClassExcept[Props]('heightChangeCB, 'breakPointEnterCB, 'breakPointLeaveCB)
-
-  private val component = ScalaComponent
-    .builder[Props]("StepToolsCell")
-    .stateless
-    .render_P { p =>
-      <.div(
-        SeqexecStyles.controlCell,
-        StepBreakStopCell(
-          StepBreakStopCell.Props(p.clientStatus,
-                                  p.focus,
-                                  p.step,
-                                  p.rowHeight,
-                                  p.breakPointEnterCB,
-                                  p.breakPointLeaveCB,
-                                  p.heightChangeCB))
-          .when(p.clientStatus.isLogged).unless(p.focus.isPreview),
-        StepIconCell(StepIconCell.Props(p.step.status, p.step.skip, p.focus.nextStepToRun.forall(_ === p.step.id)))
-      )
-    }
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
- * Component to display an icon for the state
- */
-object StepIconCell {
-  final case class Props(status: StepState, skip: Boolean, nextToRun: Boolean)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  private def stepIcon(p: Props): VdomNode =
-    p.status match {
-      case StepState.Completed => IconCheckmark
-      case StepState.Running   => IconCircleNotched.copyIcon(loading = true)
-      case StepState.Failed(_) => IconAttention
-      case StepState.Skipped   => IconReply.copyIcon(fitted = true, rotated = Icon.Rotated.CounterClockwise)
-      case _ if p.skip         => IconReply.copyIcon(fitted = true, rotated = Icon.Rotated.CounterClockwise)
-      case _ if p.nextToRun    => IconChevronRight
-      case _                   => iconEmpty
-    }
-
-  private def stepStyle(p: Props): GStyle =
-    p.status match {
-      case StepState.Running   => SeqexecStyles.runningIconCell
-      case StepState.Skipped   => SeqexecStyles.skippedIconCell
-      case StepState.Failed(_) => SeqexecStyles.errorCell
-      case _ if p.skip         => SeqexecStyles.skippedIconCell
-      case _                   => SeqexecStyles.iconCell
-    }
-
-  private val component = ScalaComponent
-    .builder[Props]("StepIconCell")
-    .stateless
-    .render_P { p =>
-      <.div(
-        stepStyle(p),
-        stepIcon(p)
-      )
-    }
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
 
 /**
   * Component to display the FPU
@@ -127,9 +48,12 @@ object FPUCell {
       }
 
       val fpuValue = for {
-        mode <- instrumentFPUModeO.getOption(p.s).orElse(FPUMode.BuiltIn.some) // If the instrument has no fpu mode default to built in
-        fpuL = if (mode === FPUMode.BuiltIn) instrumentFPUO else instrumentFPUCustomMaskO
-        fpu  <- fpuL.getOption(p.s)
+        mode <- instrumentFPUModeO
+          .getOption(p.s)
+          .orElse(FPUMode.BuiltIn.some) // If the instrument has no fpu mode default to built in
+        fpuL = if (mode === FPUMode.BuiltIn) instrumentFPUO
+        else instrumentFPUCustomMaskO
+        fpu <- fpuL.getOption(p.s)
       } yield nameMapper.getOrElse(fpu, fpu)
 
       <.div(
@@ -158,26 +82,36 @@ object FilterCell {
 
   def gpiFilter: Step => Option[String] = s => {
     // Read the filter, if not found deduce it from the obs mode
-    val f: Option[GpiFilter] = instrumentFilterO.getOption(s).flatMap(gpiFiltersMap.get).orElse {
-      for {
-        m <- instrumentObservingModeO.getOption(s)
-        o <- gpiObsMode.get(m)
-        f <- o.filter
-      } yield f
-    }
+    val f: Option[GpiFilter] =
+      instrumentFilterO.getOption(s).flatMap(gpiFiltersMap.get).orElse {
+        for {
+          m <- instrumentObservingModeO.getOption(s)
+          o <- gpiObsMode.get(m)
+          f <- o.filter
+        } yield f
+      }
     f.map(_.longName)
   }
 
-  private val component = ScalaComponent.builder[Props]("FilterCell")
+  private val component = ScalaComponent
+    .builder[Props]("FilterCell")
     .stateless
     .render_P { p =>
-
       def filterName(s: Step): Option[String] = p.i match {
-        case Instrument.GmosS => instrumentFilterO.getOption(s).flatMap(enumerations.filter.GmosSFilter.get)
-        case Instrument.GmosN => instrumentFilterO.getOption(s).flatMap(enumerations.filter.GmosNFilter.get)
-        case Instrument.F2    => instrumentFilterO.getOption(s).flatMap(enumerations.filter.F2Filter.get)
-        case Instrument.GPI   => gpiFilter(s)
-        case _                => None
+        case Instrument.GmosS =>
+          instrumentFilterO
+            .getOption(s)
+            .flatMap(enumerations.filter.GmosSFilter.get)
+        case Instrument.GmosN =>
+          instrumentFilterO
+            .getOption(s)
+            .flatMap(enumerations.filter.GmosNFilter.get)
+        case Instrument.F2 =>
+          instrumentFilterO
+            .getOption(s)
+            .flatMap(enumerations.filter.F2Filter.get)
+        case Instrument.GPI => gpiFilter(s)
+        case _              => None
       }
 
       <.div(
@@ -266,9 +200,17 @@ object ExposureTimeCell {
       )
 
       val displayedText: TagMod = (coadds, exposureTime) match {
-        case (c, Some(e)) if c.exists(_ > 1) => (List(<.span(^.display := "inline-block", s"${c.foldMap(_.show)} "), <.span(^.display := "inline-block", ^.verticalAlign := "none", "\u2A2F"), <.span(^.display := "inline-block", s"${formatExposureTime(e)}")) ::: seconds).toTagMod
-        case (_, Some(e))                    => ((s"${formatExposureTime(e)}": VdomNode) :: seconds).toTagMod
-        case _                               => EmptyVdom
+        case (c, Some(e)) if c.exists(_ > 1) =>
+          (List(
+            <.span(^.display := "inline-block", s"${c.foldMap(_.show)} "),
+            <.span(^.display := "inline-block",
+                   ^.verticalAlign := "none",
+                   "\u2A2F"),
+            <.span(^.display := "inline-block", s"${formatExposureTime(e)}")
+          ) ::: seconds).toTagMod
+        case (_, Some(e)) =>
+          ((s"${formatExposureTime(e)}": VdomNode) :: seconds).toTagMod
+        case _ => EmptyVdom
       }
 
       <.div(
@@ -288,9 +230,7 @@ object StepIdCell {
   private val component = ScalaComponent
     .builder[Int]("StepIdCell")
     .stateless
-    .render_P( p =>
-      <.div(s"${p + 1}")
-    )
+    .render_P(p => <.div(s"${p + 1}"))
     .configure(Reusability.shouldComponentUpdate)
     .build
 
@@ -301,11 +241,16 @@ object StepIdCell {
   * Component to link to the settings
   */
 object SettingsCell {
-  final case class Props(ctl: RouterCtl[Pages.SeqexecPages], instrument: Instrument, obsId: Observation.Id, index: Int, isPreview: Boolean)
+  final case class Props(ctl:        RouterCtl[Pages.SeqexecPages],
+                         instrument: Instrument,
+                         obsId:      Observation.Id,
+                         index:      Int,
+                         isPreview:  Boolean)
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private val component = ScalaComponent.builder[Props]("SettingsCell")
+  private val component = ScalaComponent
+    .builder[Props]("SettingsCell")
     .stateless
     .render_P { p =>
       val page = if (p.isPreview) {
@@ -316,7 +261,8 @@ object SettingsCell {
       <.div(
         SeqexecStyles.settingsCell,
         p.ctl.link(page)(
-          IconCaretRight.copyIcon(color = "black".some, onClick = p.ctl.setUrlAndDispatchCB(page))
+          IconCaretRight.copyIcon(color   = "black".some,
+                                  onClick = p.ctl.setUrlAndDispatchCB(page))
         )
       )
     }
@@ -339,19 +285,22 @@ object ObjectTypeCell {
     .stateless
     .render_P { p =>
       <.div( // Column object type
-        stepTypeO.getOption(p.step).map { st =>
-          val stepTypeColor = st match {
-            case _ if p.step.status === StepState.Completed => "light gray"
-            case StepType.Object                            => "green"
-            case StepType.Arc                               => "violet"
-            case StepType.Flat                              => "grey"
-            case StepType.Bias                              => "teal"
-            case StepType.Dark                              => "black"
-            case StepType.Calibration                       => "blue"
+        stepTypeO
+          .getOption(p.step)
+          .map { st =>
+            val stepTypeColor = st match {
+              case _ if p.step.status === StepState.Completed => "light gray"
+              case StepType.Object                            => "green"
+              case StepType.Arc                               => "violet"
+              case StepType.Flat                              => "grey"
+              case StepType.Bias                              => "teal"
+              case StepType.Dark                              => "black"
+              case StepType.Calibration                       => "blue"
+            }
+            Label(
+              Label.Props(st.show, color = stepTypeColor.some, size = p.size))
           }
-          Label(Label.Props(st.show, color = stepTypeColor.some, size = p.size))
-        }.whenDefined
-      )
+          .whenDefined)
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
@@ -373,12 +322,15 @@ object ObservingModeCell {
   private val component = ScalaComponent
     .builder[Props]("ObsModeCell")
     .stateless
-    .render_P ( p =>
-      <.div(
-        SeqexecStyles.componentLabel,
-        instrumentObservingModeO.getOption(p.s).flatMap(obsNames.get).getOrElse("Unknown"): String
-      )
-    )
+    .render_P(
+      p =>
+        <.div(
+          SeqexecStyles.componentLabel,
+          instrumentObservingModeO
+            .getOption(p.s)
+            .flatMap(obsNames.get)
+            .getOrElse("Unknown"): String
+      ))
     .configure(Reusability.shouldComponentUpdate)
     .build
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -3,76 +3,73 @@
 
 package seqexec.web.client.components.sequence.steps
 
-import cats.implicits._
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{Callback, CallbackTo, ScalaComponent, CatsReact}
+import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react.CallbackTo
+import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.CatsReact
 import gem.Observation
-import mouse.all._
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.model.operations.ObservationOperations._
 import seqexec.model.operations._
-import seqexec.web.client.model.ModelOps._
-import seqexec.web.client.actions.{RequestAbort, RequestObsPause, RequestObsResume, RequestStop}
-import seqexec.web.client.circuit.{SeqexecCircuit, StepsTableFocus}
+import seqexec.web.client.actions.RequestAbort
+import seqexec.web.client.actions.RequestObsPause
+import seqexec.web.client.actions.RequestObsResume
+import seqexec.web.client.actions.RequestStop
+import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.popup.Popup
-import seqexec.web.client.semanticui.elements.icon.Icon.{IconPause, IconPlay, IconStop, IconTrash}
+import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
+import seqexec.web.client.semanticui.elements.icon.Icon.IconPlay
+import seqexec.web.client.semanticui.elements.icon.Icon.IconStop
+import seqexec.web.client.semanticui.elements.icon.Icon.IconTrash
 import web.client.style._
 
 /**
- * Component to wrap the steps control buttons
- */
-object StepsControlButtonsWrapper {
-  final case class Props(loggedIn: Boolean, p: StepsTableFocus, step: Step)
-  private val component = ScalaComponent.builder[Props]("StepsControlButtonsWrapper")
-    .stateless
-    .render_P(props =>
-      <.div(
-        ^.cls := "ui two column grid stackable",
-        <.div(
-          ^.cls := "ui row",
-          <.div(
-            ^.cls := "left column five wide left floated",
-            <.div(
-              ^.cls := "ui segment basic running",
-              // We need both sequence state and step state to decide what to display
-              props.p.state.userStopRequested.fold(props.p.state.show, props.step.show)
-            )
-          ),
-          <.div(
-            ^.cls := "right floated right aligned eleven wide computer sixteen wide tablet only",
-            SeqexecStyles.buttonsRow,
-            StepsControlButtons(props.p.id, props.p.instrument, props.p.state, props.step).when(props.step.isObserving || props.step.isObservePaused)
-          ).when(props.loggedIn && props.p.state.isRunning)
-        )
-      )
-    )
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
- * Contains the control buttons like stop/abort at the row level
- */
+  * Contains the control buttons like stop/abort at the row level
+  */
 object StepsControlButtons {
-  final case class Props(id: Observation.Id, instrument: Instrument, sequenceState: SequenceState, step: Step)
-  final case class State(stopRequested: Boolean, abortRequested: Boolean, pauseRequested: Boolean, resumeRequested: Boolean) {
+  final case class Props(id:              Observation.Id,
+                         instrument:      Instrument,
+                         sequenceState:   SequenceState,
+                         stepId:          Int,
+                         isObservePaused: Boolean)
+  final case class State(stopRequested:   Boolean,
+                         abortRequested:  Boolean,
+                         pauseRequested:  Boolean,
+                         resumeRequested: Boolean) {
     val canPause: Boolean = !stopRequested && !abortRequested
-    val canAbort: Boolean = !stopRequested && !pauseRequested && !resumeRequested
-    val canStop: Boolean = !abortRequested && !pauseRequested && !resumeRequested
+    val canAbort
+      : Boolean = !stopRequested && !pauseRequested && !resumeRequested
+    val canStop
+      : Boolean            = !abortRequested && !pauseRequested && !resumeRequested
     val canResume: Boolean = canPause
   }
 
-  val StopRequested: State = State(stopRequested = true, abortRequested = false, pauseRequested = false, resumeRequested = false)
-  val AbortRequested: State = State(stopRequested = false, abortRequested = true, pauseRequested = false, resumeRequested = false)
-  val PauseRequested: State = State(stopRequested = false, abortRequested = false, pauseRequested = true, resumeRequested = false)
-  val ResumeRequested: State = State(stopRequested = false, abortRequested = false, pauseRequested = false, resumeRequested = true)
-  val NoneRequested: State = State(stopRequested = false, abortRequested = false, pauseRequested = false, resumeRequested = false)
+  val StopRequested: State = State(stopRequested = true,
+                                   abortRequested  = false,
+                                   pauseRequested  = false,
+                                   resumeRequested = false)
+  val AbortRequested: State = State(stopRequested = false,
+                                    abortRequested  = true,
+                                    pauseRequested  = false,
+                                    resumeRequested = false)
+  val PauseRequested: State = State(stopRequested = false,
+                                    abortRequested  = false,
+                                    pauseRequested  = true,
+                                    resumeRequested = false)
+  val ResumeRequested: State = State(stopRequested = false,
+                                     abortRequested  = false,
+                                     pauseRequested  = false,
+                                     resumeRequested = true)
+  val NoneRequested: State = State(stopRequested = false,
+                                   abortRequested  = false,
+                                   pauseRequested  = false,
+                                   resumeRequested = false)
 
   private val ST = ReactS.Fix[State]
 
@@ -88,68 +85,108 @@ object StepsControlButtons {
   def requestObsResume(id: Observation.Id, stepId: Int): Callback =
     Callback(SeqexecCircuit.dispatch(RequestObsResume(id, stepId)))
 
-  def handleStop(id: Observation.Id, stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
+  def handleStop(id:     Observation.Id,
+                 stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestStop(id, stepId)) >> ST.set(StopRequested).liftCB
 
-  def handleAbort(id: Observation.Id, stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
+  def handleAbort(id:     Observation.Id,
+                  stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestAbort(id, stepId)) >> ST.set(AbortRequested).liftCB
 
-  def handleObsPause(id: Observation.Id, stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
+  def handleObsPause(id:     Observation.Id,
+                     stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestObsPause(id, stepId)) >> ST.set(PauseRequested).liftCB
 
-  def handleObsResume(id: Observation.Id, stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
+  def handleObsResume(id:     Observation.Id,
+                      stepId: Int): CatsReact.ReactST[CallbackTo, State, Unit] =
     ST.retM(requestObsResume(id, stepId)) >> ST.set(ResumeRequested).liftCB
 
-  private val component = ScalaComponent.builder[Props]("StepsControlButtons")
+  private val component = ScalaComponent
+    .builder[Props]("StepsControlButtons")
     .initialState(NoneRequested)
     .renderPS { ($, p, s) =>
       <.div(
         ^.cls := "ui icon buttons",
         SeqexecStyles.notInMobile,
-        p.instrument.observationOperations(p.step).map {
-          case PauseObservation            =>
-            Popup(Popup.Props("button", "Pause the current exposure"),
-              Button(Button.Props(icon = Some(IconPause), color = Some("teal"),  onClick = $.runState(handleObsPause(p.id, p.step.id)), disabled = !s.canPause || p.step.isObservePaused))
-            )
-          case StopObservation             =>
-            Popup(Popup.Props("button", "Stop the current exposure early"),
-              Button(Button.Props(icon = Some(IconStop), color = Some("orange"), onClick = $.runState(handleStop(p.id, p.step.id)), disabled = !s.canStop))
-            )
-          case AbortObservation            =>
-            Popup(Popup.Props("button", "Abort the current exposure"),
-              Button(Button.Props(icon = Some(IconTrash), color = Some("red"), onClick = $.runState(handleAbort(p.id, p.step.id)), disabled = !s.canAbort))
-            )
-          case ResumeObservation           =>
-            Popup(Popup.Props("button", "Resume the current exposure"),
-              Button(Button.Props(icon = Some(IconPlay), color = Some("blue"), onClick = $.runState(handleObsResume(p.id, p.step.id)), disabled = !s.canResume || !p.step.isObservePaused))
-            )
-          // Hamamatsu operations
-          case PauseImmediatelyObservation =>
-            Popup(Popup.Props("button", "Pause the current exposure immediately"),
-              Button(Button.Props(icon = Some(IconPause), color = Some("teal")))
-            )
-          case PauseGracefullyObservation  =>
-            Popup(Popup.Props("button", "Pause the current exposure gracefully"),
-              Button(Button.Props(icon = Some(IconPause), color = Some("teal"), basic = true))
-            )
-          case StopImmediatelyObservation  =>
-            Popup(Popup.Props("button", "Stop the current exposure immediately"),
-              Button(Button.Props(icon = Some(IconStop), color = Some("orange")))
-            )
-          case StopGracefullyObservation   =>
-            Popup(Popup.Props("button", "Stop the current exposure gracefully"),
-              Button(Button.Props(icon = Some(IconStop), color = Some("orange"), basic = true))
-            )
-        }.toTagMod
+        p.instrument
+          .observationOperations(p.isObservePaused)
+          .map {
+            case PauseObservation =>
+              Popup(
+                Popup.Props("button", "Pause the current exposure"),
+                Button(
+                  Button.Props(icon  = Some(IconPause),
+                               color = Some("teal"),
+                               onClick =
+                                 $.runState(handleObsPause(p.id, p.stepId)),
+                               disabled = !s.canPause || p.isObservePaused))
+              )
+            case StopObservation =>
+              Popup(
+                Popup.Props("button", "Stop the current exposure early"),
+                Button(
+                  Button.Props(icon     = Some(IconStop),
+                               color    = Some("orange"),
+                               onClick  = $.runState(handleStop(p.id, p.stepId)),
+                               disabled = !s.canStop))
+              )
+            case AbortObservation =>
+              Popup(
+                Popup.Props("button", "Abort the current exposure"),
+                Button(
+                  Button.Props(
+                    icon     = Some(IconTrash),
+                    color    = Some("red"),
+                    onClick  = $.runState(handleAbort(p.id, p.stepId)),
+                    disabled = !s.canAbort))
+              )
+            case ResumeObservation =>
+              Popup(
+                Popup.Props("button", "Resume the current exposure"),
+                Button(
+                  Button.Props(icon  = Some(IconPlay),
+                               color = Some("blue"),
+                               onClick =
+                                 $.runState(handleObsResume(p.id, p.stepId)),
+                               disabled = !s.canResume || !p.isObservePaused))
+              )
+            // Hamamatsu operations
+            case PauseImmediatelyObservation =>
+              Popup(
+                Popup.Props("button", "Pause the current exposure immediately"),
+                Button(
+                  Button.Props(icon = Some(IconPause), color = Some("teal"))))
+            case PauseGracefullyObservation =>
+              Popup(Popup.Props("button",
+                                "Pause the current exposure gracefully"),
+                    Button(
+                      Button.Props(icon  = Some(IconPause),
+                                   color = Some("teal"),
+                                   basic = true)))
+            case StopImmediatelyObservation =>
+              Popup(
+                Popup.Props("button", "Stop the current exposure immediately"),
+                Button(
+                  Button.Props(icon = Some(IconStop), color = Some("orange"))))
+            case StopGracefullyObservation =>
+              Popup(Popup.Props("button",
+                                "Stop the current exposure gracefully"),
+                    Button(
+                      Button.Props(icon  = Some(IconStop),
+                                   color = Some("orange"),
+                                   basic = true)))
+          }
+          .toTagMod
       )
-    }.componentWillReceiveProps { f =>
-      f.runState(f.nextProps.step match {
-        case s if s.isObservePaused =>
-          ST.set(NoneRequested)
-        case _ =>
-          ST.nop
+    }
+    .componentWillReceiveProps { f =>
+      f.runState(if (f.nextProps.isObservePaused) {
+        ST.set(NoneRequested)
+      } else {
+        ST.nop
       })
-    }.build
+    }
+    .build
 
-  def apply(id: Observation.Id, instrument: Instrument, state: SequenceState, step: Step): Unmounted[Props, State, Unit] = component(Props(id, instrument, state, step))
+  def apply(p: Props): Unmounted[Props, State, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components.sequence.steps
+
+import cats.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.vdom.html_<^._
+import gem.Observation
+import seqexec.model.Step
+import seqexec.model.StepState
+import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.model.ClientStatus
+import seqexec.web.client.semanticui.elements.icon.Icon
+import seqexec.web.client.semanticui.elements.icon.Icon._
+import seqexec.web.client.services.HtmlConstants.iconEmpty
+import seqexec.web.client.reusability._
+import web.client.style._
+
+/**
+  * Component to display an icon for the state
+  */
+object StepToolsCell {
+  final case class Props(clientStatus:       ClientStatus,
+                         step:               Step,
+                         rowHeight:          Int,
+                         isPreview:          Boolean,
+                         nextStepToRun:      Option[Int],
+                         obsId:              Observation.Id,
+                         firstRunnableIndex: Int,
+                         breakPointEnterCB:  Int => Callback,
+                         breakPointLeaveCB:  Int => Callback,
+                         heightChangeCB:     Int => Callback)
+
+  implicit val propsReuse: Reusability[Props] =
+    Reusability.caseClassExcept[Props]('heightChangeCB,
+                                       'breakPointEnterCB,
+                                       'breakPointLeaveCB)
+
+  private val component = ScalaComponent
+    .builder[Props]("StepToolsCell")
+    .stateless
+    .render_P { p =>
+      <.div(
+        SeqexecStyles.controlCell,
+        StepBreakStopCell(
+          StepBreakStopCell.Props(p.clientStatus,
+                                  p.step,
+                                  p.rowHeight,
+                                  p.obsId,
+                                  p.firstRunnableIndex,
+                                  p.breakPointEnterCB,
+                                  p.breakPointLeaveCB,
+                                  p.heightChangeCB))
+          .when(p.clientStatus.isLogged)
+          .unless(p.isPreview),
+        StepIconCell(
+          StepIconCell.Props(p.step.status,
+                             p.step.skip,
+                             p.nextStepToRun.forall(_ === p.step.id)))
+      )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+}
+
+/**
+  * Component to display an icon for the state
+  */
+object StepIconCell {
+  final case class Props(status: StepState, skip: Boolean, nextToRun: Boolean)
+
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+
+  private def stepIcon(p: Props): VdomNode =
+    p.status match {
+      case StepState.Completed => IconCheckmark
+      case StepState.Running   => IconCircleNotched.copyIcon(loading = true)
+      case StepState.Failed(_) => IconAttention
+      case StepState.Skipped =>
+        IconReply.copyIcon(fitted  = true,
+                           rotated = Icon.Rotated.CounterClockwise)
+      case _ if p.skip =>
+        IconReply.copyIcon(fitted  = true,
+                           rotated = Icon.Rotated.CounterClockwise)
+      case _ if p.nextToRun => IconChevronRight
+      case _                => iconEmpty
+    }
+
+  private def stepStyle(p: Props): GStyle =
+    p.status match {
+      case StepState.Running   => SeqexecStyles.runningIconCell
+      case StepState.Skipped   => SeqexecStyles.skippedIconCell
+      case StepState.Failed(_) => SeqexecStyles.errorCell
+      case _ if p.skip         => SeqexecStyles.skippedIconCell
+      case _                   => SeqexecStyles.iconCell
+    }
+
+  private val component = ScalaComponent
+    .builder[Props]("StepIconCell")
+    .stateless
+    .render_P { p =>
+      <.div(
+        stepStyle(p),
+        stepIcon(p)
+      )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -11,6 +11,13 @@ import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.extra.Reusability
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.BatchExecState
+import seqexec.model.Observer
+import seqexec.model.QueueId
+import seqexec.model.Step
+import seqexec.model.StepConfig
+import seqexec.model.StepState
+import seqexec.model.UserDetails
+import seqexec.model.SequenceState
 import seqexec.web.client.model.AvailableTab
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.SectionVisibilityState
@@ -23,35 +30,42 @@ import seqexec.web.client.model.RunOperation
 import seqexec.web.client.model.SyncOperation
 import seqexec.web.client.model.TabSelected
 import seqexec.web.client.circuit._
-import seqexec.model.{Observer, QueueId, Step, StepConfig, StepState, UserDetails}
 
 package object reusability {
-  implicit val stepStateReuse: Reusability[StepState]          = Reusability.byEq
-  implicit val instrumentReuse: Reusability[Instrument]        = Reusability.byEq
-  implicit val obsIdReuse: Reusability[Observation.Id]         = Reusability.byEq
-  implicit val siteReuse: Reusability[Site]                    = Reusability.byEq
-  implicit val observerReuse: Reusability[Observer]            = Reusability.byEq
-  implicit val stepConfigReuse: Reusability[StepConfig]        = Reusability.byEq
-  implicit val stepReuse: Reusability[Step]                    = Reusability.byEq
-  implicit val clientStatusReuse: Reusability[ClientStatus]    = Reusability.byEq
-  implicit val stTbFocusReuse: Reusability[StepsTableFocus]    = Reusability.byEq
-  implicit val stASFocusReuse: Reusability[StatusAndStepFocus] = Reusability.byEq
-  implicit val sCFocusReuse: Reusability[SequenceControlFocus] = Reusability.byEq
-  implicit val stfReuse: Reusability[StepsTableAndStatusFocus] = Reusability.byEq
-  implicit val tabSelReuse: Reusability[TabSelected]           = Reusability.byRef
-  implicit val sectReuse: Reusability[SectionVisibilityState]  = Reusability.byRef
-  implicit val potStateReuse: Reusability[PotState]            = Reusability.byRef
-  implicit val webSCeuse: Reusability[WebSocketConnection]     = Reusability.by(_.ws.state)
-  implicit val runOperationReuse: Reusability[RunOperation]    = Reusability.byRef
-  implicit val syncOperationReuse: Reusability[SyncOperation]  = Reusability.byRef
-  implicit val psOperationReuse: Reusability[PauseOperation]   = Reusability.byRef
-  implicit val availableTabsReuse: Reusability[AvailableTab]   = Reusability.byEq
-  implicit val userDetailsReuse: Reusability[UserDetails]      = Reusability.byEq
-  implicit val usrNotReuse: Reusability[UserNotificationState] = Reusability.byEq
-  implicit val dcAddReuse: Reusability[AddDayCalOperation]     = Reusability.byRef
-  implicit val qoReuse: Reusability[QueueOperations]           = Reusability.byEq
-  implicit val qfReuse: Reusability[CalQueueControlFocus]      = Reusability.byEq
-  implicit val cqfReuse: Reusability[CalQueueFocus]            = Reusability.byEq
-  implicit val qidReuse: Reusability[QueueId]                  = Reusability.byEq
-  implicit val bexReuse: Reusability[BatchExecState]           = Reusability.byRef
+  implicit val stepStateReuse: Reusability[StepState]       = Reusability.byEq
+  implicit val instrumentReuse: Reusability[Instrument]     = Reusability.byEq
+  implicit val obsIdReuse: Reusability[Observation.Id]      = Reusability.byEq
+  implicit val siteReuse: Reusability[Site]                 = Reusability.byEq
+  implicit val observerReuse: Reusability[Observer]         = Reusability.byEq
+  implicit val stepConfigReuse: Reusability[StepConfig]     = Reusability.byEq
+  implicit val stepReuse: Reusability[Step]                 = Reusability.byEq
+  implicit val seqStateReuse: Reusability[SequenceState]    = Reusability.byEq
+  implicit val clientStatusReuse: Reusability[ClientStatus] = Reusability.byEq
+  implicit val stTbFocusReuse: Reusability[StepsTableFocus] = Reusability.byEq
+  implicit val stASFocusReuse: Reusability[StatusAndStepFocus] =
+    Reusability.byEq
+  implicit val sCFocusReuse: Reusability[SequenceControlFocus] =
+    Reusability.byEq
+  implicit val stfReuse: Reusability[StepsTableAndStatusFocus] =
+    Reusability.byEq
+  implicit val tabSelReuse: Reusability[TabSelected] = Reusability.byRef
+  implicit val sectReuse: Reusability[SectionVisibilityState] =
+    Reusability.byRef
+  implicit val potStateReuse: Reusability[PotState] = Reusability.byRef
+  implicit val webSCeuse: Reusability[WebSocketConnection] =
+    Reusability.by(_.ws.state)
+  implicit val runOperationReuse: Reusability[RunOperation] = Reusability.byRef
+  implicit val syncOperationReuse: Reusability[SyncOperation] =
+    Reusability.byRef
+  implicit val psOperationReuse: Reusability[PauseOperation] = Reusability.byRef
+  implicit val availableTabsReuse: Reusability[AvailableTab] = Reusability.byEq
+  implicit val userDetailsReuse: Reusability[UserDetails]    = Reusability.byEq
+  implicit val usrNotReuse: Reusability[UserNotificationState] =
+    Reusability.byEq
+  implicit val dcAddReuse: Reusability[AddDayCalOperation] = Reusability.byRef
+  implicit val qoReuse: Reusability[QueueOperations]       = Reusability.byEq
+  implicit val qfReuse: Reusability[CalQueueControlFocus]  = Reusability.byEq
+  implicit val cqfReuse: Reusability[CalQueueFocus]        = Reusability.byEq
+  implicit val qidReuse: Reusability[QueueId]              = Reusability.byEq
+  implicit val bexReuse: Reusability[BatchExecState]       = Reusability.byRef
 }


### PR DESCRIPTION
Updates to the steps tables are slow to be applied. This was traced as too much data being passed to the components. This PR passes less data which reduces the amount of data being checked to decide what to render.

This could be further improved removing some of the data of the step config but the results with this PR are very good. Table updates are rendered much faster with these changes