### PR TITLE
Refactor SeqexecEngine extracting the odb loading functions

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ODBSequencesLoader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ODBSequencesLoader.scala
@@ -1,0 +1,121 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import cats.Applicative
+import cats.Endo
+import cats.implicits._
+import cats.effect.IO
+import edu.gemini.spModel.obscomp.InstConstants
+import edu.gemini.spModel.seqcomp.SeqConfigNames.OCS_KEY
+import edu.gemini.spModel.core.SPProgramID
+import gem.Observation
+import seqexec.engine.Event
+import seqexec.engine.Sequence
+import seqexec.server.ConfigUtilOps._
+
+final class ODBSequencesLoader(odbProxy: OdbProxy, translator: SeqTranslate) {
+  private def unloadEvent(seqId: Observation.Id): executeEngine.EventType =
+    Event.modifyState[executeEngine.ConcreteTypes](
+      { st: EngineState =>
+        if (executeEngine.canUnload(seqId)(st)) {
+          (EngineState.sequences.modify(ss => ss - seqId) >>>
+            EngineState.selected.modify(ss =>
+              ss.toList.filter { case (_, x) => x =!= seqId }.toMap) >>>
+            EngineState.queues.modify(_.mapValues(
+              ExecutionQueue.queue.modify(_.filterNot(_ === seqId)))))(st)
+        } else st
+      }.withEvent(UnloadSequence(seqId)).toHandle
+    )
+
+  def loadEvents[F[_]: Applicative](
+    seqId: Observation.Id): List[executeEngine.EventType] = {
+    val t: Either[SeqexecFailure, (List[SeqexecFailure], Option[SequenceGen])] =
+      for {
+        odbSeq       <- odbProxy.read(seqId)
+        progIdString <- odbSeq
+                          .config
+                          .extractAs[String](OCS_KEY / InstConstants.PROGRAMID_PROP)
+                          .leftMap(ConfigUtilOps.explainExtractError)
+        _            <- Either.catchNonFatal(
+                          Applicative[F].pure(SPProgramID.toProgramID(progIdString)))
+                        .leftMap(e => SeqexecFailure.SeqexecException(e): SeqexecFailure)
+      } yield translator.sequence(seqId, odbSeq)
+
+    def loadSequenceEvent(seqg: SequenceGen): executeEngine.EventType =
+      Event.modifyState[executeEngine.ConcreteTypes]({ st: EngineState =>
+        st.sequences
+          .get(seqId)
+          .fold(ODBSequencesLoader.loadSequenceEndo(seqId, seqg))(
+            _ => ODBSequencesLoader.reloadSequenceEndo(seqId, seqg)
+          )(st)
+      }.withEvent(LoadSequence(seqId)).toHandle)
+
+    t.map {
+        case (err :: _, None) =>
+          List(Event.logDebugMsg(SeqexecFailure.explain(err)))
+        case (errs, Some(seq)) =>
+          loadSequenceEvent(seq) :: errs.map(e =>
+            Event.logDebugMsg(SeqexecFailure.explain(e)))
+        case _ => Nil
+      }
+      .valueOr(e => List(Event.logDebugMsg(SeqexecFailure.explain(e))))
+  }
+
+  def refreshSequenceList[F[_]: Applicative](odbList: Seq[Observation.Id])(
+    st: EngineState): List[executeEngine.EventType] = {
+    val seqexecList = st.sequences.keys.toSeq
+
+    val loads = odbList.diff(seqexecList).flatMap(loadEvents[F])
+
+    val unloads = seqexecList.diff(odbList).map(unloadEvent)
+
+    (loads ++ unloads).toList
+  }
+
+}
+
+object ODBSequencesLoader {
+
+  // TODO Parametrize the IO
+  private def toEngineSequence(
+    id:  Observation.Id,
+    seq: SequenceGen,
+    d:   HeaderExtraData
+  ): Sequence[IO] = Sequence(id, toStepList(seq, d))
+
+  private[server] def loadSequenceEndo(
+    seqId: Observation.Id,
+    seqg:  SequenceGen
+  ): Endo[EngineState] =
+    st =>
+      EngineState.sequences.modify(
+        ss =>
+          ss + (seqId -> SequenceData(
+            None,
+            seqg,
+            executeEngine.load(
+              toEngineSequence(
+                seqId,
+                seqg,
+                HeaderExtraData(st.conditions, st.operator, None))))))(st)
+
+  private[server] def reloadSequenceEndo(
+    seqId: Observation.Id,
+    seqg:  SequenceGen
+  ): Endo[EngineState] =
+    st =>
+      EngineState
+        .atSequence(seqId)
+        .modify(
+          sd =>
+            sd.copy(
+              seqGen = seqg,
+              seq = executeEngine.reload(
+                sd.seq,
+                toStepList(
+                  seqg,
+                  HeaderExtraData(st.conditions, st.operator, sd.observer)))))(st)
+
+}

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -55,7 +55,7 @@ class SeqTranslateSpec extends FlatSpec {
     ))
   )
 
-  private val baseState: EngineState = (SeqexecEngine.loadSequenceEndo(seqId, seqg) >>>
+  private val baseState: EngineState = (ODBSequencesLoader.loadSequenceEndo(seqId, seqg) >>>
     (EngineState.sequenceStateIndex(seqId) ^|-> Sequence.State.status).set(
       SequenceState.Running.init))(EngineState.default)
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -218,7 +218,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   "SeqexecEngine addSequenceToQueue" should
     "add sequence id to queue" in {
-    val s0 = SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1))(EngineState.default)
+    val s0 = ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1))(EngineState.default)
 
     (for {
       q <- async.boundedQueue[IO, executeEngine.EventType](10)
@@ -231,7 +231,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
   it should "not add sequence id if sequence does not exists" in {
     val badObsId = Observation.Id.unsafeFromString("NonExistent-1")
-    val s0 = SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1))(EngineState.default)
+    val s0 = ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1))(EngineState.default)
 
     (for {
       q <- async.boundedQueue[IO, executeEngine.EventType](10)
@@ -244,8 +244,8 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "not add sequence id if sequence is running or completed" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
       (EngineState.sequenceStateIndex(seqObsId1) ^|-> Sequence.State.status)
         .set(SequenceState.Running.init) >>>
       (EngineState.sequenceStateIndex(seqObsId2) ^|-> Sequence.State.status)
@@ -266,7 +266,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "not add sequence id if already in queue" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).modify(_ :+ seqObsId1))(EngineState.default)
 
     (for {
@@ -281,9 +281,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   "SeqexecEngine addSequencesToQueue" should
     "add sequence ids to queue" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequence(seqObsId3)))(EngineState.default)
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequence(seqObsId3)))(EngineState.default)
 
     (for {
       q <- async.boundedQueue[IO, executeEngine.EventType](10)
@@ -296,9 +296,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "not add sequence id if sequence is running or completed" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequence(seqObsId3)) >>>
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequence(seqObsId3)) >>>
       (EngineState.sequenceStateIndex(seqObsId1) ^|-> Sequence.State.status)
         .set(SequenceState.Running.init) >>>
       (EngineState.sequenceStateIndex(seqObsId2) ^|-> Sequence.State.status)
@@ -317,8 +317,8 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "not add sequence id if already in queue" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).modify(_ :+ seqObsId1))(EngineState.default)
 
     (for {
@@ -333,9 +333,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   "SeqexecEngine clearQueue" should
     "remove all sequences from queue" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequence(seqObsId3)) >>>
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequence(seqObsId3)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).modify(_ ++ List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
 
     (for {
@@ -350,8 +350,8 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   "SeqexecEngine removeSequenceFromQueue" should
     "remove sequence id from queue" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).modify(_ ++ List(seqObsId1, seqObsId2)))(EngineState.default)
 
     (for {
@@ -365,8 +365,8 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "not remove sequence id if sequence is running" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).modify(_ ++ List(seqObsId1, seqObsId2)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.cmdState).set(
         BatchCommandState.Run(Observer(""), UserDetails("", ""), clientId)) >>>
@@ -385,9 +385,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   "SeqexecEngine moveSequenceInQueue" should
     "move sequence id inside queue" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequence(seqObsId3)) >>>
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequence(seqObsId2)) >>>
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequence(seqObsId3)) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).modify(_ ++ List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
 
     def testAdvance(obsId: Observation.Id, n: Int): Option[EngineState] =
@@ -430,11 +430,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     assert(r.isEmpty)
   }
   it should "return only the first observation that uses a common resource" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2, TCS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS, TCS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
         Instrument.Gsaoi, Set(Instrument.Gsaoi, TCS))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
@@ -444,11 +444,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     r shouldBe Set(seqObsId1)
   }
   it should "return all observations with disjointed resource sets" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
       Instrument.F2, Set(Instrument.F2))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
         Instrument.Gsaoi, Set(Instrument.Gsaoi))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
@@ -458,11 +458,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     r shouldBe Set(seqObsId1, seqObsId2, seqObsId3)
   }
   it should "not return observations with resources in use" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2, TCS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS, TCS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId2, seqObsId3)) >>>
@@ -479,11 +479,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   "SeqexecEngine startQueue" should "run sequences in queue" in {
     // seqObsId1 and seqObsId2 can be run immediately, but seqObsId3 must be run after seqObsId1
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
@@ -501,11 +501,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   it should "set observer for all sequences in queue" in {
     val observer = Observer("John Doe")
     // seqObsId1 and seqObsId2 can be run immediately, but seqObsId3 must be run after seqObsId1
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
@@ -526,11 +526,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   it should "load the sequences to the corresponding instruments" in {
     // seqObsId1 and seqObsId2 can be run immediately, but seqObsId3 must be run after seqObsId1
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
@@ -547,11 +547,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   "SeqexecEngine stopQueue" should "stop running the sequences in the queue" in {
     // seqObsId1 and seqObsId2 will be run immediately, but seqObsId3 must be run after seqObsId1, and is the only one that will not run because of the stopQueue
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId) ^|-> ExecutionQueue.queue).set(
         List(seqObsId1, seqObsId2, seqObsId3)))(EngineState.default)
@@ -568,11 +568,11 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   "SeqexecEngine start sequence" should "not run sequence if running queue needs the same resources" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId3, sequenceWithResources(seqObsId3,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.queues ^|-? index(CalibrationQueueId)).modify(x => x.copy(cmdState =
         BatchCommandState.Run(Observer(""), UserDetails("", ""), clientId), queue = List(seqObsId1,
@@ -655,7 +655,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
 
   "SeqexecEngine setObserver" should "set observer's name" in {
     val observer = Observer("Joe")
-    val s0 = SeqexecEngine.loadSequenceEndo(seqObsId1, sequence(seqObsId1))(EngineState.default)
+    val s0 = ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequence(seqObsId1))(EngineState.default)
     (for {
       q <- async.boundedQueue[IO, executeEngine.EventType](10)
       sf <- advanceN(q, s0, seqexecEngine.setObserver(q, seqObsId1, UserDetails("", ""), observer), 2)
@@ -667,9 +667,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   "SeqexecEngine" should "not run 2nd sequence because it's using the same resource" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2, TCS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.sequenceStateIndex(seqObsId1) ^|-> Sequence.State.status).set(
         SequenceState.Running.init))(EngineState.default)
@@ -686,9 +686,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "run 2nd sequence when there are no shared resources" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2, TCS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.GmosS, Set(Instrument.GmosS))) >>>
       (EngineState.sequenceStateIndex(seqObsId1) ^|-> Sequence.State.status).set(
         SequenceState.Running.init))(EngineState.default)
@@ -704,7 +704,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   "SeqexecEngine configSystem" should "run a system configuration" in {
-    val s0 = SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
       Instrument.F2, Set(Instrument.F2, TCS)))(EngineState.default)
 
     (for {
@@ -720,7 +720,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "not run a system configuration if sequence is running" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2, TCS))) >>>
       (EngineState.sequenceStateIndex(seqObsId1) ^|-> Sequence.State.status).set(
         SequenceState.Running.init))(EngineState.default)
@@ -738,9 +738,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "not run a system configuration if system is in use" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.F2, TCS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.sequenceStateIndex(seqObsId1) ^|-> Sequence.State.status).set(
         SequenceState.Running.init))(EngineState.default)
@@ -758,9 +758,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   }
 
   it should "run a system configuration when other sequence is running with other systems" in {
-    val s0 = (SeqexecEngine.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
+    val s0 = (ODBSequencesLoader.loadSequenceEndo(seqObsId1, sequenceWithResources(seqObsId1,
         Instrument.F2, Set(Instrument.GmosS, TCS))) >>>
-      SeqexecEngine.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
+      ODBSequencesLoader.loadSequenceEndo(seqObsId2, sequenceWithResources(seqObsId2,
         Instrument.F2, Set(Instrument.F2))) >>>
       (EngineState.sequenceStateIndex(seqObsId1) ^|-> Sequence.State.status).set(
         SequenceState.Running.init))(EngineState.default)


### PR DESCRIPTION
`SeqexecEngine` is a fairly large class at the core of the seqexec. This PR splits a part of it, the part reading the ODB queue to simplify things