### PR TITLE
SEQNG-806: Add system configuration buttons in steps

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -66,6 +66,11 @@ object actions {
   final case class RequestObsResume(id:  Observation.Id, step: Int) extends Action
   case object RequestSoundEcho extends Action
 
+  final case class RequestResourceRun(id:       Observation.Id,
+                                      step:     StepId,
+                                      resource: Resource)
+      extends Action
+
   final case class RunStarted(s:           Observation.Id) extends Action
   final case class RunPaused(s:            Observation.Id) extends Action
   final case class RunCancelPaused(s:      Observation.Id) extends Action
@@ -141,7 +146,7 @@ object actions {
   final case class UpdateSelectedStep(id: Observation.Id, step: StepId)
       extends Action
   final case class UpdateCalTableState(id: QueueId,
-                                        s:  TableState[CalQueueTable.TableColumn])
+                                       s:  TableState[CalQueueTable.TableColumn])
       extends Action
   final case class LoadSequence(observer: Observer,
                                 i:        Instrument,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -138,6 +138,8 @@ object actions {
   final case class UpdateStepTableState(id: Observation.Id,
                                         s:  TableState[StepsTable.TableColumn])
       extends Action
+  final case class UpdateSelectedStep(id: Observation.Id, step: StepId)
+      extends Action
   final case class UpdateCalTableState(id: QueueId,
                                         s:  TableState[CalQueueTable.TableColumn])
       extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -70,6 +70,14 @@ object actions {
                                       step:     StepId,
                                       resource: Resource)
       extends Action
+  final case class RunResource(id:       Observation.Id,
+                               step:     StepId,
+                               resource: Resource)
+      extends Action
+  final case class RunResourceFailed(id:       Observation.Id,
+                                     step:     StepId,
+                                     resource: Resource)
+      extends Action
 
   final case class RunStarted(s:           Observation.Id) extends Action
   final case class RunPaused(s:            Observation.Id) extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
@@ -41,6 +41,7 @@ final class LoggingProcessor[M <: AnyRef] extends ActionProcessor[M] {
       case UpdateSessionQueueTableState(_)            =>
       case UpdateStepTableState(_, _)                 =>
       case UpdateCalTableState(_, _)                  =>
+      case UpdateSelectedStep(_, _)                   =>
       case a: Action                                  => logger.info(s"Action: ${a.show}")
       case _                                          =>
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
@@ -24,7 +24,8 @@ final case class StepsTableFocus(id:                  Observation.Id,
                                  nextStepToRun:       Option[StepId],
                                  selectedStep:        Option[StepId],
                                  isPreview:           Boolean,
-                                 tableState:          TableState[StepsTable.TableColumn])
+                                 tableState:          TableState[StepsTable.TableColumn],
+                                 tabOperations:       TabOperations)
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object StepsTableFocus {
@@ -39,7 +40,8 @@ object StepsTableFocus {
          x.nextStepToRun,
          x.selectedStep,
          x.isPreview,
-         x.tableState))
+         x.tableState,
+         x.tabOperations))
 
   def stepsTableG(
     id: Observation.Id
@@ -59,7 +61,8 @@ object StepsTableFocus {
               tab.selectedStep
                 .orElse(sequence.nextStepToRun), // start with the nextstep selected
               tab.isPreview,
-              tab.tableState
+              tab.tableState,
+              tab.tabOperations
             )
           }
       }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
@@ -16,15 +16,15 @@ import seqexec.web.client.components.sequence.steps.StepsTable
 import web.client.table._
 
 @Lenses
-final case class StepsTableFocus(
-  id:                  Observation.Id,
-  instrument:          Instrument,
-  state:               SequenceState,
-  steps:               List[Step],
-  stepConfigDisplayed: Option[Int],
-  nextStepToRun:       Option[Int],
-  isPreview:           Boolean,
-  tableState:          TableState[StepsTable.TableColumn])
+final case class StepsTableFocus(id:                  Observation.Id,
+                                 instrument:          Instrument,
+                                 state:               SequenceState,
+                                 steps:               List[Step],
+                                 stepConfigDisplayed: Option[Int],
+                                 nextStepToRun:       Option[StepId],
+                                 selectedStep:        Option[StepId],
+                                 isPreview:           Boolean,
+                                 tableState:          TableState[StepsTable.TableColumn])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object StepsTableFocus {
@@ -37,6 +37,7 @@ object StepsTableFocus {
          x.steps,
          x.stepConfigDisplayed,
          x.nextStepToRun,
+         x.selectedStep,
          x.isPreview,
          x.tableState))
 
@@ -48,14 +49,18 @@ object StepsTableFocus {
       _.flatMap {
         case SeqexecTabActive(tab, _) =>
           tab.sequence.map { sequence =>
-            StepsTableFocus(sequence.id,
-                            sequence.metadata.instrument,
-                            sequence.status,
-                            sequence.steps,
-                            tab.stepConfigDisplayed,
-                            sequence.nextStepToRun,
-                            tab.isPreview,
-                            tab.tableState)
+            StepsTableFocus(
+              sequence.id,
+              sequence.metadata.instrument,
+              sequence.status,
+              sequence.steps,
+              tab.stepConfigDisplayed,
+              sequence.nextStepToRun,
+              tab.selectedStep
+                .orElse(sequence.nextStepToRun), // start with the nextstep selected
+              tab.isPreview,
+              tab.tableState
+            )
           }
       }
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
@@ -38,13 +38,17 @@ object StepBreakStopCell {
                                        'breakPointLeaveCB)
 
   // Request a to flip the breakpoint
-  def flipBreakpoint(p: Props): Callback =
+  def flipBreakpoint(p: Props)(e: ReactEvent): Callback =
+    e.preventDefaultCB *>
+    e.stopPropagationCB *>
     Callback.when(p.clientStatus.canOperate)(
       SeqexecCircuit.dispatchCB(FlipBreakpointStep(p.obsId, p.step)) >> p
         .heightChangeCB(p.step.id))
 
   // Request a to flip the skip
-  def flipSkipped(p: Props): Callback =
+  def flipSkipped(p: Props)(e: ReactEvent): Callback =
+    e.preventDefaultCB *>
+    e.stopPropagationCB *>
     Callback.when(p.clientStatus.canOperate)(
       SeqexecCircuit.dispatchCB(FlipSkipStep(p.obsId, p.step)))
 
@@ -61,7 +65,7 @@ object StepBreakStopCell {
         <.div(
           SeqexecStyles.breakPointHandleOff.when(p.step.breakpoint),
           SeqexecStyles.breakPointHandleOn.unless(p.step.breakpoint),
-          ^.onClick --> flipBreakpoint(p),
+          ^.onClick ==> flipBreakpoint(p),
           Icon.IconRemove
             .copyIcon(fitted       = true,
                       onMouseEnter = p.breakPointEnterCB(p.step.id),
@@ -79,12 +83,12 @@ object StepBreakStopCell {
           SeqexecStyles.skipHandle,
           ^.top := (p.rowHeight / 2 - SeqexecStyles.skipHandleHeight + 2).px,
           IconPlusSquareOutline
-            .copyIcon(link = true, onClick = flipSkipped(p))
+            .copyIcon(link = true, onClickE = flipSkipped(p) _)
             .when(p.step.skip),
           IconMinusCircle
             .copyIcon(link    = true,
                       color   = Some("orange"),
-                      onClick = flipSkipped(p))
+                      onClickE = flipSkipped(p) _)
             .unless(p.step.skip)
         ).when(canSetSkipMark)
       )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -146,10 +146,8 @@ object StepProgressCell {
       props.step match {
         case step: StandardStep =>
           SubsystemControlCell(
-            SubsystemControlCell.Props(props.obsId,
-                                       props.instrument,
-                                       step.id,
-                                       step.configStatus.map(_._1)))
+            SubsystemControlCell
+              .Props(props.obsId, step.id, step.configStatus.map(_._1)))
         case _ =>
           <.div()
       }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -9,6 +9,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.Reusability
+import scala.collection.immutable.SortedMap
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.ActionStatus
 import seqexec.model.enum.Resource
@@ -19,6 +20,7 @@ import seqexec.model.Step
 import seqexec.model.StepId
 import seqexec.model.SequenceState
 import seqexec.web.client.model.ClientStatus
+import seqexec.web.client.model.ResourceRunOperation
 import seqexec.web.client.model.ModelOps._
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.semanticui.elements.icon.Icon
@@ -31,13 +33,15 @@ import web.client.style._
   * Component to display the step state and control
   */
 object StepProgressCell {
-  final case class Props(clientStatus: ClientStatus,
-                         instrument:   Instrument,
-                         obsId:        Observation.Id,
-                         state:        SequenceState,
-                         step:         Step,
-                         selectedStep: Option[StepId],
-                         isPreview:    Boolean) {
+  final case class Props(
+    clientStatus:         ClientStatus,
+    instrument:           Instrument,
+    obsId:                Observation.Id,
+    state:                SequenceState,
+    step:                 Step,
+    selectedStep:         Option[StepId],
+    isPreview:            Boolean,
+    resourceRunRequested: SortedMap[Resource, ResourceRunOperation]) {
 
     def stepSelected(i: StepId): Boolean =
       selectedStep.exists(_ === i) && !isPreview && clientStatus.isLogged
@@ -147,7 +151,10 @@ object StepProgressCell {
         case step: StandardStep =>
           SubsystemControlCell(
             SubsystemControlCell
-              .Props(props.obsId, step.id, step.configStatus.map(_._1)))
+              .Props(props.obsId,
+                     step.id,
+                     step.configStatus.map(_._1),
+                     props.resourceRunRequested))
         case _ =>
           <.div()
       }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -26,6 +26,7 @@ import seqexec.model.StepId
 import seqexec.model.StandardStep
 import seqexec.web.client.model.lenses._
 import seqexec.web.client.model.ClientStatus
+import seqexec.web.client.model.TabOperations
 import seqexec.web.client.model.Pages.SeqexecPages
 import seqexec.web.client.model.ModelOps._
 import seqexec.web.client.circuit.SeqexecCircuit
@@ -118,12 +119,14 @@ object StepsTable {
     val selectedStep: Option[StepId]                = steps.flatMap(_.selectedStep)
     val rowCount: Int                               = stepsList.length
     val nextStepToRun: Int                          = steps.foldMap(_.nextStepToRun).getOrElse(0)
-    val showDisperser: Boolean                      = showProp(InstrumentProperties.Disperser)
-    val showExposure: Boolean                       = showProp(InstrumentProperties.Exposure)
-    val showFilter: Boolean                         = showProp(InstrumentProperties.Filter)
-    val showFPU: Boolean                            = showProp(InstrumentProperties.FPU)
-    val isPreview: Boolean                          = steps.map(_.isPreview).getOrElse(false)
-    val canSetBreakpoint: Boolean                   = canOperate && !isPreview
+    val tabOperations: TabOperations =
+      steps.map(_.tabOperations).getOrElse(TabOperations.Default)
+    val showDisperser: Boolean    = showProp(InstrumentProperties.Disperser)
+    val showExposure: Boolean     = showProp(InstrumentProperties.Exposure)
+    val showFilter: Boolean       = showProp(InstrumentProperties.Filter)
+    val showFPU: Boolean          = showProp(InstrumentProperties.FPU)
+    val isPreview: Boolean        = steps.map(_.isPreview).getOrElse(false)
+    val canSetBreakpoint: Boolean = canOperate && !isPreview
     val showObservingMode: Boolean =
       showProp(InstrumentProperties.ObservingMode)
 
@@ -248,7 +251,8 @@ object StepsTable {
                                f.state,
                                row.step,
                                b.state.selected,
-                               b.props.isPreview))
+                               b.props.isPreview,
+                               b.props.tabOperations.resourceRunRequested))
 
   def stepStatusRenderer(
     offsetsDisplay: OffsetsDisplay

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -619,7 +619,8 @@ object StepsTable {
         .dispatchCB(UpdateSelectedStep(id, i)) *>
         b.modState(State.selected.set(Some(i))) *>
         recomputeRowHeightsCB(min(b.state.selected.getOrElse(i), i)))
-        .when(b.props.canControlSubsystems(i)) *>
+        .when(b.props
+          .canControlSubsystems(i) && !b.props.tabOperations.resourceInFlight) *>
         Callback.empty
     }.getOrEmpty
 
@@ -714,7 +715,13 @@ object StepsTable {
           min(c, n)
         }
         .filter(_ => s.selected =!= next.selectedStep)
-    (selected.toList ::: differentStepsStates).minimumOption.map {
+    val running: Option[StepId] =
+      if (cur.tabOperations.resourceRunRequested =!= next.tabOperations.resourceRunRequested) {
+        next.selectedStep
+      } else {
+        none
+      }
+    (running.toList ::: selected.toList ::: differentStepsStates).minimumOption.map {
       recomputeRowHeightsCB
     }.getOrEmpty
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -652,8 +652,9 @@ object StepsTable {
     )
 
   // We want clicks to be processed only if the click is not on the first row with the breakpoint/skip controls
-  private def allowedClick(index: Int, onRowClick: Option[OnRowClick])(
-    e:                            ReactMouseEvent): Callback =
+  private def allowedClick(
+    index: Int,
+    onRowClick: Option[OnRowClick])(e: ReactMouseEvent): Callback =
     onRowClick
       .filter(_ => e.clientX > ColWidths.ControlWidth)
       .map(h => h(index))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -68,7 +68,8 @@ object SubsystemControlCell {
               Button.Props(
                 size     = Size.Small,
                 color    = Some("blue"),
-                disabled = inExecution,
+                // disabled = inExecution,
+                disabled = true, // Disable to run in production
                 labeled =
                   if (inExecution) Button.LeftLabeled else Button.NotLabeled,
                 icon = p.resourcesCalls

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -5,127 +5,82 @@ package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
 import japgolly.scalajs.react.CatsReact._
+import japgolly.scalajs.react.CatsReact
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-// import japgolly.scalajs.react.Callback
-// import japgolly.scalajs.react.CallbackTo
+import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react.CallbackTo
 import japgolly.scalajs.react.ScalaComponent
 import gem.Observation
-// import seqexec.model._
+import monocle.Optional
+import monocle.macros.Lenses
+import monocle.function.At.at
+import monocle.function.At.atSortedMap
+import monocle.std
+import scala.collection.immutable.SortedMap
 import seqexec.model.enum._
+import seqexec.model.StepId
+import seqexec.web.client.actions.RequestResourceRun
+import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.popup.Popup
-// import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
-// import seqexec.web.client.semanticui.elements.icon.Icon.IconPlay
-// import seqexec.web.client.semanticui.elements.icon.Icon.IconStop
-// import seqexec.web.client.semanticui.elements.icon.Icon.IconTrash
+import seqexec.web.client.semanticui.Size
 import web.client.style._
 
 /**
   * Contains the control buttons for each subsystem
   */
 object SubsystemControlCell {
-  final case class Props(id:         Observation.Id,
-                         instrument: Instrument,
-                         stepId:     Int,
-                         resources:  List[Resource])
-  final case class State()
+  final case class Props(id:        Observation.Id,
+                         stepId:    Int,
+                         resources: List[Resource])
+
+  @Lenses
+  final case class State(resources: SortedMap[Resource, Boolean])
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object State {
+    def resource(r: Resource): Optional[State, Boolean] =
+      State.resources ^|->
+        at(r) ^<-?
+        std.option.some
+  }
 
   private val ST = ReactS.Fix[State]
-  println(ST)
+
+  def requestResourceCall(id:     Observation.Id,
+                          stepId: StepId,
+                          r:      Resource): Callback =
+    SeqexecCircuit.dispatchCB(RequestResourceRun(id, stepId, r))
+
+  def handleResourceCall(
+    id:     Observation.Id,
+    stepId: StepId,
+    r:      Resource): CatsReact.ReactST[CallbackTo, State, Unit] =
+    ST.retM(requestResourceCall(id, stepId, r)) >> ST
+      .mod(State.resource(r).set(true))
+      .liftCB
 
   private val component = ScalaComponent
     .builder[Props]("SubsystemControl")
-    .initialState(State())
+    .initialStateFromProps(p =>
+      State(SortedMap(p.resources.fproduct(_ => false): _*)))
     .renderPS { ($, p, s) =>
       <.div(
         SeqexecStyles.notInMobile,
         p.resources.map { r =>
           Popup(
             Popup.Props("button", s"Configure ${r.show}"),
-            Button(Button.Props(color = Some("green")), r.show)
-            // onClick =
-            //   $.runState(handleObsPause(p.id, p.stepId)))
+            Button(Button.Props(size  = Size.Small,
+                                color = Some("blue"),
+                                onClick = $.runState(
+                                  handleResourceCall(p.id, p.stepId, r))),
+                   r.show)
           )
         }.toTagMod
-        // .observationOperations(p.isObservePaused)
-        // .map {
-        //   case PauseObservation =>
-        //     Popup(
-        //       Popup.Props("button", "Pause the current exposure"),
-        //       Button(
-        //         Button.Props(icon  = Some(IconPause),
-        //                      color = Some("teal"),
-        //                      onClick =
-        //                        $.runState(handleObsPause(p.id, p.stepId)),
-        //                      disabled = !s.canPause || p.isObservePaused))
-        //     )
-        //   case StopObservation =>
-        //     Popup(
-        //       Popup.Props("button", "Stop the current exposure early"),
-        //       Button(
-        //         Button.Props(icon     = Some(IconStop),
-        //                      color    = Some("orange"),
-        //                      onClick  = $.runState(handleStop(p.id, p.stepId)),
-        //                      disabled = !s.canStop))
-        //     )
-        //   case AbortObservation =>
-        //     Popup(
-        //       Popup.Props("button", "Abort the current exposure"),
-        //       Button(
-        //         Button.Props(
-        //           icon     = Some(IconTrash),
-        //           color    = Some("red"),
-        //           onClick  = $.runState(handleAbort(p.id, p.stepId)),
-        //           disabled = !s.canAbort))
-        //     )
-        //   case ResumeObservation =>
-        //     Popup(
-        //       Popup.Props("button", "Resume the current exposure"),
-        //       Button(
-        //         Button.Props(icon  = Some(IconPlay),
-        //                      color = Some("blue"),
-        //                      onClick =
-        //                        $.runState(handleObsResume(p.id, p.stepId)),
-        //                      disabled = !s.canResume || !p.isObservePaused))
-        //     )
-        //   // Hamamatsu operations
-        //   case PauseImmediatelyObservation =>
-        //     Popup(
-        //       Popup.Props("button", "Pause the current exposure immediately"),
-        //       Button(
-        //         Button.Props(icon = Some(IconPause), color = Some("teal"))))
-        //   case PauseGracefullyObservation =>
-        //     Popup(Popup.Props("button",
-        //                       "Pause the current exposure gracefully"),
-        //           Button(
-        //             Button.Props(icon  = Some(IconPause),
-        //                          color = Some("teal"),
-        //                          basic = true)))
-        //   case StopImmediatelyObservation =>
-        //     Popup(
-        //       Popup.Props("button", "Stop the current exposure immediately"),
-        //       Button(
-        //         Button.Props(icon = Some(IconStop), color = Some("orange"))))
-        //   case StopGracefullyObservation =>
-        //     Popup(Popup.Props("button",
-        //                       "Stop the current exposure gracefully"),
-        //           Button(
-        //             Button.Props(icon  = Some(IconStop),
-        //                          color = Some("orange"),
-        //                          basic = true)))
-        // }
-        // .toTagMod
       )
     }
-    // .componentWillReceiveProps { f =>
-    //   f.runState(if (f.nextProps.isObservePaused) {
-    //     ST.set(NoneRequested)
-    //   } else {
-    //     ST.nop
-    //   })
-    // }
     .build
 
   def apply(p: Props): Unmounted[Props, State, Unit] = component(p)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -20,6 +20,7 @@ import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.model.ResourceRunOperation
 import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.popup.Popup
+import seqexec.web.client.semanticui.elements.icon.Icon.IconCircleNotched
 import seqexec.web.client.semanticui.Size
 import seqexec.web.client.reusability._
 import web.client.style._
@@ -42,22 +43,35 @@ object SubsystemControlCell {
     r:      Resource
   ): Callback = SeqexecCircuit.dispatchCB(RequestResourceRun(id, stepId, r))
 
+  private val RunningIcon = IconCircleNotched.copyIcon(
+    fitted      = true,
+    loading     = true,
+    extraStyles = List(SeqexecStyles.runningIcon))
+
   private val component = ScalaComponent
     .builder[Props]("SubsystemControl")
     .render_P { p =>
       <.div(
         SeqexecStyles.notInMobile,
         p.resources.map { r =>
+          val inExecution =
+            p.resourcesCalls
+              .get(r)
+              .map(_ === ResourceRunOperation.ResourceRunInFlight)
+              .getOrElse(false)
           Popup(
             Popup.Props("button", s"Configure ${r.show}"),
             Button(
               Button.Props(
-                size  = Size.Small,
-                color = Some("blue"),
-                disabled = p.resourcesCalls
+                size     = Size.Small,
+                color    = Some("blue"),
+                disabled = inExecution,
+                labeled =
+                  if (inExecution) Button.LeftLabeled else Button.NotLabeled,
+                icon = p.resourcesCalls
                   .get(r)
-                  .map(_ === ResourceRunOperation.ResourceRunInFlight)
-                  .getOrElse(false),
+                  .filter(_ === ResourceRunOperation.ResourceRunInFlight)
+                  .map(_ => RunningIcon),
                 onClick = requestResourceCall(p.id, p.stepId, r)
               ),
               r.show

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -1,0 +1,132 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components.sequence.steps
+
+import cats.implicits._
+import japgolly.scalajs.react.CatsReact._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+// import japgolly.scalajs.react.Callback
+// import japgolly.scalajs.react.CallbackTo
+import japgolly.scalajs.react.ScalaComponent
+import gem.Observation
+// import seqexec.model._
+import seqexec.model.enum._
+import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.semanticui.elements.button.Button
+import seqexec.web.client.semanticui.elements.popup.Popup
+// import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
+// import seqexec.web.client.semanticui.elements.icon.Icon.IconPlay
+// import seqexec.web.client.semanticui.elements.icon.Icon.IconStop
+// import seqexec.web.client.semanticui.elements.icon.Icon.IconTrash
+import web.client.style._
+
+/**
+  * Contains the control buttons for each subsystem
+  */
+object SubsystemControlCell {
+  final case class Props(id:         Observation.Id,
+                         instrument: Instrument,
+                         stepId:     Int,
+                         resources:  List[Resource])
+  final case class State()
+
+  private val ST = ReactS.Fix[State]
+  println(ST)
+
+  private val component = ScalaComponent
+    .builder[Props]("SubsystemControl")
+    .initialState(State())
+    .renderPS { ($, p, s) =>
+      <.div(
+        SeqexecStyles.notInMobile,
+        p.resources.map { r =>
+          Popup(
+            Popup.Props("button", s"Configure ${r.show}"),
+            Button(Button.Props(color = Some("green")), r.show)
+            // onClick =
+            //   $.runState(handleObsPause(p.id, p.stepId)))
+          )
+        }.toTagMod
+        // .observationOperations(p.isObservePaused)
+        // .map {
+        //   case PauseObservation =>
+        //     Popup(
+        //       Popup.Props("button", "Pause the current exposure"),
+        //       Button(
+        //         Button.Props(icon  = Some(IconPause),
+        //                      color = Some("teal"),
+        //                      onClick =
+        //                        $.runState(handleObsPause(p.id, p.stepId)),
+        //                      disabled = !s.canPause || p.isObservePaused))
+        //     )
+        //   case StopObservation =>
+        //     Popup(
+        //       Popup.Props("button", "Stop the current exposure early"),
+        //       Button(
+        //         Button.Props(icon     = Some(IconStop),
+        //                      color    = Some("orange"),
+        //                      onClick  = $.runState(handleStop(p.id, p.stepId)),
+        //                      disabled = !s.canStop))
+        //     )
+        //   case AbortObservation =>
+        //     Popup(
+        //       Popup.Props("button", "Abort the current exposure"),
+        //       Button(
+        //         Button.Props(
+        //           icon     = Some(IconTrash),
+        //           color    = Some("red"),
+        //           onClick  = $.runState(handleAbort(p.id, p.stepId)),
+        //           disabled = !s.canAbort))
+        //     )
+        //   case ResumeObservation =>
+        //     Popup(
+        //       Popup.Props("button", "Resume the current exposure"),
+        //       Button(
+        //         Button.Props(icon  = Some(IconPlay),
+        //                      color = Some("blue"),
+        //                      onClick =
+        //                        $.runState(handleObsResume(p.id, p.stepId)),
+        //                      disabled = !s.canResume || !p.isObservePaused))
+        //     )
+        //   // Hamamatsu operations
+        //   case PauseImmediatelyObservation =>
+        //     Popup(
+        //       Popup.Props("button", "Pause the current exposure immediately"),
+        //       Button(
+        //         Button.Props(icon = Some(IconPause), color = Some("teal"))))
+        //   case PauseGracefullyObservation =>
+        //     Popup(Popup.Props("button",
+        //                       "Pause the current exposure gracefully"),
+        //           Button(
+        //             Button.Props(icon  = Some(IconPause),
+        //                          color = Some("teal"),
+        //                          basic = true)))
+        //   case StopImmediatelyObservation =>
+        //     Popup(
+        //       Popup.Props("button", "Stop the current exposure immediately"),
+        //       Button(
+        //         Button.Props(icon = Some(IconStop), color = Some("orange"))))
+        //   case StopGracefullyObservation =>
+        //     Popup(Popup.Props("button",
+        //                       "Stop the current exposure gracefully"),
+        //           Button(
+        //             Button.Props(icon  = Some(IconStop),
+        //                          color = Some("orange"),
+        //                          basic = true)))
+        // }
+        // .toTagMod
+      )
+    }
+    // .componentWillReceiveProps { f =>
+    //   f.runState(if (f.nextProps.isObservePaused) {
+    //     ST.set(NoneRequested)
+    //   } else {
+    //     ST.nop
+    //   })
+    // }
+    .build
+
+  def apply(p: Props): Unmounted[Props, State, Unit] = component(p)
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -8,6 +8,7 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.ReactEvent
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.extra.Reusability._
 import gem.Observation
@@ -41,7 +42,9 @@ object SubsystemControlCell {
     id:     Observation.Id,
     stepId: StepId,
     r:      Resource
-  ): Callback = SeqexecCircuit.dispatchCB(RequestResourceRun(id, stepId, r))
+  )(e:      ReactEvent): Callback =
+    e.preventDefaultCB *> e.stopPropagationCB *>
+      SeqexecCircuit.dispatchCB(RequestResourceRun(id, stepId, r))
 
   private val RunningIcon = IconCircleNotched.copyIcon(
     fitted      = true,
@@ -72,7 +75,7 @@ object SubsystemControlCell {
                   .get(r)
                   .filter(_ === ResourceRunOperation.ResourceRunInFlight)
                   .map(_ => RunningIcon),
-                onClick = requestResourceCall(p.id, p.stepId, r)
+                onClickE = requestResourceCall(p.id, p.stepId, r) _
               ),
               r.show
             )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -16,6 +16,7 @@ import seqexec.web.client.model.SyncOperation
 import seqexec.web.client.model.RunOperation
 import seqexec.web.client.model.SequencesOnDisplay
 import seqexec.web.client.model.TabOperations
+import seqexec.web.client.model.ResourceRunOperation
 import seqexec.web.client.actions._
 
 /**
@@ -42,6 +43,18 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
         value.markOperations(
           id,
           TabOperations.pauseRequested.set(PauseOperation.PauseInFlight)))
+
+    case RequestResourceRun(id, _, r) =>
+      // TODO Remove this when the response comes over the WS channel
+      updated(
+        value.markOperations(
+          id,
+          TabOperations
+            .resourceRun(r)
+            .set(ResourceRunOperation.ResourceRunInFlight.some)))
+
+    case RunResource(id, _, r) =>
+      updated(value.markOperations(id, TabOperations.resourceRun(r).set(none)))
   }
 
   def handleOperationResult: PartialFunction[Any, ActionResult[M]] = {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -71,6 +71,13 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
                 id,
                 TabOperations.pauseRequested.set(PauseOperation.PauseIdle)),
               notification)
+
+    case RunResourceFailed(id, _, r) =>
+      val msg = s"Failed to run ${r.show} for sequence ${id.format}"
+      val notification = Effect(
+        Future(RequestFailedNotification(RequestFailed(msg))))
+      updated(value.markOperations(id, TabOperations.resourceRun(r).set(none)),
+              notification)
   }
 
   def handleSelectedStep: PartialFunction[Any, ActionResult[M]] = {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -73,6 +73,11 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
               notification)
   }
 
+  def handleSelectedStep: PartialFunction[Any, ActionResult[M]] = {
+    case UpdateSelectedStep(id, step) =>
+      updated(value.selectStep(id, step))
+  }
+
   override def handle: PartialFunction[Any, ActionResult[M]] =
-    List(handleRequestOperation, handleOperationResult).combineAll
+    List(handleRequestOperation, handleOperationResult, handleSelectedStep).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/RemoteRequestsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/RemoteRequestsHandler.scala
@@ -8,6 +8,7 @@ import diode.ActionHandler
 import diode.ActionResult
 import diode.Effect
 import diode.ModelRW
+import gem.Observation
 import seqexec.model.ClientId
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
@@ -111,6 +112,17 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
                       RunSyncFailed.apply))
   }
 
+  def handleResourceRun: PartialFunction[Any, ActionResult[M]] = {
+    case RequestResourceRun(id, step, resource) =>
+      effectOnly(
+        requestEffect(
+          id,
+          SeqexecWebClient.runResource(step, resource),
+          (id: Observation.Id) => RunResource(id, step, resource),
+          (id: Observation.Id) => RunResourceFailed(id, step, resource)
+        ))
+  }
+
   override def handle: PartialFunction[Any, ActionResult[M]] =
     List(handleRun,
          handlePause,
@@ -119,6 +131,7 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
          handleAbort,
          handleObsPause,
          handleObsResume,
-         handleSync).combineAll
+         handleSync,
+         handleResourceRun).combineAll
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
@@ -60,7 +60,12 @@ final case class TabOperations(
   runRequested:         RunOperation,
   syncRequested:        SyncOperation,
   pauseRequested:       PauseOperation,
-  resourceRunRequested: SortedMap[Resource, ResourceRunOperation])
+  resourceRunRequested: SortedMap[Resource, ResourceRunOperation]) {
+  // Indicate if any resource is being executed
+  def resourceInFlight: Boolean =
+    resourceRunRequested.exists(
+      _._2 === ResourceRunOperation.ResourceRunInFlight)
+}
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object TabOperations {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -11,6 +11,7 @@ import monocle.Prism
 import monocle.macros.GenPrism
 import monocle.macros.Lenses
 import seqexec.model.Observer
+import seqexec.model.StepId
 import seqexec.model.SequenceState
 import seqexec.model.SequenceView
 import seqexec.model.enum._
@@ -148,8 +149,8 @@ sealed trait SequenceTab extends SeqexecTab {
   }
 
   def isComplete: Boolean = this match {
-    case InstrumentSequenceTab(_, _, Some(_), _, _, _) => true
-    case _                                             => false
+    case InstrumentSequenceTab(_, _, Some(_), _, _, _, _) => true
+    case _                                                => false
   }
 
   def runningStep: Option[RunningStep] = this match {
@@ -163,6 +164,11 @@ sealed trait SequenceTab extends SeqexecTab {
     case _: InstrumentSequenceTab => false
     case p: PreviewSequenceTab    => p.isLoading
   }
+
+  def selectedStep: Option[StepId] = this match {
+    case i: InstrumentSequenceTab => i.selected
+    case _                        => none
+  }
 }
 
 object SequenceTab {
@@ -174,8 +180,8 @@ object SequenceTab {
     }
 
   // Some lenses
-  val stepConfigL: Lens[SequenceTab, Option[Int]] =
-    Lens[SequenceTab, Option[Int]] {
+  val stepConfigL: Lens[SequenceTab, Option[StepId]] =
+    Lens[SequenceTab, Option[StepId]] {
       case t: InstrumentSequenceTab => t.stepConfig
       case t: PreviewSequenceTab    => t.stepConfig
     }(n =>
@@ -192,7 +198,8 @@ final case class InstrumentSequenceTab(
   inst:              Instrument,
   currentSequence:   Option[SequenceView],
   completedSequence: Option[SequenceView],
-  stepConfig:        Option[Int],
+  stepConfig:        Option[StepId],
+  selected:          Option[StepId],
   tableState:        TableState[StepsTable.TableColumn],
   tabOperations:     TabOperations)
     extends SequenceTab
@@ -206,6 +213,7 @@ object InstrumentSequenceTab {
          x.currentSequence,
          x.completedSequence,
          x.stepConfig,
+         x.selectedStep,
          x.tableState,
          x.tabOperations))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -46,7 +46,18 @@ package object reusability {
   implicit val stepReuse: Reusability[Step]                 = Reusability.byEq
   implicit val seqStateReuse: Reusability[SequenceState]    = Reusability.byEq
   implicit val clientStatusReuse: Reusability[ClientStatus] = Reusability.byEq
-  implicit val stTbFocusReuse: Reusability[StepsTableFocus] = Reusability.byEq
+  implicit val stTbFocusReuse: Reusability[StepsTableFocus] =
+    Reusability.by { x =>
+      (x.id,
+       x.instrument,
+       x.state,
+       x.steps,
+       x.stepConfigDisplayed,
+       x.nextStepToRun,
+       x.selectedStep,
+       x.isPreview,
+       x.tableState) // Don't include tabOperations on the check
+    }
   implicit val stASFocusReuse: Reusability[StatusAndStepFocus] =
     Reusability.byEq
   implicit val sCFocusReuse: Reusability[SequenceControlFocus] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -9,8 +9,10 @@ import gem.Observation
 import gem.enum.Site
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.extra.Reusability
+import scala.collection.immutable.SortedMap
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.BatchExecState
+import seqexec.model.enum.Resource
 import seqexec.model.Observer
 import seqexec.model.QueueId
 import seqexec.model.Step
@@ -28,6 +30,7 @@ import seqexec.web.client.model.PauseOperation
 import seqexec.web.client.model.QueueOperations
 import seqexec.web.client.model.RunOperation
 import seqexec.web.client.model.SyncOperation
+import seqexec.web.client.model.ResourceRunOperation
 import seqexec.web.client.model.TabSelected
 import seqexec.web.client.model.SoundSelection
 import seqexec.web.client.circuit._
@@ -35,6 +38,7 @@ import seqexec.web.client.circuit._
 package object reusability {
   implicit val stepStateReuse: Reusability[StepState]       = Reusability.byEq
   implicit val instrumentReuse: Reusability[Instrument]     = Reusability.byEq
+  implicit val resourceReuse: Reusability[Resource]         = Reusability.byEq
   implicit val obsIdReuse: Reusability[Observation.Id]      = Reusability.byEq
   implicit val siteReuse: Reusability[Site]                 = Reusability.byEq
   implicit val observerReuse: Reusability[Observer]         = Reusability.byEq
@@ -59,6 +63,8 @@ package object reusability {
   implicit val syncOperationReuse: Reusability[SyncOperation] =
     Reusability.byRef
   implicit val psOperationReuse: Reusability[PauseOperation] = Reusability.byRef
+  implicit val rrOperationReuse: Reusability[ResourceRunOperation] =
+    Reusability.byRef
   implicit val availableTabsReuse: Reusability[AvailableTab] = Reusability.byEq
   implicit val userDetailsReuse: Reusability[UserDetails]    = Reusability.byEq
   implicit val usrNotReuse: Reusability[UserNotificationState] =
@@ -70,4 +76,9 @@ package object reusability {
   implicit val qidReuse: Reusability[QueueId]              = Reusability.byEq
   implicit val bexReuse: Reusability[BatchExecState]       = Reusability.byRef
   implicit val soundReuse: Reusability[SoundSelection]     = Reusability.byRef
+
+  implicit val resMap: Reusability[Map[Resource, ResourceRunOperation]] =
+    Reusability.map
+  implicit val resSMap: Reusability[SortedMap[Resource, ResourceRunOperation]] =
+    Reusability.by(_.toMap)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -22,6 +22,7 @@ import seqexec.model.enum.Instrument
 import seqexec.model.enum.ImageQuality
 import seqexec.model.enum.SkyBackground
 import seqexec.model.enum.WaterVapor
+import seqexec.model.enum.Resource
 import seqexec.web.model.boopickle._
 import seqexec.web.common.LogMessage
 import seqexec.web.common.LogMessage._
@@ -393,6 +394,18 @@ object SeqexecWebClient extends ModelBooPicklers {
       .post(
         url =
           s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/move/${encodeURI(obsId.self.format)}/$pos/${encodeURI(clientId.self.show)}",
+        responseType = "arraybuffer"
+      )
+      .map(_ => ())
+
+  /**
+    * Runs a reusource
+    */
+  def runResource(pos: Int, resource: Resource)(obsId: Observation.Id): Future[Unit] =
+    Ajax
+      .post(
+        url =
+          s"$baseUrl/commands/execute/${encodeURI(obsId.self.format)}/$pos/${encodeURI(resource.show)}",
         responseType = "arraybuffer"
       )
       .map(_ => ())

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -12,6 +12,7 @@ import gem.Observation
 import gem.enum.Site
 import scala.collection.immutable.SortedMap
 import seqexec.model.enum.Instrument
+import seqexec.model.enum.Resource
 import seqexec.model.enum.BatchExecState
 import seqexec.model.enum.QueueManipulationOp
 import seqexec.model.ClientId
@@ -76,18 +77,34 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val poCogen: Cogen[PauseOperation] =
     Cogen[String].contramap(_.productPrefix)
 
+  implicit val arbResourceRunOperation: Arbitrary[ResourceRunOperation] =
+    Arbitrary(
+      Gen.oneOf(ResourceRunOperation.ResourceRunIdle,
+                ResourceRunOperation.ResourceRunInFlight))
+
+  implicit val rruCogen: Cogen[ResourceRunOperation] =
+    Cogen[String].contramap(_.productPrefix)
+
   implicit val arbTabOperations: Arbitrary[TabOperations] =
     Arbitrary {
       for {
         r <- arbitrary[RunOperation]
         s <- arbitrary[SyncOperation]
         p <- arbitrary[PauseOperation]
-      } yield TabOperations(r, s, p)
+        u <- arbitrary[SortedMap[Resource, ResourceRunOperation]]
+      } yield TabOperations(r, s, p, u)
     }
 
   implicit val toCogen: Cogen[TabOperations] =
-    Cogen[(RunOperation, SyncOperation, PauseOperation)].contramap(x =>
-      (x.runRequested, x.syncRequested, x.pauseRequested))
+    Cogen[(RunOperation,
+           SyncOperation,
+           PauseOperation,
+           List[(Resource, ResourceRunOperation)])].contramap(
+      x =>
+        (x.runRequested,
+         x.syncRequested,
+         x.pauseRequested,
+         x.resourceRunRequested.toList))
 
   implicit val arbAddDayCalOperation: Arbitrary[AddDayCalOperation] =
     Arbitrary(
@@ -482,18 +499,20 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         se <- arbitrary[Option[StepId]]
         p  <- arbitrary[Boolean]
         ts <- arbitrary[TableState[StepsTable.TableColumn]]
-      } yield StepsTableFocus(id, i, ss, s, n, e, se, p, ts)
+        to <- arbitrary[TabOperations]
+      } yield StepsTableFocus(id, i, ss, s, n, e, se, p, ts, to)
     }
 
   implicit val sstCogen: Cogen[StepsTableFocus] =
-    Cogen[(Observation.Id,
-           Instrument,
-           SequenceState,
-           List[Step],
-           Option[Int],
-           Option[StepId],
-           Option[StepId],
-           TableState[StepsTable.TableColumn])].contramap { x =>
+    Cogen[
+      (Observation.Id,
+       Instrument,
+       SequenceState,
+       List[Step],
+       Option[Int],
+       Option[StepId],
+       Option[StepId],
+       TableState[StepsTable.TableColumn])].contramap { x =>
       (x.id,
        x.instrument,
        x.state,
@@ -706,8 +725,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
       .contramap(_.obsProgress.toList)
 
   implicit val arbObsClass: Arbitrary[ObsClass] =
-    Arbitrary(
-      Gen.oneOf(ObsClass.All, ObsClass.Daytime, ObsClass.Nighttime))
+    Arbitrary(Gen.oneOf(ObsClass.All, ObsClass.Daytime, ObsClass.Nighttime))
 
   implicit val obsClassCogen: Cogen[ObsClass] =
     Cogen[String].contramap(_.productPrefix)
@@ -724,8 +742,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
       .contramap(_.obsClass)
 
   implicit val arbSoundSelection: Arbitrary[SoundSelection] =
-    Arbitrary(
-      Gen.oneOf(SoundSelection.SoundOn, SoundSelection.SoundOff))
+    Arbitrary(Gen.oneOf(SoundSelection.SoundOn, SoundSelection.SoundOff))
 
   implicit val soundSelClassCogen: Cogen[SoundSelection] =
     Cogen[String].contramap(_.productPrefix)
@@ -823,7 +840,13 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         site        <- arbitrary[Option[Site]]
         sound       <- arbitrary[SoundSelection]
       } yield
-        WebSocketsFocus(navLocation, sequences, user, observer, clientId, site, sound)
+        WebSocketsFocus(navLocation,
+                        sequences,
+                        user,
+                        observer,
+                        clientId,
+                        site,
+                        sound)
     }
 
   implicit val wsfCogen: Cogen[WebSocketsFocus] =

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -187,12 +187,14 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         pr  <- arbitrary[Option[SequenceView]]
         ts  <- arbitrary[TableState[StepsTable.TableColumn]]
         to  <- arbitrary[TabOperations]
+        se  <- arbitrary[Option[StepId]]
       } yield
         InstrumentSequenceTab(
           i,
           sv.map(k => k.copy(metadata = k.metadata.copy(instrument = i))),
           pr,
           idx,
+          se,
           ts,
           to)
     }
@@ -201,13 +203,15 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     Cogen[(Instrument,
            Option[SequenceView],
            Option[SequenceView],
-           Option[Int],
+           Option[StepId],
+           Option[StepId],
            TableState[StepsTable.TableColumn],
            TabOperations)].contramap { x =>
       (x.inst,
        x.currentSequence,
        x.completedSequence,
        x.stepConfig,
+       x.selectedStep,
        x.tableState,
        x.tabOperations)
     }
@@ -475,9 +479,10 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         s  <- arbitrary[List[Step]]
         n  <- arbitrary[Option[Int]]
         e  <- arbitrary[Option[Int]]
+        se <- arbitrary[Option[StepId]]
         p  <- arbitrary[Boolean]
         ts <- arbitrary[TableState[StepsTable.TableColumn]]
-      } yield StepsTableFocus(id, i, ss, s, n, e, p, ts)
+      } yield StepsTableFocus(id, i, ss, s, n, e, se, p, ts)
     }
 
   implicit val sstCogen: Cogen[StepsTableFocus] =
@@ -486,7 +491,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
            SequenceState,
            List[Step],
            Option[Int],
-           Option[Int],
+           Option[StepId],
+           Option[StepId],
            TableState[StepsTable.TableColumn])].contramap { x =>
       (x.id,
        x.instrument,
@@ -494,6 +500,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
        x.steps,
        x.stepConfigDisplayed,
        x.nextStepToRun,
+       x.selectedStep,
        x.tableState)
     }
 

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
@@ -90,7 +90,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
       SequencesQueue(loaded, Conditions.Default, None, SortedMap.empty, queue))
     sod.tabs.length should be(2)
     sod.tabs.toList.lift(1) should matchPattern {
-      case Some(InstrumentSequenceTab(_, s, _, _, _, _))
+      case Some(InstrumentSequenceTab(_, s, _, _, _, _, _))
           if s.exists(_.id === obsId) =>
     }
   }
@@ -109,7 +109,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
 
     sod2.tabs.length should be(3)
     sod2.tabs.toList.lift(2) should matchPattern {
-      case Some(InstrumentSequenceTab(_, s, _, _, _, _))
+      case Some(InstrumentSequenceTab(_, s, _, _, _, _, _))
           if s.exists(_.id === obsId) =>
     }
     sod2.tabs.focus should matchPattern {

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -9,6 +9,8 @@ import gem.Observation
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.server.middleware.GZip
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 import seqexec.server.SeqexecEngine
 import seqexec.server
 import seqexec.model.enum.CloudCover
@@ -169,6 +171,11 @@ class SeqexecCommandRoutes(auth:       AuthenticationService,
     case POST -> Root / "queue" / QueueIdVar(qid) / "stop" / ClientIDVar(clientId) as _ =>
       se.stopQueue(inputQueue, qid, clientId) *>
         Ok(s"Stopped from queue $qid")
+
+    case POST -> Root / "execute" / ObsIdVar(oid) / PosIntVar(step) / ResourceVar(resource) as _ =>
+      // Just simulate a delay
+      IO.sleep(2.seconds) *>
+        Ok(s"Run ${resource.show} from config at ${oid.format}/$step")
 
   }
 

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/package.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/package.scala
@@ -9,6 +9,7 @@ import seqexec.model.QueueId
 import seqexec.model.Observer
 import seqexec.model.Operator
 import seqexec.model.enum.Instrument
+import seqexec.model.enum.Resource
 import seqexec.model.ClientId
 
 trait Var {
@@ -45,6 +46,11 @@ trait Var {
   object PosIntVar {
     def unapply(str: String): Option[Int] =
       Either.catchNonFatal(str.toInt).toOption.filter(_ >= 0)
+  }
+
+  object ResourceVar {
+    def unapply(str: String): Option[Resource] =
+      Instrument.allResources.find(_.show === str)
   }
 
   object BooleanVar {


### PR DESCRIPTION
This PR adds buttons to request configuring a subsystem for a given step. This lets you select a step and it will show the buttons for that step. The backend is not yet implemented so it is just simulated but it would let @jluhrs to test

Here it is in action

https://monosnap.com/file/CVwpsSr7tsTPGdLJij3fDEgKLJO4b7#

There are several things pending though
* Get the state to be reflected on all clients
* Forbid multiple clients requesting the same resource
* Display configuration error messages
* Show activity on the rest of the UI