### PR TITLE
SEQNG-826 Catch errors when binding to stop and abort channels.

### DIFF
--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -129,27 +129,43 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
             }
         });
 
+        ReadOnlyClientEpicsChannel<Short> stopMark = null;
         if(stopCmd!=null && stopCmd.length()>0) {
-            stopMark = epicsReader.getShortChannel(stopCmd + CAD_MARK_SUFFIX);
-            stopMark.registerListener(stopMarkListener = (String arg0, List<Short> newVals) -> {
-                if (newVals != null && !newVals.isEmpty()) {
-                    CaObserveSenderImpl.this.onStopMarkChange(newVals.get(0));
-                }
-            });
+            try {
+                stopMark = epicsReader.getShortChannel(stopCmd + CAD_MARK_SUFFIX);
+            } catch(Throwable e) {
+                LOG.warn(e.getMessage());
+            }
+            if(stopMark!=null) {
+                stopMark.registerListener(stopMarkListener = (String arg0, List<Short> newVals) -> {
+                    if (newVals != null && !newVals.isEmpty()) {
+                        CaObserveSenderImpl.this.onStopMarkChange(newVals.get(0));
+                    }
+                });
+            }
         } else {
             stopMark = null;
         }
+        this.stopMark = stopMark;
 
+        ReadOnlyClientEpicsChannel<Short> abortMark = null;
         if(abortCmd!=null && abortCmd.length()>0) {
-            abortMark = epicsReader.getShortChannel(abortCmd + CAD_MARK_SUFFIX);
-            abortMark.registerListener(abortMarkListener = (String arg0, List<Short> newVals) -> {
-                if (newVals != null && !newVals.isEmpty()) {
-                    CaObserveSenderImpl.this.onAbortMarkChange(newVals.get(0));
-                }
-            });
+            try {
+                abortMark = epicsReader.getShortChannel(abortCmd + CAD_MARK_SUFFIX);
+            } catch(Throwable e) {
+                LOG.warn(e.getMessage());
+            }
+            if(abortMark!=null) {
+                abortMark.registerListener(abortMarkListener = (String arg0, List<Short> newVals) -> {
+                    if (newVals != null && !newVals.isEmpty()) {
+                        CaObserveSenderImpl.this.onAbortMarkChange(newVals.get(0));
+                    }
+                });
+            }
         } else {
             abortMark = null;
         }
+        this.abortMark = abortMark;
 
         executor = new ScheduledThreadPoolExecutor(2);
     }


### PR DESCRIPTION
This solves the issue with Seqexec crashing on startup if GNIRS was not available (could have happened with other instruments, but was discovered with GNIRS).