### PR TITLE
Several countdown fixes

### DIFF
--- a/modules/seqexec/server/src/main/resources/Flamingos2.xml
+++ b/modules/seqexec/server/src/main/resources/Flamingos2.xml
@@ -453,6 +453,11 @@
             <type>STRING</type>
             <description>Temperature reported by LS-332 Channel B</description>
         </attribute>
+        <attribute name="countdown">
+            <channel>sad:TIMELEFT</channel>
+            <type>INTEGER</type>
+            <description>Remaining time in current exposure</description>
+        </attribute>
         <attribute name="WCSDIM">
             <channel>sad:WCSDIM</channel>
             <type>STRING</type>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -253,7 +253,8 @@ object EpicsUtil {
         c <- rem
         s <- st
         if s.isBusy
-      } yield Progress(total, RemainingTime(c))
-    })
+      } yield Progress(if(total>c) total else c, RemainingTime(c))
+    }).dropWhile(_.remaining.self.value === 0.0) // drop leading zeros
+      .takeThrough(_.remaining.self.value > 0.0) // drop all tailing zeros but the first one
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -252,6 +252,7 @@ object EpicsUtil {
       for{
         c <- rem
         s <- st
+        dummy = s // Hack to avoid scala/bug#11175
         if s.isBusy
       } yield Progress(if(total>c) total else c, RemainingTime(c))
     }).dropWhile(_.remaining.self.value === 0.0) // drop leading zeros

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ProgressUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ProgressUtil.scala
@@ -26,6 +26,12 @@ object ProgressUtil {
     Scheduler[F](1).flatMap(sch =>
       sch.awakeEvery(PollPeriod).evalMapAccumulate(s0){case (st, t) => fs(t).run(st)}.map(_._2))
 
+  def fromStateTOption[F[_]: Effect, S](fs: FiniteDuration => StateT[F, S, Option[Progress]])
+  : S => Stream[F, Progress] = s0 =>
+    Scheduler[F](1).flatMap(sch =>
+      sch.awakeEvery(PollPeriod).evalMapAccumulate(s0){case (st, t) => fs(t).run(st)}.map(_._2))
+      .collect{ case Some(p) => p }
+
   def countdown[F[_]: Effect](total: Time, elapsed: Time): Stream[F, Progress] =
     ProgressUtil.fromF[F] {
       t: FiniteDuration => {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
@@ -140,6 +140,7 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
         val m = if (total >= st) total else st
         val p = for {
           obst <- Flamingos2Epics.instance.observeState
+          dummy = obst // Hack to avoid scala/bug#11175
           if obst.isBusy
           rem <- Flamingos2Epics.instance.countdown.map(_.seconds)
         } yield Progress(m, RemainingTime(rem))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
@@ -6,7 +6,7 @@ package seqexec.server.flamingos2
 import cats.data.EitherT
 import cats.effect.IO
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.{EpicsCodex, ObserveCommand, Progress, ProgressUtil, RemainingTime, SeqAction}
+import seqexec.server.{EpicsCodex, EpicsUtil, ObserveCommand, Progress, SeqAction}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.{Decker, Filter, ReadoutMode, WindowCover, _}
 import org.log4s.getLogger
 import squants.{Seconds, Time}
@@ -133,9 +133,9 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
     _ <- Flamingos2Epics.instance.endObserveCmd.post
   } yield ()
 
-  override def observeProgress(total: Time): fs2.Stream[IO, Progress] = ProgressUtil.fromFOption(
-    _ => IO(Flamingos2Epics.instance.countdown.map(c => Progress(total, RemainingTime(c.seconds))))
-  )
+  override def observeProgress(total: Time): fs2.Stream[IO, Progress] =
+    EpicsUtil.countdown[IO](total, IO(Flamingos2Epics.instance.countdown.map(_.seconds)),
+      IO(Flamingos2Epics.instance.observeState))
 
   val ReadoutTimeout: Time = Seconds(300)
   val DefaultTimeout: Time = Seconds(60)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
@@ -6,10 +6,11 @@ package seqexec.server.flamingos2
 import cats.data.EitherT
 import cats.effect.IO
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.{EpicsCodex, ObserveCommand, Progress, ProgressUtil, SeqAction}
+import seqexec.server.{EpicsCodex, ObserveCommand, Progress, ProgressUtil, RemainingTime, SeqAction}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.{Decker, Filter, ReadoutMode, WindowCover, _}
 import org.log4s.getLogger
 import squants.{Seconds, Time}
+import squants.time.TimeConversions._
 
 object Flamingos2ControllerEpics extends Flamingos2Controller {
   private val Log = getLogger
@@ -19,20 +20,16 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
 
   override def getConfig: SeqAction[Flamingos2Config] = ??? // scalastyle:ignore
 
-  implicit val encodeReadoutMode: EncodeEpicsValue[ReadoutMode, String] = EncodeEpicsValue((a: ReadoutMode)
-    => a match {
-      case ReadoutMode.SCIENCE     => "SCI"
-      case ReadoutMode.ENGINEERING => "ENG"
-    }
-  )
+  implicit val encodeReadoutMode: EncodeEpicsValue[ReadoutMode, String] = EncodeEpicsValue {
+    case ReadoutMode.SCIENCE     => "SCI"
+    case ReadoutMode.ENGINEERING => "ENG"
+  }
 
-  implicit val encodeBiasMode: EncodeEpicsValue[BiasMode, String] = EncodeEpicsValue((a: BiasMode)
-    => a match {
-      case BiasMode.Imaging  => "Imaging"
-      case BiasMode.LongSlit => "Long_Slit"
-      case BiasMode.MOS      => "Mos"
-    }
-  )
+  implicit val encodeBiasMode: EncodeEpicsValue[BiasMode, String] = EncodeEpicsValue {
+    case BiasMode.Imaging  => "Imaging"
+    case BiasMode.LongSlit => "Long_Slit"
+    case BiasMode.MOS      => "Mos"
+  }
 
   def setDCConfig(dc: DCConfig): SeqAction[Unit] = for {
     _ <- Flamingos2Epics.instance.dcConfigCmd.setExposureTime(dc.t.toSeconds.toDouble)
@@ -41,77 +38,65 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
     _ <- Flamingos2Epics.instance.dcConfigCmd.setBiasMode(encode(dc.b))
   } yield ()
 
-  implicit val encodeWindowCoverPosition: EncodeEpicsValue[WindowCover, String] = EncodeEpicsValue((a: WindowCover)
-    => a match {
-      case WindowCover.OPEN  => "Open"
-      case WindowCover.CLOSE => "Closed"
-    }
-  )
+  implicit val encodeWindowCoverPosition: EncodeEpicsValue[WindowCover, String] = EncodeEpicsValue {
+    case WindowCover.OPEN  => "Open"
+    case WindowCover.CLOSE => "Closed"
+  }
 
-  implicit val encodeDeckerPosition: EncodeEpicsValue[Decker, String] = EncodeEpicsValue((a: Decker)
-    => a match {
-      case Decker.IMAGING   => "Open"
-      case Decker.LONG_SLIT => "Long_Slit"
-      case Decker.MOS       => "Mos"
-    }
-  )
+  implicit val encodeDeckerPosition: EncodeEpicsValue[Decker, String] = EncodeEpicsValue {
+    case Decker.IMAGING   => "Open"
+    case Decker.LONG_SLIT => "Long_Slit"
+    case Decker.MOS       => "Mos"
+  }
 
-  implicit val encodeFPUPosition: EncodeEpicsValue[FocalPlaneUnit, (String, String)] = EncodeEpicsValue((a: FocalPlaneUnit)
-    => a match {
-      case FocalPlaneUnit.Open        => ("Open", "null")
-      case FocalPlaneUnit.GridSub1Pix => ("sub1-pix_grid", "null")
-      case FocalPlaneUnit.Grid2Pix    => ("2-pix_grid", "null")
-      case FocalPlaneUnit.Slit1Pix    => ("1pix-slit", "null")
-      case FocalPlaneUnit.Slit2Pix    => ("2pix-slit", "null")
-      case FocalPlaneUnit.Slit3Pix    => ("3pix-slit", "null")
-      case FocalPlaneUnit.Slit4Pix    => ("4pix-slit", "null")
-      case FocalPlaneUnit.Slit6Pix    => ("6pix-slit", "null")
-      case FocalPlaneUnit.Slit8Pix    => ("8pix-slit", "null")
-      case FocalPlaneUnit.Custom(s)   => ("null", s)
-    }
-  )
+  implicit val encodeFPUPosition: EncodeEpicsValue[FocalPlaneUnit, (String, String)] = EncodeEpicsValue {
+    case FocalPlaneUnit.Open        => ("Open", "null")
+    case FocalPlaneUnit.GridSub1Pix => ("sub1-pix_grid", "null")
+    case FocalPlaneUnit.Grid2Pix    => ("2-pix_grid", "null")
+    case FocalPlaneUnit.Slit1Pix    => ("1pix-slit", "null")
+    case FocalPlaneUnit.Slit2Pix    => ("2pix-slit", "null")
+    case FocalPlaneUnit.Slit3Pix    => ("3pix-slit", "null")
+    case FocalPlaneUnit.Slit4Pix    => ("4pix-slit", "null")
+    case FocalPlaneUnit.Slit6Pix    => ("6pix-slit", "null")
+    case FocalPlaneUnit.Slit8Pix    => ("8pix-slit", "null")
+    case FocalPlaneUnit.Custom(s)   => ("null", s)
+  }
 
-  implicit val encodeFilterPosition: EncodeEpicsValue[Filter, String] = EncodeEpicsValue((a: Filter)
-    => a match {
-      case Filter.OPEN    => "Open"
-      case Filter.Y       => "Y_G0811"
-      case Filter.F1056   => "F1056"
-      case Filter.F1063   => "F1063"
-      case Filter.J_LOW   => "J-lo_G0801"
-      case Filter.J       => "J_G0802"
-      case Filter.H       => "H_G0803"
-      case Filter.K_LONG  => "K-long_G0812"
-      case Filter.K_SHORT => "Ks_G0804"
-      case Filter.JH      => "JH_G0809"
-      case Filter.HK      => "HK_G0806"
-      case Filter.DARK    => "DK_G0807"
-      case Filter.K_BLUE  => "K-blue_G0814"
-      case Filter.K_RED   => "K-red_G0815"
-    }
-  )
+  implicit val encodeFilterPosition: EncodeEpicsValue[Filter, String] = EncodeEpicsValue {
+    case Filter.OPEN    => "Open"
+    case Filter.Y       => "Y_G0811"
+    case Filter.F1056   => "F1056"
+    case Filter.F1063   => "F1063"
+    case Filter.J_LOW   => "J-lo_G0801"
+    case Filter.J       => "J_G0802"
+    case Filter.H       => "H_G0803"
+    case Filter.K_LONG  => "K-long_G0812"
+    case Filter.K_SHORT => "Ks_G0804"
+    case Filter.JH      => "JH_G0809"
+    case Filter.HK      => "HK_G0806"
+    case Filter.DARK    => "DK_G0807"
+    case Filter.K_BLUE  => "K-blue_G0814"
+    case Filter.K_RED   => "K-red_G0815"
+  }
 
-  implicit val encodeLyotPosition: EncodeEpicsValue[Lyot, String] = EncodeEpicsValue((a: Lyot)
-    => a match {
-      case LyotWheel.OPEN       => "f/16_G5830"
-      case LyotWheel.HIGH       => "null"
-      case LyotWheel.LOW        => "null"
-      case LyotWheel.GEMS_OVER  => "GEMS_over_G5836"
-      case LyotWheel.GEMS_UNDER => "GEMS_under_G5835"
-      case LyotWheel.GEMS       => "Gems_G5835"
-      case LyotWheel.H1         => "Hart1_G5833"
-      case LyotWheel.H2         => "Hart2_G5834"
-    }
-  )
+  implicit val encodeLyotPosition: EncodeEpicsValue[Lyot, String] = EncodeEpicsValue {
+    case LyotWheel.OPEN       => "f/16_G5830"
+    case LyotWheel.HIGH       => "null"
+    case LyotWheel.LOW        => "null"
+    case LyotWheel.GEMS_OVER  => "GEMS_over_G5836"
+    case LyotWheel.GEMS_UNDER => "GEMS_under_G5835"
+    case LyotWheel.GEMS       => "Gems_G5835"
+    case LyotWheel.H1         => "Hart1_G5833"
+    case LyotWheel.H2         => "Hart2_G5834"
+  }
 
-  implicit val encodeGrismPosition: EncodeEpicsValue[Grism, String] = EncodeEpicsValue((a: Grism)
-    => a match {
-      case Grism.Open    => "Open"
-      case Grism.R1200HK => "HK_G5802"
-      case Grism.R1200JH => "JH_G5801"
-      case Grism.R3000   => "R3K_G5803"
-      case Grism.Dark    => "DK_G5804"
-    }
-  )
+  implicit val encodeGrismPosition: EncodeEpicsValue[Grism, String] = EncodeEpicsValue {
+    case Grism.Open    => "Open"
+    case Grism.R1200HK => "HK_G5802"
+    case Grism.R1200JH => "JH_G5801"
+    case Grism.R3000   => "R3K_G5803"
+    case Grism.Dark    => "DK_G5804"
+  }
 
   def setCCConfig(cc: CCConfig): SeqAction[Unit] = {
     val fpu = encode(cc.fpu)
@@ -148,8 +133,9 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
     _ <- Flamingos2Epics.instance.endObserveCmd.post
   } yield ()
 
-  override def observeProgress(total: Time): fs2.Stream[IO, Progress] =
-    ProgressUtil.countdown[IO](total, Seconds(0))
+  override def observeProgress(total: Time): fs2.Stream[IO, Progress] = ProgressUtil.fromFOption(
+    _ => IO(Flamingos2Epics.instance.countdown.map(c => Progress(total, RemainingTime(c.seconds))))
+  )
 
   val ReadoutTimeout: Time = Seconds(300)
   val DefaultTimeout: Time = Seconds(60)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Epics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Epics.scala
@@ -80,7 +80,7 @@ final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) 
 
   }
 
-  private val f2State = epicsService.getStatusAcceptor("flamingos2::dcstatus")
+  private val f2State = epicsService.getStatusAcceptor("flamingos2::status")
 
   def exposureTime: Option[String] = Option(f2State.getStringAttribute("exposureTime").value)
 
@@ -102,6 +102,10 @@ final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) 
 
   def countdown: Option[Int] = Option(f2State.getIntegerAttribute("countdown").value)
     .map(_.toInt)
+
+  private val observeCAttr: CaAttribute[CarState] = f2State.addEnum("observeState",
+    F2_TOP + "observeC.VAL", classOf[CarState])
+  def observeState: Option[CarState] = Option(observeCAttr.value)
 
   // For FITS keywords
   def health: Option[String] = Option(f2State.getStringAttribute("INHEALTH").value)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Epics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Epics.scala
@@ -54,7 +54,8 @@ final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) 
   object configCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::config"))
 
-    private val useElectronicOffsetting = cs.map(_.addInteger("useElectronicOffsetting", F2_TOP + "wfs:followA.K", "Enable electronic Offsets", false))
+    private val useElectronicOffsetting = cs.map(_.addInteger("useElectronicOffsetting",
+      s"${F2_TOP}wfs:followA.K", "Enable electronic Offsets", false))
     def setUseElectronicOffsetting(v: Integer): SeqAction[Unit] = setParameter(useElectronicOffsetting, v)
 
     private val filter = cs.map(_.getString("filter"))
@@ -104,7 +105,7 @@ final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) 
     .map(_.toInt)
 
   private val observeCAttr: CaAttribute[CarState] = f2State.addEnum("observeState",
-    F2_TOP + "observeC.VAL", classOf[CarState])
+    s"{F2_TOP}observeC.VAL", classOf[CarState])
   def observeState: Option[CarState] = Option(observeCAttr.value)
 
   // For FITS keywords

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Epics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Epics.scala
@@ -100,6 +100,9 @@ final class Flamingos2Epics(epicsService: CaService, tops: Map[String, String]) 
 
   def windowCover: Option[String] = Option(f2State.getStringAttribute("windowCover").value)
 
+  def countdown: Option[Int] = Option(f2State.getIntegerAttribute("countdown").value)
+    .map(_.toInt)
+
   // For FITS keywords
   def health: Option[String] = Option(f2State.getStringAttribute("INHEALTH").value)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -6,8 +6,13 @@ package seqexec.server.gmos
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.EpicsCodex.EncodeEpicsValue
 import seqexec.server.gmos.GmosController.Config.{Beam, InBeam, OutOfBeam, ROI}
-import seqexec.server.{EpicsCodex, EpicsUtil, ObserveCommand, Progress, SeqAction, SeqexecFailure}
+import seqexec.server.EpicsCodex
+import seqexec.server.EpicsUtil
 import seqexec.server.EpicsUtil.smartSetParam
+import seqexec.server.ObserveCommand
+import seqexec.server.Progress
+import seqexec.server.SeqAction
+import seqexec.server.SeqexecFailure
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.AmpReadMode
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.AmpGain
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.AmpCount
@@ -70,7 +75,7 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
 
   private def setShutterState(s: ShutterState): SeqAction[Unit] = s match {
     case UnsetShutter => SeqAction.void
-    case s            => DC.setShutterState(encode(s))
+    case sh           => DC.setShutterState(encode(sh))
   }
 
   private def roiNumUsed(s: RegionsOfInterest): Int = s.rois match {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -6,7 +6,7 @@ package seqexec.server.gmos
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.EpicsCodex.EncodeEpicsValue
 import seqexec.server.gmos.GmosController.Config.{Beam, InBeam, OutOfBeam, ROI}
-import seqexec.server.{EpicsCodex, ObserveCommand, Progress, ProgressUtil, RemainingTime, SeqAction, SeqexecFailure}
+import seqexec.server.{EpicsCodex, EpicsUtil, ObserveCommand, Progress, SeqAction, SeqexecFailure}
 import seqexec.server.EpicsUtil.smartSetParam
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.AmpReadMode
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.AmpGain
@@ -245,9 +245,8 @@ class GmosControllerEpics[T<:GmosController.SiteDependentTypes](encoders: GmosCo
   } yield if(ret === ObserveCommand.Success) ObserveCommand.Aborted else ret
 
   override def observeProgress(total: Time, elapsed: ElapsedTime): Stream[IO, Progress] =
-    ProgressUtil.fromFOption(_ => IO(
-      GmosEpics.instance.countdown.map(c => Progress(total, RemainingTime(c.seconds)))
-    ))
+    EpicsUtil.countdown[IO](total, IO(GmosEpics.instance.countdown.map(_.seconds)),
+      IO(GmosEpics.instance.observeState))
 }
 
 object GmosControllerEpics {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
@@ -33,7 +33,8 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
     val stageMode: Option[CaParameter[String]] = cs.map(_.getString("stageMode"))
     def setStageMode(v: String): SeqAction[Unit] = setParameter(stageMode, v)
 
-    val useElectronicOffsetting: Option[CaParameter[Integer]] = cs.map(_.addInteger("useElectronicOffsetting", GMOS_TOP + "wfs:followA.K", "Enable electronic Offsets", false))
+    val useElectronicOffsetting: Option[CaParameter[Integer]] = cs.map(_.addInteger
+    ("useElectronicOffsetting", s"{GMOS_TOP}wfs:followA.K", "Enable electronic Offsets", false))
     def setElectronicOffsetting(v: Integer): SeqAction[Unit] = setParameter(useElectronicOffsetting, v)
 
     val filter1: Option[CaParameter[String]] = cs.map(_.getString("filter1"))
@@ -69,7 +70,7 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
 
   private val stopCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::stop"))
   private val observeAS: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::observeCmd",
-      GMOS_TOP + "apply", GMOS_TOP + "applyC", GMOS_TOP + "dc:observeC", false, GMOS_TOP + "stop", GMOS_TOP + "abort", ""))
+      s"${GMOS_TOP}apply", s"${GMOS_TOP}applyC", s"${GMOS_TOP}dc:observeC", false, s"${GMOS_TOP}stop", s"${GMOS_TOP}abort", ""))
 
   object continueCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::continue"))
@@ -107,7 +108,7 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
   object configDCCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::dcconfig"))
 
-    val roiNumUsed: Option[CaParameter[JDouble]] = cs.map(_.addDouble("roiNumUsed", GMOS_TOP + "dc:roiNumrois", "Number of ROI used", false))
+    val roiNumUsed: Option[CaParameter[JDouble]] = cs.map(_.addDouble("roiNumUsed", s"${GMOS_TOP}dc:roiNumrois", "Number of ROI used", false))
     def setRoiNumUsed(v: Int): SeqAction[Unit] = setParameter(roiNumUsed, java.lang.Double.valueOf(v.toDouble))
 
     val rois: Map[Int, RoiParameters] = (1 to 5).map(i => i -> RoiParameters(cs, i))(breakOut)
@@ -127,10 +128,10 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
     val gainSetting: Option[CaParameter[Integer]] = cs.map(_.getInteger("gainSetting"))
     def setGainSetting(v: Int): SeqAction[Unit] = setParameter(gainSetting, Integer.valueOf(v))
 
-    val ccdXBinning: Option[CaParameter[JDouble]] = cs.map(_.addDouble("ccdXBinning", GMOS_TOP + "dc:roiXBin", "CCD X Binning Value", false))
+    val ccdXBinning: Option[CaParameter[JDouble]] = cs.map(_.addDouble("ccdXBinning", s"${GMOS_TOP}dc:roiXBin", "CCD X Binning Value", false))
     def setCcdXBinning(v: Int): SeqAction[Unit] = setParameter(ccdXBinning, java.lang.Double.valueOf(v.toDouble))
 
-    val ccdYBinning: Option[CaParameter[JDouble]] = cs.map(_.addDouble("ccdYBinning", GMOS_TOP + "dc:roiYBin", "CCD Y Binning Value", false))
+    val ccdYBinning: Option[CaParameter[JDouble]] = cs.map(_.addDouble("ccdYBinning", s"${GMOS_TOP}dc:roiYBin", "CCD Y Binning Value", false))
     def setCcdYBinning(v: Int): SeqAction[Unit] = setParameter(ccdYBinning, java.lang.Double.valueOf(v.toDouble))
 
     val nsPairs: Option[CaParameter[Integer]] = cs.map(_.getInteger("nsPairs"))
@@ -193,7 +194,7 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
   def dcName: Option[String] = Option(dcState.getStringAttribute("gmosdc").value)
 
   private val observeCAttr: CaAttribute[CarState] = dcState.addEnum("observeC",
-    GMOS_TOP + "dc:observeC", classOf[CarState])
+    s"${GMOS_TOP}dc:observeC", classOf[CarState])
   def observeState: Option[CarState] = Option(observeCAttr.value)
 
   // CC status values

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
@@ -8,10 +8,8 @@ import java.lang.{Double => JDouble}
 import edu.gemini.epics.acm._
 import seqexec.server.EpicsCommand.setParameter
 import seqexec.server.gmos.GmosEpics.{RoiParameters, RoiStatus}
-import seqexec.server.{EpicsCommand, EpicsSystem, ObserveCommand, SeqAction, SeqexecFailure}
-import seqexec.server.EpicsUtil._
+import seqexec.server.{EpicsCommand, EpicsSystem, ObserveCommand, SeqAction}
 import org.log4s.{Logger, getLogger}
-import squants.Time
 
 import scala.collection.breakOut
 import scala.concurrent.duration._
@@ -194,13 +192,9 @@ class GmosEpics(epicsService: CaService, tops: Map[String, String]) {
 
   def dcName: Option[String] = Option(dcState.getStringAttribute("gmosdc").value)
 
-  private val observeCAttr: Option[CaAttribute[CarState]] = Option(dcState.addEnum("observeC",
-    GMOS_TOP + "dc:observeC", classOf[CarState]))
-  def observeC: Option[CarState] = observeCAttr.map(_.value)
-
-  def waitObserve(t: Time): SeqAction[CarState] = observeCAttr.map(attr =>
-    waitForValues(attr, List(CarState.IDLE, CarState.ERROR, CarState.PAUSED),t , "GMOS observe state")).getOrElse(
-    SeqAction.fail(SeqexecFailure.Unexpected(s"Cannot access ${GMOS_TOP}dc:observeC")))
+  private val observeCAttr: CaAttribute[CarState] = dcState.addEnum("observeC",
+    GMOS_TOP + "dc:observeC", classOf[CarState])
+  def observeState: Option[CarState] = Option(observeCAttr.value)
 
   // CC status values
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -296,10 +296,11 @@ object GnirsControllerEpics extends GnirsController {
   private def smartSetDoubleParam(relTolerance: Double)(v: Double, get: => Option[Double], set: SeqAction[Unit]): List[SeqAction[Unit]] =
     if(get.forall(x => (v === 0.0 && x =!= 0.0) || abs((x - v)/v) > relTolerance)) List(set) else Nil
 
-  override def observeProgress(total: Time): Stream[IO, Progress] = ProgressUtil.fromFOption(_ => IO(
-    GnirsEpics.instance.countDown.flatMap(x => Try(x.toDouble).toOption)
-      .map(c => Progress(total, RemainingTime(c.seconds)))
-  ))
+  override def observeProgress(total: Time): Stream[IO, Progress] =
+    EpicsUtil.countdown[IO](total,
+      IO(GnirsEpics.instance.countDown.flatMap(x => Try(x.toDouble).toOption).map(_.seconds)),
+      IO(GnirsEpics.instance.observeState)
+    )
 
 
   private val DefaultTimeout: Time = Seconds(60)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsEpics.scala
@@ -146,6 +146,10 @@ class GnirsEpics(epicsService: CaService, tops: Map[String, String]) {
 
   def lowNoise: Option[Int] = Option(dcState.getIntegerAttribute("lowNoise").value).map(_.toInt)
 
+  private val observeCAttr: CaAttribute[CarStateGEM5] = dcState.addEnum("observeState",
+    GNIRS_TOP + "dc:observeC.VAL", classOf[CarStateGEM5])
+  def observeState: Option[CarStateGEM5] = Option(observeCAttr.value)
+
   def dhcConnected: Option[Int] = Option(dcState.getIntegerAttribute("dhcConnected").value).map(_.toInt)
 
   def minInt: Option[Double] = Option(dcState.getDoubleAttribute("minInt").value).map(_.toDouble)


### PR DESCRIPTION
Countdowns are not so pretty when dealing with the real world.

1. Seqexec now uses the FLAMINGOS-2 provided countdown.
2. Guarded against limit cases, like the countdown not having a valid value for several seconds after starting the observation.
3. I had to implement a special case for FLAMINGOS-2, because its countdown does not count down the exposition, but the whole observe command.