### PR TITLE
SEQNG-784: Extract GiapiInstrumentController

### DIFF
--- a/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
@@ -10,9 +10,9 @@ import giapi.client.{Giapi, GiapiClient}
 /**
   * Client for GHOST
   */
-final class GHOSTClient[F[_]](override val giapi: Giapi[F]) extends GiapiClient[F]
+final class GhostClient[F[_]](override val giapi: Giapi[F]) extends GiapiClient[F]
 
-object GHOSTExample extends App {
+object GhostExample extends App {
 
   import cats.effect.IO
   import scala.concurrent.duration._
@@ -38,7 +38,7 @@ object GHOSTExample extends App {
         .connect)(
       giapi => {
         val client =
-          new GHOSTClient[IO](giapi)
+          new GhostClient[IO](giapi)
         val r = for {
           f <- client.observe("TEST_S20180509", 5.seconds)
         } yield f

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
@@ -13,7 +13,7 @@ import mouse.boolean._
 /**
   * Client for GPI
   */
-final class GPIClient[F[_]](override val giapi: Giapi[F]) extends GiapiClient[F] {
+final class GpiClient[F[_]](override val giapi: Giapi[F]) extends GiapiClient[F] {
   import GiapiClient.DefaultCommandTimeout
 
   ///////////////
@@ -112,7 +112,7 @@ object GPIExample extends App {
         .connect)(
       giapi => {
         val client =
-          new GPIClient[IO](giapi)
+          new GpiClient[IO](giapi)
         val r =
           for {
             hs <- client.heartbeatS.flatMap(_.take(3).compile.toVector)
@@ -133,7 +133,7 @@ object GPIExample extends App {
         .connect)(
       giapi => {
         val client =
-          new GPIClient[IO](giapi)
+          new GpiClient[IO](giapi)
         val r =
           for {
             _ <- client.calExitShutter(true) // Open the shutter

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
@@ -42,14 +42,14 @@ sealed abstract class Instrument(ordinal: Int, label: String)
 object Instrument {
 
   case object F2    extends Instrument(11, "Flamingos2")
-  case object GHOST extends Instrument(12, "GHOST")
+  case object Ghost extends Instrument(12, "GHOST")
   case object GmosS extends Instrument(13, "GMOS-S")
   case object GmosN extends Instrument(14, "GMOS-N")
-  case object GNIRS extends Instrument(15, "GNIRS")
-  case object GPI   extends Instrument(16, "GPI")
-  case object GSAOI extends Instrument(17, "GSAOI")
-  case object NIRI  extends Instrument(18, "NIRI")
-  case object NIFS  extends Instrument(19, "NIFS")
+  case object Gnirs extends Instrument(15, "GNIRS")
+  case object Gpi   extends Instrument(16, "GPI")
+  case object Gsaoi extends Instrument(17, "GSAOI")
+  case object Niri  extends Instrument(18, "NIRI")
+  case object Nifs  extends Instrument(19, "NIFS")
 
   implicit val equal: Eq[Instrument] =
     Eq.by(x => x: Resource)
@@ -58,10 +58,10 @@ object Instrument {
     Show.show(_.label)
 
   val gsInstruments: NonEmptyList[Instrument] =
-    NonEmptyList.of(F2, GHOST, GmosS, GPI, GSAOI)
+    NonEmptyList.of(F2, Ghost, GmosS, Gpi, Gsaoi)
 
   val gnInstruments: NonEmptyList[Instrument] =
-    NonEmptyList.of(GmosN, GNIRS, NIRI, NIFS)
+    NonEmptyList.of(GmosN, Gnirs, Niri, Nifs)
 
   val all: NonEmptyList[Instrument] =
     gsInstruments.concatNel(gnInstruments)

--- a/modules/seqexec/model/src/main/scala/seqexec/model/operations.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/operations.scala
@@ -103,8 +103,8 @@ object operations {
     F2 -> F2SupportedOperations,
     GmosS -> GmosSupportedOperations,
     GmosN -> GmosSupportedOperations,
-    GNIRS -> GnirsSupportedOperations,
-    NIRI -> NiriSupportedOperations
+    Gnirs -> GnirsSupportedOperations,
+    Niri -> NiriSupportedOperations
   )
 
   final implicit class SupportedOperationsOps(val i: Instrument)

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -72,21 +72,21 @@ trait SeqexecModelArbitraries extends ArbObservation {
       Instrument.F2,
       Instrument.GmosS,
       Instrument.GmosN,
-      Instrument.GPI,
-      Instrument.GSAOI,
-      Instrument.GNIRS,
-      Instrument.NIRI,
-      Instrument.NIFS
+      Instrument.Gpi,
+      Instrument.Gsaoi,
+      Instrument.Gnirs,
+      Instrument.Niri,
+      Instrument.Nifs
     ))
   implicit val insArb = Arbitrary[Instrument](
     Gen.oneOf(Instrument.F2,
               Instrument.GmosS,
               Instrument.GmosN,
-              Instrument.GPI,
-              Instrument.GSAOI,
-              Instrument.GNIRS,
-              Instrument.NIRI,
-              Instrument.NIFS))
+              Instrument.Gpi,
+              Instrument.Gsaoi,
+              Instrument.Gnirs,
+              Instrument.Niri,
+              Instrument.Nifs))
 
   implicit val queueIdArb: Arbitrary[QueueId] = Arbitrary {
     arbitrary[UUID].map(QueueId)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
@@ -11,7 +11,7 @@ import giapi.client.commands.{CommandResult, CommandResultException, Configurati
 import org.log4s.getLogger
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.SeqexecFailure.{Execution, SeqexecException}
-import seqexec.server.keywords.GDSClient
+import seqexec.server.keywords.GdsClient
 import squants.time.Time
 
 import scala.concurrent.duration._
@@ -23,7 +23,7 @@ abstract class GiapiInstrumentController[F[_]: Sync, CFG, C <: GiapiClient[F]] {
   private val Log = getLogger
 
   def client: C
-  def gdsClient: GDSClient
+  def gdsClient: GdsClient
   def name: String
   def configuration(config: CFG): Configuration
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package seqexec.server.giapi
+package seqexec.server
 
 import cats.data.EitherT
 import cats.effect.Sync
@@ -9,13 +9,12 @@ import cats.implicits._
 import giapi.client.GiapiClient
 import giapi.client.commands.{CommandResult, CommandResultException, Configuration}
 import org.log4s.getLogger
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.SeqexecFailure.{Execution, SeqexecException}
+import seqexec.server.keywords.GDSClient
+import squants.time.Time
 
 import scala.concurrent.duration._
-import seqexec.model.dhs.ImageFileId
-import seqexec.server.keywords.GDSClient
-import seqexec.server.SeqActionF
-import seqexec.server.SeqexecFailure.{Execution, SeqexecException}
-import squants.time.Time
 
 /**
   * Superclass for all GIAPI instrument controllers.

--- a/modules/seqexec/server/src/main/scala/seqexec/server/OdbProxy.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/OdbProxy.scala
@@ -13,11 +13,11 @@ import edu.gemini.wdba.session.client.WDBA_XmlRpc_SessionClient
 import gem.Observation
 import seqexec.model.dhs.ImageFileId
 
-class ODBProxy(val loc: Peer, cmds: ODBProxy.OdbCommands) {
+class OdbProxy(val loc: Peer, cmds: OdbProxy.OdbCommands) {
 
   def host(): Peer = loc
   def read(oid: Observation.Id): Either[SeqexecFailure, SeqexecSequence] =
-    SeqExecService.client(loc).sequence(new SPObservationID(oid.format)).leftMap(SeqexecFailure.ODBSeqError)
+    SeqExecService.client(loc).sequence(new SPObservationID(oid.format)).leftMap(SeqexecFailure.OdbSeqError)
 
   val queuedSequences: SeqAction[List[Observation.Id]] = cmds.queuedSequences()
   val datasetStart: (Observation.Id, String, ImageFileId) => SeqAction[Boolean] = cmds.datasetStart
@@ -31,7 +31,7 @@ class ODBProxy(val loc: Peer, cmds: ODBProxy.OdbCommands) {
 
 }
 
-object ODBProxy {
+object OdbProxy {
   trait OdbCommands {
     def queuedSequences(): SeqAction[List[Observation.Id]]
     def datasetStart(obsId: Observation.Id, dataId: String, fileId: ImageFileId): SeqAction[Boolean]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -17,6 +17,7 @@ import edu.gemini.epics.acm.CaService
 import gem.Observation
 import gem.enum.Site
 import giapi.client.Giapi
+import giapi.client.ghost.GHOSTClient
 import giapi.client.gpi.GPIClient
 import seqexec.engine
 import seqexec.engine.Result.Partial

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -25,7 +25,7 @@ import seqexec.engine.Handle
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.model.events._
-import seqexec.model.{ActionType, UserDetails, StepId}
+import seqexec.model.{ActionType, StepId, UserDetails}
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.keywords._
 import seqexec.server.flamingos2.{Flamingos2ControllerEpics, Flamingos2ControllerSim, Flamingos2ControllerSimBad, Flamingos2Epics}
@@ -42,7 +42,6 @@ import edu.gemini.spModel.core.{Peer, SPProgramID}
 import edu.gemini.spModel.obscomp.InstConstants
 import edu.gemini.spModel.seqcomp.SeqConfigNames.OCS_KEY
 import fs2.{Scheduler, Stream}
-import giapi.client.ghost.GHOSTClient
 import org.http4s.client.Client
 import org.http4s.Uri
 import knobs.Config

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -17,8 +17,8 @@ import edu.gemini.epics.acm.CaService
 import gem.Observation
 import gem.enum.Site
 import giapi.client.Giapi
-import giapi.client.ghost.GHOSTClient
-import giapi.client.gpi.GPIClient
+import giapi.client.ghost.GhostClient
+import giapi.client.gpi.GpiClient
 import seqexec.engine
 import seqexec.engine.Result.Partial
 import seqexec.engine.{Step => _, _}
@@ -31,10 +31,10 @@ import seqexec.server.ConfigUtilOps._
 import seqexec.server.keywords._
 import seqexec.server.flamingos2.{Flamingos2ControllerEpics, Flamingos2ControllerSim, Flamingos2ControllerSimBad, Flamingos2Epics}
 import seqexec.server.gcal.{GcalControllerEpics, GcalControllerSim, GcalEpics}
-import seqexec.server.ghost.GHOSTController
+import seqexec.server.ghost.GhostController
 import seqexec.server.gmos.{GmosControllerSim, GmosEpics, GmosNorthControllerEpics, GmosSouthControllerEpics}
 import seqexec.server.gnirs.{GnirsControllerEpics, GnirsControllerSim, GnirsEpics}
-import seqexec.server.gpi.GPIController
+import seqexec.server.gpi.GpiController
 import seqexec.server.niri.NiriControllerSim
 import seqexec.server.gws.GwsEpics
 import seqexec.server.tcs.{TcsControllerEpics, TcsControllerSim, TcsEpics}
@@ -58,13 +58,13 @@ import shapeless.tag
 class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecMetrics) {
   import SeqexecEngine._
 
-  val odbProxy: ODBProxy = new ODBProxy(new Peer(settings.odbHost, 8443, null),
-    if (settings.odbNotifications) ODBProxy.OdbCommandsImpl(new Peer(settings.odbHost, 8442, null))
-    else ODBProxy.DummyOdbCommands)
+  val odbProxy: OdbProxy = new OdbProxy(new Peer(settings.odbHost, 8443, null),
+    if (settings.odbNotifications) OdbProxy.OdbCommandsImpl(new Peer(settings.odbHost, 8442, null))
+    else OdbProxy.DummyOdbCommands)
 
-  val gpiGDS: GDSClient = GDSClient(settings.gpiGdsControl.command.fold(httpClient, GDSClient.alwaysOkClient), settings.gpiGDS)
+  val gpiGDS: GdsClient = GdsClient(settings.gpiGdsControl.command.fold(httpClient, GdsClient.alwaysOkClient), settings.gpiGDS)
 
-  val ghostGDS: GDSClient = GDSClient(settings.ghostControl.command.fold(httpClient, GDSClient.alwaysOkClient), settings.ghostGDS)
+  val ghostGDS: GdsClient = GdsClient(settings.ghostControl.command.fold(httpClient, GdsClient.alwaysOkClient), settings.ghostGDS)
 
   private val systems = SeqTranslate.Systems(
     odbProxy,
@@ -76,8 +76,8 @@ class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecM
     settings.gmosControl.command.fold(GmosSouthControllerEpics, GmosControllerSim.south),
     settings.gmosControl.command.fold(GmosNorthControllerEpics, GmosControllerSim.north),
     settings.gnirsControl.command.fold(GnirsControllerEpics, GnirsControllerSim),
-    GPIController(new GPIClient(settings.gpiGiapi), gpiGDS),
-    GHOSTController(new GHOSTClient(settings.ghostGiapi), ghostGDS),
+    GpiController(new GpiClient(settings.gpiGiapi), gpiGDS),
+    GhostController(new GhostClient(settings.ghostGiapi), ghostGDS),
     settings.niriControl.command.fold(NiriControllerSim, NiriControllerSim)
   )
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
@@ -36,13 +36,13 @@ object SeqexecFailure {
   final case class Timeout(msg: String) extends SeqexecFailure
 
   /** Sequence loading errors */
-  final case class ODBSeqError(fail: SeqFailure) extends SeqexecFailure
+  final case class OdbSeqError(fail: SeqFailure) extends SeqexecFailure
 
   /** Exception thrown while communicating with the GDS */
-  final case class GDSException(ex: Throwable, url: Uri) extends SeqexecFailure
+  final case class GdsException(ex: Throwable, url: Uri) extends SeqexecFailure
 
   /** XMLRPC error while communicating with the GDS */
-  final case class GDSXMLError(msg: String, url: Uri) extends SeqexecFailure
+  final case class GdsXmlError(msg: String, url: Uri) extends SeqexecFailure
 
   def explain(f: SeqexecFailure): String = f match {
     case UnrecognizedInstrument(name) => s"Unrecognized instrument: $name"
@@ -55,10 +55,10 @@ object SeqexecFailure {
     case Unexpected(msg)              => s"Unexpected error: $msg"
     case Timeout(msg)                 => s"Timeout while waiting for $msg"
     case EmptySequence(title)         => s"Attempt to enqueue empty sequence $title"
-    case ODBSeqError(fail)            => SeqFailure.explain(fail)
-    case GDSException(ex, url)        =>
+    case OdbSeqError(fail)            => SeqFailure.explain(fail)
+    case GdsException(ex, url)        =>
       s"Failure connecting with GDS at $url: ${ex.getMessage}"
-    case GDSXMLError(msg, url)        => s"XML RPC error with GDS at $url: $msg"
+    case GdsXmlError(msg, url)        => s"XML RPC error with GDS at $url: $msg"
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GHOSTController.scala
@@ -14,8 +14,8 @@ import seqexec.server.keywords.GDSClient
 import scala.concurrent.duration._
 import org.log4s._
 import seqexec.server.ConfigUtilOps.{ContentError, ExtractFailure}
+import seqexec.server.GiapiInstrumentController
 import seqexec.server.ghost.GHOSTController.GHOSTConfig
-import seqexec.server.giapi.GiapiInstrumentController
 
 final case class GHOSTController[F[_]: Sync](override val client: GHOSTClient[F],
                                              override val gdsClient: GDSClient)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -10,7 +10,7 @@ import cats.implicits._
 import fs2.Stream
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
-import edu.gemini.spModel.gemini.ghost.Ghost
+import edu.gemini.spModel.gemini.ghost.{Ghost => SPGhost}
 import gem.math.{Coordinates, Declination, RightAscension}
 import gem.optics.Format
 
@@ -19,20 +19,20 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.{Instrument, Resource}
 import seqexec.server.ConfigUtilOps._
 import seqexec.server._
-import seqexec.server.keywords.{GDSClient, GDSInstrument, KeywordsClient}
-import seqexec.server.ghost.GHOSTController._
+import seqexec.server.keywords.{GdsClient, GdsInstrument, KeywordsClient}
+import seqexec.server.ghost.GhostController._
 import squants.time.{Seconds, Time}
 
 import scala.reflect.ClassTag
 
-final case class GHOST[F[_]: Sync](controller: GHOSTController[F])
+final case class Ghost[F[_]: Sync](controller: GhostController[F])
     extends InstrumentSystem[F]
-    with GDSInstrument {
-  override val gdsClient: GDSClient = controller.gdsClient
+    with GdsInstrument {
+  override val gdsClient: GdsClient = controller.gdsClient
 
   override val keywordsClient: KeywordsClient[IO] = this
 
-  override val resource: Resource = Instrument.GHOST
+  override val resource: Resource = Instrument.Ghost
 
   override val sfName: String = "GHOST"
 
@@ -50,7 +50,7 @@ final case class GHOST[F[_]: Sync](controller: GHOSTController[F])
     }
 
   override def configure(config: Config): SeqActionF[F, ConfigResult[F]] =
-    GHOST
+    Ghost
       .fromSequenceConfig[F](config)
       .flatMap(controller.applyConfig)
       .map(_ => ConfigResult[F](this))
@@ -64,13 +64,13 @@ final case class GHOST[F[_]: Sync](controller: GHOSTController[F])
   override def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress] = Stream.empty
 }
 
-object GHOST {
+object Ghost {
   val INSTRUMENT_NAME_PROP: String = "GHOST"
   val name: String                 = INSTRUMENT_NAME_PROP
 
   val sfName: String = "GHOST"
 
-  def fromSequenceConfig[F[_]: Sync](config: Config): SeqActionF[F, GHOSTConfig] = {
+  def fromSequenceConfig[F[_]: Sync](config: Config): SeqActionF[F, GhostConfig] = {
     def extractor[A : ClassTag](propName: String): Option[A] =
       config.extractAs[A](INSTRUMENT_KEY / propName).toOption
 
@@ -90,25 +90,25 @@ object GHOST {
     EitherT {
       Sync[F].delay {
         (for {
-          baseRAHMS     <- raExtractor(Ghost.BaseRAHMS)
-          baseDecDMS    <- decExtractor(Ghost.BaseDecDMS)
+          baseRAHMS     <- raExtractor(SPGhost.BaseRAHMS)
+          baseDecDMS    <- decExtractor(SPGhost.BaseDecDMS)
 
-          srifu1Name    = extractor[String](Ghost.SRIFU1Name)
-          srifu1RAHMS   <- raExtractor(Ghost.SRIFU1RAHMS)
-          srifu1DecHDMS <- decExtractor(Ghost.SRIFU1DecDMS)
+          srifu1Name    = extractor[String](SPGhost.SRIFU1Name)
+          srifu1RAHMS   <- raExtractor(SPGhost.SRIFU1RAHMS)
+          srifu1DecHDMS <- decExtractor(SPGhost.SRIFU1DecDMS)
 
-          srifu2Name    = extractor[String](Ghost.SRIFU2Name)
-          srifu2RAHMS   <- raExtractor(Ghost.SRIFU2RAHMS)
-          srifu2DecHDMS <- decExtractor(Ghost.SRIFU2DecDMS)
+          srifu2Name    = extractor[String](SPGhost.SRIFU2Name)
+          srifu2RAHMS   <- raExtractor(SPGhost.SRIFU2RAHMS)
+          srifu2DecHDMS <- decExtractor(SPGhost.SRIFU2DecDMS)
 
-          hrifu1Name    = extractor[String](Ghost.HRIFU1Name)
-          hrifu1RAHMS   <- raExtractor(Ghost.HRIFU1RAHMS)
-          hrifu1DecHDMS <- decExtractor(Ghost.HRIFU1DecDMS)
+          hrifu1Name    = extractor[String](SPGhost.HRIFU1Name)
+          hrifu1RAHMS   <- raExtractor(SPGhost.HRIFU1RAHMS)
+          hrifu1DecHDMS <- decExtractor(SPGhost.HRIFU1DecDMS)
 
-          hrifu2RAHMS   <- raExtractor(Ghost.HRIFU2RAHMS)
-          hrifu2DecHDMS <- decExtractor(Ghost.HRIFU2DecDMS)
+          hrifu2RAHMS   <- raExtractor(SPGhost.HRIFU2RAHMS)
+          hrifu2DecHDMS <- decExtractor(SPGhost.HRIFU2DecDMS)
 
-          config <- GHOSTConfig(
+          config <- GhostConfig(
             (baseRAHMS, baseDecDMS).mapN(Coordinates.apply),
             1.minute,
             srifu1Name, (srifu1RAHMS, srifu1DecHDMS).mapN(Coordinates.apply),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
@@ -8,28 +8,28 @@ import cats.{Eq, Show}
 import cats.effect.Sync
 import gem.math.Coordinates
 import giapi.client.commands.Configuration
-import giapi.client.ghost.GHOSTClient
-import seqexec.server.keywords.GDSClient
+import giapi.client.ghost.GhostClient
+import seqexec.server.keywords.GdsClient
 
 import scala.concurrent.duration._
 import org.log4s._
 import seqexec.server.ConfigUtilOps.{ContentError, ExtractFailure}
 import seqexec.server.GiapiInstrumentController
-import seqexec.server.ghost.GHOSTController.GHOSTConfig
+import seqexec.server.ghost.GhostController.GhostConfig
 
-final case class GHOSTController[F[_]: Sync](override val client: GHOSTClient[F],
-                                             override val gdsClient: GDSClient)
-  extends GiapiInstrumentController[F, GHOSTConfig, GHOSTClient[F]] {
+final case class GhostController[F[_]: Sync](override val client: GhostClient[F],
+                                             override val gdsClient: GdsClient)
+  extends GiapiInstrumentController[F, GhostConfig, GhostClient[F]] {
 
-  import GHOSTController._
+  import GhostController._
   val Log: Logger = getLogger
 
   override val name = "GHOST"
 
-  override def configuration(config: GHOSTConfig): Configuration = config.configuration
+  override def configuration(config: GhostConfig): Configuration = config.configuration
 }
 
-object GHOSTController {
+object GhostController {
   private def ifuConfig(ifuNum: IFUNum,
                         ifuTargetType: IFUTargetType,
                         coordinates: Coordinates,
@@ -103,7 +103,7 @@ object GHOSTController {
   }
 
   // GHOST has a number of different possible configuration modes: we add types for them here.
-  sealed trait GHOSTConfig {
+  sealed trait GhostConfig {
     def baseCoords: Option[Coordinates]
     def expTime: Duration
 
@@ -120,7 +120,7 @@ object GHOSTController {
     def configuration: Configuration = ifu1Config |+| ifu2Config
   }
 
-  sealed trait StandardResolutionMode extends GHOSTConfig {
+  sealed trait StandardResolutionMode extends GhostConfig {
     import StandardResolutionMode._
 
     def ifu1Coordinates: Coordinates
@@ -190,7 +190,7 @@ object GHOSTController {
     }
   }
 
-  sealed trait HighResolutionMode extends GHOSTConfig {
+  sealed trait HighResolutionMode extends GhostConfig {
     import HighResolutionMode._
 
     override def ifu1BundleType: BundleConfig = BundleConfig.HighRes
@@ -231,7 +231,7 @@ object GHOSTController {
 
   // These are the parameters passed to GHOST from the WDBA.
   // We use them to determine the type of configuration being used by GHOST, and instantiate it.
-  object GHOSTConfig {
+  object GhostConfig {
     def apply(baseCoords: Option[Coordinates],
               expTime: Duration,
               srifu1Name: Option[String],
@@ -241,7 +241,7 @@ object GHOSTController {
               hrifu1Name: Option[String],
               hrifu1Coords: Option[Coordinates],
               hrifu2Name: Option[String],
-              hrifu2Coords: Option[Coordinates]): Either[ExtractFailure, GHOSTConfig] = {
+              hrifu2Coords: Option[Coordinates]): Either[ExtractFailure, GhostConfig] = {
       import IFUTargetType._
 
       val sifu1 = determineType(srifu1Name)
@@ -270,7 +270,7 @@ object GHOSTController {
       }
     }
 
-    implicit val eq: Eq[GHOSTConfig] = Eq.fromUniversalEquals
-    implicit val show: Show[GHOSTConfig] = Show.fromToString
+    implicit val eq: Eq[GhostConfig] = Eq.fromUniversalEquals
+    implicit val show: Show[GhostConfig] = Show.fromToString
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostHeader.scala
@@ -8,7 +8,7 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.server.SeqAction
 import seqexec.server.keywords._
 
-object GHOSTHeader {
+object GhostHeader {
 
   def header(): Header =
     new Header {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/giapi/GiapiInstrumentController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/giapi/GiapiInstrumentController.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.giapi
+
+import cats.data.EitherT
+import cats.effect.Sync
+import cats.implicits._
+import giapi.client.GiapiClient
+import giapi.client.commands.{CommandResult, CommandResultException, Configuration}
+import org.log4s.getLogger
+
+import scala.concurrent.duration._
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.keywords.GDSClient
+import seqexec.server.SeqActionF
+import seqexec.server.SeqexecFailure.{Execution, SeqexecException}
+import squants.time.Time
+
+/**
+  * Superclass for all GIAPI instrument controllers.
+  */
+abstract class GiapiInstrumentController[F[_]: Sync, CFG, C <: GiapiClient[F]] {
+  private val Log = getLogger
+
+  def client: C
+  def gdsClient: GDSClient
+  def name: String
+  def configuration(config: CFG): Configuration
+
+  private def configure(config: CFG): SeqActionF[F, CommandResult] = {
+    EitherT(client.genericApply(configuration(config)).attempt)
+      .leftMap {
+        // The GMP sends these cryptic messages but we can do better
+        case CommandResultException(_, "Message cannot be null") => Execution("Unhandled Apply command")
+        case CommandResultException(_, m)                        => Execution(m)
+        case f                                                   => SeqexecException(f)
+      }
+  }
+
+  def applyConfig(config: CFG): SeqActionF[F, Unit] =
+    for {
+      _ <- SeqActionF.apply(Log.debug(s"Start $name configuration"))
+      _ <- SeqActionF.apply(Log.debug(s"$name configuration $config"))
+      _ <- configure(config)
+      _ <- SeqActionF.apply(Log.debug(s"Completed $name configuration"))
+    } yield ()
+
+  def observe(fileId: ImageFileId, expTime: Time): SeqActionF[F, ImageFileId] =
+    EitherT(client.observe(fileId, expTime.toMilliseconds.milliseconds).map(_ => fileId).attempt)
+      .leftMap {
+        case CommandResultException(_, "Message cannot be null") => Execution("Unhandled observe command")
+        case CommandResultException(_, m)                        => Execution(m)
+        case f                                                   => SeqexecException(f)
+      }
+
+  def endObserve: SeqActionF[F, Unit] =
+    SeqActionF.void
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -42,7 +42,7 @@ final case class Gnirs(controller: GnirsController, dhsClient: DhsClient) extend
   override def calcObserveTime(config: Config): Time =
     (extractExposureTime(config), extractCoadds(config)).mapN(_ * _.toDouble).getOrElse(10000.seconds)
 
-  override val resource: Resource = Instrument.GNIRS
+  override val resource: Resource = Instrument.Gnirs
 
   override def configure(config: Config): SeqAction[ConfigResult[IO]] =
     SeqAction.either(fromSequenceConfig(config)).flatMap(controller.applyConfig).map(_ => ConfigResult(this))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GPIController.scala
@@ -19,10 +19,10 @@ import edu.gemini.spModel.gemini.gpi.Gpi.{Shutter => LegacyShutter}
 import giapi.client.commands.Configuration
 import giapi.client.gpi.GPIClient
 import mouse.boolean._
+import seqexec.server.GiapiInstrumentController
 
 import scala.concurrent.duration._
 import seqexec.server.keywords.GDSClient
-import seqexec.server.giapi.GiapiInstrumentController
 import seqexec.server.gpi.GPIController.GPIConfig
 
 object GPILookupTables {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
@@ -17,15 +17,15 @@ import edu.gemini.spModel.gemini.gpi.Gpi.{ObservingMode => LegacyObservingMode}
 import edu.gemini.spModel.gemini.gpi.Gpi.{PupilCamera => LegacyPupilCamera}
 import edu.gemini.spModel.gemini.gpi.Gpi.{Shutter => LegacyShutter}
 import giapi.client.commands.Configuration
-import giapi.client.gpi.GPIClient
+import giapi.client.gpi.GpiClient
 import mouse.boolean._
 import seqexec.server.GiapiInstrumentController
 
 import scala.concurrent.duration._
-import seqexec.server.keywords.GDSClient
-import seqexec.server.gpi.GPIController.GPIConfig
+import seqexec.server.keywords.GdsClient
+import seqexec.server.gpi.GpiController.GpiConfig
 
-object GPILookupTables {
+object GpiLookupTables {
 
   val apodizerLUT: Map[LegacyApodizer, String] = Map(
     LegacyApodizer.CLEAR     -> "CLEAR",
@@ -92,17 +92,17 @@ object GPILookupTables {
   )
 }
 
-final case class GPIController[F[_]: Sync](override val client: GPIClient[F],
-                                           override val gdsClient: GDSClient)
-  extends GiapiInstrumentController[F, GPIConfig, GPIClient[F]] {
+final case class GpiController[F[_]: Sync](override val client: GpiClient[F],
+                                           override val gdsClient: GdsClient)
+  extends GiapiInstrumentController[F, GpiConfig, GpiClient[F]] {
 
-  import GPIController._
-  import GPILookupTables._
+  import GpiController._
+  import GpiLookupTables._
 
   private val UNKNOWN_SETTING = "UNKNOWN"
   override val name = "GPI"
 
-  private def obsModeConfiguration(config: GPIConfig): Configuration =
+  private def obsModeConfiguration(config: GpiConfig): Configuration =
     config.mode.fold(
       m =>
         Configuration.single("gpi:observationMode.mode",
@@ -123,7 +123,7 @@ final case class GPIController[F[_]: Sync](override val client: GPIClient[F],
     )
 
   // scalastyle:off
-  override def configuration(config: GPIConfig): Configuration = {
+  override def configuration(config: GpiConfig): Configuration = {
     Configuration.single("gpi:selectAdc.deploy",
       (config.adc === LegacyAdc.IN)
         .fold(1, 0)) |+|
@@ -184,7 +184,7 @@ final case class GPIController[F[_]: Sync](override val client: GPIClient[F],
   // scalastyle:on
 }
 
-object GPIController {
+object GpiController {
 
   implicit val apodizerEq: Eq[LegacyApodizer] = Eq.by(_.displayValue)
 
@@ -255,7 +255,7 @@ object GPIController {
     implicit val show: Show[NonStandardModeParams] = Show.fromToString
   }
 
-  final case class GPIConfig(
+  final case class GpiConfig(
       adc: LegacyAdc,
       expTime: Duration,
       coAdds: Int,
@@ -267,9 +267,9 @@ object GPIController {
       pc: LegacyPupilCamera,
       aoFlags: AOFlags)
 
-  object GPIConfig {
+  object GpiConfig {
     private implicit val durationEq: Eq[Duration] = Eq.by(_.toMillis)
-    implicit val eq: Eq[GPIConfig] = Eq.by(
+    implicit val eq: Eq[GpiConfig] = Eq.by(
       x =>
         (x.adc,
          x.expTime,
@@ -281,6 +281,6 @@ object GPIController {
          x.asu,
          x.pc,
          x.aoFlags))
-    implicit val show: Show[GPIConfig] = Show.fromToString
+    implicit val show: Show[GpiConfig] = Show.fromToString
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
@@ -12,10 +12,10 @@ import seqexec.server.keywords._
 import seqexec.server.tcs.TcsKeywordsReader
 import seqexec.server.tcs.CRFollow
 
-object GPIHeader {
+object GpiHeader {
 
   def header(inst: InstrumentSystem[IO],
-             gdsClient: GDSClient,
+             gdsClient: GdsClient,
              tcsKeywordsReader: TcsKeywordsReader,
              obsKeywordsReader: ObsKeywordsReader): Header =
     new Header {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GdsClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GdsClient.scala
@@ -20,7 +20,7 @@ import seqexec.server.SeqActionF
 /**
   * Gemini Data service client
   */
-final case class GDSClient(client: Client[IO], gdsUri: Uri)
+final case class GdsClient(client: Client[IO], gdsUri: Uri)
     extends Http4sClientDsl[IO] {
 
   // Build an xml rpc request to store keywords
@@ -38,10 +38,10 @@ final case class GDSClient(client: Client[IO], gdsUri: Uri)
     </methodCall>
 
   private def handleConnectionError(e: Throwable): SeqexecFailure =
-    SeqexecFailure.GDSException(e, gdsUri)
+    SeqexecFailure.GdsException(e, gdsUri)
 
   private def handleXmlError(xml: Elem): SeqActionF[IO, Unit] =
-    EitherT.fromEither(GDSClient.checkError(xml, gdsUri))
+    EitherT.fromEither(GdsClient.checkError(xml, gdsUri))
 
   /**
     * Set the keywords for an image
@@ -137,7 +137,7 @@ final case class GDSClient(client: Client[IO], gdsUri: Uri)
     </param>
 }
 
-object GDSClient {
+object GdsClient {
 
   def checkError(e: Elem, gdsUri: Uri): Either[SeqexecFailure, Unit] = {
     val v = for {
@@ -145,7 +145,7 @@ object GDSClient {
       if (m \ "name").text === "faultString"
     } yield (m \ "value").text.trim
     v.headOption.fold(().asRight[SeqexecFailure])(
-      SeqexecFailure.GDSXMLError(_, gdsUri).asLeft[Unit])
+      SeqexecFailure.GdsXmlError(_, gdsUri).asLeft[Unit])
   }
 
   /**

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -50,8 +50,8 @@ package keywords {
     }
   }
 
-  trait GDSInstrument extends KeywordsClient[IO] {
-    val gdsClient: GDSClient
+  trait GdsInstrument extends KeywordsClient[IO] {
+    val gdsClient: GdsClient
 
     def setKeywords(id: ImageFileId,
                     keywords: KeywordBag,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -47,7 +47,7 @@ final case class Niri(controller: NiriController, dhsClient: DhsClient)
   : fs2.Stream[IO, Progress] = controller.observeProgress(total)
 
   override val dhsInstrumentName: String = "NIRI"
-  override val resource: Resource = Instrument.NIRI
+  override val resource: Resource = Instrument.Niri
 
   /**
     * Called to configure a system

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
@@ -169,13 +169,13 @@ object TcsControllerEpics extends TcsController {
   private def getInstPort(inst: Instrument): Option[Int] = (inst match {
     case Instrument.GmosS |
          Instrument.GmosN  => TcsEpics.instance.gmosPort
-    case Instrument.GSAOI  => TcsEpics.instance.gsaoiPort
+    case Instrument.Gsaoi  => TcsEpics.instance.gsaoiPort
     case Instrument.F2     => TcsEpics.instance.f2Port
-    case Instrument.GPI    => TcsEpics.instance.gpiPort
-    case Instrument.NIRI   => TcsEpics.instance.niriPort
-    case Instrument.GNIRS  => TcsEpics.instance.gnirsPort
-    case Instrument.NIFS   => TcsEpics.instance.nifsPort
-    case Instrument.GHOST  => TcsEpics.instance.ghostPort
+    case Instrument.Gpi    => TcsEpics.instance.gpiPort
+    case Instrument.Niri   => TcsEpics.instance.niriPort
+    case Instrument.Gnirs  => TcsEpics.instance.gnirsPort
+    case Instrument.Nifs   => TcsEpics.instance.nifsPort
+    case Instrument.Ghost  => TcsEpics.instance.ghostPort
     case _                 => None
   }).flatMap(p => if (p === 0) None else Some(p))
 
@@ -199,10 +199,10 @@ object TcsControllerEpics extends TcsController {
     val instNameMap: Map[Instrument, SFInstName] = Map(
       Instrument.GmosS -> SFInstName("gmos"),
       Instrument.GmosN -> SFInstName("gmos"),
-      Instrument.GSAOI -> SFInstName("gsaoi"),
-      Instrument.GNIRS -> SFInstName("gnirs"),
+      Instrument.Gsaoi -> SFInstName("gsaoi"),
+      Instrument.Gnirs -> SFInstName("gnirs"),
       Instrument.F2    -> SFInstName("f2"),
-      Instrument.GPI   -> SFInstName("gpi")
+      Instrument.Gpi   -> SFInstName("gpi")
     )
 
     private def findInstrument(str: String): Option[Instrument] = instNameMap.find{ case (_, n) => str.startsWith(n.self)}.map(_._1)

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -9,7 +9,7 @@ import cats.implicits._
 import cats.effect._
 import fs2.Stream
 import giapi.client.Giapi
-import giapi.client.gpi.GPIClient
+import giapi.client.gpi.GpiClient
 import gem.Observation
 import gem.enum.Site
 import seqexec.engine.{Action, Result, Sequence}
@@ -17,20 +17,20 @@ import seqexec.model.enum.Instrument.GmosS
 import seqexec.model.{ActionType, SequenceState, StepConfig}
 import seqexec.server.SeqTranslate.ObserveContext
 import seqexec.server.keywords.DhsClientSim
-import seqexec.server.keywords.GDSClient
+import seqexec.server.keywords.GdsClient
 import seqexec.server.flamingos2.Flamingos2ControllerSim
 import seqexec.server.gcal.GcalControllerSim
 import seqexec.server.gmos.GmosControllerSim
 import seqexec.server.gnirs.GnirsControllerSim
 import seqexec.server.tcs.TcsControllerSim
-import seqexec.server.gpi.GPIController
+import seqexec.server.gpi.GpiController
 import edu.gemini.spModel.core.Peer
-import giapi.client.ghost.GHOSTClient
+import giapi.client.ghost.GhostClient
 import org.scalatest.FlatSpec
 import org.http4s.Uri._
 import squants.time.Seconds
 import seqexec.server.Response.Observed
-import seqexec.server.ghost.GHOSTController
+import seqexec.server.ghost.GhostController
 import seqexec.server.niri.NiriControllerSim
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Throw"))
@@ -79,7 +79,7 @@ class SeqTranslateSpec extends FlatSpec {
     .modify(_.mark(0)(Result.Error("error")))(baseState)
 
   private val systems = SeqTranslate.Systems(
-    new ODBProxy(new Peer("localhost", 8443, null), ODBProxy.DummyOdbCommands),
+    new OdbProxy(new Peer("localhost", 8443, null), OdbProxy.DummyOdbCommands),
     DhsClientSim(LocalDate.of(2016, 4, 15)),
     TcsControllerSim,
     GcalControllerSim,
@@ -87,10 +87,10 @@ class SeqTranslateSpec extends FlatSpec {
     GmosControllerSim.south,
     GmosControllerSim.north,
     GnirsControllerSim,
-    GPIController(new GPIClient(Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
-    new GDSClient(GDSClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))),
-    GHOSTController(new GHOSTClient[IO](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
-    new GDSClient(GDSClient.alwaysOkClient, uri("hhttp://localhost:8888/xmlrpc"))),
+    GpiController(new GpiClient(Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
+    new GdsClient(GdsClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))),
+    GhostController(new GhostClient[IO](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
+    new GdsClient(GdsClient.alwaysOkClient, uri("hhttp://localhost:8888/xmlrpc"))),
     NiriControllerSim
   )
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import seqexec.engine
 import seqexec.engine.Result.PauseContext
 import seqexec.engine._
-import seqexec.server.keywords.GDSClient
+import seqexec.server.keywords.GdsClient
 import seqexec.model.{ActionType, CalibrationQueueId, ClientId, Conditions, Observer, Operator, SequenceState, UserDetails}
 import seqexec.model.enum._
 import seqexec.model.enum.Resource.TCS
@@ -183,7 +183,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     }
 
   private val sm = SeqexecMetrics.build[IO](Site.GS, new CollectorRegistry()).unsafeRunSync
-  private val seqexecEngine = SeqexecEngine(GDSClient.alwaysOkClient, defaultSettings, sm)
+  private val seqexecEngine = SeqexecEngine(GdsClient.alwaysOkClient, defaultSettings, sm)
   private def advanceOne(q: EventQueue, s0: EngineState, put: IO[Either[SeqexecFailure, Unit]]): IO[Option[EngineState]] =
     (put *> seqexecEngine.stream(q.dequeue)(s0).take(1).compile.last).map(_.map(_._2))
 
@@ -435,7 +435,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
       SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS, TCS))) >>>
       SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
-        Instrument.GSAOI, Set(Instrument.GSAOI, TCS))) >>>
+        Instrument.Gsaoi, Set(Instrument.Gsaoi, TCS))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
 
@@ -449,7 +449,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
       SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS))) >>>
       SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
-        Instrument.GSAOI, Set(Instrument.GSAOI))) >>>
+        Instrument.Gsaoi, Set(Instrument.Gsaoi))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
@@ -14,8 +14,8 @@ import gem.enum.KeywordName
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import seqexec.server.flamingos2.Flamingos2Controller
-import seqexec.server.gpi.GPIController
-import seqexec.server.gpi.GPIController._
+import seqexec.server.gpi.GpiController
+import seqexec.server.gpi.GpiController._
 import seqexec.server.gcal.GcalController
 import seqexec.server.gcal.GcalController._
 import seqexec.server.tcs.{CRFollow, TcsController, TcsControllerEpics}
@@ -43,8 +43,8 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.server.flamingos2.Flamingos2Controller.ExposureTime
-import seqexec.server.ghost.GHOSTController
-import seqexec.server.ghost.GHOSTController.GHOSTConfig
+import seqexec.server.ghost.GhostController
+import seqexec.server.ghost.GhostController.GhostConfig
 
 object SeqexecServerArbitraries extends ArbTime {
 
@@ -158,7 +158,7 @@ object SeqexecServerArbitraries extends ArbTime {
     } yield EngineState.default.copy(queues = q, selected = s, conditions = c, operator = o)
   }
 
-  implicit val gpiAOFlagsArb: Arbitrary[GPIController.AOFlags] = Arbitrary{
+  implicit val gpiAOFlagsArb: Arbitrary[GpiController.AOFlags] = Arbitrary{
     for {
       useAo    <- arbitrary[Boolean]
       useCal   <- arbitrary[Boolean]
@@ -168,11 +168,11 @@ object SeqexecServerArbitraries extends ArbTime {
       magI     <- arbitrary[Double]
     } yield AOFlags(useAo, useCal, aoOpt, alignFpm, magH, magI)
   }
-  implicit val gpiAOFlagsCogen: Cogen[GPIController.AOFlags] =
+  implicit val gpiAOFlagsCogen: Cogen[GpiController.AOFlags] =
     Cogen[(Boolean, Boolean, Boolean, Boolean)]
       .contramap(x => (x.useAo, x.useCal, x.aoOptimize, x.alignFpm))
 
-  implicit val gpiArtificialSourcesArb: Arbitrary[GPIController.ArtificialSources] = Arbitrary {
+  implicit val gpiArtificialSourcesArb: Arbitrary[GpiController.ArtificialSources] = Arbitrary {
     for {
       ir  <- arbitrary[LegacyArtificialSource]
       vis <- arbitrary[LegacyArtificialSource]
@@ -182,11 +182,11 @@ object SeqexecServerArbitraries extends ArbTime {
   }
   implicit val asCogen: Cogen[LegacyArtificialSource] =
     Cogen[String].contramap(_.displayValue)
-  implicit val gpiArtificialSourcesCogen: Cogen[GPIController.ArtificialSources] =
+  implicit val gpiArtificialSourcesCogen: Cogen[GpiController.ArtificialSources] =
           Cogen[(LegacyArtificialSource, LegacyArtificialSource, LegacyArtificialSource, Double)]
       .contramap(x => (x.ir, x.vis, x.sc, x.attenuation))
 
-  implicit val gpiShuttersArb: Arbitrary[GPIController.Shutters] = Arbitrary {
+  implicit val gpiShuttersArb: Arbitrary[GpiController.Shutters] = Arbitrary {
     for {
       ent <- arbitrary[LegacyShutter]
       cal <- arbitrary[LegacyShutter]
@@ -196,7 +196,7 @@ object SeqexecServerArbitraries extends ArbTime {
   }
   implicit val shutCogen: Cogen[LegacyShutter] =
     Cogen[String].contramap(_.displayValue)
-  implicit val gpiShuttersCogen: Cogen[GPIController.Shutters] =
+  implicit val gpiShuttersCogen: Cogen[GpiController.Shutters] =
     Cogen[(LegacyShutter, LegacyShutter, LegacyShutter, LegacyShutter)]
       .contramap(x => (x.entranceShutter, x.calEntranceShutter, x.calScienceShutter, x.calReferenceShutter))
   implicit val gpiNonStandardModParamsArb: Arbitrary[NonStandardModeParams] = Arbitrary {
@@ -219,7 +219,7 @@ object SeqexecServerArbitraries extends ArbTime {
     Cogen[(LegacyApodizer, LegacyFPM, LegacyLyot, LegacyFilter)]
       .contramap(x => (x.apodizer, x.fpm, x.lyot, x.filter))
 
-  implicit val gpiConfigArb: Arbitrary[GPIController.GPIConfig] = Arbitrary {
+  implicit val gpiConfigArb: Arbitrary[GpiController.GpiConfig] = Arbitrary {
     for {
       adc   <- arbitrary[LegacyAdc]
       exp   <- arbitrary[Duration]
@@ -227,11 +227,11 @@ object SeqexecServerArbitraries extends ArbTime {
       mode  <- arbitrary[Either[LegacyObservingMode, NonStandardModeParams]]
       disp  <- arbitrary[LegacyDisperser]
       dispA <- arbitrary[Double]
-      shut  <- arbitrary[GPIController.Shutters]
-      asu   <- arbitrary[GPIController.ArtificialSources]
+      shut  <- arbitrary[GpiController.Shutters]
+      asu   <- arbitrary[GpiController.ArtificialSources]
       pc    <- arbitrary[LegacyPupilCamera]
-      ao    <- arbitrary[GPIController.AOFlags]
-    } yield GPIConfig(adc, exp, coa, mode, disp, dispA, shut, asu, pc, ao)
+      ao    <- arbitrary[GpiController.AOFlags]
+    } yield GpiConfig(adc, exp, coa, mode, disp, dispA, shut, asu, pc, ao)
   }
 
   implicit val adcCogen: Cogen[LegacyAdc] =
@@ -240,23 +240,23 @@ object SeqexecServerArbitraries extends ArbTime {
     Cogen[String].contramap(_.displayValue)
   implicit val ppCogen: Cogen[LegacyPupilCamera] =
     Cogen[String].contramap(_.displayValue)
-  implicit val gpiConfigCogen: Cogen[GPIController.GPIConfig] =
-    Cogen[(LegacyAdc, Duration, Int, Either[LegacyObservingMode, NonStandardModeParams], GPIController.Shutters, GPIController.ArtificialSources, LegacyPupilCamera, GPIController.AOFlags)]
+  implicit val gpiConfigCogen: Cogen[GpiController.GpiConfig] =
+    Cogen[(LegacyAdc, Duration, Int, Either[LegacyObservingMode, NonStandardModeParams], GpiController.Shutters, GpiController.ArtificialSources, LegacyPupilCamera, GpiController.AOFlags)]
       .contramap(x => (x.adc, x.expTime, x.coAdds, x.mode, x.shutters, x.asu, x.pc, x.aoFlags))
 
-  val ghostSRSingleTargetConfigGen: Gen[GHOSTController.StandardResolutionMode.SingleTarget] =
+  val ghostSRSingleTargetConfigGen: Gen[GhostController.StandardResolutionMode.SingleTarget] =
     for {
       basePos <- arbitrary[Option[Coordinates]]
       exp <- arbitrary[ExposureTime]
       srifu1Name <- arbitrary[String]
       srifu1Pos <- arbitrary[Coordinates]
-    } yield GHOSTController.StandardResolutionMode.SingleTarget(basePos, exp, srifu1Name, srifu1Pos)
+    } yield GhostController.StandardResolutionMode.SingleTarget(basePos, exp, srifu1Name, srifu1Pos)
 
-  implicit val ghostSRSingleTargetConfigCogen: Cogen[GHOSTController.StandardResolutionMode.SingleTarget] =
+  implicit val ghostSRSingleTargetConfigCogen: Cogen[GhostController.StandardResolutionMode.SingleTarget] =
     Cogen[(Option[Coordinates], ExposureTime, String, Coordinates)]
       .contramap(x => (x.baseCoords, x.expTime, x.ifu1TargetName, x.ifu1Coordinates))
 
-  val ghostSRDualTargetConfigGen: Gen[GHOSTController.StandardResolutionMode.DualTarget] =
+  val ghostSRDualTargetConfigGen: Gen[GhostController.StandardResolutionMode.DualTarget] =
     for {
       basePos    <- arbitrary[Option[Coordinates]]
       exp        <- arbitrary[ExposureTime]
@@ -264,64 +264,64 @@ object SeqexecServerArbitraries extends ArbTime {
       srifu1Pos  <- arbitrary[Coordinates]
       srifu2Name <- arbitrary[String]
       srifu2Pos  <- arbitrary[Coordinates]
-    } yield GHOSTController.StandardResolutionMode.DualTarget(basePos, exp, srifu1Name, srifu1Pos, srifu2Name, srifu2Pos)
+    } yield GhostController.StandardResolutionMode.DualTarget(basePos, exp, srifu1Name, srifu1Pos, srifu2Name, srifu2Pos)
 
-  implicit val ghostSRDualTargetConfigCogen: Cogen[GHOSTController.StandardResolutionMode.DualTarget] =
+  implicit val ghostSRDualTargetConfigCogen: Cogen[GhostController.StandardResolutionMode.DualTarget] =
     Cogen[(Option[Coordinates], ExposureTime, String, Coordinates, String, Coordinates)]
       .contramap(x => (x.baseCoords, x.expTime, x.ifu1TargetName, x.ifu1Coordinates, x.ifu2TargetName, x.ifu2Coordinates))
 
-  val ghostSRTargetSkyConfigGen: Gen[GHOSTController.StandardResolutionMode.TargetPlusSky] =
+  val ghostSRTargetSkyConfigGen: Gen[GhostController.StandardResolutionMode.TargetPlusSky] =
     for {
       basePos    <- arbitrary[Option[Coordinates]]
       exp        <- arbitrary[ExposureTime]
       srifu1Name <- arbitrary[String]
       srifu1Pos  <- arbitrary[Coordinates]
       srifu2Pos  <- arbitrary[Coordinates]
-    } yield GHOSTController.StandardResolutionMode.TargetPlusSky(basePos, exp, srifu1Name, srifu1Pos, srifu2Pos)
+    } yield GhostController.StandardResolutionMode.TargetPlusSky(basePos, exp, srifu1Name, srifu1Pos, srifu2Pos)
 
-  implicit val ghostSRTargetSkyConfigCogen: Cogen[GHOSTController.StandardResolutionMode.TargetPlusSky] =
+  implicit val ghostSRTargetSkyConfigCogen: Cogen[GhostController.StandardResolutionMode.TargetPlusSky] =
     Cogen[(Option[Coordinates], ExposureTime, String, Coordinates, Coordinates)]
       .contramap(x => (x.baseCoords, x.expTime, x.ifu1TargetName, x.ifu1Coordinates, x.ifu2Coordinates))
 
-  implicit val ghostSRSkyTargetConfigGen: Gen[GHOSTController.StandardResolutionMode.SkyPlusTarget] =
+  implicit val ghostSRSkyTargetConfigGen: Gen[GhostController.StandardResolutionMode.SkyPlusTarget] =
     for {
       basePos    <- arbitrary[Option[Coordinates]]
       exp        <- arbitrary[ExposureTime]
       srifu1Pos  <- arbitrary[Coordinates]
       srifu2Name <- arbitrary[String]
       srifu2Pos  <- arbitrary[Coordinates]
-    } yield GHOSTController.StandardResolutionMode.SkyPlusTarget(basePos, exp, srifu1Pos, srifu2Name, srifu2Pos)
+    } yield GhostController.StandardResolutionMode.SkyPlusTarget(basePos, exp, srifu1Pos, srifu2Name, srifu2Pos)
 
-  implicit val ghostSRSkyTargetConfigCogen: Cogen[GHOSTController.StandardResolutionMode.SkyPlusTarget] =
+  implicit val ghostSRSkyTargetConfigCogen: Cogen[GhostController.StandardResolutionMode.SkyPlusTarget] =
     Cogen[(Option[Coordinates], ExposureTime, Coordinates, String, Coordinates)]
       .contramap(x => (x.baseCoords, x.expTime, x.ifu1Coordinates, x.ifu2TargetName, x.ifu2Coordinates))
 
-  implicit val ghostHRSingleTargetConfigGen: Gen[GHOSTController.HighResolutionMode.SingleTarget] =
+  implicit val ghostHRSingleTargetConfigGen: Gen[GhostController.HighResolutionMode.SingleTarget] =
     for {
       basePos   <- arbitrary[Option[Coordinates]]
       exp       <- arbitrary[ExposureTime]
       hrifu1Name <- arbitrary[String]
       hrifu1Pos <- arbitrary[Coordinates]
-    } yield GHOSTController.HighResolutionMode.SingleTarget(basePos, exp, hrifu1Name, hrifu1Pos)
+    } yield GhostController.HighResolutionMode.SingleTarget(basePos, exp, hrifu1Name, hrifu1Pos)
 
-  implicit val ghostHRSingleTargetConfigCogen: Cogen[GHOSTController.HighResolutionMode.SingleTarget] =
+  implicit val ghostHRSingleTargetConfigCogen: Cogen[GhostController.HighResolutionMode.SingleTarget] =
     Cogen[(Option[Coordinates], ExposureTime, String, Coordinates)]
       .contramap(x => (x.baseCoords, x.expTime, x.ifu1TargetName, x.ifu1Coordinates))
 
-  implicit val ghostHRTargetPlusSkyConfigGen: Gen[GHOSTController.HighResolutionMode.TargetPlusSky] =
+  implicit val ghostHRTargetPlusSkyConfigGen: Gen[GhostController.HighResolutionMode.TargetPlusSky] =
     for {
       basePos    <- arbitrary[Option[Coordinates]]
       exp        <- arbitrary[ExposureTime]
       hrifu1Name <- arbitrary[String]
       hrifu1Pos  <- arbitrary[Coordinates]
       hrifu2Pos  <- arbitrary[Coordinates]
-    } yield GHOSTController.HighResolutionMode.TargetPlusSky(basePos, exp, hrifu1Name, hrifu1Pos, hrifu2Pos)
+    } yield GhostController.HighResolutionMode.TargetPlusSky(basePos, exp, hrifu1Name, hrifu1Pos, hrifu2Pos)
 
-  implicit val ghostHRTargetSkyConfigCogen: Cogen[GHOSTController.HighResolutionMode.TargetPlusSky] =
+  implicit val ghostHRTargetSkyConfigCogen: Cogen[GhostController.HighResolutionMode.TargetPlusSky] =
     Cogen[(Option[Coordinates], ExposureTime, String, Coordinates, Coordinates)]
       .contramap(x => (x.baseCoords, x.expTime, x.ifu1TargetName, x.ifu1Coordinates, x.ifu2Coordinates))
 
-  implicit val ghostConfigArb: Arbitrary[GHOSTConfig] = Arbitrary {
+  implicit val ghostConfigArb: Arbitrary[GhostConfig] = Arbitrary {
     Gen.oneOf(
       ghostSRSingleTargetConfigGen,
       ghostSRDualTargetConfigGen,
@@ -332,55 +332,55 @@ object SeqexecServerArbitraries extends ArbTime {
   }
 
   object GhostHelpers {
-    def extractSRIFU1Name(x: GHOSTController.GHOSTConfig): Option[String] = x match {
-      case GHOSTController.StandardResolutionMode.SingleTarget(_, _, name, _)     => Some(name)
-      case GHOSTController.StandardResolutionMode.DualTarget(_, _, name, _, _, _) => Some(name)
-      case GHOSTController.StandardResolutionMode.TargetPlusSky(_, _, name, _, _) => Some(name)
-      case _: GHOSTController.StandardResolutionMode.SkyPlusTarget                => Some("Sky")
+    def extractSRIFU1Name(x: GhostController.GhostConfig): Option[String] = x match {
+      case GhostController.StandardResolutionMode.SingleTarget(_, _, name, _)     => Some(name)
+      case GhostController.StandardResolutionMode.DualTarget(_, _, name, _, _, _) => Some(name)
+      case GhostController.StandardResolutionMode.TargetPlusSky(_, _, name, _, _) => Some(name)
+      case _: GhostController.StandardResolutionMode.SkyPlusTarget                => Some("Sky")
       case _                                                                      => None
     }
 
-    def extractSRIFU1Coordinates(x: GHOSTController.GHOSTConfig): Option[Coordinates] = x match {
-      case c: GHOSTController.StandardResolutionMode => Some(c.ifu1Coordinates)
+    def extractSRIFU1Coordinates(x: GhostController.GhostConfig): Option[Coordinates] = x match {
+      case c: GhostController.StandardResolutionMode => Some(c.ifu1Coordinates)
       case _                                         => None
     }
 
-    def extractSRIFU2Name(x: GHOSTController.GHOSTConfig): Option[String] = x match {
-      case GHOSTController.StandardResolutionMode.DualTarget(_, _, _, _, name, _) => Some(name)
-      case _: GHOSTController.StandardResolutionMode.TargetPlusSky                => Some("Sky")
-      case GHOSTController.StandardResolutionMode.SkyPlusTarget(_, _, _, name, _) => Some(name)
+    def extractSRIFU2Name(x: GhostController.GhostConfig): Option[String] = x match {
+      case GhostController.StandardResolutionMode.DualTarget(_, _, _, _, name, _) => Some(name)
+      case _: GhostController.StandardResolutionMode.TargetPlusSky                => Some("Sky")
+      case GhostController.StandardResolutionMode.SkyPlusTarget(_, _, _, name, _) => Some(name)
       case _                                                                      => None
     }
 
-    def extractSRIFU2Coordinates(x: GHOSTController.GHOSTConfig): Option[Coordinates] = x match {
-      case GHOSTController.StandardResolutionMode.DualTarget(_, _, _, _, _, coords) => Some(coords)
-      case GHOSTController.StandardResolutionMode.TargetPlusSky(_, _, _, _, coords) => Some(coords)
-      case GHOSTController.StandardResolutionMode.SkyPlusTarget(_, _, _, _, coords) => Some(coords)
+    def extractSRIFU2Coordinates(x: GhostController.GhostConfig): Option[Coordinates] = x match {
+      case GhostController.StandardResolutionMode.DualTarget(_, _, _, _, _, coords) => Some(coords)
+      case GhostController.StandardResolutionMode.TargetPlusSky(_, _, _, _, coords) => Some(coords)
+      case GhostController.StandardResolutionMode.SkyPlusTarget(_, _, _, _, coords) => Some(coords)
       case _                                                                        => None
     }
 
-    def extractHRIFU1Name(x: GHOSTController.GHOSTConfig): Option[String] = x match {
-      case c: GHOSTController.HighResolutionMode => Some(c.ifu1TargetName)
+    def extractHRIFU1Name(x: GhostController.GhostConfig): Option[String] = x match {
+      case c: GhostController.HighResolutionMode => Some(c.ifu1TargetName)
       case _                                     => None
     }
 
-    def extractHRIFU1Coordinates(x: GHOSTController.GHOSTConfig): Option[Coordinates] = x match {
-      case c: GHOSTController.HighResolutionMode => Some(c.ifu1Coordinates)
+    def extractHRIFU1Coordinates(x: GhostController.GhostConfig): Option[Coordinates] = x match {
+      case c: GhostController.HighResolutionMode => Some(c.ifu1Coordinates)
       case _                                     => None
     }
 
-    def extractHRIFU2Name(x: GHOSTController.GHOSTConfig): Option[String] = x match {
-      case _: GHOSTController.HighResolutionMode.TargetPlusSky => Some("Sky")
+    def extractHRIFU2Name(x: GhostController.GhostConfig): Option[String] = x match {
+      case _: GhostController.HighResolutionMode.TargetPlusSky => Some("Sky")
       case _                                                   => None
     }
 
-    def extractHRIFU2Coordinates(x: GHOSTController.GHOSTConfig): Option[Coordinates] = x match {
-      case c: GHOSTController.HighResolutionMode.TargetPlusSky => Some(c.ifu2Coordinates)
+    def extractHRIFU2Coordinates(x: GhostController.GhostConfig): Option[Coordinates] = x match {
+      case c: GhostController.HighResolutionMode.TargetPlusSky => Some(c.ifu2Coordinates)
       case _                                                   => None
     }
   }
 
-  implicit val ghostConfigCoGen: Cogen[GHOSTController.GHOSTConfig] = {
+  implicit val ghostConfigCoGen: Cogen[GhostController.GhostConfig] = {
     import GhostHelpers._
     Cogen[(Option[Coordinates],
       Duration,

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerLensesSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerLensesSpec.scala
@@ -41,7 +41,7 @@ final class SeqexecServerLensesSpec extends CatsSuite with ArbObservation {
     (x.queues, x.selected, x.conditions, x.operator, x.sequences))
 
   checkAll("selected optional",
-           LensTests(EngineState.instrumentLoadedL(Instrument.GPI)))
+           LensTests(EngineState.instrumentLoadedL(Instrument.Gpi)))
 
   private val seqId = Observation.Id.unsafeFromString("GS-2018B-Q-0-1")
   // Some sanity checks
@@ -50,20 +50,20 @@ final class SeqexecServerLensesSpec extends CatsSuite with ArbObservation {
       selected =
         Map(Instrument.F2 -> Observation.Id.unsafeFromString("GS-2018B-Q-1-1")))
     EngineState
-      .instrumentLoadedL(Instrument.GPI)
+      .instrumentLoadedL(Instrument.Gpi)
       .set(seqId.some)
       .apply(base) shouldEqual base.copy(
-      selected = base.selected + (Instrument.GPI -> seqId))
+      selected = base.selected + (Instrument.Gpi -> seqId))
   }
   test("Support replacing loaded sequences") {
     val base = EngineState.default.copy(
       selected =
-        Map(Instrument.GPI -> Observation.Id.unsafeFromString("GS-2018B-Q-1-1"),
+        Map(Instrument.Gpi -> Observation.Id.unsafeFromString("GS-2018B-Q-1-1"),
             Instrument.F2  -> Observation.Id.unsafeFromString("GS-2018B-Q-2-1")))
     EngineState
-      .instrumentLoadedL(Instrument.GPI)
+      .instrumentLoadedL(Instrument.Gpi)
       .set(seqId.some)
       .apply(base) shouldEqual base.copy(
-      selected = base.selected.updated(Instrument.GPI, seqId))
+      selected = base.selected.updated(Instrument.Gpi, seqId))
   }
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/ghost/GhostSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/ghost/GhostSpec.scala
@@ -5,7 +5,7 @@ package seqexec.server.ghost
 
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
-import seqexec.server.ghost.GHOSTController._
+import seqexec.server.ghost.GhostController._
 
 /**
   * Tests GHOST Config typeclasses
@@ -13,5 +13,5 @@ import seqexec.server.ghost.GHOSTController._
 final class GhostSpec extends CatsSuite {
   import seqexec.server.SeqexecServerArbitraries._
 
-  checkAll("Eq[GHOSTConfig]", EqTests[GHOSTConfig].eqv)
+  checkAll("Eq[GHOSTConfig]", EqTests[GhostConfig].eqv)
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/gpi/GpiSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/gpi/GpiSpec.scala
@@ -5,7 +5,7 @@ package seqexec.server.gpi
 
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
-import seqexec.server.gpi.GPIController._
+import seqexec.server.gpi.GpiController._
 
 /**
   * Tests GPI Config typeclasses
@@ -17,5 +17,5 @@ final class GpiSpec extends CatsSuite {
   checkAll("Eq[ArtificialSources]", EqTests[ArtificialSources].eqv)
   checkAll("Eq[Shutters]", EqTests[Shutters].eqv)
   checkAll("Eq[NonStandardModeParams]", EqTests[NonStandardModeParams].eqv)
-  checkAll("Eq[GPIConfig]", EqTests[GPIConfig].eqv)
+  checkAll("Eq[GPIConfig]", EqTests[GpiConfig].eqv)
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/keywords/GdsClientSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/keywords/GdsClientSpec.scala
@@ -8,10 +8,10 @@ import org.http4s.Uri._
 import scala.xml.XML
 
 @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-final class GDSClientSpec extends CatsSuite {
+final class GdsClientSpec extends CatsSuite {
   test("GDSClient should reject bad responses") {
     val xml = XML.load(getClass.getResource("/gds-bad-resp.xml"))
-    GDSClient
+    GdsClient
       .checkError(xml, uri("http://localhost:8888/xmlrpc"))
       .isLeft shouldEqual true
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -110,7 +110,7 @@ object FilterCell {
           instrumentFilterO
             .getOption(s)
             .flatMap(enumerations.filter.F2Filter.get)
-        case Instrument.GPI => gpiFilter(s)
+        case Instrument.Gpi => gpiFilter(s)
         case _              => None
       }
 
@@ -143,7 +143,7 @@ object DisperserCell {
       val nameMapper: Map[String, String] = p.i match {
         case Instrument.GmosS => enumerations.disperser.GmosSDisperser
         case Instrument.GmosN => enumerations.disperser.GmosNDisperser
-        case Instrument.GPI   => gpiDispersers
+        case Instrument.Gpi   => gpiDispersers
         case _                => Map.empty
       }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -101,7 +101,7 @@ object ModelOps {
             status = StepState.Running,
             configStatus = List((Resource.TCS, ActionStatus.Pending),
                                 (Resource.Gcal, ActionStatus.Running),
-                                (Instrument.GPI, ActionStatus.Completed))
+                                (Instrument.Gpi, ActionStatus.Completed))
           )
         case s => s
       })
@@ -146,18 +146,18 @@ object ModelOps {
             InstrumentProperties.Offsets,
             InstrumentProperties.Disperser,
             InstrumentProperties.FPU)
-      case Instrument.GNIRS =>
+      case Instrument.Gnirs =>
         Set(InstrumentProperties.Exposure,
             InstrumentProperties.Filter,
             InstrumentProperties.Offsets,
             InstrumentProperties.Disperser,
             InstrumentProperties.FPU)
-      case Instrument.GPI =>
+      case Instrument.Gpi =>
         Set(InstrumentProperties.Exposure,
             InstrumentProperties.Filter,
             InstrumentProperties.ObservingMode,
             InstrumentProperties.Disperser)
-      case Instrument.GHOST => Set.empty
+      case Instrument.Ghost => Set.empty
       case _                =>
         Set(InstrumentProperties.Exposure,
             InstrumentProperties.Filter,

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
@@ -26,7 +26,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     SequencesOnDisplay.Empty.tabs.length should be(1)
   }
   test("Support adding preview") {
-    val m = SequenceMetadata(Instrument.GPI, None, "Obs")
+    val m = SequenceMetadata(Instrument.Gpi, None, "Obs")
     val s = SequenceView(Observation.Id.unsafeFromString("GS-2018A-Q-0-1"),
                          m,
                          SequenceState.Idle,
@@ -37,7 +37,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     sod.tabs.length should be(2)
   }
   test("Focus on preview") {
-    val m = SequenceMetadata(Instrument.GPI, None, "Obs")
+    val m = SequenceMetadata(Instrument.Gpi, None, "Obs")
     val s = SequenceView(Observation.Id.unsafeFromString("GS-2018A-Q-0-1"),
                          m,
                          SequenceState.Idle,
@@ -49,7 +49,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     sod.tabs.focus.isPreview should be(true)
   }
   test("Unset preview") {
-    val m = SequenceMetadata(Instrument.GPI, None, "Obs")
+    val m = SequenceMetadata(Instrument.Gpi, None, "Obs")
     val s = SequenceView(Observation.Id.unsafeFromString("GS-2018A-Q-0-1"),
                          m,
                          SequenceState.Idle,
@@ -62,7 +62,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
   }
   test("Replace preview") {
     val obsId = Observation.Id.unsafeFromString("GS-2018A-Q-0-1")
-    val m     = SequenceMetadata(Instrument.GPI, None, "Obs")
+    val m     = SequenceMetadata(Instrument.Gpi, None, "Obs")
     val s     = SequenceView(obsId, m, SequenceState.Idle, Nil, None)
     val sod =
       SequencesOnDisplay.Empty.previewSequence(s.metadata.instrument, s)
@@ -81,11 +81,11 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     }
   }
   test("Update loaded") {
-    val m      = SequenceMetadata(Instrument.GPI, None, "Obs")
+    val m      = SequenceMetadata(Instrument.Gpi, None, "Obs")
     val obsId  = Observation.Id.unsafeFromString("GS-2018A-Q-0-1")
     val s      = SequenceView(obsId, m, SequenceState.Idle, Nil, None)
     val queue  = List(s)
-    val loaded = Map((Instrument.GPI: Instrument) -> obsId)
+    val loaded = Map((Instrument.Gpi: Instrument) -> obsId)
     val sod = SequencesOnDisplay.Empty.updateFromQueue(
       SequencesQueue(loaded, Conditions.Default, None, SortedMap.empty, queue))
     sod.tabs.length should be(2)
@@ -95,11 +95,11 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     }
   }
   test("Add preview with loaded") {
-    val m      = SequenceMetadata(Instrument.GPI, None, "Obs")
+    val m      = SequenceMetadata(Instrument.Gpi, None, "Obs")
     val obsId  = Observation.Id.unsafeFromString("GS-2018A-Q-0-1")
     val s      = SequenceView(obsId, m, SequenceState.Idle, Nil, None)
     val queue  = List(s)
-    val loaded = Map((Instrument.GPI: Instrument) -> obsId)
+    val loaded = Map((Instrument.Gpi: Instrument) -> obsId)
     val sod = SequencesOnDisplay.Empty.updateFromQueue(
       SequencesQueue(loaded, Conditions.Default, None, SortedMap.empty, queue))
 


### PR DESCRIPTION
A lot of code was reused between the `GhostController` and the `GpiController`, leading to the refactoring of this class to extract the common behaviour into a shared superclass.

@swalker2m has also pointed out that naming conventions were not being maintained (e.g. `GHOSTController`, which should have been `GhostController`), so as a minor addition to this PR, I fixed GHOST, GPI, etc. to use the first-letter-capitalized rule.

If you have any strong feelings about the capitalization, lets' address them in the comment section here.