### PR TITLE
First implementation of NIRI support

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -34,6 +34,7 @@ import seqexec.server.ghost.GHOSTController
 import seqexec.server.gmos.{GmosControllerSim, GmosEpics, GmosNorthControllerEpics, GmosSouthControllerEpics}
 import seqexec.server.gnirs.{GnirsControllerEpics, GnirsControllerSim, GnirsEpics}
 import seqexec.server.gpi.GPIController
+import seqexec.server.niri.NiriControllerSim
 import seqexec.server.gws.GwsEpics
 import seqexec.server.tcs.{TcsControllerEpics, TcsControllerSim, TcsEpics}
 import edu.gemini.seqexec.odb.SmartGcal
@@ -76,7 +77,8 @@ class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecM
     settings.gmosControl.command.fold(GmosNorthControllerEpics, GmosControllerSim.north),
     settings.gnirsControl.command.fold(GnirsControllerEpics, GnirsControllerSim),
     GPIController(new GPIClient(settings.gpiGiapi), gpiGDS),
-    GHOSTController(new GHOSTClient(settings.ghostGiapi), ghostGDS)
+    GHOSTController(new GHOSTClient(settings.ghostGiapi), ghostGDS),
+    settings.niriControl.command.fold(NiriControllerSim, NiriControllerSim)
   )
 
   private val translatorSettings = TranslateSettings(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriController.scala
@@ -1,0 +1,67 @@
+package seqexec.server.niri
+
+import cats.Show
+import cats.effect.IO
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.niri.NiriController.NiriConfig
+import seqexec.server.{ObserveCommand, Progress, SeqAction}
+import squants.{Length, Time}
+
+trait NiriController {
+
+  def applyConfig(config: NiriConfig): SeqAction[Unit]
+
+  def observe(fileId: ImageFileId, expTime: Time): SeqAction[ObserveCommand.Result]
+
+  def endObserve: SeqAction[Unit]
+
+  def stopObserve: SeqAction[Unit]
+
+  def abortObserve: SeqAction[Unit]
+
+  def observeProgress(total: Time): fs2.Stream[IO, Progress]
+
+}
+
+object NiriController {
+  type ExposureTime = Time
+  type Coadds = Int
+  type Camera = edu.gemini.spModel.gemini.niri.Niri.Camera
+  type BeamSplitter = edu.gemini.spModel.gemini.niri.Niri.BeamSplitter
+  type BuiltInROI = edu.gemini.spModel.gemini.niri.Niri.BuiltinROI
+  type Filter = edu.gemini.spModel.gemini.niri.Niri.Filter
+  type Focus = edu.gemini.spModel.gemini.niri.Niri.Focus
+  type Disperser = edu.gemini.spModel.gemini.niri.Niri.Disperser
+  type Mask = edu.gemini.spModel.gemini.niri.Niri.Mask
+
+  sealed trait WindowCover
+  object WindowCover {
+    case object Closed extends WindowCover
+    case object Open extends  WindowCover
+  }
+
+  sealed trait ReadMode
+  object ReadMode {
+    case object LowRN extends ReadMode
+    case object MediumRN extends ReadMode
+    case object HighRN extends ReadMode
+  }
+
+  final case class DCConfig(exposureTime: ExposureTime,
+                            coadds: Coadds,
+                            readMode: ReadMode,
+                            builtInROI: BuiltInROI
+                           )
+  final case class CCConfig(windowCover: WindowCover,
+                            camera: Camera,
+                            beamSplitter: BeamSplitter,
+                            filter: Filter,
+                            focus: Focus,
+                            disperser: Disperser,
+                            mask: Mask
+                           )
+  final case class NiriConfig(cc: CCConfig, dc: DCConfig)
+
+  implicit val cfgShow: Show[NiriConfig] = Show.fromToString
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriController.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.niri
 
 import cats.Show
@@ -5,7 +8,7 @@ import cats.effect.IO
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.niri.NiriController.NiriConfig
 import seqexec.server.{ObserveCommand, Progress, SeqAction}
-import squants.{Length, Time}
+import squants.Time
 
 trait NiriController {
 
@@ -34,17 +37,13 @@ object NiriController {
   type Disperser = edu.gemini.spModel.gemini.niri.Niri.Disperser
   type Mask = edu.gemini.spModel.gemini.niri.Niri.Mask
 
-  sealed trait WindowCover
-  object WindowCover {
-    case object Closed extends WindowCover
-    case object Open extends  WindowCover
-  }
-
   sealed trait ReadMode
   object ReadMode {
     case object LowRN extends ReadMode
     case object MediumRN extends ReadMode
+    case object MediumRNDeep extends ReadMode
     case object HighRN extends ReadMode
+    case object ThermalIR extends ReadMode
   }
 
   final case class DCConfig(exposureTime: ExposureTime,
@@ -52,14 +51,17 @@ object NiriController {
                             readMode: ReadMode,
                             builtInROI: BuiltInROI
                            )
-  final case class CCConfig(windowCover: WindowCover,
-                            camera: Camera,
-                            beamSplitter: BeamSplitter,
-                            filter: Filter,
-                            focus: Focus,
-                            disperser: Disperser,
-                            mask: Mask
-                           )
+  sealed trait CCConfig
+  case object Dark extends CCConfig
+
+  final case class Common(camera: Camera,
+                          beamSplitter: BeamSplitter,
+                          filter: Filter,
+                          focus: Focus,
+                          disperser: Disperser,
+                          mask: Mask
+                         ) extends CCConfig
+
   final case class NiriConfig(cc: CCConfig, dc: DCConfig)
 
   implicit val cfgShow: Show[NiriConfig] = Show.fromToString

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerSim.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.niri
 
 import cats.effect.IO

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerSim.scala
@@ -11,7 +11,7 @@ import seqexec.server.{InstrumentControllerSim, ObserveCommand, Progress, SeqAct
 import squants.Time
 import squants.time.TimeConversions._
 
-class NiriControllerSim extends NiriController {
+object NiriControllerSim extends NiriController {
 
   private val sim: InstrumentControllerSim = InstrumentControllerSim(s"NIRI")
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerSim.scala
@@ -1,0 +1,29 @@
+package seqexec.server.niri
+
+import cats.effect.IO
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.InstrumentSystem.ElapsedTime
+import seqexec.server.niri.NiriController.NiriConfig
+import seqexec.server.{InstrumentControllerSim, ObserveCommand, Progress, SeqAction}
+import squants.Time
+import squants.time.TimeConversions._
+
+class NiriControllerSim extends NiriController {
+
+  private val sim: InstrumentControllerSim = InstrumentControllerSim(s"NIRI")
+
+  override def observe(fileId: ImageFileId, expTime: Time): SeqAction[ObserveCommand.Result] =
+    sim.observe(fileId, expTime)
+
+  override def applyConfig(config: NiriConfig): SeqAction[Unit] = sim.applyConfig(config)
+
+  override def stopObserve: SeqAction[Unit] = sim.stopObserve
+
+  override def abortObserve: SeqAction[Unit] = sim.abortObserve
+
+  override def endObserve: SeqAction[Unit] = sim.endObserve
+
+  override def observeProgress(total: Time): fs2.Stream[IO, Progress] =
+    sim.observeCountdown(total, ElapsedTime(0.seconds))
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriHeader.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.niri
+
+import gem.Observation
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.SeqAction
+import seqexec.server.keywords.Header
+
+object NiriHeader {
+  def header: Header = new Header {
+    override def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqAction[Unit] =
+      SeqAction.void
+
+    override def sendAfter(id: ImageFileId): SeqAction[Unit] = SeqAction.void
+  }
+}

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -31,6 +31,7 @@ import org.http4s.Uri._
 import squants.time.Seconds
 import seqexec.server.Response.Observed
 import seqexec.server.ghost.GHOSTController
+import seqexec.server.niri.NiriControllerSim
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Throw"))
 class SeqTranslateSpec extends FlatSpec {
@@ -89,7 +90,8 @@ class SeqTranslateSpec extends FlatSpec {
     GPIController(new GPIClient(Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
     new GDSClient(GDSClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))),
     GHOSTController(new GHOSTClient[IO](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
-    new GDSClient(GDSClient.alwaysOkClient, uri("hhttp://localhost:8888/xmlrpc")))
+    new GDSClient(GDSClient.alwaysOkClient, uri("hhttp://localhost:8888/xmlrpc"))),
+    NiriControllerSim
   )
 
   private val translatorSettings = TranslateSettings(tcsKeywords = false, f2Keywords = false, gwsKeywords = false,


### PR DESCRIPTION
Seqexec Server is now able to read NIRI sequences and run them in simulation mode.
Still missing:
- EPICS code
- Show NIRI sequences in client
- FITS headers