### PR TITLE
SEQNG-825: Fix GHOST coordinates

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOST.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOST.scala
@@ -11,7 +11,7 @@ import fs2.Stream
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import edu.gemini.spModel.gemini.ghost.Ghost
-import gem.math.{Angle, HourAngle}
+import gem.math.{Declination, RightAscension}
 import gem.optics.Format
 
 import scala.concurrent.duration._
@@ -84,8 +84,8 @@ object GHOST {
       }.getOrElse(Right(None))
     }
 
-    val raExtractor = formatExtractor[HourAngle](HourAngle.fromStringHMS)
-    val decExtractor = formatExtractor[Angle](Angle.fromStringDMS)
+    val raExtractor = formatExtractor[RightAscension](RightAscension.fromStringHMS)
+    val decExtractor = formatExtractor[Declination](Declination.fromStringSignedDMS)
 
     EitherT {
       Sync[F].delay {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOST.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOST.scala
@@ -11,7 +11,7 @@ import fs2.Stream
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import edu.gemini.spModel.gemini.ghost.Ghost
-import gem.math.{Declination, RightAscension}
+import gem.math.{Coordinates, Declination, RightAscension}
 import gem.optics.Format
 
 import scala.concurrent.duration._
@@ -111,13 +111,13 @@ object GHOST {
         } yield {
           val hrifu2Name = hrifu2RAHMS.as("Sky")
           GHOSTConfig(
-            baseRAHMS, baseDecDMS, 1.minute,
-            srifu1Name, srifu1RAHMS, srifu1DecHDMS,
-            srifu2Name, srifu2RAHMS, srifu2DecHDMS,
-            hrifu1Name, hrifu1RAHMS, hrifu1DecHDMS,
-            hrifu2Name, hrifu2RAHMS, hrifu2DecHDMS)}
-          )
-          .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
+            (baseRAHMS, baseDecDMS).mapN(Coordinates.apply),
+            1.minute,
+            srifu1Name, (srifu1RAHMS, srifu1DecHDMS).mapN(Coordinates.apply),
+            srifu2Name, (srifu2RAHMS, srifu2DecHDMS).mapN(Coordinates.apply),
+            hrifu1Name, (hrifu1RAHMS, hrifu1DecHDMS).mapN(Coordinates.apply),
+            hrifu2Name, (hrifu2RAHMS, hrifu2DecHDMS).mapN(Coordinates.apply))}
+          ).leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
       }
     }
   }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
@@ -7,7 +7,7 @@ import cats.data.EitherT
 import cats.implicits._
 import cats.{Eq, Show}
 import cats.effect.Sync
-import gem.math.{Angle, Declination, HourAngle, RightAscension}
+import gem.math.{Declination, RightAscension}
 import giapi.client.commands.{CommandResult, CommandResultException, Configuration}
 import giapi.client.ghost.GHOSTClient
 import seqexec.model.dhs.ImageFileId
@@ -45,8 +45,8 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
         val ifuTargetType = IFUTargetType.determineType(nameOpt)
         cfg("target", ifuTargetType.targetType) |+|
           cfg("type", DemandType.DemandRADec.demandType) |+|
-          cfg("ra", ra.) |+|
-          cfg("dec", dec.toDoubleDegrees) |+|
+          cfg("ra", ra.toHourAngle.toDoubleDegrees) |+|
+          cfg("dec", dec.toAngle.toSignedDoubleDegrees) |+|
           cfg("bundle", bundleConfig.determineType(ifuTargetType).configName)
 
       // Case 2: IFU is explicitly excluded from use.
@@ -173,21 +173,21 @@ object GHOSTController {
     * will force others to be None. Eventually, we will want to represent all the target information in a type-safe
     * way that GHOST uses in the ODB.
     */
-  final case class GHOSTConfig(baseRAHMS: Option[HourAngle],
-                               baseDecDMS: Option[Angle],
+  final case class GHOSTConfig(baseRAHMS: Option[RightAscension],
+                               baseDecDMS: Option[Declination],
                                expTime: Duration,
                                srifu1Name: Option[String],
-                               srifu1CoordsRAHMS: Option[HourAngle],
-                               srifu1CoordsDecDMS: Option[Angle],
+                               srifu1CoordsRAHMS: Option[RightAscension],
+                               srifu1CoordsDecDMS: Option[Declination],
                                srifu2Name: Option[String],
-                               srifu2CoordsRAHMS: Option[HourAngle],
-                               srifu2CoordsDecDMS: Option[Angle],
+                               srifu2CoordsRAHMS: Option[RightAscension],
+                               srifu2CoordsDecDMS: Option[Declination],
                                hrifu1Name: Option[String],
-                               hrifu1CoordsRAHMS: Option[HourAngle],
-                               hrifu1CoordsDecDMS: Option[Angle],
+                               hrifu1CoordsRAHMS: Option[RightAscension],
+                               hrifu1CoordsDecDMS: Option[Declination],
                                hrifu2Name: Option[String],
-                               hrifu2CoordsRAHMS: Option[HourAngle],
-                               hrifu2CoordsDecDMS: Option[Angle])
+                               hrifu2CoordsRAHMS: Option[RightAscension],
+                               hrifu2CoordsDecDMS: Option[Declination])
 
   object GHOSTConfig {
     private implicit val durationEq: Eq[Duration] = Eq.by(_.toMillis)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
@@ -7,7 +7,7 @@ import cats.data.EitherT
 import cats.implicits._
 import cats.{Eq, Show}
 import cats.effect.Sync
-import gem.math.{Declination, RightAscension}
+import gem.math.Coordinates
 import giapi.client.commands.{CommandResult, CommandResultException, Configuration}
 import giapi.client.ghost.GHOSTClient
 import seqexec.model.dhs.ImageFileId
@@ -33,24 +33,23 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
   // Right now, this only generate a config if the name, RA, and dec are defined: otherwise, we get the empty config.
   private def ifuConfig(ifuNum: IFUNum,
                         nameOpt: Option[String],
-                        raOpt: Option[RightAscension],
-                        decOpt: Option[Declination],
+                        coordsOpt: Option[Coordinates],
                         bundleConfig: BundleConfig): Configuration = {
     def cfg[P: Show](paramName: String, paramVal: P) =
       Configuration.single(s"${ifuNum.ifuStr}.$paramName", paramVal)
 
-    (raOpt, decOpt) match {
+    coordsOpt match {
       // Case 1: IFU is in use here for an actual position.
-      case (Some(ra), Some(dec)) if nameOpt.isDefined =>
+      case Some(coords) if nameOpt.isDefined =>
         val ifuTargetType = IFUTargetType.determineType(nameOpt)
         cfg("target", ifuTargetType.targetType) |+|
           cfg("type", DemandType.DemandRADec.demandType) |+|
-          cfg("ra", ra.toHourAngle.toDoubleDegrees) |+|
-          cfg("dec", dec.toAngle.toSignedDoubleDegrees) |+|
+          cfg("ra", coords.ra.toHourAngle.toDoubleDegrees) |+|
+          cfg("dec", coords.dec.toAngle.toSignedDoubleDegrees) |+|
           cfg("bundle", bundleConfig.determineType(ifuTargetType).configName)
 
       // Case 2: IFU is explicitly excluded from use.
-      case (None, None) if nameOpt.isDefined =>
+      case None if nameOpt.isDefined =>
         cfg("target", IFUTargetType.NoTarget.targetType) |+|
           cfg("type", DemandType.DemandPark.demandType)
 
@@ -61,18 +60,14 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
   }
 
   private def ifu1Config(config: GHOSTConfig): Configuration = {
-    val srConfig = ifuConfig(IFUNum.IFU1, config.srifu1Name, config.srifu1CoordsRAHMS,
-      config.srifu1CoordsDecDMS, BundleConfig.Standard)
-    val hrConfig = ifuConfig(IFUNum.IFU2, config.hrifu1Name, config.hrifu1CoordsRAHMS,
-      config.hrifu1CoordsDecDMS, BundleConfig.HighRes)
+    val srConfig = ifuConfig(IFUNum.IFU1, config.srifu1Name, config.srifu1Coords, BundleConfig.Standard)
+    val hrConfig = ifuConfig(IFUNum.IFU2, config.hrifu1Name, config.hrifu1Coords, BundleConfig.HighRes)
     srConfig |+| hrConfig
   }
 
   private def ifu2Config(config: GHOSTConfig): Configuration = {
-    val srConfig = ifuConfig(IFUNum.IFU2, config.srifu2Name, config.srifu2CoordsRAHMS,
-      config.srifu2CoordsDecDMS, BundleConfig.Standard)
-    val hrConfig = ifuConfig(IFUNum.IFU2, config.hrifu2Name, config.srifu2CoordsRAHMS, config.srifu2CoordsDecDMS,
-      BundleConfig.HighRes)
+    val srConfig = ifuConfig(IFUNum.IFU2, config.srifu2Name, config.srifu2Coords, BundleConfig.Standard)
+    val hrConfig = ifuConfig(IFUNum.IFU2, config.hrifu2Name, config.srifu2Coords, BundleConfig.HighRes)
     srConfig |+| hrConfig
   }
 
@@ -173,41 +168,31 @@ object GHOSTController {
     * will force others to be None. Eventually, we will want to represent all the target information in a type-safe
     * way that GHOST uses in the ODB.
     */
-  final case class GHOSTConfig(baseRAHMS: Option[RightAscension],
-                               baseDecDMS: Option[Declination],
+  final case class GHOSTConfig(baseCoords: Option[Coordinates],
                                expTime: Duration,
                                srifu1Name: Option[String],
-                               srifu1CoordsRAHMS: Option[RightAscension],
-                               srifu1CoordsDecDMS: Option[Declination],
+                               srifu1Coords: Option[Coordinates],
                                srifu2Name: Option[String],
-                               srifu2CoordsRAHMS: Option[RightAscension],
-                               srifu2CoordsDecDMS: Option[Declination],
+                               srifu2Coords: Option[Coordinates],
                                hrifu1Name: Option[String],
-                               hrifu1CoordsRAHMS: Option[RightAscension],
-                               hrifu1CoordsDecDMS: Option[Declination],
+                               hrifu1Coords: Option[Coordinates],
                                hrifu2Name: Option[String],
-                               hrifu2CoordsRAHMS: Option[RightAscension],
-                               hrifu2CoordsDecDMS: Option[Declination])
+                               hrifu2Coords: Option[Coordinates])
 
   object GHOSTConfig {
     private implicit val durationEq: Eq[Duration] = Eq.by(_.toMillis)
     implicit val eq: Eq[GHOSTConfig] = Eq.by(
       x =>
-        (x.baseRAHMS,
-          x.baseDecDMS,
+        (x.baseCoords,
           x.expTime,
           x.srifu1Name,
-          x.srifu1CoordsRAHMS,
-          x.srifu1CoordsDecDMS,
+          x.srifu1Coords,
           x.srifu2Name,
-          x.srifu2CoordsRAHMS,
-          x.srifu2CoordsDecDMS,
+          x.srifu2Coords,
           x.hrifu1Name,
-          x.hrifu1CoordsRAHMS,
-          x.hrifu1CoordsDecDMS,
+          x.hrifu1Coords,
           x.hrifu2Name,
-          x.hrifu2CoordsRAHMS,
-          x.hrifu2CoordsDecDMS))
+          x.hrifu2Coords))
 
     implicit val show: Show[GHOSTConfig] = Show.fromToString
   }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
@@ -7,7 +7,7 @@ import cats.data.EitherT
 import cats.implicits._
 import cats.{Eq, Show}
 import cats.effect.Sync
-import gem.math.{Angle, HourAngle}
+import gem.math.{Angle, Declination, HourAngle, RightAscension}
 import giapi.client.commands.{CommandResult, CommandResultException, Configuration}
 import giapi.client.ghost.GHOSTClient
 import seqexec.model.dhs.ImageFileId
@@ -33,8 +33,8 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
   // Right now, this only generate a config if the name, RA, and dec are defined: otherwise, we get the empty config.
   private def ifuConfig(ifuNum: IFUNum,
                         nameOpt: Option[String],
-                        raOpt: Option[HourAngle],
-                        decOpt: Option[Angle],
+                        raOpt: Option[RightAscension],
+                        decOpt: Option[Declination],
                         bundleConfig: BundleConfig): Configuration = {
     def cfg[P: Show](paramName: String, paramVal: P) =
       Configuration.single(s"${ifuNum.ifuStr}.$paramName", paramVal)
@@ -45,7 +45,7 @@ final case class GHOSTController[F[_]: Sync](ghostClient: GHOSTClient[F],
         val ifuTargetType = IFUTargetType.determineType(nameOpt)
         cfg("target", ifuTargetType.targetType) |+|
           cfg("type", DemandType.DemandRADec.demandType) |+|
-          cfg("ra", ra.toDoubleDegrees) |+|
+          cfg("ra", ra.) |+|
           cfg("dec", dec.toDoubleDegrees) |+|
           cfg("bundle", bundleConfig.determineType(ifuTargetType).configName)
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
@@ -7,7 +7,8 @@ import edu.gemini.seqexec.server.tcs.{BinaryOnOff, BinaryYesNo}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams
 import gem.arb.ArbTime
-import gem.arb.ArbAngle._
+import gem.arb.ArbDeclination._
+import gem.arb.ArbRightAscension._
 import gem.arb.ArbEnumerated._
 import gem.Observation
 import gem.enum.KeywordName
@@ -34,7 +35,7 @@ import edu.gemini.spModel.gemini.gpi.Gpi.{Lyot => LegacyLyot}
 import edu.gemini.spModel.gemini.gpi.Gpi.{ObservingMode => LegacyObservingMode}
 import edu.gemini.spModel.gemini.gpi.Gpi.{PupilCamera => LegacyPupilCamera}
 import edu.gemini.spModel.gemini.gpi.Gpi.{Shutter => LegacyShutter}
-import gem.math.{Angle, HourAngle}
+import gem.math.{Declination, RightAscension}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import squants.space.LengthConversions._
@@ -245,14 +246,14 @@ object SeqexecServerArbitraries extends ArbTime {
 
   implicit val ghostConfigArb: Arbitrary[GHOSTController.GHOSTConfig] = Arbitrary {
     for {
-      baseRA <- arbitrary[HourAngle]
-      baseDec <- arbitrary[Angle]
+      baseRA <- arbitrary[RightAscension]
+      baseDec <- arbitrary[Declination]
       srifu1name <- arbitrary[String]
-      srifu1RA <- arbitrary[HourAngle]
-      srifu1Dec <- arbitrary[Angle]
+      srifu1RA <- arbitrary[RightAscension]
+      srifu1Dec <- arbitrary[Declination]
       srifu2name <- arbitrary[String]
-      srifu2RA <- arbitrary[HourAngle]
-      srifu2Dec <- arbitrary[Angle]
+      srifu2RA <- arbitrary[RightAscension]
+      srifu2Dec <- arbitrary[Declination]
     } yield GHOSTConfig(Some(baseRA), Some(baseDec), 60.seconds,
       Some(srifu1name), Some(srifu1RA), Some(srifu1Dec),
       Some(srifu2name), Some(srifu1RA), Some(srifu1Dec),
@@ -261,11 +262,11 @@ object SeqexecServerArbitraries extends ArbTime {
     }
 
   implicit val ghostCogen: Cogen[GHOSTController.GHOSTConfig] =
-    Cogen[(Option[HourAngle], Option[Angle], Duration,
-      Option[String], Option[HourAngle], Option[Angle],
-      Option[String], Option[HourAngle], Option[Angle],
-      Option[String], Option[HourAngle], Option[Angle],
-      Option[String], Option[HourAngle], Option[Angle])]
+    Cogen[(Option[RightAscension], Option[Declination], Duration,
+      Option[String], Option[RightAscension], Option[Declination],
+      Option[String], Option[RightAscension], Option[Declination],
+      Option[String], Option[RightAscension], Option[Declination],
+      Option[String], Option[RightAscension], Option[Declination])]
     .contramap(x => (x.baseRAHMS, x.baseDecDMS, x.expTime,
       x.srifu2Name, x.srifu1CoordsRAHMS, x.srifu1CoordsDecDMS,
       x.srifu2Name, x.srifu2CoordsRAHMS, x.srifu2CoordsDecDMS,

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
@@ -7,8 +7,7 @@ import edu.gemini.seqexec.server.tcs.{BinaryOnOff, BinaryYesNo}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams
 import gem.arb.ArbTime
-import gem.arb.ArbDeclination._
-import gem.arb.ArbRightAscension._
+import gem.arb.ArbCoordinates._
 import gem.arb.ArbEnumerated._
 import gem.Observation
 import gem.enum.KeywordName
@@ -35,7 +34,7 @@ import edu.gemini.spModel.gemini.gpi.Gpi.{Lyot => LegacyLyot}
 import edu.gemini.spModel.gemini.gpi.Gpi.{ObservingMode => LegacyObservingMode}
 import edu.gemini.spModel.gemini.gpi.Gpi.{PupilCamera => LegacyPupilCamera}
 import edu.gemini.spModel.gemini.gpi.Gpi.{Shutter => LegacyShutter}
-import gem.math.{Declination, RightAscension}
+import gem.math.Coordinates
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import squants.space.LengthConversions._
@@ -246,32 +245,28 @@ object SeqexecServerArbitraries extends ArbTime {
 
   implicit val ghostConfigArb: Arbitrary[GHOSTController.GHOSTConfig] = Arbitrary {
     for {
-      baseRA <- arbitrary[RightAscension]
-      baseDec <- arbitrary[Declination]
+      basePos    <- arbitrary[Coordinates]
       srifu1name <- arbitrary[String]
-      srifu1RA <- arbitrary[RightAscension]
-      srifu1Dec <- arbitrary[Declination]
+      srifu1Pos  <- arbitrary[Coordinates]
       srifu2name <- arbitrary[String]
-      srifu2RA <- arbitrary[RightAscension]
-      srifu2Dec <- arbitrary[Declination]
-    } yield GHOSTConfig(Some(baseRA), Some(baseDec), 60.seconds,
-      Some(srifu1name), Some(srifu1RA), Some(srifu1Dec),
-      Some(srifu2name), Some(srifu1RA), Some(srifu1Dec),
-      None, None, None,
-      None, None, None)
+      srifu2Pos  <- arbitrary[Coordinates]
+    } yield GHOSTConfig(Some(basePos), 60.seconds,
+      Some(srifu1name), Some(srifu1Pos),
+      Some(srifu2name), Some(srifu2Pos),
+      None, None, None, None)
     }
 
   implicit val ghostCogen: Cogen[GHOSTController.GHOSTConfig] =
-    Cogen[(Option[RightAscension], Option[Declination], Duration,
-      Option[String], Option[RightAscension], Option[Declination],
-      Option[String], Option[RightAscension], Option[Declination],
-      Option[String], Option[RightAscension], Option[Declination],
-      Option[String], Option[RightAscension], Option[Declination])]
-    .contramap(x => (x.baseRAHMS, x.baseDecDMS, x.expTime,
-      x.srifu2Name, x.srifu1CoordsRAHMS, x.srifu1CoordsDecDMS,
-      x.srifu2Name, x.srifu2CoordsRAHMS, x.srifu2CoordsDecDMS,
-      x.hrifu1Name, x.hrifu1CoordsRAHMS, x.hrifu1CoordsDecDMS,
-      x.hrifu2Name, x.hrifu2CoordsRAHMS, x.hrifu2CoordsDecDMS
+    Cogen[(Option[Coordinates], Duration,
+      Option[String], Option[Coordinates],
+      Option[String], Option[Coordinates],
+      Option[String], Option[Coordinates],
+      Option[String], Option[Coordinates])]
+    .contramap(x => (x.baseCoords, x.expTime,
+      x.srifu2Name, x.srifu1Coords,
+      x.srifu2Name, x.srifu2Coords,
+      x.hrifu1Name, x.hrifu1Coords,
+      x.hrifu2Name, x.hrifu2Coords
     ))
 
   implicit val keywordTypeArb: Arbitrary[KeywordType] = Arbitrary {


### PR DESCRIPTION
During GHOST testing, it was discovered that the seqexec had illegal values for declination. This was due to me using `HourAngle` and `Angle` instead of `RightAscension` and `Declination`, as I should have.

This fixes that.