### PR TITLE
SEQNG-678: GHOST configuration

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
@@ -114,7 +114,7 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
 
   // We use a dummy observation for now, since at this point, we cannot actually observe using the instrument.
   def observe(fileId: ImageFileId, expTime: Time): SeqActionF[F, ImageFileId] =
-    SeqActionF.apply(fileId)
+    SeqActionF.apply((fileId, expTime)._1) // suppress unused error
   //    EitherT(ghostClient.observe(fileId, expTime.toMilliseconds.milliseconds).map(_ => fileId).attempt)
   //      .leftMap {
   //        case CommandResultException(_, "Message cannot be null") => Execution("Unhandled observe command")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
@@ -39,9 +39,9 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
     def cfg[P: Show](paramName: String, paramVal: P) =
       Configuration.single(s"${ifuNum.ifuStr}.$paramName", paramVal)
 
-    (nameOpt, raOpt, decOpt) match {
+    (raOpt, decOpt) match {
       // Case 1: IFU is in use here for an actual position.
-      case (Some(name@_), Some(ra), Some(dec)) =>
+      case (Some(ra), Some(dec)) if nameOpt.isDefined =>
         val ifuTargetType = IFUTargetType.determineType(nameOpt)
         cfg("target", ifuTargetType.targetType) |+|
           cfg("type", DemandType.DemandRADec.demandType) |+|
@@ -50,7 +50,7 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
           cfg("bundle", bundleConfig.determineType(ifuTargetType).configName)
 
       // Case 2: IFU is explicitly excluded from use.
-      case (Some(name@_), None, None) =>
+      case (None, None) if nameOpt.isDefined =>
         cfg("target", IFUTargetType.NoTarget.targetType) |+|
           cfg("type", DemandType.DemandPark.demandType)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
@@ -41,7 +41,7 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
 
     (nameOpt, raOpt, decOpt) match {
       // Case 1: IFU is in use here for an actual position.
-      case (Some(name), Some(ra), Some(dec)) =>
+      case (Some(name@_), Some(ra), Some(dec)) =>
         val ifuTargetType = IFUTargetType.determineType(nameOpt)
         cfg("target", ifuTargetType.targetType) |+|
           cfg("type", DemandType.DemandRADec.demandType) |+|
@@ -50,7 +50,7 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
           cfg("bundle", bundleConfig.determineType(ifuTargetType).configName)
 
       // Case 2: IFU is explicitly excluded from use.
-      case (Some(name), None, None) =>
+      case (Some(name@_), None, None) =>
         cfg("target", IFUTargetType.NoTarget.targetType) |+|
           cfg("type", DemandType.DemandPark.demandType)
 
@@ -60,24 +60,40 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
     }
   }
 
-  private def srifuConfig(config: GHOSTConfig): Configuration =
-    ifuConfig(IFUNum.IFU1, config.srifu1Name, config.srifu1CoordsRAHMS,
-      config.srifu1CoordsDecDMS, BundleConfig.Standard) |+|
-      ifuConfig(IFUNum.IFU2, config.srifu2Name, config.srifu2CoordsRAHMS,
-        config.srifu2CoordsDecDMS, BundleConfig.Standard)
+  private def ifu1Config(config: GHOSTConfig): Configuration = {
+    val srConfig = ifuConfig(IFUNum.IFU1, config.srifu1Name, config.srifu1CoordsRAHMS,
+      config.srifu1CoordsDecDMS, BundleConfig.Standard)
+    val hrConfig = ifuConfig(IFUNum.IFU2, config.hrifu1Name, config.hrifu1CoordsRAHMS,
+      config.hrifu1CoordsDecDMS, BundleConfig.HighRes)
+    srConfig |+| hrConfig
+  }
 
-  private def hrifuConfig(config: GHOSTConfig): Configuration =
-    ifuConfig(IFUNum.IFU2, config.hrifu1Name, config.hrifu1CoordsRAHMS,
-      config.hrifu1CoordsDecDMS, BundleConfig.HighRes) |+|
-      ifuConfig(IFUNum.IFU2, config.srifu2Name, config.srifu2CoordsRAHMS, config.srifu2CoordsDecDMS,
-        BundleConfig.HighRes)
+  private def ifu2Config(config: GHOSTConfig): Configuration = {
+    val srConfig = ifuConfig(IFUNum.IFU2, config.srifu2Name, config.srifu2CoordsRAHMS,
+      config.srifu2CoordsDecDMS, BundleConfig.Standard)
+    val hrConfig = ifuConfig(IFUNum.IFU2, config.hrifu2Name, config.srifu2CoordsRAHMS, config.srifu2CoordsDecDMS,
+      BundleConfig.HighRes)
+    srConfig |+| hrConfig
+  }
+
 
   // If the srifu parameters are defined, use them; otherwise, use the hrifu parameters.
-  // Which set of parameters is determined completely by which of srifuName and hrifuName is set.
-  // TODO: What do we do with the base position explicit override?
-  // TODO: This was not on the list of provided parameter names.
+  // Which set of parameters to use is determined completely by which of srifuName and hrifuName is set.
+  // If neither is set, we do not use the IFU and request to be parked.
   private def ghostConfig(config: GHOSTConfig): SeqActionF[F, CommandResult] = {
-    val giapiApply = srifuConfig(config) |+| hrifuConfig(config)
+    val giapiApplyUF1Config = ifu1Config(config)
+    val giapiApplyUF1Modified = if (giapiApplyUF1Config === Configuration.Zero) {
+      Configuration.single(s"${IFUNum.IFU1.ifuStr}.target", IFUTargetType.NoTarget.targetType) |+|
+        Configuration.single(s"${IFUNum.IFU1.ifuStr}.type", DemandType.DemandPark.demandType)
+    } else giapiApplyUF1Config
+
+    val giapiApplyUF2Config = ifu2Config(config)
+    val giapiApplyUF2Modified = if (giapiApplyUF2Config === Configuration.Zero) {
+      Configuration.single(s"${IFUNum.IFU2.ifuStr}.target", IFUTargetType.NoTarget.targetType) |+|
+        Configuration.single(s"${IFUNum.IFU2.ifuStr}.type", DemandType.DemandPark.demandType)
+    } else giapiApplyUF2Config
+
+    val giapiApply = giapiApplyUF1Modified |+| giapiApplyUF2Modified
 
     EitherT(ghostClient.genericApply(giapiApply).attempt)
       .leftMap {
@@ -96,13 +112,15 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
       _ <- SeqActionF.apply(Log.debug("Completed GHOST configuration"))
     } yield ()
 
+  // We use a dummy observation for now, since at this point, we cannot actually observe using the instrument.
   def observe(fileId: ImageFileId, expTime: Time): SeqActionF[F, ImageFileId] =
-    EitherT(ghostClient.observe(fileId, expTime.toMilliseconds.milliseconds).map(_ => fileId).attempt)
-      .leftMap {
-        case CommandResultException(_, "Message cannot be null") => Execution("Unhandled observe command")
-        case CommandResultException(_, m)                        => Execution(m)
-        case f                                                   => SeqexecException(f)
-      }
+    SeqActionF.apply(fileId)
+  //    EitherT(ghostClient.observe(fileId, expTime.toMilliseconds.milliseconds).map(_ => fileId).attempt)
+  //      .leftMap {
+  //        case CommandResultException(_, "Message cannot be null") => Execution("Unhandled observe command")
+  //        case CommandResultException(_, m)                        => Execution(m)
+  //        case f                                                   => SeqexecException(f)
+  //      }
 
   def endObserve: SeqActionF[F, Unit] = SeqActionF.void
 }
@@ -128,11 +146,11 @@ object GHOSTController {
     case object IFU2 extends IFUNum(ifuNum = 2)
   }
 
-  sealed abstract class IFUTargetType(val targetType: Int)
+  sealed abstract class IFUTargetType(val targetType: String)
   object IFUTargetType {
-    case object NoTarget extends IFUTargetType(targetType = 0)
-    case object SkyPosition extends IFUTargetType(targetType = 1)
-    case object Target extends IFUTargetType(targetType = 2)
+    case object NoTarget extends IFUTargetType(targetType = "IFU_TARGET_NONE")
+    case object SkyPosition extends IFUTargetType(targetType = "IFU_TARGET_SKY")
+    case object Target extends IFUTargetType(targetType = "IFU_TARGET_OBJECT")
 
     def determineType(name: Option[String]): IFUTargetType = name match {
       case None        => NoTarget
@@ -176,20 +194,20 @@ object GHOSTController {
     implicit val eq: Eq[GHOSTConfig] = Eq.by(
       x =>
         (x.baseRAHMS,
-         x.baseDecDMS,
-         x.expTime,
-         x.srifu1Name,
-         x.srifu1CoordsRAHMS,
-         x.srifu1CoordsDecDMS,
-         x.srifu2Name,
-         x.srifu2CoordsRAHMS,
-         x.srifu2CoordsDecDMS,
-         x.hrifu1Name,
-         x.hrifu1CoordsRAHMS,
-         x.hrifu1CoordsDecDMS,
-         x.hrifu2Name,
-         x.hrifu2CoordsRAHMS,
-         x.hrifu2CoordsDecDMS))
+          x.baseDecDMS,
+          x.expTime,
+          x.srifu1Name,
+          x.srifu1CoordsRAHMS,
+          x.srifu1CoordsDecDMS,
+          x.srifu2Name,
+          x.srifu2CoordsRAHMS,
+          x.srifu2CoordsDecDMS,
+          x.hrifu1Name,
+          x.hrifu1CoordsRAHMS,
+          x.hrifu1CoordsDecDMS,
+          x.hrifu2Name,
+          x.hrifu2CoordsRAHMS,
+          x.hrifu2CoordsDecDMS))
 
     implicit val show: Show[GHOSTConfig] = Show.fromToString
   }


### PR DESCRIPTION
HI all,

Last week when speaking with the instrument team from Australia, I received some answers that necessitated changes to the way GHOSTController worked: hence, this PR.

The idea for each IFU is:
1. If the standard resolution configuration is set, use it.
2. Otherwise if the high resolution configuration is set, use it.
3. Otherwise the IFU must be moved out of the way: request it to be parked.

We are also temporarily turning off observes since they will not be involved in tonight's testing, and all we want to do is test configuration applies.