### PR TITLE
SEQNG-813: Index obs progress by ons id and step id

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/ObservationProgress.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ObservationProgress.scala
@@ -9,12 +9,13 @@ import gem.Observation
 import squants.Time
 
 final case class ObservationProgress(obsId:     Observation.Id,
+                                     stepId:    StepId,
                                      total:     Time,
                                      remaining: Time)
 
 object ObservationProgress {
 
   implicit val equal: Eq[ObservationProgress] =
-    Eq.by(x => (x.obsId, x.total, x.remaining))
+    Eq.by(x => (x.obsId, x.stepId, x.total, x.remaining))
 
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -504,14 +504,15 @@ trait SeqexecModelArbitraries extends ArbObservation {
     Arbitrary {
       for {
         o <- arbitrary[Observation.Id]
+        s <- arbitrary[StepId]
         t <- arbitrary[Time]
         r <- arbitrary[Time]
-      } yield ObservationProgress(o, t, r)
+      } yield ObservationProgress(o, s, t, r)
     }
 
   implicit val observationInProgressCogen: Cogen[ObservationProgress] =
-    Cogen[(Observation.Id, Time, Time)]
-      .contramap(x => (x.obsId, x.total, x.remaining))
+    Cogen[(Observation.Id, StepId, Time, Time)]
+      .contramap(x => (x.obsId, x.stepId, x.total, x.remaining))
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -860,8 +860,8 @@ object SeqexecEngine extends SeqexecConfiguration {
     case engine.SystemUpdate(se, _)             => se match {
       // TODO: Sequence completed event not emited by engine.
       case engine.Completed(_, _, _, _)                                    => SequenceUpdated(svs)
-      case engine.PartialResult(i, _, _, Partial(Progress(t, r)))          =>
-        ObservationProgressEvent(ObservationProgress(i, t, r.self))
+      case engine.PartialResult(i, s, _, Partial(Progress(t, r)))          =>
+        ObservationProgressEvent(ObservationProgress(i, s, t, r.self))
       case engine.PartialResult(_, _, _, Partial(FileIdAllocated(fileId))) =>
         FileIdStepExecuted(fileId, svs)
       case engine.PartialResult(_, _, _, _)                                => SequenceUpdated(svs)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
@@ -121,9 +121,10 @@ object SeqexecCircuit
     this.zoomG(SequenceInfoFocus.sequenceInfoG(id))
 
   def obsProgressReader(
-    id: Observation.Id
+    id:     Observation.Id,
+    stepId: StepId
   ): ModelR[SeqexecAppRootModel, Option[ObservationProgress]] =
-    this.zoomL(AllObservationsProgressState.progressStateL(id))
+    this.zoomL(AllObservationsProgressState.progressStateL(id, stepId))
 
   def statusAndStepReader(
     id: Observation.Id

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
@@ -14,6 +14,7 @@ import java.time.Duration
 import monocle.macros.Lenses
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.ObservationProgress
+import seqexec.model.StepId
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.reusability._
@@ -129,10 +130,11 @@ object SmoothProgressBar {
   */
 object ObservationProgressBar {
   final case class Props(obsId:  Observation.Id,
+                         stepId: StepId,
                          fileId: ImageFileId,
                          paused: Boolean) {
     protected[steps] val connect =
-      SeqexecCircuit.connect(SeqexecCircuit.obsProgressReader(obsId))
+      SeqexecCircuit.connect(SeqexecCircuit.obsProgressReader(obsId, stepId))
   }
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
@@ -145,7 +147,7 @@ object ObservationProgressBar {
         SeqexecStyles.observationProgressRow,
         p.connect(x =>
           x() match {
-            case Some(ObservationProgress(_, r, t)) =>
+            case Some(ObservationProgress(_, _, r, t)) =>
               SmoothProgressBar(
                 SmoothProgressBar.Props(p.fileId,
                                         r.millis,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -16,6 +16,7 @@ import seqexec.model.enum.Instrument
 import seqexec.model.StepState
 import seqexec.model.StandardStep
 import seqexec.model.Step
+import seqexec.model.StepId
 import seqexec.model.SequenceState
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.ModelOps._
@@ -79,12 +80,14 @@ object StepProgressCell {
 
   def stepObservationStatusAndFile(
     props:  Props,
+    stepId: StepId,
     fileId: ImageFileId
   ): VdomElement =
     <.div(
       SeqexecStyles.configuringRow,
       ObservationProgressBar(
-        ObservationProgressBar.Props(props.obsId, fileId, paused = false)),
+        ObservationProgressBar
+          .Props(props.obsId, stepId, fileId, paused = false)),
       StepsControlButtons(
         StepsControlButtons.Props(props.obsId,
                                   props.instrument,
@@ -94,11 +97,14 @@ object StepProgressCell {
         .when(controlButtonsActive(props))
     )
 
-  def stepObservationPaused(props: Props, fileId: ImageFileId): VdomElement =
+  def stepObservationPaused(props:  Props,
+                            stepId: StepId,
+                            fileId: ImageFileId): VdomElement =
     <.div(
       SeqexecStyles.configuringRow,
       ObservationProgressBar(
-        ObservationProgressBar.Props(props.obsId, fileId, paused = true)),
+        ObservationProgressBar
+          .Props(props.obsId, stepId, fileId, paused = true)),
       StepsControlButtons(
         StepsControlButtons.Props(props.obsId,
                                   props.instrument,
@@ -139,14 +145,14 @@ object StepProgressCell {
       case (_, s @ StandardStep(_, _, StepState.Running, _, _, None, _, _)) =>
         // Case configuring, label and status icons
         stepSystemsStatus(s)
-      case (_, s @ StandardStep(_, _, _, _, _, Some(fileId), _, _))
+      case (_, s @ StandardStep(i, _, _, _, _, Some(fileId), _, _))
           if s.isObservePaused =>
         // Case for exposure paused, label and control buttons
-        stepObservationPaused(props, fileId)
+        stepObservationPaused(props, i, fileId)
       case (_,
-            StandardStep(_, _, StepState.Running, _, _, Some(fileId), _, _)) =>
+            StandardStep(i, _, StepState.Running, _, _, Some(fileId), _, _)) =>
         // Case for a exposure onging, progress bar and control buttons
-        stepObservationStatusAndFile(props, fileId)
+        stepObservationStatusAndFile(props, i, fileId)
       case (_, s) if s.wasSkipped =>
         <.p("Skipped")
       case (_, _) if props.step.skip =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ObservationsProgressStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ObservationsProgressStateHandler.scala
@@ -26,7 +26,10 @@ class ObservationsProgressStateHandler[M](
 
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(ObservationProgressEvent(e)) =>
-      updatedL(AllObservationsProgressState.progressByIdL(e.obsId).set(e.some))
+      updatedL(
+        AllObservationsProgressState
+          .progressByIdL(e.obsId, e.stepId)
+          .set(e.some))
 
     // Remove the progress once the step completes
     case ServerMessage(e @ StepExecuted(obsId, _)) =>
@@ -38,7 +41,9 @@ class ObservationsProgressStateHandler[M](
           if curStep.observeStatus === ActionStatus.Completed && !curStep.isObservePaused
         } yield
           updatedL(
-            AllObservationsProgressState.progressByIdL(e.obsId).set(none))
+            AllObservationsProgressState
+              .progressByIdL(e.obsId, curSIdx)
+              .set(none))
 
       upd.getOrElse(noChange)
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AllObservationsProgressState.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AllObservationsProgressState.scala
@@ -11,6 +11,7 @@ import monocle.macros.Lenses
 import monocle.function.At.at
 import monocle.function.At.atSortedMap
 import seqexec.model.ObservationProgress
+import seqexec.model.StepId
 import scala.collection.immutable.SortedMap
 
 /**
@@ -18,7 +19,7 @@ import scala.collection.immutable.SortedMap
   */
 @Lenses
 final case class AllObservationsProgressState(
-  obsProgress: SortedMap[Observation.Id, ObservationProgress])
+  obsProgress: SortedMap[(Observation.Id, StepId), ObservationProgress])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object AllObservationsProgressState {
@@ -29,15 +30,17 @@ object AllObservationsProgressState {
     Eq.by(_.obsProgress)
 
   def progressStateL(
-    obsId: Observation.Id
+    obsId:  Observation.Id,
+    stepId: StepId
   ): Lens[SeqexecAppRootModel, Option[ObservationProgress]] =
-    SeqexecAppRootModel.uiModel  ^|->
+    SeqexecAppRootModel.uiModel ^|->
       SeqexecUIModel.obsProgress ^|->
-      progressByIdL(obsId)
+      progressByIdL(obsId, stepId)
 
   def progressByIdL(
-    obsId: Observation.Id
+    obsId:  Observation.Id,
+    stepId: StepId
   ): Lens[AllObservationsProgressState, Option[ObservationProgress]] =
-    AllObservationsProgressState.obsProgress ^|-> at(obsId)
+    AllObservationsProgressState.obsProgress ^|-> at((obsId, stepId))
 
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -23,6 +23,7 @@ import seqexec.model.SequenceView
 import seqexec.model.SequencesQueue
 import seqexec.model.Notification
 import seqexec.model.Step
+import seqexec.model.StepId
 import seqexec.model.UserDetails
 import seqexec.model.ObservationProgress
 import seqexec.model.events.ServerLogMessage
@@ -689,12 +690,12 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     : Arbitrary[AllObservationsProgressState] =
     Arbitrary {
       for {
-        ops <- arbitrary[SortedMap[Observation.Id, ObservationProgress]]
+        ops <- arbitrary[SortedMap[(Observation.Id, StepId), ObservationProgress]]
       } yield AllObservationsProgressState(ops)
     }
 
   implicit val obsProgressCogen: Cogen[AllObservationsProgressState] =
-    Cogen[List[(Observation.Id, ObservationProgress)]]
+    Cogen[List[((Observation.Id, StepId), ObservationProgress)]]
       .contramap(_.obsProgress.toList)
 
   implicit val arbSeqexecUIModel: Arbitrary[SeqexecUIModel] =


### PR DESCRIPTION
As a continuation of https://github.com/gemini-hlsw/ocs3/pull/725 we can do the same on the client side. This avoids a UI glitch when ending a step and starting the next