### PR TITLE
SEQNG-786: Better change handling on the session queue

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -14,7 +14,7 @@ import seqexec.model.events._
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.sequence.steps.StepsTable
-import seqexec.web.client.components.SessionQueueTableBody
+import seqexec.web.client.components.SessionQueueTable
 import seqexec.web.client.components.queue.CalQueueTable
 import org.scalajs.dom.WebSocket
 import web.client.table._
@@ -131,7 +131,7 @@ object actions {
 
   final case class UpdateStepsConfigTableState(s: TableState[StepConfigTable.TableColumn])
       extends Action
-  final case class UpdateSessionQueueTableState(s: TableState[SessionQueueTableBody.TableColumn])
+  final case class UpdateSessionQueueTableState(s: TableState[SessionQueueTable.TableColumn])
       extends Action
   final case class UpdateStepTableState(id: Observation.Id,
                                         s:  TableState[StepsTable.TableColumn])

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/AppTableStates.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/AppTableStates.scala
@@ -13,13 +13,13 @@ import seqexec.model._
 import seqexec.web.client.model._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.sequence.steps.StepsTable
-import seqexec.web.client.components.SessionQueueTableBody
+import seqexec.web.client.components.SessionQueueTable
 import seqexec.web.client.components.queue.CalQueueTable
 import web.client.table._
 
 @Lenses
 final case class AppTableStates(
-  queueTable:      TableState[SessionQueueTableBody.TableColumn],
+  queueTable:      TableState[SessionQueueTable.TableColumn],
   stepConfigTable: TableState[StepConfigTable.TableColumn],
   stepsTables:     Map[Observation.Id, TableState[StepsTable.TableColumn]],
   queueTables:     Map[QueueId, TableState[CalQueueTable.TableColumn]])
@@ -47,9 +47,13 @@ object AppTableStates {
               .updateTableStates(v.queueTables)
       ))
 
-  def stepTableAtL(id: Observation.Id): Lens[AppTableStates, Option[TableState[StepsTable.TableColumn]]] =
+  def stepTableAtL(
+    id: Observation.Id
+  ): Lens[AppTableStates, Option[TableState[StepsTable.TableColumn]]] =
     AppTableStates.stepsTables ^|-> at(id)
 
-  def queueTableAtL(id: QueueId): Lens[AppTableStates, Option[TableState[CalQueueTable.TableColumn]]] =
+  def queueTableAtL(
+    id: QueueId
+  ): Lens[AppTableStates, Option[TableState[CalQueueTable.TableColumn]]] =
     AppTableStates.queueTables ^|-> at(id)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StatusAndLoadedSequencesFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StatusAndLoadedSequencesFocus.scala
@@ -4,7 +4,6 @@
 package seqexec.web.client.circuit
 
 import cats.Eq
-import cats.Order
 import cats.implicits._
 import gem.Observation
 import monocle.Getter
@@ -13,7 +12,7 @@ import seqexec.model.enum._
 import seqexec.web.client.model._
 import seqexec.web.client.model.lenses.firstScienceStepTargetNameT
 import seqexec.web.client.model.ModelOps._
-import seqexec.web.client.components.SessionQueueTableBody
+import seqexec.web.client.components.SessionQueueTable
 import web.client.table._
 
 final case class SequenceInSessionQueue(id:            Observation.Id,
@@ -27,29 +26,52 @@ final case class SequenceInSessionQueue(id:            Observation.Id,
                                         nextStepToRun: Option[Int])
 
 object SequenceInSessionQueue {
-  implicit val order: Order[SequenceInSessionQueue] = Order.by(_.id)
-  implicit val ordering: scala.math.Ordering[SequenceInSessionQueue] =
-    order.toOrdering
+  implicit val eq: Eq[SequenceInSessionQueue] =
+    Eq.by(
+      x =>
+        (x.id,
+         x.status,
+         x.instrument,
+         x.active,
+         x.loaded,
+         x.name,
+         x.targetName,
+         x.runningStep,
+         x.nextStepToRun))
 }
 
 final case class StatusAndLoadedSequencesFocus(
   status:     ClientStatus,
   sequences:  List[SequenceInSessionQueue],
-  tableState: TableState[SessionQueueTableBody.TableColumn])
+  tableState: TableState[SessionQueueTable.TableColumn])
 
 object StatusAndLoadedSequencesFocus {
   implicit val eq: Eq[StatusAndLoadedSequencesFocus] =
     Eq.by(x => (x.status, x.sequences, x.tableState))
 
-  val statusAndLoadedSequencesG: Getter[SeqexecAppRootModel, StatusAndLoadedSequencesFocus] =
-    ClientStatus.clientStatusFocusL.asGetter.zip(SeqexecAppRootModel.sessionQueueL.asGetter.zip(SeqexecAppRootModel.sequencesOnDisplayL.asGetter.zip(SeqexecAppRootModel.queueTableStateL.asGetter))) >>> {
+  val statusAndLoadedSequencesG
+    : Getter[SeqexecAppRootModel, StatusAndLoadedSequencesFocus] =
+    ClientStatus.clientStatusFocusL.asGetter.zip(
+      SeqexecAppRootModel.sessionQueueL.asGetter.zip(
+        SeqexecAppRootModel.sequencesOnDisplayL.asGetter
+          .zip(SeqexecAppRootModel.queueTableStateL.asGetter))) >>> {
       case (s, (queue, (sod, queueTable))) =>
         val sequencesInQueue = queue.map { s =>
-          val active = sod.idDisplayed(s.id)
-          val loaded = sod.loadedIds.contains(s.id)
+          val active     = sod.idDisplayed(s.id)
+          val loaded     = sod.loadedIds.contains(s.id)
           val targetName = firstScienceStepTargetNameT.headOption(s)
-          SequenceInSessionQueue(s.id, s.status, s.metadata.instrument, active, loaded, s.metadata.name, targetName, s.runningStep, s.nextStepToRun)
+          SequenceInSessionQueue(s.id,
+                                 s.status,
+                                 s.metadata.instrument,
+                                 active,
+                                 loaded,
+                                 s.metadata.name,
+                                 targetName,
+                                 s.runningStep,
+                                 s.nextStepToRun)
         }
-        StatusAndLoadedSequencesFocus(s, sequencesInQueue.sorted, queueTable)
+        StatusAndLoadedSequencesFocus(s,
+                                      sequencesInQueue.sortBy(_.id),
+                                      queueTable)
     }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueArea.scala
@@ -26,12 +26,14 @@ object SessionQueueTableSection {
       p =>
         <.div(
           SeqexecStyles.queueListPane,
-          sequencesConnect(c => SessionQueueTableBody(p, c))
+          sequencesConnect(c => SessionQueueTable(p, c()))
       ))
     .configure(Reusability.shouldComponentUpdate)
     .build
 
-  def apply(ctl: RouterCtl[SeqexecPages]): Unmounted[RouterCtl[SeqexecPages], Unit, Unit] =
+  def apply(
+    ctl: RouterCtl[SeqexecPages]
+  ): Unmounted[RouterCtl[SeqexecPages], Unit, Unit] =
     component(ctl)
 
 }
@@ -53,7 +55,9 @@ object SessionQueueArea {
     .configure(Reusability.shouldComponentUpdate)
     .build
 
-  def apply(ctl: RouterCtl[SeqexecPages]): Unmounted[RouterCtl[SeqexecPages], Unit, Unit] =
+  def apply(
+    ctl: RouterCtl[SeqexecPages]
+  ): Unmounted[RouterCtl[SeqexecPages], Unit, Unit] =
     component(ctl)
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -6,13 +6,14 @@ package seqexec.web.client.components
 import cats.implicits._
 import cats.data.NonEmptyList
 import cats.Eq
-import diode.react.ModelProxy
 import gem.Observation
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
+import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.raw.JsNumber
 import mouse.all._
 import monocle.Lens
@@ -35,27 +36,29 @@ import seqexec.web.client.semanticui.elements.icon.Icon.IconCheckmark
 import seqexec.web.client.semanticui.elements.icon.Icon.IconCircleNotched
 import seqexec.web.client.semanticui.elements.icon.Icon.IconRefresh
 import seqexec.web.client.semanticui.elements.icon.Icon.IconSelectedRadio
+import seqexec.web.client.reusability._
 import web.client.style._
 import web.client.utils._
 import web.client.table._
 
-object SessionQueueTableBody {
+object SessionQueueTable {
   type Backend = RenderScope[Props, State, Unit]
 
-  private val PhoneCut                 = 400.0
-  private val LargePhoneCut            = 570.0
-  private val IconColumnWidth          = 25.0
-  private val ObsIdColumnWidth         = 140.0
-  private val ObsIdMinWidth            = 66.2167 + SeqexecStyles.TableBorderWidth
-  private val StateColumnWidth         = 80.0
-  private val StateMinWidth            = 53.3667 + SeqexecStyles.TableBorderWidth
-  private val InstrumentColumnWidth    = 80.0
-  private val InstrumentMinWidth       = 90.4333 + SeqexecStyles.TableBorderWidth
-  private val TargetNameColumnWidth    = 140.0
-  private val TargetMinWidth           = 60.0167 + SeqexecStyles.TableBorderWidth
-  private val ObsNameColumnWidth       = 140.0
-  private val ObsNameMinWidth          = 60.0167 + SeqexecStyles.TableBorderWidth
-  private val SessionQueueColumnStyle: String = SeqexecStyles.queueTextColumn.htmlClass
+  private val PhoneCut              = 400.0
+  private val LargePhoneCut         = 570.0
+  private val IconColumnWidth       = 25.0
+  private val ObsIdColumnWidth      = 140.0
+  private val ObsIdMinWidth         = 66.2167 + SeqexecStyles.TableBorderWidth
+  private val StateColumnWidth      = 80.0
+  private val StateMinWidth         = 53.3667 + SeqexecStyles.TableBorderWidth
+  private val InstrumentColumnWidth = 80.0
+  private val InstrumentMinWidth    = 90.4333 + SeqexecStyles.TableBorderWidth
+  private val TargetNameColumnWidth = 140.0
+  private val TargetMinWidth        = 60.0167 + SeqexecStyles.TableBorderWidth
+  private val ObsNameColumnWidth    = 140.0
+  private val ObsNameMinWidth       = 60.0167 + SeqexecStyles.TableBorderWidth
+  private val SessionQueueColumnStyle: String =
+    SeqexecStyles.queueTextColumn.htmlClass
 
   sealed trait TableColumn extends Product with Serializable
   case object IconColumn       extends TableColumn
@@ -120,19 +123,19 @@ object SessionQueueTableBody {
     ObsNameColumnMeta)
 
   val columnsDefaultWidth: Map[TableColumn, Double] = Map(
-    IconColumn       -> IconColumnWidth,
-    ObsIdColumn      -> ObsIdColumnWidth,
-    StateColumn      -> StateColumnWidth,
+    IconColumn -> IconColumnWidth,
+    ObsIdColumn -> ObsIdColumnWidth,
+    StateColumn -> StateColumnWidth,
     InstrumentColumn -> InstrumentColumnWidth,
     TargetNameColumn -> TargetNameColumnWidth,
-    ObsNameColumn    -> ObsNameColumnWidth
+    ObsNameColumn -> ObsNameColumnWidth
   )
 
   final case class Props(ctl:       RouterCtl[SeqexecPages],
-                         sequences: ModelProxy[StatusAndLoadedSequencesFocus]) {
-    val sequencesList: List[SequenceInSessionQueue] = sequences().sequences
+                         sequences: StatusAndLoadedSequencesFocus) {
+    val sequencesList: List[SequenceInSessionQueue] = sequences.sequences
 
-    val startState: TableState[TableColumn] = sequences().tableState
+    val startState: TableState[TableColumn] = sequences.tableState
 
     def rowGetter(i: Int): SessionQueueRow =
       sequencesList
@@ -153,9 +156,9 @@ object SessionQueueTableBody {
     val rowCount: Int =
       sequencesList.size
 
-    val canOperate: Boolean = sequences().status.canOperate
+    val canOperate: Boolean = sequences.status.canOperate
 
-    val user: Option[UserDetails] = sequences().status.u
+    val user: Option[UserDetails] = sequences.status.u
   }
 
   final case class State(tableState: TableState[TableColumn],
@@ -302,6 +305,14 @@ object SessionQueueTableBody {
       tableState ^|-> TableState.scrollPosition[TableColumn]
   }
 
+  implicit val tcReuse: Reusability[TableColumn] = Reusability.byRef
+  implicit val sqSeFocusReuse: Reusability[SequenceInSessionQueue] =
+    Reusability.byEq
+  implicit val stSeFocusReuse: Reusability[StatusAndLoadedSequencesFocus] =
+    Reusability.by(x => (x.status, x.sequences, x.tableState))
+  implicit val propsReuse: Reusability[Props] = Reusability.by(_.sequences)
+  implicit val stateReuse: Reusability[State] = Reusability.derive[State]
+
   // ScalaJS defined trait
   // scalastyle:off
   trait SessionQueueRow extends js.Object {
@@ -343,15 +354,15 @@ object SessionQueueTableBody {
     }
 
     def unapply(l: SessionQueueRow):
-      Option[(Observation.Id,
-         SequenceState,
-         Instrument,
-         Option[String],
-         String,
-         Boolean,
-         Boolean,
-         Option[Int],
-         Option[RunningStep])] =
+     Option[(Observation.Id,
+       SequenceState,
+       Instrument,
+       Option[String],
+       String,
+       Boolean,
+       Boolean,
+       Option[Int],
+       Option[RunningStep])] =
       Some(
         (l.obsId,
          l.status,
@@ -394,7 +405,8 @@ object SessionQueueTableBody {
     }
 
   private def linkedTextRenderer(p: Props)(
-      f: SessionQueueRow => TagMod): CellRenderer[js.Object, js.Object, SessionQueueRow] =
+    f:                              SessionQueueRow => TagMod
+  ): CellRenderer[js.Object, js.Object, SessionQueueRow] =
     (_, _, _, row: SessionQueueRow, _) => {
       linkTo(p, pageOf(row))(SeqexecStyles.queueTextColumn, f(row))
     }
@@ -428,7 +440,9 @@ object SessionQueueTableBody {
     <.p(SeqexecStyles.queueText, targetName)
   }
 
-  private def statusIconRenderer(b: Backend): CellRenderer[js.Object, js.Object, SessionQueueRow] =
+  private def statusIconRenderer(
+    b: Backend
+  ): CellRenderer[js.Object, js.Object, SessionQueueRow] =
     (_, _, _, row: SessionQueueRow, index) => {
       val isFocused = row.active
       val icon: TagMod =
@@ -646,9 +660,10 @@ object SessionQueueTableBody {
       .withWidths(p.sequencesList)
 
   private val component = ScalaComponent
-    .builder[Props]("SessionQueueTableBody")
+    .builder[Props]("SessionQueueTable")
     .initialStateFromProps(initialState)
     .render($ => AutoSizer(AutoSizer.props(table($), disableHeight = true)))
+    .configure(Reusability.shouldComponentUpdate)
     .componentWillReceiveProps { $ =>
       $.modState { s =>
         s.loginState($.nextProps.canOperate)
@@ -658,9 +673,10 @@ object SessionQueueTableBody {
     }
     .build
 
-  def apply(ctl: RouterCtl[SeqexecPages],
-            p:   ModelProxy[StatusAndLoadedSequencesFocus])
-    : Unmounted[Props, State, Unit] =
+  def apply(
+    ctl: RouterCtl[SeqexecPages],
+    p:   StatusAndLoadedSequencesFocus
+  ): Unmounted[Props, State, Unit] =
     component(Props(ctl, p))
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
@@ -100,9 +100,9 @@ object SmoothProgressBar {
       val remaining   = Duration.ofMillis(s.total - s.value)
       val durationStr = encodeDuration(remaining)
       val remainingStr =
-        if (durationStr.isEmpty) " - Completing..." else s" - $durationStr"
+        if (durationStr.isEmpty) " - Completing..." else s" - $durationStr left"
       val label =
-        if (p.paused) s"${p.fileId} - Paused - $durationStr"
+        if (p.paused) s"${p.fileId} - Paused - $durationStr left"
         else if (s.value > 0) s"${p.fileId}$remainingStr"
         else s"${p.fileId} - Completing..."
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -19,7 +19,7 @@ import seqexec.model.QueueId
 import seqexec.model.SequenceView
 import seqexec.model.SequencesQueue
 import seqexec.web.client.components.sequence.steps.StepConfigTable
-import seqexec.web.client.components.SessionQueueTableBody
+import seqexec.web.client.components.SessionQueueTable
 import web.client.table._
 
 /**
@@ -60,7 +60,7 @@ object SeqexecAppRootModel {
     SeqexecAppRootModel.sequences ^|-> SequencesQueue.sessionQueue
 
   val queueTableStateL
-    : Lens[SeqexecAppRootModel, TableState[SessionQueueTableBody.TableColumn]] =
+    : Lens[SeqexecAppRootModel, TableState[SessionQueueTable.TableColumn]] =
     SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.queueTableState
 
   val configTableStateL

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -10,7 +10,7 @@ import seqexec.model.Observer
 import seqexec.model.UserDetails
 import seqexec.web.common.FixedLengthBuffer
 import seqexec.web.client.components.sequence.steps.StepConfigTable
-import seqexec.web.client.components.SessionQueueTableBody
+import seqexec.web.client.components.SessionQueueTable
 import web.client.table._
 
 /**
@@ -24,7 +24,7 @@ final case class SeqexecUIModel(
   globalLog:          GlobalLog,
   sequencesOnDisplay: SequencesOnDisplay,
   configTableState:   TableState[StepConfigTable.TableColumn],
-  queueTableState:    TableState[SessionQueueTableBody.TableColumn],
+  queueTableState:    TableState[SessionQueueTable.TableColumn],
   defaultObserver:    Observer,
   notification:       UserNotificationState,
   queues:             CalibrationQueues,
@@ -40,7 +40,7 @@ object SeqexecUIModel {
     GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
     SequencesOnDisplay.Empty,
     StepConfigTable.InitialTableState,
-    SessionQueueTableBody.InitialTableState.tableState,
+    SessionQueueTable.InitialTableState.tableState,
     Observer(""),
     UserNotificationState.Empty,
     CalibrationQueues.Default,

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -42,7 +42,7 @@ import seqexec.web.client.components.sequence.steps.OffsetFns.OffsetsDisplay
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.components.queue.CalQueueTable
-import seqexec.web.client.components.SessionQueueTableBody
+import seqexec.web.client.components.SessionQueueTable
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Arbitrary
 import org.scalacheck._
@@ -642,10 +642,10 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val stepConfigTableColumnCogen: Cogen[StepConfigTable.TableColumn] =
     Cogen[String].contramap(_.productPrefix)
 
-  implicit val arbQueueTableBodyTableColumn: Arbitrary[SessionQueueTableBody.TableColumn] =
-    Arbitrary(Gen.oneOf(SessionQueueTableBody.all.map(_.column).toList))
+  implicit val arbQueueTableBodyTableColumn: Arbitrary[SessionQueueTable.TableColumn] =
+    Arbitrary(Gen.oneOf(SessionQueueTable.all.map(_.column).toList))
 
-  implicit val queueTableBodyTableColumnCogen: Cogen[SessionQueueTableBody.TableColumn] =
+  implicit val queueTableBodyTableColumnCogen: Cogen[SessionQueueTable.TableColumn] =
     Cogen[String].contramap(_.productPrefix)
 
   implicit val arbStepsTableTableColumn: Arbitrary[StepsTable.TableColumn] =
@@ -708,7 +708,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         sequencesOnDisplay <- arbitrary[SequencesOnDisplay]
         syncInProgress     <- arbitrary[Boolean]
         configTableState   <- arbitrary[TableState[StepConfigTable.TableColumn]]
-        queueTableState    <- arbitrary[TableState[SessionQueueTableBody.TableColumn]]
+        queueTableState    <- arbitrary[TableState[SessionQueueTable.TableColumn]]
         defaultObserver    <- arbitrary[Observer]
         notification       <- arbitrary[UserNotificationState]
         queues             <- arbitrary[CalibrationQueues]
@@ -739,7 +739,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
        GlobalLog,
        SequencesOnDisplay,
        TableState[StepConfigTable.TableColumn],
-       TableState[SessionQueueTableBody.TableColumn],
+       TableState[SessionQueueTable.TableColumn],
        Observer,
        UserNotificationState,
        CalibrationQueues,
@@ -829,7 +829,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val arbAppTableStates: Arbitrary[AppTableStates] =
     Arbitrary {
       for {
-        qt <- arbitrary[TableState[SessionQueueTableBody.TableColumn]]
+        qt <- arbitrary[TableState[SessionQueueTable.TableColumn]]
         ct <- arbitrary[TableState[StepConfigTable.TableColumn]]
         st <- arbitrary[Map[Observation.Id, TableState[StepsTable.TableColumn]]]
         kt <- arbitrary[Map[QueueId, TableState[CalQueueTable.TableColumn]]]
@@ -837,7 +837,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     }
 
   implicit val appTableStatesCogen: Cogen[AppTableStates] =
-    Cogen[(TableState[SessionQueueTableBody.TableColumn],
+    Cogen[(TableState[SessionQueueTable.TableColumn],
            TableState[StepConfigTable.TableColumn],
            List[(Observation.Id, TableState[StepsTable.TableColumn])])]
       .contramap { x =>


### PR DESCRIPTION
A bug in a previous refactoring produced that not all changes to the global state be reflected on the session queue, e.g. when going from one step to the next

This PR fixes this and adds some improvements to reduce the amount of refreshes