### PR TITLE
Functor.as/void

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ package-lock.json
 
 # Project specific
 modules/edu.gemini.seqexec.web/edu.gemini.seqexec.web.server/log/
+.bloop/

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -82,7 +82,7 @@ class Engine[D, U](stateL: Engine.State[D]) {
           case r                 =>
             singleRunFailed(c, Result.Error(s"Unhandled result for single run action: $r"))
         }
-      ).map[EventResult.Outcome](_ => EventResult.Ok)
+      ).as[EventResult.Outcome](EventResult.Ok)
     ).getOrElse(pure[EventResult.Outcome](EventResult.Failure))
 
   }
@@ -312,7 +312,7 @@ class Engine[D, U](stateL: Engine.State[D]) {
     ev match {
       case EventUser(ue)   => handleUserEvent(ue)
       case EventSystem(se) => handleSystemEvent(se)(ec).flatMap(x =>
-        userReact.applyOrElse(se, (_:SystemEvent) =>  unit).map(_ => x))
+        userReact.applyOrElse(se, (_:SystemEvent) =>  unit).as(x))
     }
   }
 

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
@@ -192,7 +192,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
             q.enqueue1(Event.start[executionEngine.ConcreteTypes](seqId, user, clientId, always)),
             startedFlag.decrement,
             q.enqueue1(Event.nullEvent),
-            q.enqueue1(Event.getState[executionEngine.ConcreteTypes] { _ => Stream.eval(finishFlag.increment).map(_ => Event.nullEvent).some })
+            q.enqueue1(Event.getState[executionEngine.ConcreteTypes] { _ => Stream.eval(finishFlag.increment).as(Event.nullEvent).some })
           ).sequence,
           executionEngine.process(PartialFunction.empty)(q.dequeue)(qs).drop(1).takeThrough(a => !isFinished(a._2.sequences(seqId).status)).compile.drain
         ).parSequence)
@@ -406,7 +406,7 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
 
     val c = ActionCoordsInSeq(stepId, ExecutionIndex(0), ActionIndex(0))
     val event = Event.modifyState[executionEngine.ConcreteTypes](
-      executionEngine.startSingle(ActionCoords(seqId, c)).map(_ => ())
+      executionEngine.startSingle(ActionCoords(seqId, c)).void
     )
     val sfs = executionEngine.process(PartialFunction.empty)(Stream.eval(IO.pure(event)))(s0)
       .map(_._2).take(2).compile.toList.unsafeRunSync

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -239,7 +239,7 @@ object EpicsUtil {
       }
     })))
 
-  def waitForValue[T](attr: CaAttribute[T], v: T, timeout: Time, name: String): SeqAction[Unit] = waitForValues[T](attr, List(v), timeout, name).map(_ => ())
+  def waitForValue[T](attr: CaAttribute[T], v: T, timeout: Time, name: String): SeqAction[Unit] = waitForValues[T](attr, List(v), timeout, name).void
 
   def setTimeout(os: Option[CaApplySender], t: Time):SeqAction[Unit] = SeqAction.either{
     os.map(_.setTimeout(t.toMilliseconds.toLong, MILLISECONDS).asRight).getOrElse(SeqexecFailure.Unexpected("Unable to set timeout for EPICS command.").asLeft)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
@@ -46,7 +46,7 @@ abstract class GiapiInstrumentController[F[_]: Sync, CFG, C <: GiapiClient[F]] {
     } yield ()
 
   def observe(fileId: ImageFileId, expTime: Time): SeqActionF[F, ImageFileId] =
-    EitherT(client.observe(fileId, expTime.toMilliseconds.milliseconds).map(_ => fileId).attempt)
+    EitherT(client.observe(fileId, expTime.toMilliseconds.milliseconds).as(fileId).attempt)
       .leftMap {
         case CommandResultException(_, "Message cannot be null") => Execution("Unhandled observe command")
         case CommandResultException(_, m)                        => Execution(m)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -39,11 +39,11 @@ final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsCl
 
   // FLAMINGOS-2 does not support abort or stop.
   override def observe(config: Config): SeqObserve[ImageFileId, ObserveCommand.Result] = Reader {
-    fileId => f2Controller.observe(fileId, calcObserveTime(config)).map(_ => ObserveCommand.Success)
+    fileId => f2Controller.observe(fileId, calcObserveTime(config)).as(ObserveCommand.Success)
   }
 
   override def configure(config: Config): SeqAction[ConfigResult[IO]] =
-    fromSequenceConfig(config).flatMap(f2Controller.applyConfig).map(_ => ConfigResult(this))
+    fromSequenceConfig(config).flatMap(f2Controller.applyConfig).as(ConfigResult(this))
 
   override def notifyObserveEnd: SeqAction[Unit] = f2Controller.endObserve
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -46,14 +46,14 @@ final case class Ghost[F[_]: Sync](controller: GhostController[F])
     Reader { fileId =>
       controller
         .observe(fileId, calcObserveTime(config))
-        .map(_ => ObserveCommand.Success: ObserveCommand.Result)
+        .as(ObserveCommand.Success: ObserveCommand.Result)
     }
 
   override def configure(config: Config): SeqActionF[F, ConfigResult[F]] =
     Ghost
       .fromSequenceConfig[F](config)
       .flatMap(controller.applyConfig)
-      .map(_ => ConfigResult[F](this))
+      .as(ConfigResult[F](this))
 
   override def notifyObserveEnd: SeqActionF[F, Unit] = controller.endObserve
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -103,7 +103,7 @@ abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosContro
   override def notifyObserveStart: SeqAction[Unit] = SeqAction.void
 
   override def configure(config: Config): SeqAction[ConfigResult[IO]] =
-    fromSequenceConfig(config).flatMap(controller.applyConfig).map(_ => ConfigResult(this))
+    fromSequenceConfig(config).flatMap(controller.applyConfig).as(ConfigResult(this))
 
   override def calcObserveTime(config: Config): Time =
     config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -45,7 +45,7 @@ final case class Gnirs(controller: GnirsController, dhsClient: DhsClient) extend
   override val resource: Resource = Instrument.Gnirs
 
   override def configure(config: Config): SeqAction[ConfigResult[IO]] =
-    SeqAction.either(fromSequenceConfig(config)).flatMap(controller.applyConfig).map(_ => ConfigResult(this))
+    SeqAction.either(fromSequenceConfig(config)).flatMap(controller.applyConfig).as(ConfigResult(this))
 
   override def notifyObserveEnd: SeqAction[Unit] = controller.endObserve
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -215,7 +215,7 @@ object GnirsControllerEpics extends GnirsController {
       case c:Other => setOtherCCParams(c)
     }
     if (params.isEmpty) SeqAction(EpicsCommand.Completed)
-    else params.sequence.map(_ => ()) *>
+    else params.sequence. void*>
       ccCmd.setTimeout(ConfigTimeout) *>
       ccCmd.post
   }
@@ -247,7 +247,7 @@ object GnirsControllerEpics extends GnirsController {
     val params =  expTimeWriter ++ coaddsWriter ++ biasWriter ++ lowNoiseWriter ++ digitalAvgsWriter
 
     if(params.isEmpty) SeqAction(EpicsCommand.Completed)
-    else params.sequence.map(_ => ()) *>
+    else params.sequence. void*>
       dcCmd.setTimeout(DefaultTimeout) *>
       dcCmd.post
   }
@@ -281,19 +281,19 @@ object GnirsControllerEpics extends GnirsController {
     EitherT.right[SeqexecFailure](IO(Log.debug("Send endObserve to GNIRS"))) *>
       GnirsEpics.instance.endObserveCmd.setTimeout(DefaultTimeout) *>
       GnirsEpics.instance.endObserveCmd.mark *>
-      GnirsEpics.instance.endObserveCmd.post.map(_ => ())
+      GnirsEpics.instance.endObserveCmd.post.void
 
   override def stopObserve: SeqAction[Unit] =
     EitherT.right[SeqexecFailure](IO(Log.info("Stop GNIRS exposure"))) *>
       GnirsEpics.instance.stopCmd.setTimeout(DefaultTimeout) *>
       GnirsEpics.instance.stopCmd.mark *>
-      GnirsEpics.instance.stopCmd.post.map(_ => ())
+      GnirsEpics.instance.stopCmd.post.void
 
   override def abortObserve: SeqAction[Unit] =
     EitherT.right[SeqexecFailure](IO(Log.info("Abort GNIRS exposure"))) *>
       GnirsEpics.instance.abortCmd.setTimeout(DefaultTimeout) *>
       GnirsEpics.instance.abortCmd.mark *>
-      GnirsEpics.instance.abortCmd.post.map(_ => ())
+      GnirsEpics.instance.abortCmd.post.void
 
   private def removePartName(s: String) = {
     val pattern = "_G[0-9]{4}$"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -58,14 +58,14 @@ final case class Gpi[F[_]: Effect](controller: GpiController[F])
     Reader { fileId =>
       controller
         .observe(fileId, timeoutTolerance + calcObserveTime(config))
-        .map(_ => ObserveCommand.Success: ObserveCommand.Result)
+        .as(ObserveCommand.Success: ObserveCommand.Result)
     }
 
   override def configure(config: Config): SeqActionF[F, ConfigResult[F]] =
     Gpi
       .fromSequenceConfig[F](config)
       .flatMap(controller.applyConfig)
-      .map(_ => ConfigResult(this))
+      .as(ConfigResult(this))
 
   override def notifyObserveEnd: SeqActionF[F, Unit] = controller.endObserve
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -54,7 +54,7 @@ final case class Niri(controller: NiriController, dhsClient: DhsClient)
     */
   override def configure(config: Config): SeqActionF[IO, ConfigResult[IO]] =
     SeqAction.either(fromSequenceConfig(config))
-      .flatMap(controller.applyConfig).map(_ => ConfigResult(this))
+      .flatMap(controller.applyConfig).as(ConfigResult(this))
 
   override def notifyObserveStart: SeqActionF[IO, Unit] = SeqAction.void
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
@@ -81,7 +81,7 @@ final case class Tcs(tcsController: TcsController, subsystems: NonEmptyList[Subs
         _ <- tcsController.guide(tcsConfig.gc)
       } yield ConfigResult(this)
     else
-      tcsController.applyConfig(subsystems, tcsConfig).map(_ => ConfigResult(this))
+      tcsController.applyConfig(subsystems, tcsConfig).as(ConfigResult(this))
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
@@ -423,7 +423,7 @@ object TcsControllerEpics extends TcsController {
     _ <- EitherT.right(IO.apply(Log.info("TCS guide command post")))
   } yield ()
 
-  override def notifyObserveStart: SeqAction[Unit] = TcsEpics.instance.observe.mark *> TcsEpics.instance.post.map(_ => ())
+  override def notifyObserveStart: SeqAction[Unit] = TcsEpics.instance.observe.mark *> TcsEpics.instance.post.void
 
-  override def notifyObserveEnd: SeqAction[Unit] = TcsEpics.instance.endObserve.mark *> TcsEpics.instance.post.map(_ => ())
+  override def notifyObserveEnd: SeqAction[Unit] = TcsEpics.instance.endObserve.mark *> TcsEpics.instance.post.void
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -74,7 +74,7 @@ object SubsystemControlCell {
                 icon = p.resourcesCalls
                   .get(r)
                   .filter(_ === ResourceRunOperation.ResourceRunInFlight)
-                  .map(_ => RunningIcon),
+                  .as(RunningIcon),
                 onClickE = requestResourceCall(p.id, p.stepId, r) _
               ),
               r.show

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ConditionsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ConditionsHandler.scala
@@ -3,7 +3,11 @@
 
 package seqexec.web.client.handlers
 
-import diode.{ActionHandler, ActionResult, Effect, ModelRW, NoAction}
+import diode.ActionHandler
+import diode.ActionResult
+import diode.Effect
+import diode.ModelRW
+import diode.NoAction
 import seqexec.model.Conditions
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
@@ -12,30 +16,32 @@ import cats.implicits._
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 /**
- * Handles updates to conditions
- */
-class ConditionsHandler[M](modelRW: ModelRW[M, Conditions]) extends ActionHandler(modelRW) with Handlers[M, Conditions] {
+  * Handles updates to conditions
+  */
+class ConditionsHandler[M](modelRW: ModelRW[M, Conditions])
+    extends ActionHandler(modelRW)
+    with Handlers[M, Conditions] {
   val iqHandle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateImageQuality(iq) =>
-      val updateE = Effect(SeqexecWebClient.setImageQuality(iq).map(_ => NoAction))
+      val updateE = Effect(SeqexecWebClient.setImageQuality(iq).as(NoAction))
       updated(value.copy(iq = iq), updateE)
   }
 
   val ccHandle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateCloudCover(cc) =>
-      val updateE = Effect(SeqexecWebClient.setCloudCover(cc).map(_ => NoAction))
+      val updateE = Effect(SeqexecWebClient.setCloudCover(cc).as(NoAction))
       updated(value.copy(cc = cc), updateE)
   }
 
   val sbHandle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateSkyBackground(sb) =>
-      val updateE = Effect(SeqexecWebClient.setSkyBackground(sb).map(_ => NoAction))
+      val updateE = Effect(SeqexecWebClient.setSkyBackground(sb).as(NoAction))
       updated(value.copy(sb = sb), updateE)
   }
 
   val wvHandle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateWaterVapor(wv) =>
-      val updateE = Effect(SeqexecWebClient.setWaterVapor(wv).map(_ => NoAction))
+      val updateE = Effect(SeqexecWebClient.setWaterVapor(wv).as(NoAction))
       updated(value.copy(wv = wv), updateE)
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/LoadedSequencesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/LoadedSequencesHandler.scala
@@ -66,7 +66,7 @@ class LoadedSequencesHandler[M](modelRW: ModelRW[M, SODLocationFocus])
             Effect(
               SeqexecWebClient
                 .loadSequence(i, id, observer, cid)
-                .map(_ => NoAction)))
+                .as(NoAction)))
         .getOrElse(VoidEffect)
       val update = SODLocationFocus.sod.modify(_.markAsLoading(id))
       updatedLE(update, loadSequence)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OpenConnectionHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OpenConnectionHandler.scala
@@ -3,6 +3,7 @@
 
 package seqexec.web.client.handlers
 
+import cats.implicits._
 import diode.ActionHandler
 import diode.ActionResult
 import diode.ModelRW
@@ -21,7 +22,7 @@ class OpenConnectionHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(ConnectionOpenEvent(u, _)) =>
       val ts = u
-        .map(_ => CalQueueTable.State.EditableTableState)
+        .as(CalQueueTable.State.EditableTableState)
         .getOrElse(CalQueueTable.State.ROTableState)
       updatedL(CalibrationQueues.tableStatesT.set(ts))
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/RemoteRequestsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/RemoteRequestsHandler.scala
@@ -29,7 +29,7 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
             Effect(
               SeqexecWebClient
                 .run(s, clientId)
-                .map(_ => RunStarted(s))
+                .as(RunStarted(s))
                 .recover {
                   case _ => RunStartFailed(s)
                 }))
@@ -61,7 +61,7 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
         Effect(
           SeqexecWebClient
             .stop(id, step)
-            .map(_ => RunStop(id))
+            .as(RunStop(id))
             .recover {
               case _ => RunStopFailed(id)
             }))
@@ -73,7 +73,7 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
         Effect(
           SeqexecWebClient
             .abort(id, step)
-            .map(_ => RunAbort(id))
+            .as(RunAbort(id))
             .recover {
               case _ => RunAbortFailed(id)
             }))
@@ -85,7 +85,7 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
         Effect(
           SeqexecWebClient
             .pauseObs(id, step)
-            .map(_ => RunObsPause(id))
+            .as(RunObsPause(id))
             .recover {
               case _ => RunObsPauseFailed(id)
             }))
@@ -97,7 +97,7 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
         Effect(
           SeqexecWebClient
             .resumeObs(id, step)
-            .map(_ => RunObsPause(id))
+            .as(RunObsPause(id))
             .recover {
               case _ => RunObsResumeFailed(id)
             }))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
@@ -59,7 +59,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
   val soundCheck: PartialFunction[Any, ActionResult[M]] = {
     case RequestSoundEcho =>
       val soundEffect = Effect(
-        Future(SequenceCompleteAudio.play()).map(_ => NoAction))
+        Future(SequenceCompleteAudio.play()).as(NoAction))
       effectOnly(soundEffect)
   }
 
@@ -71,8 +71,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
   val connectionOpenMessage: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(ConnectionOpenEvent(u, c)) =>
       // After connected to the Websocket request a refresh
-      val refreshRequestE = Effect(
-        SeqexecWebClient.refresh(c).map(_ => NoAction))
+      val refreshRequestE = Effect(SeqexecWebClient.refresh(c).as(NoAction))
       // This is a hack
       val calQueueObserverE = u
         .map(m => Effect(Future(UpdateCalTabObserver(Observer(m.displayName)))))
@@ -101,7 +100,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       val audioEffect = curStep
         .filter(ifLoggedIn)
         .fold(VoidEffect)(_ =>
-          Effect(Future(StepBeepAudio.play()).map(_ => NoAction)))
+          Effect(Future(StepBeepAudio.play()).as(NoAction)))
       updated(value.copy(sequences = filterSequences(sv)), audioEffect)
   }
 
@@ -110,7 +109,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       // Play audio when the sequence completes
       val audioEffect =
         if (loggedIn)
-          Effect(Future(SequenceCompleteAudio.play()).map(_ => NoAction))
+          Effect(Future(SequenceCompleteAudio.play()).as(NoAction))
         else VoidEffect
       updated(value.copy(sequences = filterSequences(sv)), audioEffect)
   }
@@ -127,7 +126,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       // Play audio when the sequence gets into an error state
       val audioEffect =
         if (loggedIn)
-          Effect(Future(SequenceErrorAudio.play()).map(_ => NoAction))
+          Effect(Future(SequenceErrorAudio.play()).as(NoAction))
         else VoidEffect
       updated(value.copy(sequences = filterSequences(sv)), audioEffect)
   }
@@ -137,7 +136,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       // Play audio when the sequence gets paused
       val audioEffect =
         if (loggedIn)
-          Effect(Future(SequencePausedAudio.play()).map(_ => NoAction))
+          Effect(Future(SequencePausedAudio.play()).as(NoAction))
         else VoidEffect
       updated(value.copy(sequences = filterSequences(sv)), audioEffect)
   }
@@ -147,7 +146,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       // Play audio when the sequence gets paused
       val audioEffect =
         if (loggedIn)
-          Effect(Future(ExposurePausedAudio.play()).map(_ => NoAction))
+          Effect(Future(ExposurePausedAudio.play()).as(NoAction))
         else VoidEffect
       updated(value.copy(sequences = filterSequences(sv)), audioEffect)
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/UserLoginHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/UserLoginHandler.scala
@@ -3,8 +3,13 @@
 
 package seqexec.web.client.handlers
 
-import diode.{ActionHandler, ActionResult, Effect, ModelRW, NoAction}
-import seqexec.model.{ UserDetails }
+import cats.implicits._
+import diode.ActionHandler
+import diode.ActionResult
+import diode.Effect
+import diode.ModelRW
+import diode.NoAction
+import seqexec.model.UserDetails
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
 import scala.concurrent.Future
@@ -13,7 +18,9 @@ import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 /**
   * Handles actions related to opening/closing the login box
   */
-class UserLoginHandler[M](modelRW: ModelRW[M, Option[UserDetails]]) extends ActionHandler(modelRW) with Handlers[M, Option[UserDetails]] {
+class UserLoginHandler[M](modelRW: ModelRW[M, Option[UserDetails]])
+    extends ActionHandler(modelRW)
+    with Handlers[M, Option[UserDetails]] {
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case LoggedIn(u) =>
       // Close the login box
@@ -23,7 +30,7 @@ class UserLoginHandler[M](modelRW: ModelRW[M, Option[UserDetails]]) extends Acti
       updated(Some(u), reconnect + effect)
 
     case Logout =>
-      val effect = Effect(SeqexecWebClient.logout().map(_ => NoAction))
+      val effect    = Effect(SeqexecWebClient.logout().as(NoAction))
       val reConnect = Effect(Future(Reconnect))
       // Remove the user and call logout
       updated(None, effect + reConnect)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/WebSocketHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/WebSocketHandler.scala
@@ -106,7 +106,7 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection])
       // Capture the WS, or it maybe invalid during the Future
       val ws = value.ws
       val closeCurrent = Effect(
-        Future(ws.foreach(_.close())).map(_ => NoAction))
+        Future(ws.foreach(_.close())).as(NoAction))
       val reConnect = Effect(webSocket)
       updated(value.copy(ws = Pot.empty[WebSocket], nextAttempt = 0, autoReconnect = false), closeCurrent >> reConnect)
   }
@@ -120,7 +120,7 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection])
     case WSClose =>
       // Forcefully close the websocket as requested when reloading the code via HMR
       val ws = value.ws
-      val closeEffect = Effect(Future(ws.foreach(_.close())).map(_ => NoAction))
+      val closeEffect = Effect(Future(ws.foreach(_.close())).as(NoAction))
       updated(value.copy(ws = Pot.empty[WebSocket], nextAttempt = 0, autoReconnect = false), closeEffect)
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/handlers.scala
@@ -29,7 +29,7 @@ class OperatorHandler[M](modelRW: ModelRW[M, Option[Operator]])
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateOperator(name) =>
       val updateOperatorE = Effect(
-        SeqexecWebClient.setOperator(name).map(_ => NoAction))
+        SeqexecWebClient.setOperator(name).as(NoAction))
       updated(name.some, updateOperatorE)
   }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/package.scala
@@ -4,6 +4,7 @@
 package seqexec.web.client
 
 import cats.Monoid
+import cats.implicits._
 import diode.Action
 import diode.ActionHandler
 import diode.ActionResult
@@ -37,7 +38,7 @@ package handlers {
                                                    r: A => C): Effect =
       Effect(
         f(a)
-          .map(_ => m(a))
+          .as(m(a))
           .recover {
             case _ => r(a)
           }
@@ -50,7 +51,7 @@ package handlers {
       r: A => D): Effect =
       Effect(
         f(a._1, a._2)
-          .map(_ => m(a._1))
+          .as(m(a._1))
           .recover {
             case _ => r(a._1)
           }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -59,7 +59,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(id.format)}/sync",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to execute a sequence
@@ -70,7 +70,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(id.format)}/start/${encodeURI(clientId.self.show)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set a breakpoint
@@ -81,7 +81,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(sid.format)}/${step.id}/breakpoint/${step.breakpoint}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set a breakpoint
@@ -92,7 +92,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(sid.format)}/${step.id}/skip/${step.skip}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to stop immediately this sequence
@@ -103,7 +103,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/stop",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to abort this sequenece
@@ -114,7 +114,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/abort",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to hold the current exposure
@@ -125,7 +125,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/pauseObs",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to resume the current exposure
@@ -136,7 +136,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/resumeObs",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set the operator name of a sequence
@@ -147,7 +147,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/operator/${encodeURI(name.show)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set the observer name of a sequence
@@ -159,7 +159,7 @@ object SeqexecWebClient extends ModelBooPicklers {
           s"$baseUrl/commands/${encodeURI(id.format)}/observer/${encodeURI(name)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set the Conditions globally
@@ -171,7 +171,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         responseType = "arraybuffer",
         data         = Pickle.intoBytes(conditions)
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set the ImageQuality
@@ -183,7 +183,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         responseType = "arraybuffer",
         data         = Pickle.intoBytes[ImageQuality](iq)
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set the CloudCover
@@ -195,7 +195,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         responseType = "arraybuffer",
         data         = Pickle.intoBytes[CloudCover](cc)
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set the WaterVapor
@@ -207,7 +207,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         responseType = "arraybuffer",
         data         = Pickle.intoBytes[WaterVapor](wv)
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to set the SkyBackground
@@ -219,7 +219,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         responseType = "arraybuffer",
         data         = Pickle.intoBytes[SkyBackground](sb)
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to send a copy of the current state
@@ -230,7 +230,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/refresh/${encodeURI(clientId.self.show)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to pause a sequence
@@ -241,7 +241,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(id.format)}/pause",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Requests the backend to cancel a pausing request in process
@@ -252,7 +252,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/${encodeURI(id.format)}/cancelpause",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Login request
@@ -288,7 +288,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/load/${encodeURI(instrument.show)}/${encodeURI(id.format)}/${encodeURI(name.value)}/${encodeURI(clientId.self.show)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Log record
@@ -323,7 +323,7 @@ object SeqexecWebClient extends ModelBooPicklers {
           s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/remove/${encodeURI(id.format)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Clears a queue
@@ -334,7 +334,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/clear",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Runs a queue
@@ -349,7 +349,7 @@ object SeqexecWebClient extends ModelBooPicklers {
             observer.value)}/${encodeURI(clientId.self.show)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Stops a queue
@@ -361,7 +361,7 @@ object SeqexecWebClient extends ModelBooPicklers {
           s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/stop/${encodeURI(clientId.self.show)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Add a sequence from a queue
@@ -373,7 +373,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         responseType = "arraybuffer",
         data         = Pickle.intoBytes(ids)
       )
-      .map(_ => ())
+      .void
 
   /**
     * Add a sequence from a queue
@@ -384,7 +384,7 @@ object SeqexecWebClient extends ModelBooPicklers {
         url          = s"$baseUrl/commands/queue/${encodeURI(qid.self.show)}/add/${encodeURI(id.format)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Stops a queue
@@ -396,7 +396,7 @@ object SeqexecWebClient extends ModelBooPicklers {
           s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/move/${encodeURI(obsId.self.format)}/$pos/${encodeURI(clientId.self.show)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
   /**
     * Runs a reusource
@@ -408,6 +408,6 @@ object SeqexecWebClient extends ModelBooPicklers {
           s"$baseUrl/commands/execute/${encodeURI(obsId.self.format)}/$pos/${encodeURI(resource.show)}",
         responseType = "arraybuffer"
       )
-      .map(_ => ())
+      .void
 
 }


### PR DESCRIPTION
Mechanical refactoring of places where `Functor.as` or `Functor.void` can be used instead of `map`