### PR TITLE
SEQNG-630A: Don't send apply if the config won't change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,7 +332,7 @@ lazy val giapi = project
   .enablePlugins(GitBranchPrompt)
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(Cats.value, Mouse.value, Shapeless.value, CatsEffect.value, Fs2, GiapiJmsUtil, GiapiJmsProvider, GiapiStatusService, Giapi, GiapiCommandsClient) ++ Logging,
+    libraryDependencies ++= Seq(Cats.value, Mouse.value, Shapeless.value, CatsEffect.value, Fs2, GiapiJmsUtil, GiapiJmsProvider, GiapiStatusService, Giapi, GiapiCommandsClient) ++ Logging ++ Monocle.value,
     libraryDependencies ++= Seq(GmpStatusGateway % "test", GmpStatusDatabase % "test", GmpCmdJmsBridge % "test", NopSlf4j % "test"),
     excludeDependencies ++= Seq(
       // Remove to silence logging on tests

--- a/modules/giapi/src/main/scala/giapi/client/GiapiDb.scala
+++ b/modules/giapi/src/main/scala/giapi/client/GiapiDb.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package giapi.client
+
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import cats.Applicative
+import cats.implicits._
+import monocle.Lens
+import monocle.function.At.at
+import monocle.function.At.atMap
+
+sealed trait StatusValue extends Product with Serializable
+
+object StatusValue {
+  final case class IntValue(value:    Int) extends StatusValue
+  final case class StringValue(value: String) extends StatusValue
+  final case class FloatValue(value:  Float) extends StatusValue
+  final case class DoubleValue(value: Double) extends StatusValue
+}
+
+/////////////////////////////////////////////////////////////////
+// The GiapiDb stores values streamed from the GMP
+/////////////////////////////////////////////////////////////////
+trait GiapiDb[F[_]] {
+
+  def value(i: String): F[Option[StatusValue]]
+
+  def update[A: ItemGetter](i: String, s: A): F[Unit]
+}
+
+object GiapiDb {
+  def newDb[F[_]: Sync](): F[GiapiDb[F]] =
+    Ref.of[F, Map[String, StatusValue]](Map.empty).map { ref =>
+      def dbat(i: String): Lens[Map[String, StatusValue], Option[StatusValue]] =
+        at(i)
+
+      new GiapiDb[F] {
+        def value(i: String): F[Option[StatusValue]] =
+          ref.get.map(_.get(i))
+
+        def update[A: ItemGetter](i: String, s: A): F[Unit] =
+          ItemGetter[A].value(s) match {
+            case Some(a: Int) =>
+              ref.update(dbat(i).set(StatusValue.IntValue(a).some))
+            case Some(a: String) =>
+              ref.update(dbat(i).set(StatusValue.StringValue(a).some))
+            case Some(a: Float) =>
+              ref.update(dbat(i).set(StatusValue.FloatValue(a).some))
+            case Some(a: Double) =>
+              ref.update(dbat(i).set(StatusValue.DoubleValue(a).some))
+            case _ =>
+              Applicative[F].unit
+          }
+      }
+    }
+}

--- a/modules/giapi/src/main/scala/giapi/client/GiapiDb.scala
+++ b/modules/giapi/src/main/scala/giapi/client/GiapiDb.scala
@@ -7,7 +7,6 @@ import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import cats.Applicative
-import cats.implicits._
 import monocle.Lens
 import monocle.function.At.at
 import monocle.function.At.atMap

--- a/modules/giapi/src/main/scala/giapi/client/GiapiStatusDb.scala
+++ b/modules/giapi/src/main/scala/giapi/client/GiapiStatusDb.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package giapi.client
+
+import cats.Applicative
+import cats.Functor
+import cats.implicits._
+import cats.effect.Sync
+import cats.effect.Resource
+import cats.effect.Effect
+import cats.effect.ConcurrentEffect
+import cats.effect.implicits._
+import edu.gemini.aspen.giapi.status.StatusHandler
+import edu.gemini.aspen.giapi.status.StatusItem
+import edu.gemini.aspen.giapi.statusservice.StatusHandlerAggregate
+
+/////////////////////////////////////////////////////////////////
+// Links status streaming with the giapi db
+/////////////////////////////////////////////////////////////////
+trait GiapiStatusDb[F[_]] {
+  def value(i: String): F[Option[StatusValue]]
+}
+
+object GiapiStatusDb {
+  def newStatusDb[F[_]: ConcurrentEffect, G[_]: Functor](
+    agg:   StatusHandlerAggregate,
+    items: List[String]): F[GiapiStatusDb[F]] = {
+
+    def streamItems(
+      db: GiapiDb[F]
+    ): F[Resource[F, StatusHandler]] =
+      Sync[F].delay {
+
+        def statusHandler = new StatusHandler {
+
+          override def update[B](item: StatusItem[B]): Unit =
+            // Check the item name and attempt convert it to A
+            if (items.contains(item.getName)) {
+              val r = Option(item.getValue) match {
+                case Some(a: Int) =>
+                  db.update[Int](item.getName, a)
+                case Some(a: String) =>
+                  db.update[String](item.getName, a)
+                case Some(a: Float) =>
+                  db.update[Float](item.getName, a)
+                case Some(a: Double) =>
+                  db.update[Double](item.getName, a)
+                case _ =>
+                  Applicative[F].unit
+              }
+              r.toIO.unsafeRunAsync(_ => ())
+            }
+
+          override def getName: String = "StatusHandler"
+        }
+
+        // A trivial resource that binds and unbinds a status handler.
+        Resource.make(
+          Effect[F].delay {
+            val sh = statusHandler
+            agg.bindStatusHandler(sh)
+            sh
+          }
+        )(sh => Effect[F].delay(agg.unbindStatusHandler(sh)))
+      }
+
+    for {
+      db <- GiapiDb.newDb
+      _  <- streamItems(db)
+    } yield
+      new GiapiStatusDb[F] {
+        def value(i: String): F[Option[StatusValue]] =
+          db.value(i)
+      }
+  }
+
+}

--- a/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
@@ -5,35 +5,58 @@ package giapi.client.ghost
 
 import cats.effect._
 import cats.implicits._
-import giapi.client.{Giapi, GiapiClient}
+import giapi.client.Giapi
+import giapi.client.GiapiClient
 import giapi.client.syntax.giapiconfig._
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 
 /** Client for GHOST */
-final class GhostClient[F[_]](override val giapi: Giapi[F]) extends GiapiClient[F]
+final class GhostClient[F[_]](override val giapi: Giapi[F])
+    extends GiapiClient[F]
 
-object GhostExample extends IOApp {
+object GhostClient {
+  // Used for simulations
+  def simulatedGhostClient(
+    ec: ExecutionContext): Resource[IO, GhostClient[IO]] =
+    Resource.liftF(
+      Giapi.giapiConnectionIO(ec).connect.map(new GhostClient(_))
+    )
 
-  val ghostStatus: Resource[IO, Giapi[IO]] =
-    Resource.make(
-      Giapi.giapiConnection[IO](
-        "failover:(tcp://127.0.0.1:61616)",
-        ExecutionContext.global
-      ).connect)(_.close)
+  def ghostClient[F[_]: ConcurrentEffect](
+    url:     String,
+    context: ExecutionContext): Resource[F, GhostClient[F]] = {
+    val ghostStatus: Resource[F, Giapi[F]] =
+      Resource.make(
+        Giapi
+          .giapiConnection[F](
+            url,
+            context
+          )
+          .connect)(_.close)
 
-  val ghostSequence: Resource[IO, Giapi[IO]] =
-    Resource.make(
-      Giapi.giapiConnection[IO](
-        "failover:(tcp://127.0.0.1:61616)",
-        ExecutionContext.global
-      ).connect)(_.close)
+    val ghostSequence: Resource[F, Giapi[F]] =
+      Resource.make(
+        Giapi
+          .giapiConnection[F](
+            url,
+            context
+          )
+          .connect)(_.close)
 
-  val ghostClient: Resource[IO, GhostClient[IO]] =
     for {
       _ <- ghostStatus
       c <- ghostSequence
     } yield new GhostClient(c)
+  }
+}
+
+object GhostExample extends IOApp {
+
+  val url = "failover:(tcp://127.0.0.1:61616)"
+
+  val ghostClient: Resource[IO, GhostClient[IO]] =
+    GhostClient.ghostClient(url, ExecutionContext.global)
 
   def run(args: List[String]): IO[ExitCode] =
     ghostClient.use { client =>

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
@@ -164,7 +164,7 @@ object GPIExample extends cats.effect.IOApp {
   import cats.effect.ExitCode
   import scala.concurrent.duration._
 
-  val url = "failover:(tcp://172.17.107.50:61616)"
+  val url = "failover:(tcp://127.0.0.1:61616)"
 
   val gpi: Resource[IO, GpiClient[IO]] =
     GpiClient.gpiClient[IO](url, ExecutionContext.global)

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
@@ -95,8 +95,8 @@ final class GpiClient[F[_]: Sync] private (override val giapi: Giapi[F],
       DefaultCommandTimeout)
 
   def ifsConfigure(integrationTime: Double,
-                   coAdds: Int,
-                   readoutMode: Int): F[CommandResult] =
+                   coAdds:          Int,
+                   readoutMode:     Int): F[CommandResult] =
     giapi.command(
       Command(
         SequenceCommand.APPLY,
@@ -113,7 +113,7 @@ final class GpiClient[F[_]: Sync] private (override val giapi: Giapi[F],
 
   override def genericApply(configuration: Configuration): F[CommandResult] = {
     // TODO Implement a smarter apply
-    def smartApply(): F[CommandResult] =
+    def smartApply: F[CommandResult] =
       giapi.command(Command(
                       SequenceCommand.APPLY,
                       Activity.PRESET_START,
@@ -123,7 +123,7 @@ final class GpiClient[F[_]: Sync] private (override val giapi: Giapi[F],
 
     for {
       _ <- statusDb.value("gpi:fpu") // placeholder
-      a <- smartApply()
+      a <- smartApply
     } yield a
   }
 }
@@ -150,10 +150,7 @@ object GpiClient {
         GiapiStatusDb.newStatusDb[F](url, List("gpi:heartbeat"))
       )(_.close)
 
-    for {
-      c <- giapi
-      d <- db
-    } yield new GpiClient[F](c, d)
+    (giapi, db).mapN { new GpiClient[F](_, _) }
   }
 
 }

--- a/modules/giapi/src/main/scala/giapi/client/package.scala
+++ b/modules/giapi/src/main/scala/giapi/client/package.scala
@@ -20,9 +20,11 @@ import giapi.client.commands._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import shapeless.Typeable._
-import fs2.{Stream, concurrent}
+import fs2.Stream
+import fs2.concurrent
 import fs2.concurrent.Queue
-import giapi.client.commands.{Command, CommandResultException}
+import giapi.client.commands.Command
+import giapi.client.commands.CommandResultException
 
 package object client {
 
@@ -204,17 +206,18 @@ package client {
       */
     // scalastyle:off
     def giapiConnection[F[_]: ConcurrentEffect](
-        url: String,
-        ec: ExecutionContext): GiapiConnection[F] =
+      url: String,
+      ec:  ExecutionContext
+    ): GiapiConnection[F] =
       new GiapiConnection[F] {
-        private def giapi(c: ActiveMQJmsProvider,
+        private def giapi(c:  ActiveMQJmsProvider,
                           sg: StatusGetter,
                           cc: CommandSenderClient,
                           ss: StatusStreamer) =
           new Giapi[F] {
             private val commandsAckTimeout                  = 2000.milliseconds
             implicit val executionContext: ExecutionContext = ec
-            implicit val timer: Timer[IO] = IO.timer(ec)
+            implicit val timer: Timer[IO]                   = IO.timer(ec)
 
             override def get[A: ItemGetter](statusItem: String): F[A] =
               getO[A](statusItem).flatMap {
@@ -256,9 +259,9 @@ package client {
 
         def connect: F[Giapi[F]] =
           for {
-            c   <- Sync[F].delay(new ActiveMQJmsProvider(url)) // Build the connection
-            _   <- Sync[F].delay(c.startConnection())          // Start the connection
-            c   <- build(c)                                    // Build the interpreter
+            c <- Sync[F].delay(new ActiveMQJmsProvider(url)) // Build the connection
+            _ <- Sync[F].delay(c.startConnection()) // Start the connection
+            c <- build(c) // Build the interpreter
           } yield c
       }
     // scalastyle:on
@@ -295,6 +298,7 @@ package client {
         override def close: IO[Unit] = IO.unit
       })
     }
+
   }
 
 }

--- a/modules/giapi/src/main/scala/giapi/client/package.scala
+++ b/modules/giapi/src/main/scala/giapi/client/package.scala
@@ -9,8 +9,10 @@ import cats.effect.concurrent._
 import cats.effect.implicits._
 import cats.implicits._
 import edu.gemini.aspen.giapi.commands.HandlerResponse.Response
-import edu.gemini.aspen.giapi.status.{StatusHandler, StatusItem}
-import edu.gemini.aspen.giapi.statusservice.{StatusHandlerAggregate, StatusService}
+import edu.gemini.aspen.giapi.status.StatusHandler
+import edu.gemini.aspen.giapi.status.StatusItem
+import edu.gemini.aspen.giapi.statusservice.StatusHandlerAggregate
+import edu.gemini.aspen.giapi.statusservice.StatusService
 import edu.gemini.aspen.giapi.util.jms.status.StatusGetter
 import edu.gemini.aspen.gmp.commands.jms.client.CommandSenderClient
 import edu.gemini.aspen.giapi.commands.SequenceCommand
@@ -262,7 +264,7 @@ package client {
             c   <- build(ref)                                  // Build the interpreter
           } yield c
       }
-      // scalastyle:on
+    // scalastyle:on
 
     /**
       * Interpreter on Id

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -16,7 +16,6 @@ import monocle.Optional
 import edu.gemini.epics.acm.CaService
 import gem.Observation
 import gem.enum.Site
-import giapi.client.Giapi
 import giapi.client.ghost.GhostClient
 import giapi.client.gpi.GpiClient
 import seqexec.engine
@@ -45,13 +44,12 @@ import org.http4s.Uri
 import knobs.Config
 import mouse.all._
 import seqexec.model.dhs.ImageFileId
-
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
-import shapeless.tag.@@
+import scala.concurrent.ExecutionContext
 import shapeless.tag
 
-class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecMetrics)(
+class SeqexecEngine(httpClient: Client[IO], settings: Settings, sm: SeqexecMetrics)(
   implicit ceio: ConcurrentEffect[IO], tio: Timer[IO]
 ) {
   import SeqexecEngine._
@@ -76,8 +74,8 @@ class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecM
     settings.gmosControl.command.fold(GmosSouthControllerEpics, GmosControllerSim.south),
     settings.gmosControl.command.fold(GmosNorthControllerEpics, GmosControllerSim.north),
     settings.gnirsControl.command.fold(GnirsControllerEpics, GnirsControllerSim),
-    GpiController(GpiClient.gpiClient(settings.gpiGiapi), gpiGDS),
-    GhostController(new GhostClient(settings.ghostGiapi), ghostGDS),
+    GpiController(settings.gpi, gpiGDS),
+    GhostController(settings.ghost, ghostGDS),
     settings.niriControl.command.fold(NiriControllerEpics, NiriControllerSim)
   )
 
@@ -204,17 +202,6 @@ class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecM
           List(Event.logWarningMsg(SeqexecFailure.explain(r)))
         ).some.filter(_.nonEmpty).map(Stream.emits(_).covary[IO])
       )
-  // def seqQueueRefreshStream: Stream[IO, executeEngine.EventType] =
-  //   Scheduler[IO](corePoolSize = 1).flatMap { scheduler =>
-  //     val fd = Duration(settings.odbQueuePollingInterval.toSeconds, TimeUnit.SECONDS)
-  //     scheduler.fixedDelay[IO](fd).evalMap(_ =>
-  //       odbProxy.queuedSequences.value).map { x =>
-  //       Event.getState[executeEngine.ConcreteTypes](st =>
-  //         x.map(odbLoader.refreshSequenceList(_)(st)).valueOr(r =>
-  //           List(Event.logWarningMsg(SeqexecFailure.explain(r)))
-  //         ).some.filter(_.nonEmpty).map(Stream.emits(_).covary[IO])
-  //       )
-  //     }
     }
   }
 
@@ -516,7 +503,7 @@ class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecM
 
 object SeqexecEngine extends SeqexecConfiguration {
 
-  def apply(httpClient: Client[IO], settings: Settings[IO], c: SeqexecMetrics)(
+  def apply(httpClient: Client[IO], settings: Settings, c: SeqexecMetrics)(
     implicit ceio: ConcurrentEffect[IO],
               tio: Timer[IO]
   ): SeqexecEngine = new SeqexecEngine(httpClient, settings, c)
@@ -698,35 +685,23 @@ object SeqexecEngine extends SeqexecConfiguration {
     IO.apply(Paths.get(smartGCalLocation)).map { p => SmartGcal.initialize(peer, p) }
   }
 
-  // TODO: Initialization is a bit of a mess, with a mix of effectful and effectless code, and values
-  // that should go from one to the other. This should be improved.
-  def giapiConnection[T](controlName: String, urlName: String)(
-    implicit ev: ConcurrentEffect[IO]
-  ): Kleisli[IO, Config, Giapi[IO] @@ T] = Kleisli { cfg: Config =>
-    val control = cfg.require[ControlStrategy](controlName)
-    val url  = cfg.require[String](urlName)
-    if (control.command) {
-      Giapi.giapiConnection[IO](url, scala.concurrent.ExecutionContext.Implicits.global).connect
-    } else {
-      Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect
-    }
-  } .map(tag[T][Giapi[IO]](_)) // Tag the connection
-
   // scalastyle:off
-  def seqexecConfiguration(gpiGiapi: Giapi[IO] @@ GpiSettings, ghostGiapi: Giapi[IO] @@ GhostSettings)(
+  def seqexecConfiguration(ec: ExecutionContext)(
     implicit cs: ContextShift[IO]
-  ): Kleisli[IO, Config, Settings[IO]] = Kleisli { cfg: Config =>
+  ): Kleisli[IO, Config, Settings] = Kleisli { cfg: Config =>
     val site                    = cfg.require[Site]("seqexec-engine.site")
     val odbHost                 = cfg.require[String]("seqexec-engine.odb")
     val dhsServer               = cfg.require[Uri]("seqexec-engine.dhsServer")
     val dhsControl              = cfg.require[ControlStrategy]("seqexec-engine.systemControl.dhs")
     val f2Control               = cfg.require[ControlStrategy]("seqexec-engine.systemControl.f2")
     val gcalControl             = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gcal")
+    val ghostUrl                = cfg.require[String]("seqexec-engine.ghostUrl")
     val ghostControl            = cfg.require[ControlStrategy]("seqexec-engine.systemControl.ghost")
     val ghostGdsControl         = cfg.require[ControlStrategy]("seqexec-engine.systemControl.ghostGds")
     val gmosControl             = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gmos")
     val gnirsControl            = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gnirs")
     val gpiControl              = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gpi")
+    val gpiUrl                  = cfg.require[String]("seqexec-engine.gpiUrl")
     val gpiGdsControl           = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gpiGds")
     val gsaoiControl            = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gsaoi")
     val gwsControl              = cfg.require[ControlStrategy]("seqexec-engine.systemControl.gws")
@@ -786,11 +761,28 @@ object SeqexecEngine extends SeqexecConfiguration {
 
     val smartGcal = smartGcalEnable.fold(initSmartGCal(smartGCalHost, smartGCalDir), IO.unit)
 
-    smartGcal *>
-      epicsInit *>
-      (for {
-        now <- IO(LocalDate.now)
-      } yield Settings(site,
+    def gpiClient: cats.effect.Resource[IO, GpiClient[IO]] =
+      if (gpiControl === FullControl) {
+        GpiClient.gpiClient[IO](gpiUrl, ec)
+      } else {
+        GpiClient.simulatedGpiClient(ec)
+      }
+
+    def ghostClient: cats.effect.Resource[IO, GhostClient[IO]] =
+      if (gpiControl === FullControl) {
+        GhostClient.ghostClient[IO](ghostUrl, ec)
+      } else {
+        GhostClient.simulatedGhostClient(ec)
+      }
+
+    def settings: IO[Settings] = {
+      val giapiClients = for {
+        now   <- cats.effect.Resource.liftF(IO(LocalDate.now))
+        gpi   <- gpiClient
+        ghost <- ghostClient
+      } yield (now, gpi, ghost)
+      giapiClients.use { case (now, gpi, ghost) =>
+        IO.delay(Settings(site,
                        odbHost,
                        now,
                        dhsServer,
@@ -812,12 +804,16 @@ object SeqexecEngine extends SeqexecConfiguration {
                        instForceError,
                        failAt,
                        odbQueuePollingInterval,
-                       gpiGiapi,
-                       ghostGiapi,
+                       gpi,
+                       ghost,
                        gpiGDS,
-                       ghostGDS)
-      )
+                       ghostGDS))
+                     }
+                   }
 
+    smartGcal *>
+      epicsInit *>
+      settings
 
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -76,7 +76,7 @@ class SeqexecEngine(httpClient: Client[IO], settings: Settings[IO], sm: SeqexecM
     settings.gmosControl.command.fold(GmosSouthControllerEpics, GmosControllerSim.south),
     settings.gmosControl.command.fold(GmosNorthControllerEpics, GmosControllerSim.north),
     settings.gnirsControl.command.fold(GnirsControllerEpics, GnirsControllerSim),
-    GpiController(new GpiClient(settings.gpiGiapi), gpiGDS),
+    GpiController(GpiClient.gpiClient(settings.gpiGiapi), gpiGDS),
     GhostController(new GhostClient(settings.ghostGiapi), ghostGDS),
     settings.niriControl.command.fold(NiriControllerEpics, NiriControllerSim)
   )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
@@ -8,8 +8,6 @@ import java.time.LocalDate
 import org.http4s.Uri
 import scala.concurrent.duration.Duration
 import shapeless.tag.@@
-import giapi.client.gpi.GpiClient
-import giapi.client.ghost.GhostClient
 
 trait GpiSettings
 trait GhostSettings
@@ -36,7 +34,5 @@ final case class Settings(site:                    Site,
                           instForceError:          Boolean,
                           failAt:                  Int,
                           odbQueuePollingInterval: Duration,
-                          gpi:                     GpiClient[cats.effect.IO],
-                          ghost:                   GhostClient[cats.effect.IO],
                           gpiGDS:                  Uri @@ GpiSettings,
                           ghostGDS:                Uri @@ GhostSettings)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
@@ -4,38 +4,39 @@
 package seqexec.server
 
 import gem.enum.Site
-import giapi.client.Giapi
 import java.time.LocalDate
 import org.http4s.Uri
 import scala.concurrent.duration.Duration
 import shapeless.tag.@@
+import giapi.client.gpi.GpiClient
+import giapi.client.ghost.GhostClient
 
 trait GpiSettings
 trait GhostSettings
 
-final case class Settings[F[_]](site:                    Site,
-                                odbHost:                 String,
-                                date:                    LocalDate,
-                                dhsURI:                  Uri,
-                                dhsControl:              ControlStrategy,
-                                f2Control:               ControlStrategy,
-                                gcalControl:             ControlStrategy,
-                                ghostControl:            ControlStrategy,
-                                gmosControl:             ControlStrategy,
-                                gnirsControl:            ControlStrategy,
-                                gpiControl:              ControlStrategy,
-                                gpiGdsControl:           ControlStrategy,
-                                ghostGdsControl:         ControlStrategy,
-                                gsaoiControl:            ControlStrategy,
-                                gwsControl:              ControlStrategy,
-                                nifsControl:             ControlStrategy,
-                                niriControl:             ControlStrategy,
-                                tcsControl:              ControlStrategy,
-                                odbNotifications:        Boolean,
-                                instForceError:          Boolean,
-                                failAt:                  Int,
-                                odbQueuePollingInterval: Duration,
-                                gpiGiapi:                Giapi[F] @@ GpiSettings,
-                                ghostGiapi:              Giapi[F] @@ GhostSettings,
-                                gpiGDS:                  Uri @@ GpiSettings,
-                                ghostGDS:                Uri @@ GhostSettings)
+final case class Settings(site:                    Site,
+                          odbHost:                 String,
+                          date:                    LocalDate,
+                          dhsURI:                  Uri,
+                          dhsControl:              ControlStrategy,
+                          f2Control:               ControlStrategy,
+                          gcalControl:             ControlStrategy,
+                          ghostControl:            ControlStrategy,
+                          gmosControl:             ControlStrategy,
+                          gnirsControl:            ControlStrategy,
+                          gpiControl:              ControlStrategy,
+                          gpiGdsControl:           ControlStrategy,
+                          ghostGdsControl:         ControlStrategy,
+                          gsaoiControl:            ControlStrategy,
+                          gwsControl:              ControlStrategy,
+                          nifsControl:             ControlStrategy,
+                          niriControl:             ControlStrategy,
+                          tcsControl:              ControlStrategy,
+                          odbNotifications:        Boolean,
+                          instForceError:          Boolean,
+                          failAt:                  Int,
+                          odbQueuePollingInterval: Duration,
+                          gpi:                     GpiClient[cats.effect.IO],
+                          ghost:                   GhostClient[cats.effect.IO],
+                          gpiGDS:                  Uri @@ GpiSettings,
+                          ghostGDS:                Uri @@ GhostSettings)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -105,6 +105,8 @@ package server {
       case "simulated" => Some(Simulated)
       case _           => None
     }
+
+    implicit val eq: Eq[ControlStrategy] = Eq.fromUniversalEquals
   }
 
   final case class HeaderExtraData(conditions: Conditions, operator: Option[Operator], observer: Option[Observer])

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -91,7 +91,7 @@ class SeqTranslateSpec extends FlatSpec {
     GmosControllerSim.south,
     GmosControllerSim.north,
     GnirsControllerSim,
-    GpiController(new GpiClient(Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
+    GpiController(new GpiClient(Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync, null),
     new GdsClient(GdsClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))),
     GhostController(new GhostClient[IO](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
     new GdsClient(GdsClient.alwaysOkClient, uri("hhttp://localhost:8888/xmlrpc"))),

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -8,8 +8,8 @@ import java.time.LocalDate
 import cats.implicits._
 import cats.effect._
 import fs2.Stream
-import giapi.client.Giapi
 import giapi.client.gpi.GpiClient
+import giapi.client.ghost.GhostClient
 import gem.Observation
 import gem.enum.Site
 import scala.concurrent.ExecutionContext
@@ -26,7 +26,6 @@ import seqexec.server.gnirs.GnirsControllerSim
 import seqexec.server.tcs.TcsControllerSim
 import seqexec.server.gpi.GpiController
 import edu.gemini.spModel.core.Peer
-import giapi.client.ghost.GhostClient
 import org.scalatest.FlatSpec
 import org.http4s.Uri._
 import squants.time.Seconds
@@ -82,6 +81,13 @@ class SeqTranslateSpec extends FlatSpec {
   private val s5: EngineState = EngineState.sequenceStateIndex(seqId)
     .modify(_.mark(0)(Result.Error("error")))(baseState)
 
+  val gpiSim = GpiClient.simulatedGpiClient(scala.concurrent.ExecutionContext.Implicits.global).use(x => IO(GpiController(x,
+    new GdsClient(GdsClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))))
+  ).unsafeRunSync
+  val ghostSim = GhostClient.simulatedGhostClient(scala.concurrent.ExecutionContext.Implicits.global).use(x => IO(GhostController(x,
+    new GdsClient(GdsClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))))
+  ).unsafeRunSync
+
   private val systems = SeqTranslate.Systems(
     new OdbProxy(new Peer("localhost", 8443, null), new OdbProxy.DummyOdbCommands),
     DhsClientSim(LocalDate.of(2016, 4, 15)),
@@ -91,10 +97,8 @@ class SeqTranslateSpec extends FlatSpec {
     GmosControllerSim.south,
     GmosControllerSim.north,
     GnirsControllerSim,
-    GpiController(new GpiClient(Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync, null),
-    new GdsClient(GdsClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))),
-    GhostController(new GhostClient[IO](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
-    new GdsClient(GdsClient.alwaysOkClient, uri("hhttp://localhost:8888/xmlrpc"))),
+    gpiSim,
+    ghostSim,
     NiriControllerSim
   )
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -6,9 +6,10 @@ package seqexec.server
 import cats.effect.{ ContextShift, IO, Timer }
 import cats.implicits._
 import fs2.concurrent.Queue
+import giapi.client.gpi.GpiClient
+import giapi.client.ghost.GhostClient
 import gem.Observation
 import gem.enum.Site
-import giapi.client.Giapi
 import io.prometheus.client._
 import java.time.LocalDate
 import java.util.UUID
@@ -39,6 +40,9 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   implicit val ioTimer: Timer[IO] =
     IO.timer(ExecutionContext.global)
 
+  val gpiSim = GpiClient.simulatedGpiClient(scala.concurrent.ExecutionContext.Implicits.global).use(IO(_)).unsafeRunSync
+  val ghostSim = GhostClient.simulatedGhostClient(scala.concurrent.ExecutionContext.Implicits.global).use(IO(_)).unsafeRunSync
+
   private val defaultSettings = Settings(Site.GS,
     odbHost = "localhost",
     date = LocalDate.of(2017, 1, 1),
@@ -61,8 +65,8 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     instForceError = false,
     failAt = 0,
     10.seconds,
-    tag[GpiSettings][Giapi[IO]](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
-    tag[GhostSettings][Giapi[IO]](Giapi.giapiConnectionIO(scala.concurrent.ExecutionContext.Implicits.global).connect.unsafeRunSync),
+    gpiSim,
+    ghostSim,
     tag[GpiSettings][Uri](uri("http://localhost:8888/xmlrpc")),
     tag[GhostSettings][Uri](uri("http://localhost:8888/xmlrpc"))
   )

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -65,8 +65,6 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     instForceError = false,
     failAt = 0,
     10.seconds,
-    gpiSim,
-    ghostSim,
     tag[GpiSettings][Uri](uri("http://localhost:8888/xmlrpc")),
     tag[GhostSettings][Uri](uri("http://localhost:8888/xmlrpc"))
   )
@@ -194,7 +192,7 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
     }
 
   private val sm = SeqexecMetrics.build[IO](Site.GS, new CollectorRegistry()).unsafeRunSync
-  private val seqexecEngine = SeqexecEngine(GdsClient.alwaysOkClient, defaultSettings, sm)
+  private val seqexecEngine = SeqexecEngine(GdsClient.alwaysOkClient, gpiSim, ghostSim, defaultSettings, sm)
   private def advanceOne(q: EventQueue, s0: EngineState, put: IO[Either[SeqexecFailure, Unit]]): IO[Option[EngineState]] =
     (put *> seqexecEngine.stream(q.dequeue)(s0).take(1).compile.last).map(_.map(_._2))
 

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -32,8 +32,6 @@ import scala.concurrent.ExecutionContext
 import seqexec.model.events._
 import seqexec.server
 import seqexec.server.{SeqexecMetrics, SeqexecConfiguration, SeqexecEngine, executeEngine}
-import seqexec.server.GpiSettings
-import seqexec.server.GhostSettings
 import seqexec.web.server.OcsBuildInfo
 import seqexec.web.server.logging.AppenderForClients
 import seqexec.web.server.security.{AuthenticationConfig, AuthenticationService, LDAPConfig}
@@ -216,16 +214,12 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
       Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
     }
 
-    def engineIO(httpClient: Client[IO], collector: CollectorRegistry): IO[SeqexecEngine] =
+    def engineIO(httpClient: Client[IO], collector: CollectorRegistry, bec: ExecutionContext): IO[SeqexecEngine] =
       for {
         _          <- configLog // Initialize log before the engine is setup
         c          <- config
         site       <- IO.pure(c.require[Site]("seqexec-engine.site"))
-        giapiGPI   <- SeqexecEngine.giapiConnection[GpiSettings]("seqexec-engine.systemControl.gpi",
-                                                    "seqexec-engine.gpiUrl").run(c)
-        giapiGHOST <- SeqexecEngine.giapiConnection[GhostSettings]("seqexec-engine.systemControl.ghost",
-                                                    "seqexec-engine.ghostUrl").run(c)
-        seqc       <- SeqexecEngine.seqexecConfiguration(giapiGPI, giapiGHOST).run(c)
+        seqc       <- SeqexecEngine.seqexecConfiguration(bec).run(c)
         met        <- SeqexecMetrics.build[IO](site, collector)
       } yield SeqexecEngine(httpClient, seqc, met)
 
@@ -252,8 +246,8 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
         inq    <- Resource.liftF(Queue.bounded[IO, executeEngine.EventType](10))
         out    <- Resource.liftF(Topic[IO, SeqexecEvent](NullEvent))
         cr     <- Resource.liftF(IO(new CollectorRegistry))
-        engine <- Resource.liftF(engineIO(cli, cr))
         bec    <- blockingExecutionContext
+        engine <- Resource.liftF(engineIO(cli, cr, bec))
         _      <- webServerIO(inq, out, engine, cr, bec)
         _      <- Resource.liftF(engine.eventStream(inq).to(out.publish).compile.drain.start)
       } yield ExitCode.Success


### PR DESCRIPTION
This is the first part of SEQNG-630. In this task we want to create an in memory db that track status item values. In the second part we'll want to use those value to decide if we really need to configure the instrument or not

This task let me learn quite a bit of `cats-effect` but I'm probably making some mistakes. @tpolecat I'd appreciate if we reviewed it

The creation of the db is fairly straightforward but the integration with `GpiClient` and with the rest of the seqexec involved some challenges. Some are commented inline

This PR doesn't change the functionality and it has been tested against GPI