### PR TITLE
SEQNG-458 Clean the preview tab if removed from the odb queue

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -141,10 +141,16 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
           curTableState,
           TabOperations.Default).some
     }
+    val ids = s.collect {
+      case Some(s) => s.id
+    }
     // Store current focus
     val currentFocus = tabs.focus
     // Save the current preview
-    val onlyPreview  = SequencesOnDisplay.previewTab.headOption(this)
+    val onlyPreview  = SequencesOnDisplay
+      .previewTab
+      .headOption(this)
+      .filter(p => ids.contains(p.obsId))
     val sequenceTabs = (onlyPreview :: instTabs).collect { case Some(x) => x }
     // new zipper
     val newZipper =


### PR DESCRIPTION
This is a tiny bug, if an obs is in preview but it is removed from the odb queue it remains in preview. This PR will remove it from the UI