### PR TITLE
SEQNG-718: Support D&D to the cal queue

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -64,6 +64,11 @@ body {
 .SeqexecStyles-tabLabel {
   width: 100%;
   text-align: center;
+  pointer-events: none;
+}
+
+.SeqexecStyles-dropOnTab {
+  background-color: darken(@secondaryBackground, 10%) !important;
 }
 
 .SeqexecStyles-previewTabLabel {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -288,4 +288,7 @@ object SeqexecStyles {
 
   val filterActiveButton: GStyle =
     GStyle.fromString("SeqexecStyles-filterActiveButton")
+
+  val dropOnTab: GStyle =
+    GStyle.fromString("SeqexecStyles-dropOnTab")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -245,8 +245,9 @@ object SessionQueueTable {
         val optimalSizes = sequences.foldLeft(columnsDefaultWidth) {
           case (currWidths,
                 SequenceInSessionQueue(id, st, i, _, _, n, _, t, r, _, _)) =>
-            val idWidth = max(currWidths.getOrElse(ObsIdColumn, ObsIdMinWidth),
-                              tableTextWidth(id.format)) + SeqexecStyles.TableRightPadding
+            val idWidth = max(
+              currWidths.getOrElse(ObsIdColumn, ObsIdMinWidth),
+              tableTextWidth(id.format)) + SeqexecStyles.TableRightPadding
             val statusWidth =
               max(currWidths.getOrElse(StateColumn, StateMinWidth),
                   tableTextWidth(statusText(st, r)))
@@ -446,6 +447,7 @@ object SessionQueueTable {
     <.a(
       ^.href := p.ctl.urlFor(page).value,
       ^.onClick ==> { _.preventDefaultCB },
+      ^.draggable := false,
       mod.toTagMod
     )
 
@@ -626,17 +628,17 @@ object SessionQueueTable {
         SeqexecStyles.headerRowStyle
       case (_, SessionQueueRow(_, s, _, _, _, _, _, _, _, _, _))
           if s == SequenceState.Completed =>
-        SeqexecStyles.stepRow |+| SeqexecStyles.rowPositive
+        SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow |+| SeqexecStyles.rowPositive
       case (_, SessionQueueRow(_, s, _, _, _, _, _, _, _, _, _))
           if s.isRunning =>
-        SeqexecStyles.stepRow |+| SeqexecStyles.rowWarning
+        SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow |+| SeqexecStyles.rowWarning
       case (_, SessionQueueRow(_, s, _, _, _, _, _, _, _, _, _)) if s.isError =>
-        SeqexecStyles.stepRow |+| SeqexecStyles.rowNegative
+        SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow |+| SeqexecStyles.rowNegative
       case (_, SessionQueueRow(_, s, _, _, _, _, _, active, _, _, _))
           if active && !s.isInProcess =>
-        SeqexecStyles.stepRow |+| SeqexecStyles.rowActive
+        SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow |+| SeqexecStyles.rowActive
       case _ =>
-        SeqexecStyles.stepRow
+        SeqexecStyles.stepRow |+| SeqexecStyles.draggableRow
     }).htmlClass
 
   // scalastyle:off
@@ -806,10 +808,42 @@ object SessionQueueTable {
         onScroll         = (_, _, pos) => updateScrollPosition(b, pos),
         onRowDoubleClick = doubleClick(b),
         onRowClick       = singleClick(b),
-        headerHeight     = SeqexecStyles.headerHeight
+        headerHeight     = SeqexecStyles.headerHeight,
+        rowRenderer      = draggableRowRenderer
       ),
       columns(b, size): _*
     ).vdomElement
+
+  def dragStart(obsId: Observation.Id)(e: ReactDragEvent): Callback =
+    Callback {
+      e.dataTransfer.setData("text/plain", obsId.format)
+    }
+
+  private def draggableRowRenderer =
+    (className:        String,
+     columns:          Array[VdomNode],
+     index:            Int,
+     isScrolling:      Boolean,
+     key:              String,
+     rowData:          SessionQueueRow,
+     onRowClick:       Option[OnRowClick],
+     onRowDoubleClick: Option[OnRowClick],
+     onRowMouseOut:    Option[OnRowClick],
+     onRowMouseOver:   Option[OnRowClick],
+     onRowRightClick:  Option[OnRowClick],
+     style:            Style) => {
+      <.div(
+        ^.cls := className,
+        ^.draggable := true,
+        ^.key := key,
+        ^.role := "row",
+        ^.onDragStart ==> dragStart(rowData.obsId),
+        ^.style := Style.toJsObject(style),
+        ^.onClick -->? onRowClick.map(h => h(index)),
+        ^.onDoubleClick -->? onRowDoubleClick.map(h => h(index)),
+        columns.toTagMod
+      ): VdomElement
+    }
 
   def initialState(p: Props): State =
     InitialTableState

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -809,17 +809,18 @@ object SessionQueueTable {
         onRowDoubleClick = doubleClick(b),
         onRowClick       = singleClick(b),
         headerHeight     = SeqexecStyles.headerHeight,
-        rowRenderer      = draggableRowRenderer
+        rowRenderer      = draggableRowRenderer(b)
       ),
       columns(b, size): _*
     ).vdomElement
 
-  def dragStart(obsId: Observation.Id)(e: ReactDragEvent): Callback =
+  def dragStart(b: Backend, obsId: Observation.Id)(
+    e:             ReactDragEvent): Callback =
     Callback {
       e.dataTransfer.setData("text/plain", obsId.format)
-    }
+    }.when(b.props.canOperate) *> Callback.empty
 
-  private def draggableRowRenderer =
+  private def draggableRowRenderer(b: Backend) =
     (className:        String,
      columns:          Array[VdomNode],
      index:            Int,
@@ -834,10 +835,10 @@ object SessionQueueTable {
      style:            Style) => {
       <.div(
         ^.cls := className,
-        ^.draggable := true,
+        ^.draggable := b.props.canOperate,
         ^.key := key,
         ^.role := "row",
-        ^.onDragStart ==> dragStart(rowData.obsId),
+        ^.onDragStart ==> dragStart(b, rowData.obsId),
         ^.style := Style.toJsObject(style),
         ^.onClick -->? onRowClick.map(h => h(index)),
         ^.onDoubleClick -->? onRowDoubleClick.map(h => h(index)),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/CalibrationQueueTab.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/CalibrationQueueTab.scala
@@ -4,12 +4,19 @@
 package seqexec.web.client.components.tabs
 
 import cats.implicits._
+import gem.Observation
 import japgolly.scalajs.react.extra.router.RouterCtl
+import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react._
+import monocle.macros.Lenses
 import seqexec.model.enum.BatchExecState
+import seqexec.model.CalibrationQueueId
+import seqexec.web.client.circuit.SeqexecCircuit
+import seqexec.web.client.actions.RequestAddSeqCal
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.model.CalibrationQueueTabActive
 import seqexec.web.client.model.TabSelected
@@ -21,13 +28,27 @@ import seqexec.web.client.reusability._
 import web.client.style._
 
 object CalibrationQueueTab {
+  type Backend = RenderScope[Props, State, Unit]
+
   final case class Props(router: RouterCtl[SeqexecPages],
                          tab:    CalibrationQueueTabActive)
 
+  @Lenses
+  final case class State(draggingOver: Option[String]) {
+    val onDrag: Boolean = draggingOver.isDefined
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object State
+
   implicit val propsReuse: Reusability[Props] =
     Reusability.by(x => (x.tab.active, x.tab.calibrationTab.state))
+  implicit val stateReuse: Reusability[State] = Reusability.derive[State]
 
-  private def showCalibrationQueue(p: Props, page: SeqexecPages)(e: ReactEvent): Callback =
+  private val ST = ReactS.Fix[State]
+
+  def showCalibrationQueue(p: Props, page: SeqexecPages)(
+    e:                        ReactEvent): Callback =
     // prevent default to avoid the link jumping
     e.preventDefaultCB *>
       // Request to display the selected sequence
@@ -36,7 +57,28 @@ object CalibrationQueueTab {
         .unless(p.tab.active === TabSelected.Selected) *>
       Callback.empty
 
-  private def linkTo(p: Props, page: SeqexecPages)(mod: TagMod*) = {
+  def addToQueueE(e: ReactDragEvent): Callback =
+    e.preventDefaultCB *>
+      Option(e.dataTransfer.getData("text/plain"))
+        .flatMap(Observation.Id.fromString)
+        .map { id =>
+          SeqexecCircuit.dispatchCB(RequestAddSeqCal(CalibrationQueueId, id))
+        }
+        .getOrEmpty
+
+  private def onDragEnter(e: ReactDragEvent) =
+    ST.mod(State.draggingOver.set(Option(e.dataTransfer.getData("text/plain"))))
+      .liftCB
+
+  private def onDrop(e: ReactDragEvent) =
+    ST.retM(addToQueueE(e)) *>
+      onDragEnd
+
+  private def onDragEnd =
+    ST.mod(State.draggingOver.set(none)).liftCB
+
+  private def linkTo(b: Backend, page: SeqexecPages)(mod: TagMod*) = {
+    val p      = b.props
     val active = p.tab.active
 
     <.a(
@@ -49,23 +91,34 @@ object CalibrationQueueTab {
       SeqexecStyles.tab,
       dataTab := "daycalqueue",
       SeqexecStyles.inactiveTabContent.when(active === TabSelected.Background),
-      SeqexecStyles.activeTabContent.when(active === TabSelected.Selected),
+      SeqexecStyles.activeTabContent
+        .when(active === TabSelected.Selected)
+        .unless(b.state.onDrag),
+      SeqexecStyles.dropOnTab.when(b.state.onDrag),
+      ^.onDragOver ==> { (e: ReactDragEvent) =>
+        e.preventDefaultCB *> Callback { e.dataTransfer.dropEffect = "copy" }
+      },
+      ^.onDragEnter ==> b.runStateFn(onDragEnter),
+      ^.onDrop ==> b.runStateFn(onDrop),
+      ^.onDragEnd --> b.runState(onDragEnd),
+      ^.onDragLeave --> b.runState(onDragEnd),
       mod.toTagMod
     )
   }
 
   private val component = ScalaComponent
     .builder[Props]("CalibrationQueueTab")
-    .stateless
-    .render_P { p =>
-      val icon = p.tab.calibrationTab.state match {
+    .initialState(State(None))
+    .render { b =>
+      val tab = b.props.tab
+      val icon = tab.calibrationTab.state match {
         case BatchExecState.Running =>
           IconCircleNotched.copyIcon(loading = true)
         case BatchExecState.Completed => IconCheckmark
         case _                        => IconSelectedRadio
       }
 
-      val color = p.tab.calibrationTab.state match {
+      val color = tab.calibrationTab.state match {
         case BatchExecState.Running   => "orange"
         case BatchExecState.Completed => "green"
         case _                        => "grey"
@@ -76,16 +129,16 @@ object CalibrationQueueTab {
           SeqexecStyles.tabLabel,
           <.div(SeqexecStyles.activeInstrumentLabel, "Daytime Queue"),
           Label(
-            Label.Props(p.tab.calibrationTab.state.show,
+            Label.Props(tab.calibrationTab.state.show,
                         color       = color.some,
                         icon        = icon.some,
                         extraStyles = List(SeqexecStyles.labelPointer)))
         )
 
-      linkTo(p, CalibrationQueuePage)(tabContent)
+      linkTo(b, CalibrationQueuePage)(tabContent)
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
 
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+  def apply(p: Props): Unmounted[Props, State, Unit] = component(p)
 }


### PR DESCRIPTION
After several failed attempts to integrate libraries to do DnD I resorted to do this with the plain HTML5 DnD API. the API is well know for its quirks so it maybe not that robust but seems to work fine in Chrome/FF

This version is also limited and less polished as I'd like but given we have other ways to add seqs to the queue I'll accept this limited version.

Now it is possible to grab a sequenc from the session table and drop it on teh daytime queue tab. This also lets you do this even if other tab is selected.

Here's a video

https://monosnap.com/file/payj5aY8sm1agn62g9VYu2hJtXDh2H#