### PR TITLE
Fix to keep completed tabs

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -128,13 +128,14 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
         val curTableState = tab
           .map(_.tableState)
           .getOrElse(StepsTable.State.InitialTableState)
-        val s = tag[InstrumentSequenceTab.LoadedSV][SequenceView](x).asRight
-        val seq = tab.map{t => if (t.isComplete) tag[InstrumentSequenceTab.CompletedSV][SequenceView](x).asLeft else s}
+        val left = tag[InstrumentSequenceTab.CompletedSV][SequenceView](x)
+        val right = tag[InstrumentSequenceTab.LoadedSV][SequenceView](x)
+        val seq = tab.filter(_.isComplete).as(left).toLeft(right)
         val stepConfig   = tab.flatMap(_.stepConfig)
         val selectedStep = tab.flatMap(_.selectedStep)
         InstrumentSequenceTab(
           x.metadata.instrument,
-          seq.getOrElse(s),
+          seq,
           stepConfig,
           selectedStep,
           curTableState,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -128,11 +128,13 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
         val curTableState = tab
           .map(_.tableState)
           .getOrElse(StepsTable.State.InitialTableState)
+        val s = tag[InstrumentSequenceTab.LoadedSV][SequenceView](x).asRight
+        val seq = tab.map{t => if (t.isComplete) tag[InstrumentSequenceTab.CompletedSV][SequenceView](x).asLeft else s}
         val stepConfig   = tab.flatMap(_.stepConfig)
         val selectedStep = tab.flatMap(_.selectedStep)
         InstrumentSequenceTab(
           x.metadata.instrument,
-          tag[InstrumentSequenceTab.LoadedSV][SequenceView](x).asRight,
+          seq.getOrElse(s),
           stepConfig,
           selectedStep,
           curTableState,
@@ -461,7 +463,7 @@ object SequencesOnDisplay {
 
   private def instrumentTab(tab: SeqexecTab): Boolean =
     tab match {
-      case i: InstrumentSequenceTab => !i.isComplete
+      case _: InstrumentSequenceTab => true
       case _                        => false
     }
 


### PR DESCRIPTION
We have to keep tabs when they are completed on the client while they are removed on the server. The last PR broke that but this PR restores that functionality 