### PR TITLE
SEQNG-830 Better handling of obsolete FLAMINGOS2 filters

### DIFF
--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -42,7 +42,7 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
     private final short MRK_PRESET = 2;
     private final short MRK_IDLE = 0;
 
-    private final Boolean trace = true;
+    private final Boolean trace = false;
 
     private long timeout;
     private TimeUnit timeoutUnit;

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -158,6 +158,7 @@ object EpicsCodex {
 
   object EncodeEpicsValue {
     def apply[A, T](f: A => T): EncodeEpicsValue[A, T] = (a: A) => f(a)
+    def applyO[A, T](f: PartialFunction[A, T]): EncodeEpicsValue[A, Option[T]] = (a: A) => f.lift(a)
   }
 
   def encode[A, T](a: A)(implicit e: EncodeEpicsValue[A, T]): T = e.encode(a)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -47,7 +47,7 @@ final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsCl
 
   override def notifyObserveEnd: SeqAction[Unit] = f2Controller.endObserve
 
-  override def notifyObserveStart = SeqAction.void
+  override def notifyObserveStart: SeqAction[Unit] = SeqAction.void
 
   override def calcObserveTime(config: Config): Time =
     config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP)
@@ -121,10 +121,13 @@ object Flamingos2 {
       p <- config.extractAs[WindowCover](INSTRUMENT_KEY / WINDOW_COVER_PROP).recover { case _:ConfigUtilOps.ExtractFailure => windowCoverFromObserveType(obsType)}
       q <- config.extractAs[Decker](INSTRUMENT_KEY / DECKER_PROP)
       r <- fpuConfig(config)
-      s <- config.extractAs[Filter](INSTRUMENT_KEY / FILTER_PROP)
+      f <- config.extractAs[Filter](INSTRUMENT_KEY / FILTER_PROP)
+      s <- if(f.isObsolete) ContentError(s"Obsolete filter ${f.displayValue}").asLeft
+           else f.asRight
       t <- config.extractAs[LyotWheel](INSTRUMENT_KEY / LYOT_WHEEL_PROP)
       u <- config.extractAs[Disperser](INSTRUMENT_KEY / DISPERSER_PROP).map(disperserFromObserveType(obsType, _))
-    } yield CCConfig(p, q, r, s, t, u)).leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
+    } yield CCConfig(p, q, r, s, t, u)).leftMap(e => SeqexecFailure.Unexpected
+    (ConfigUtilOps.explain(e)))
 
   def dcConfigFromSequenceConfig(config: Config): TrySeq[DCConfig] =
     (for {


### PR DESCRIPTION
New Seqexec was not producing the error message that the old one was causing when trying to use an obsolete filter in FLAMINGOS2. The root of the issue was in the instrument, but I still put some checks in Seqexec to reject the obsolete filters.