### PR TITLE
SEQNG-630B: Initialize the db upon startup

### DIFF
--- a/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
@@ -147,7 +147,8 @@ object GpiClient {
 
     val db: Resource[F, GiapiStatusDb[F]] =
       Resource.make(
-        GiapiStatusDb.newStatusDb[F](url, List("gpi:heartbeat"))
+        GiapiStatusDb
+          .newStatusDb[F](url, List("gpi:heartbeat", "gpi:polarizerAngle"))
       )(_.close)
 
     (giapi, db).mapN { new GpiClient[F](_, _) }


### PR DESCRIPTION
This is the next step of SEQNG-630. We need to initialize the status db on startup otherwise we only get values when the items change