### PR TITLE
Shape Geometry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   )
   .jsSettings(commonJSSettings)
   .jvmSettings(
-    libraryDependencies += Fs2
+    libraryDependencies ++= Seq(Fs2, Jts)
   )
 
 lazy val db = project

--- a/modules/core/jvm/src/main/scala/gem/geom/jts/Jts.scala
+++ b/modules/core/jvm/src/main/scala/gem/geom/jts/Jts.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom.jts
+
+import org.locationtech.jts.geom.{ GeometryFactory, PrecisionModel }
+
+/**
+ * Shared JTS setup.
+ */
+object Jts {
+
+  val precisionModel: PrecisionModel =
+    new PrecisionModel()
+
+  val geometryFactory: GeometryFactory =
+    new GeometryFactory(precisionModel)
+
+}

--- a/modules/core/jvm/src/main/scala/gem/geom/jts/JtsDemo.scala
+++ b/modules/core/jvm/src/main/scala/gem/geom/jts/JtsDemo.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom.jts
+
+import gem.geom.jts.interpreter._
+import gem.geom.GmosOiwfsProbeArm
+
+import java.awt._
+import java.awt.event._
+
+import scala.collection.JavaConverters._
+
+/**
+ * Throwaway demo code to visualize a shape created using `ShapeExpression`s.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.AsInstanceOf"))
+object JtsDemo extends Frame("JTS Demo") {
+
+  val canvasSize: Int = 800
+
+  val hints: Map[RenderingHints.Key, Object] =
+    Map(
+      RenderingHints.KEY_ANTIALIASING -> RenderingHints.VALUE_ANTIALIAS_ON,
+      RenderingHints.KEY_RENDERING    -> RenderingHints.VALUE_RENDER_QUALITY
+    )
+
+  object canvas extends Canvas {
+    setBackground(Color.lightGray)
+    setSize(canvasSize, canvasSize)
+
+    override def paint(g: Graphics): Unit = {
+      val g2d = g.asInstanceOf[Graphics2D]
+      g2d.setRenderingHints(hints.asJava)
+      g2d.translate(canvasSize/2, canvasSize/2)
+
+      // Cross hair showing center.
+      g2d.drawLine(-2, 0, 2, 0)
+      g2d.drawLine(0, -2, 0, 2)
+
+      GmosOiwfsProbeArm.shape.eval match {
+        case jts: JtsShape => g2d.draw(jts.toAwt)
+        case x             => sys.error(s"Whoa unexpected shape type: $x")
+      }
+
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    setSize(canvasSize, canvasSize)
+
+    addWindowListener(new WindowAdapter() {
+      override def windowClosing(windowEvent: WindowEvent): Unit = {
+        System.exit(0)
+      }
+    })
+
+    add(BorderLayout.CENTER, canvas)
+
+    setVisible(true)
+  }
+}

--- a/modules/core/jvm/src/main/scala/gem/geom/jts/JtsShape.scala
+++ b/modules/core/jvm/src/main/scala/gem/geom/jts/JtsShape.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom.jts
+
+import gem.geom.jts.syntax.all._
+
+import gem.geom.Shape
+import gem.math.Offset
+import org.locationtech.jts.awt.{PointTransformation, ShapeWriter}
+import org.locationtech.jts.geom.{Coordinate, Geometry}
+
+import java.awt.geom.Point2D;
+
+/**
+ * JVM / JTS implementation of Shape.
+ */
+final case class JtsShape(g: Geometry) extends Shape {
+
+  import JtsShape._
+
+  override def contains(o: Offset): Boolean =
+    g.contains(o.point)
+
+  override def area: Long =
+    g.getArea.round
+
+  /**
+   * Converts to the AWT equivalent at 1 arcsec / pixel.  This is specific to
+   * the Java implementation.  (The scale should probably be explicitly
+   * specified.)
+   */
+  def toAwt: java.awt.Shape =
+    awtWriter.toShape(g)
+}
+
+object JtsShape {
+
+  // Converts points to AWT at arcsec / pixel scale.
+  private val toArcsec: PointTransformation =
+    new PointTransformation {
+      def transform(s: Coordinate, d: Point2D): Unit =
+        // With AWT canvas, y increases towards the bottom
+        d.setLocation(s.x / 1000000.0, - s.y / 1000000.0)
+    }
+
+  private val awtWriter: ShapeWriter =
+    new ShapeWriter(toArcsec)
+
+}

--- a/modules/core/jvm/src/main/scala/gem/geom/jts/JtsShapeInterpreter.scala
+++ b/modules/core/jvm/src/main/scala/gem/geom/jts/JtsShapeInterpreter.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom.jts
+
+import syntax.all._
+
+import gem.geom.ShapeExpression.{Difference, Ellipse, Intersection, Polygon, Rectangle, Rotate, Translate, Union}
+import gem.geom.{Shape, ShapeExpression, ShapeInterpreter}
+
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.util.AffineTransformation
+
+/**
+ * JVM-specific JTS shape interpreter.
+ */
+object JtsShapeInterpreter extends ShapeInterpreter {
+
+  private def toGeometry(e: ShapeExpression): Geometry =
+    e match {
+      // Constructors
+      case Ellipse(a, b)      => a.shapeFactory(b).createEllipse
+      case Polygon(os)        => Jts.geometryFactory.createPolygon(os.map(_.coordinate).toArray)
+      case Rectangle(a, b)    => a.shapeFactory(b).createRectangle
+
+      // Combinations
+      case Difference(a, b)   => toGeometry(a).difference(toGeometry(b))
+      case Intersection(a, b) => toGeometry(a).intersection(toGeometry(b))
+      case Union(a, b)        => toGeometry(a).union(toGeometry(b))
+
+      // Transformations
+      case Rotate(e, a)       =>
+        AffineTransformation
+          .rotationInstance(a.toDoubleDegrees)
+          .transform(toGeometry(e))
+
+      case Translate(e, o)    =>
+        val c = o.coordinate
+        AffineTransformation
+          .translationInstance(c.x, c.y)
+          .transform(toGeometry(e))
+    }
+
+  override def interpret(e: ShapeExpression): Shape =
+    JtsShape(toGeometry(e))
+}
+
+
+object interpreter {
+
+  implicit val value: ShapeInterpreter =
+    JtsShapeInterpreter
+
+}
+

--- a/modules/core/jvm/src/main/scala/gem/geom/jts/syntax/Angle.scala
+++ b/modules/core/jvm/src/main/scala/gem/geom/jts/syntax/Angle.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom.jts.syntax
+
+import gem.math.Angle
+
+// Syntax used in the JVM / JTS implementation only.
+
+final class AngleOps(val self: Angle) extends AnyVal {
+  def µas: Long =
+    Angle.signedMicroarcseconds.get(self)
+}
+
+trait ToAngleOps {
+  implicit def ToAngleOps(a: Angle): AngleOps = new AngleOps(a)
+}
+
+object angle extends ToAngleOps
+

--- a/modules/core/jvm/src/main/scala/gem/geom/jts/syntax/Offset.scala
+++ b/modules/core/jvm/src/main/scala/gem/geom/jts/syntax/Offset.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom.jts.syntax
+
+import gem.geom.jts.Jts.geometryFactory
+
+import angle._
+import offset._
+
+import gem.math.Offset
+
+import org.locationtech.jts.geom.{Coordinate, Envelope, Geometry}
+import org.locationtech.jts.util.GeometricShapeFactory
+
+// Syntax used in the JVM/ JTS implementation only.
+
+final class OffsetOps(val self: Offset) extends AnyVal {
+
+  def µas: (Long, Long) =
+    (self.p.toAngle.µas, self.q.toAngle.µas)
+
+  def coordinate: Coordinate = {
+    val (p, q) = µas
+    // Offset p is flipped around the y axis so it increases to the left
+    new Coordinate(-p.toDouble, q.toDouble)
+  }
+
+  def point: Geometry =
+    geometryFactory.createPoint(coordinate)
+
+  def envelope(that: Offset): Envelope =
+    new Envelope(coordinate, that.coordinate)
+
+  def shapeFactory(that: Offset): GeometricShapeFactory = {
+    val f  = new GeometricShapeFactory(geometryFactory)
+    f.setEnvelope(envelope(that))
+    f
+  }
+
+}
+
+trait ToOffsetOps {
+  implicit def ToOffsetOps(o: Offset): OffsetOps = new OffsetOps(o)
+}
+
+object offset extends ToOffsetOps

--- a/modules/core/jvm/src/main/scala/gem/geom/jts/syntax/package.scala
+++ b/modules/core/jvm/src/main/scala/gem/geom/jts/syntax/package.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom.jts
+
+package object syntax {
+
+  // Syntax used in the JTS / JVM implementation only.
+
+  object all extends ToAngleOps
+                with ToOffsetOps
+
+}

--- a/modules/core/shared/src/main/scala/gem/geom/GmosOiwfsProbeArm.scala
+++ b/modules/core/shared/src/main/scala/gem/geom/GmosOiwfsProbeArm.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom
+
+import gem.math.Angle
+
+import gem.syntax.shapeexpression._
+
+// WIP: would need to be moved out of this package and is missing the
+// calculation for particular offset position impact on the arm rotation
+
+/**
+ * Description of the GMOS OIWFS probe arm geometry.
+ */
+object GmosOiwfsProbeArm {
+  val PickoffArmLength: Angle      = 358460.mas
+  val PickoffMirrorSize: Angle     =  20000.mas
+  val ProbeArmLength: Angle        = PickoffArmLength - (PickoffMirrorSize / 2)
+  val ProbeArmTaperedWidth: Angle  =  15000.mas
+  val ProbeArmTaperedLength: Angle = 180000.mas
+
+  private val arm: ShapeExpression = {
+    val hm  = PickoffMirrorSize    / 2
+    val htw = ProbeArmTaperedWidth / 2
+
+    val p0 = (-hm,                           htw  )
+    val p1 = (p0._1 - ProbeArmTaperedLength, hm   )
+    val p2 = (p0._1 - ProbeArmLength,        p1._2)
+    val p3 = (p2._1,                        -hm   )
+    val p4 = (p1._1,                         p3._2)
+    val p5 = (p0._1,                        -htw  )
+
+    ShapeExpression.polygon(p0, p1, p2, p3, p4, p5, p0)
+  }
+
+  private val pickoff: ShapeExpression = {
+    val s = PickoffMirrorSize / 2
+    ShapeExpression.rectangle((s, s), (s - PickoffMirrorSize, s - PickoffMirrorSize))
+  }
+
+  /**
+   * Description of the GMOS OIWFS probe arm with the pickoff mirror centered
+   * at the base position.
+   */
+  val shape: ShapeExpression =
+    arm ∪ pickoff
+
+  // Syntax to simplify the implementation.
+
+  private implicit class IntOps(val self: Int) extends AnyVal {
+    def mas: Angle =
+      Angle.signedMicroarcseconds.reverseGet(self.toLong * 1000)
+  }
+
+  private implicit class AngleOps(val self: Angle) extends AnyVal {
+    def /(d: Int): Angle =
+      Angle.fromMicroarcseconds(self.toMicroarcseconds / d)
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/geom/Shape.scala
+++ b/modules/core/shared/src/main/scala/gem/geom/Shape.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom
+
+import gem.math.Offset
+
+/**
+ * Shape description usable for testing point inclusion and calculating the
+ * area.  Point inclusion is used to determine, for instance, guide star
+ * reachability for a probe range.  Comparative area is usable when calculating
+ * which guide star options produce the minimum vignetting (probe arm shadow
+ * intersected with science area).
+ */
+trait Shape {
+
+  /**
+   * Determines whether the given position is contained in the shape.
+   */
+  def contains(o: Offset): Boolean
+
+  /**
+   * Area of the shape. The value is in microarcseconds angular separation^2
+   * but the absolute value is less useful than comparing across multiple
+   * shapes (to determine minimum vignetting).
+   */
+  def area: Long
+
+}

--- a/modules/core/shared/src/main/scala/gem/geom/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/gem/geom/ShapeExpression.scala
@@ -1,0 +1,76 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom
+
+import gem.math.{ Angle, Offset }
+
+/**
+ * Describes a `Shape`, which is produced by evaluating the expression using
+ * the JVM or JavaScript specific interpreter.
+ */
+sealed trait ShapeExpression {
+
+  /**
+   * Evaluates the expression into a `Shape`, assuming an interpreter is in
+   * scope.
+   *
+   * @param ev shape interpreter to use
+   *
+   * @return Shape implementation
+   */
+  def eval(implicit ev: ShapeInterpreter): Shape =
+    ev.interpret(this)
+
+}
+
+object ShapeExpression {
+
+  /**
+   * Ellipse contained in the rectangle defined by the two positions.
+   *
+   * @group Constructors
+   */
+  final case class Ellipse(a: Offset, b: Offset)                         extends ShapeExpression
+
+  /**
+   * Polygon defined by a list of offset positions.
+   *
+   * @group Constructors
+   */
+  final case class Polygon(os: List[Offset])                             extends ShapeExpression
+
+  /**
+   * Rectangle defined by two offset positions.
+   *
+   * @group Constructors
+   */
+  final case class Rectangle(a: Offset, b: Offset)                       extends ShapeExpression
+
+  /**
+   * @group Combinations
+   */
+  final case class Difference(a: ShapeExpression, b: ShapeExpression)    extends ShapeExpression
+
+  /**
+   * @group Combinations
+   */
+  final case class Intersection(a: ShapeExpression, b: ShapeExpression)  extends ShapeExpression
+
+  /**
+   * @group Combinations
+   */
+  final case class Union(a: ShapeExpression, b: ShapeExpression)         extends ShapeExpression
+
+
+  /**
+   * @group Transformations
+   */
+  final case class Rotate(e: ShapeExpression, a: Angle)                  extends ShapeExpression
+
+  /**
+   * @group Transformations
+   */
+  final case class Translate(e: ShapeExpression, o: Offset)              extends ShapeExpression
+
+}

--- a/modules/core/shared/src/main/scala/gem/geom/ShapeInterpreter.scala
+++ b/modules/core/shared/src/main/scala/gem/geom/ShapeInterpreter.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.geom
+
+/**
+ * Interprets a `ShapeExpression` to a `Shape`.
+ */
+trait ShapeInterpreter {
+  def interpret(e: ShapeExpression): Shape
+}

--- a/modules/core/shared/src/main/scala/gem/syntax/ShapeExpression.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/ShapeExpression.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import gem.geom.ShapeExpression
+import gem.geom.ShapeExpression._
+
+import gem.math.{Angle, Offset}
+
+final class ShapeExpressionOps(val self: ShapeExpression) extends AnyVal {
+
+  def difference(that: ShapeExpression): ShapeExpression =
+    Difference(self, that)
+
+  def intersection(that: ShapeExpression): ShapeExpression =
+    Intersection(self, that)
+
+  def rotate(a: Angle): ShapeExpression =
+    Rotate(self, a)
+
+  def translate(o: Offset): ShapeExpression =
+    Translate(self, o)
+
+  def union(that: ShapeExpression): ShapeExpression =
+    Union(self, that)
+
+  def -(that: ShapeExpression): ShapeExpression =
+    difference(that)
+
+  def ∩(that: ShapeExpression): ShapeExpression =
+    intersection(that)
+
+  def ⟲(a: Angle): ShapeExpression =
+    rotate(a)
+
+  def ↗(o: Offset): ShapeExpression =
+    translate(o)
+
+  def ∪(that: ShapeExpression): ShapeExpression =
+    union(that)
+
+}
+
+trait ToShapeExpressionOps {
+  implicit def ToShapeExpressionOps(e: ShapeExpression): ShapeExpressionOps =
+    new ShapeExpressionOps(e)
+}
+
+final class ShapeExpressionCompanionOps(val self: ShapeExpression.type) extends AnyVal {
+
+  // Simplified constructors
+
+  private def offset(o: (Angle, Angle)): Offset =
+    Offset(Offset.P(o._1), Offset.Q(o._2))
+
+  def ellipse(a: (Angle, Angle), b: (Angle, Angle)): ShapeExpression =
+    Ellipse(offset(a), offset(b))
+
+  def polygon(os: (Angle, Angle)*): ShapeExpression =
+    Polygon(os.toList.map(offset))
+
+  def rectangle(a: (Angle, Angle), b: (Angle, Angle)): ShapeExpression =
+    Rectangle(offset(a), offset(b))
+
+}
+
+trait ToShapeExpressionCompanionOps {
+  implicit def ToShapeExpressionCompanionOps(c: ShapeExpression.type): ShapeExpressionCompanionOps =
+    new ShapeExpressionCompanionOps(c)
+}
+
+object shapeexpression extends ToShapeExpressionOps with ToShapeExpressionCompanionOps

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -110,6 +110,9 @@ object Settings {
     val tucoVersion             = "0.3.1"
     val declineVersion          = "0.4.2"
 
+    // Java Libraries
+    val jts                     = "1.16.0"
+
     // test libraries
     val scalaTest               = "3.0.5"
     val scalaCheck              = "1.13.5"
@@ -195,6 +198,7 @@ object Settings {
     val Http4sXml              = "org.http4s"                         %%  "http4s-scala-xml"                 % LibraryVersions.http4sVersion
     val Http4sPrometheus       = "org.http4s"                         %%  "http4s-prometheus-server-metrics" % LibraryVersions.http4sVersion
     val Flyway                 = "org.flywaydb"                       %   "flyway-core"                      % LibraryVersions.flywayVersion
+    val Jts                    = "org.locationtech.jts"               %   "jts-core"                         % LibraryVersions.jts
     val Atto                   = Def.setting("org.tpolecat"           %%% "atto-core"                        % LibraryVersions.attoVersion)
     val Monocle                = Def.setting(Seq(
       "com.github.julien-truffaut" %%% "monocle-core"   % LibraryVersions.monocleVersion,


### PR DESCRIPTION
This PR is a WIP and not intended to be merged yet, if ever.   I wanted to show what I've been playing with, document it before I leave for a few days, and see whether it makes any sense.

The issue is defining shapes for use in AGS, etc.  This would include probe arms, probe ranges, and detector areas at least.  There are two main operations needed for AGS:

1) Determine whether a point is contained in a shape (guide star reachability)
2) Determine the area of a shape relative to another shape (vignetting comparisons)

```scala
trait Shape {

  /**
   * Determines whether the given position is contained in the shape.
   */
  def contains(o: Offset): Boolean

  /**
   * Area of the shape. The value is in microarcseconds angular separation^2
   * but the absolute value is less useful than comparing across multiple
   * shapes (to determine minimum vignetting).
   */
  def area: Long

}
```

Instead of using AWT though, I wanted to find a geometry library either in Scala (fail) or else with Java and JavaScript implementations (see [JTS](https://github.com/locationtech/jts)/[JSTS](https://github.com/bjornharrtell/jsts)) .  So the idea is to describe the Shape in an ADT and then interpret it down to a specific shape implementation in a language/library-specific interpreter.

```scala
sealed trait ShapeExpression {

  def eval(implicit ev: ShapeInterpreter): Shape =
    ev.interpret(this)

}

object ShapeExpression {

  final case class Ellipse(a: Offset, b: Offset)                         extends ShapeExpression
  final case class Polygon(os: List[Offset])                             extends ShapeExpression
  final case class Rectangle(a: Offset, b: Offset)                       extends ShapeExpression

  final case class Difference(a: ShapeExpression, b: ShapeExpression)    extends ShapeExpression
  final case class Intersection(a: ShapeExpression, b: ShapeExpression)  extends ShapeExpression
  final case class Union(a: ShapeExpression, b: ShapeExpression)         extends ShapeExpression

  final case class Rotate(e: ShapeExpression, a: Angle)                  extends ShapeExpression
  final case class Translate(e: ShapeExpression, o: Offset)              extends ShapeExpression

}
```

Note that the shapes are defined with `Offset` positions, which seemed like the natural way to do it.  Usually they are specified in terms of arcsec sizes and at offset position locations.  With some syntax (not shown) here's the JTS/JVM implementation of the interpreter:

```scala
object JtsShapeInterpreter extends ShapeInterpreter {

  private def toGeometry(e: ShapeExpression): Geometry =
    e match {
      // Constructors
      case Ellipse(a, b)      => a.shapeFactory(b).createEllipse
      case Polygon(os)        => Jts.geometryFactory.createPolygon(os.map(_.coordinate).toArray)
      case Rectangle(a, b)    => a.shapeFactory(b).createRectangle

      // Combinations
      case Difference(a, b)   => toGeometry(a).difference(toGeometry(b))
      case Intersection(a, b) => toGeometry(a).intersection(toGeometry(b))
      case Union(a, b)        => toGeometry(a).union(toGeometry(b))

      // Transformations
      case Rotate(e, a)       =>
        AffineTransformation
          .rotationInstance(a.toDoubleDegrees)
          .transform(toGeometry(e))

      case Translate(e, o)    =>
        val c = o.coordinate
        AffineTransformation
          .translationInstance(c.x, c.y)
          .transform(toGeometry(e))
    }

  override def interpret(e: ShapeExpression): Shape =
    JtsShape(toGeometry(e))
}
```
Hiding some syntax support, the GMOS OIWFS probe arm can be defined as a `ShapeExpression`:
```scala
  val PickoffArmLength: Angle      = 358460.mas
  val PickoffMirrorSize: Angle     =  20000.mas
  val ProbeArmLength: Angle        = PickoffArmLength - (PickoffMirrorSize / 2)
  val ProbeArmTaperedWidth: Angle  =  15000.mas
  val ProbeArmTaperedLength: Angle = 180000.mas

  private val arm: ShapeExpression = {
    val hm  = PickoffMirrorSize    / 2
    val htw = ProbeArmTaperedWidth / 2

    val p0 = (-hm,                           htw  )
    val p1 = (p0._1 - ProbeArmTaperedLength, hm   )
    val p2 = (p0._1 - ProbeArmLength,        p1._2)
    val p3 = (p2._1,                        -hm   )
    val p4 = (p1._1,                         p3._2)
    val p5 = (p0._1,                        -htw  )

    ShapeExpression.polygon(p0, p1, p2, p3, p4, p5, p0)
  }

  private val pickoff: ShapeExpression = {
    val s = PickoffMirrorSize / 2
    ShapeExpression.rectangle((s, s), (s - PickoffMirrorSize, s - PickoffMirrorSize))
  }

  /**
   * Description of the GMOS OIWFS probe arm with the pickoff mirror centered
   * at the base position.
   */
  val shape: ShapeExpression =
    arm ∪ pickoff
```

Note `arm ∪ pickoff` to combine the probe arm proper with the pickoff mirror.  Here's an AWT plot obtained from the resulting shape with the pickoff mirror centered at the origin (marked with a +).

<img width="391" alt="screen shot 2019-01-15 at 16 17 02" src="https://user-images.githubusercontent.com/4906023/51205468-c2b89e80-18e4-11e9-9ec5-a67f29449f66.png">

where the `toAwt` below is only defined in the `JtsShape` implementation and only needed to visualize the shape for the demo:

```scala
    import gem.geom.jts.interpreter._

    override def paint(g: Graphics): Unit = {
      val g2d = g.asInstanceOf[Graphics2D]

      GmosOiwfsProbeArm.shape.eval match {
        case jts: JtsShape => g2d.draw(jts.toAwt)
        case x             => sys.error(s"Whoa unexpected shape type: $x")
      }
  }
```
