### PR TITLE
Timer implicit and GiapiConfig

### DIFF
--- a/modules/giapi/src/main/scala/giapi/client/GiapiConfig.scala
+++ b/modules/giapi/src/main/scala/giapi/client/GiapiConfig.scala
@@ -3,7 +3,18 @@
 
 package giapi.client
 
+import cats.Show
+
 // Produce a configuration string for Giapi.
 trait GiapiConfig[T] {
   def configValue(t: T): String
+}
+
+object GiapiConfig {
+  implicit val stringConfig: GiapiConfig[String] = t => t
+  implicit val intConfig: GiapiConfig[Int]       = _.toString
+  implicit val doubleConfig: GiapiConfig[Double] = d => f"$d%1.6f"
+
+  def fromShow[A: Show]: GiapiConfig[A] = Show[A].show(_)
+  def apply[A](implicit instance: GiapiConfig[A]): GiapiConfig[A] = instance
 }

--- a/modules/giapi/src/main/scala/giapi/client/GiapiConfig.scala
+++ b/modules/giapi/src/main/scala/giapi/client/GiapiConfig.scala
@@ -3,8 +3,6 @@
 
 package giapi.client
 
-import cats.Show
-
 // Produce a configuration string for Giapi.
 trait GiapiConfig[T] {
   def configValue(t: T): String
@@ -14,7 +12,12 @@ object GiapiConfig {
   implicit val stringConfig: GiapiConfig[String] = t => t
   implicit val intConfig: GiapiConfig[Int]       = _.toString
   implicit val doubleConfig: GiapiConfig[Double] = d => f"$d%1.6f"
+  implicit val floatConfig: GiapiConfig[Float]   = d => f"$d%1.6f"
 
-  def fromShow[A: Show]: GiapiConfig[A] = Show[A].show(_)
+  @inline
   def apply[A](implicit instance: GiapiConfig[A]): GiapiConfig[A] = instance
+
+  def instance[A](f: A => String): GiapiConfig[A] = new GiapiConfig[A] {
+    def configValue(t: A) = f(t)
+  }
 }

--- a/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
@@ -7,7 +7,6 @@ import cats.effect._
 import cats.implicits._
 import giapi.client.Giapi
 import giapi.client.GiapiClient
-import giapi.client.syntax.giapiconfig._
 import scala.concurrent.duration._
 
 /** Client for GHOST */

--- a/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
@@ -9,7 +9,6 @@ import giapi.client.Giapi
 import giapi.client.GiapiClient
 import giapi.client.syntax.giapiconfig._
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext
 
 /** Client for GHOST */
 final class GhostClient[F[_]](override val giapi: Giapi[F])
@@ -17,21 +16,18 @@ final class GhostClient[F[_]](override val giapi: Giapi[F])
 
 object GhostClient {
   // Used for simulations
-  def simulatedGhostClient(
-    ec: ExecutionContext): Resource[IO, GhostClient[IO]] =
+  def simulatedGhostClient(implicit timer: Timer[IO]): Resource[IO, GhostClient[IO]] =
     Resource.liftF(
-      Giapi.giapiConnectionIO(ec).connect.map(new GhostClient(_))
+      Giapi.giapiConnectionIO.connect.map(new GhostClient(_))
     )
 
   def ghostClient[F[_]: ConcurrentEffect](
-    url:     String,
-    context: ExecutionContext): Resource[F, GhostClient[F]] = {
+    url:     String)(implicit timer: Timer[IO]): Resource[F, GhostClient[F]] = {
     val ghostStatus: Resource[F, Giapi[F]] =
       Resource.make(
         Giapi
           .giapiConnection[F](
-            url,
-            context
+            url
           )
           .connect)(_.close)
 
@@ -39,8 +35,7 @@ object GhostClient {
       Resource.make(
         Giapi
           .giapiConnection[F](
-            url,
-            context
+            url
           )
           .connect)(_.close)
 
@@ -56,7 +51,7 @@ object GhostExample extends IOApp {
   val url = "failover:(tcp://127.0.0.1:61616)"
 
   val ghostClient: Resource[IO, GhostClient[IO]] =
-    GhostClient.ghostClient(url, ExecutionContext.global)
+    GhostClient.ghostClient(url)
 
   def run(args: List[String]): IO[ExitCode] =
     ghostClient.use { client =>

--- a/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
@@ -4,7 +4,6 @@
 package giapi.client.ghost
 
 import cats.effect._
-import cats.implicits._
 import giapi.client.Giapi
 import giapi.client.GiapiClient
 import scala.concurrent.duration._

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
@@ -18,7 +18,6 @@ import giapi.client.commands.Configuration
 import giapi.client.Giapi
 import giapi.client.GiapiClient
 import giapi.client.GiapiStatusDb
-import giapi.client.syntax.giapiconfig._
 import mouse.boolean._
 
 /**

--- a/modules/giapi/src/main/scala/giapi/client/syntax/giapiconfig.scala
+++ b/modules/giapi/src/main/scala/giapi/client/syntax/giapiconfig.scala
@@ -3,7 +3,6 @@
 
 package giapi.client.syntax
 
-import cats.Show
 import giapi.client.GiapiConfig
 
 final class GiapiConfigOps[A](val a: A) extends AnyVal {
@@ -15,10 +14,4 @@ trait ToGiapiCofigOps {
   implicit def ToGiapiConfigOps[A](value: A): GiapiConfigOps[A] = new GiapiConfigOps(value)
 }
 
-object giapiconfig extends ToGiapiCofigOps {
-  implicit val stringConfig: GiapiConfig[String] = t => t
-  implicit val intConfig: GiapiConfig[Int] = _.toString
-  implicit val doubleConfig: GiapiConfig[Double] = d => f"$d%1.6f"
-  def fromShow[A: Show]: GiapiConfig[A] = Show[A].show(_)
-  def apply[A](implicit instance: GiapiConfig[A]): GiapiConfig[A] = instance
-}
+object giapiconfig extends ToGiapiCofigOps

--- a/modules/giapi/src/test/scala/giapi/client/GiapiArbitraries.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiArbitraries.scala
@@ -5,7 +5,6 @@ package giapi.client
 
 import cats.implicits._
 import giapi.client.commands._
-import giapi.client.syntax.giapiconfig._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
 import org.scalacheck.Arbitrary._

--- a/modules/main/src/main/scala/MainServer.scala
+++ b/modules/main/src/main/scala/MainServer.scala
@@ -4,7 +4,6 @@
 package gem.main
 
 import cats.effect._
-import cats.implicits._
 import gem.dao.DatabaseConfiguration
 import gem.web.WebServer
 import gem.telnetd.TelnetServer

--- a/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
@@ -7,7 +7,6 @@ import cats.data.EitherT
 import cats.effect.Sync
 import cats.implicits._
 import giapi.client.GiapiClient
-import giapi.client.syntax.giapiconfig._
 import giapi.client.commands.{CommandResult, CommandResultException, Configuration}
 import org.log4s.getLogger
 import seqexec.model.dhs.ImageFileId

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -48,7 +48,6 @@ import seqexec.server.altair.AltairEpics
 
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext
 import shapeless.tag
 
 class SeqexecEngine(httpClient: Client[IO], gpi: GpiClient[IO], ghost: GhostClient[IO], settings: Settings, sm: SeqexecMetrics)(
@@ -676,18 +675,18 @@ object SeqexecEngine extends SeqexecConfiguration {
     }._2
   }
 
-  def gpiClient(control: ControlStrategy, gpiUrl: String, ec: ExecutionContext)(implicit cs: ContextShift[IO]): cats.effect.Resource[IO, GpiClient[IO]] =
+  def gpiClient(control: ControlStrategy, gpiUrl: String)(implicit cs: ContextShift[IO], t: Timer[IO]): cats.effect.Resource[IO, GpiClient[IO]] =
     if (control === FullControl) {
-      GpiClient.gpiClient[IO](gpiUrl, ec)
+      GpiClient.gpiClient[IO](gpiUrl)
     } else {
-      GpiClient.simulatedGpiClient(ec)
+      GpiClient.simulatedGpiClient
     }
 
-  def ghostClient(control: ControlStrategy, ghostUrl: String, ec: ExecutionContext)(implicit cs: ContextShift[IO]): cats.effect.Resource[IO, GhostClient[IO]] =
+  def ghostClient(control: ControlStrategy, ghostUrl: String)(implicit cs: ContextShift[IO], t: Timer[IO]): cats.effect.Resource[IO, GhostClient[IO]] =
     if (control === FullControl) {
-      GhostClient.ghostClient[IO](ghostUrl, ec)
+      GhostClient.ghostClient[IO](ghostUrl)
     } else {
-      GhostClient.simulatedGhostClient(ec)
+      GhostClient.simulatedGhostClient
     }
 
   private def decodeTops(s: String): Map[String, String] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
@@ -4,7 +4,7 @@
 package seqexec.server.ghost
 
 import cats.implicits._
-import cats.{Eq, Show}
+import cats.Eq
 import cats.effect.Sync
 import gem.math.Coordinates
 import giapi.client.commands.Configuration
@@ -12,7 +12,6 @@ import giapi.client.ghost.GhostClient
 import giapi.client.GiapiConfig
 import giapi.client.syntax.giapiconfig._
 import seqexec.server.keywords.GdsClient
-
 import scala.concurrent.duration._
 import org.log4s._
 import seqexec.server.ConfigUtilOps.{ContentError, ExtractFailure}
@@ -300,7 +299,7 @@ object GhostController {
       case _                                            => false
     }
 
-    implicit val show: Show[GhostConfig] = Show.fromToString
-    implicit val configure: GiapiConfig[GhostConfig] = GiapiConfig.fromShow
+    implicit val configIFNum: GiapiConfig[IFUNum] =
+      GiapiConfig.instance(x => s"$x")
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
@@ -301,6 +301,6 @@ object GhostController {
     }
 
     implicit val show: Show[GhostConfig] = Show.fromToString
-    implicit val configure: GiapiConfig[GhostConfig] = fromShow
+    implicit val configure: GiapiConfig[GhostConfig] = GiapiConfig.fromShow
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
@@ -17,11 +17,9 @@ import edu.gemini.spModel.gemini.gpi.Gpi.{ObservingMode => LegacyObservingMode}
 import edu.gemini.spModel.gemini.gpi.Gpi.{PupilCamera => LegacyPupilCamera}
 import edu.gemini.spModel.gemini.gpi.Gpi.{Shutter => LegacyShutter}
 import giapi.client.commands.Configuration
-import giapi.client.GiapiConfig
 import giapi.client.gpi.GpiClient
 import mouse.boolean._
 import seqexec.server.GiapiInstrumentController
-
 import scala.concurrent.duration._
 import seqexec.server.keywords.GdsClient
 import seqexec.server.gpi.GpiController.GpiConfig
@@ -281,7 +279,5 @@ object GpiController {
          x.asu,
          x.pc,
          x.aoFlags))
-    implicit val show: Show[GpiConfig] = Show.fromToString
-    implicit val giapiConfigure: GiapiConfig[GpiConfig] = GiapiConfig.fromShow
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
@@ -19,7 +19,6 @@ import edu.gemini.spModel.gemini.gpi.Gpi.{Shutter => LegacyShutter}
 import giapi.client.commands.Configuration
 import giapi.client.GiapiConfig
 import giapi.client.gpi.GpiClient
-import giapi.client.syntax.giapiconfig._
 import mouse.boolean._
 import seqexec.server.GiapiInstrumentController
 
@@ -283,6 +282,6 @@ object GpiController {
          x.pc,
          x.aoFlags))
     implicit val show: Show[GpiConfig] = Show.fromToString
-    implicit val giapiConfigure: GiapiConfig[GpiConfig] = fromShow
+    implicit val giapiConfigure: GiapiConfig[GpiConfig] = GiapiConfig.fromShow
   }
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -81,10 +81,10 @@ class SeqTranslateSpec extends FlatSpec {
   private val s5: EngineState = EngineState.sequenceStateIndex(seqId)
     .modify(_.mark(0)(Result.Error("error")))(baseState)
 
-  val gpiSim = GpiClient.simulatedGpiClient(scala.concurrent.ExecutionContext.Implicits.global).use(x => IO(GpiController(x,
+  val gpiSim = GpiClient.simulatedGpiClient.use(x => IO(GpiController(x,
     new GdsClient(GdsClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))))
   ).unsafeRunSync
-  val ghostSim = GhostClient.simulatedGhostClient(scala.concurrent.ExecutionContext.Implicits.global).use(x => IO(GhostController(x,
+  val ghostSim = GhostClient.simulatedGhostClient.use(x => IO(GhostController(x,
     new GdsClient(GdsClient.alwaysOkClient, uri("http://localhost:8888/xmlrpc"))))
   ).unsafeRunSync
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -40,8 +40,8 @@ class SeqexecEngineSpec extends FlatSpec with Matchers with NonImplicitAssertion
   implicit val ioTimer: Timer[IO] =
     IO.timer(ExecutionContext.global)
 
-  val gpiSim = GpiClient.simulatedGpiClient(scala.concurrent.ExecutionContext.Implicits.global).use(IO(_)).unsafeRunSync
-  val ghostSim = GhostClient.simulatedGhostClient(scala.concurrent.ExecutionContext.Implicits.global).use(IO(_)).unsafeRunSync
+  val gpiSim = GpiClient.simulatedGpiClient.use(IO(_)).unsafeRunSync
+  val ghostSim = GhostClient.simulatedGhostClient.use(IO(_)).unsafeRunSync
 
   private val defaultSettings = Settings(Site.GS,
     odbHost = "localhost",

--- a/modules/telnetd/src/main/scala/gem/telnetd/TelnetServer.scala
+++ b/modules/telnetd/src/main/scala/gem/telnetd/TelnetServer.scala
@@ -5,7 +5,6 @@ package gem.telnetd
 
 import gem.Log
 import cats.effect._
-import cats.implicits._
 import gem.dao.DatabaseConfiguration
 import tuco._, Tuco._
 

--- a/modules/web/src/main/scala/gem/web/WebServer.scala
+++ b/modules/web/src/main/scala/gem/web/WebServer.scala
@@ -5,7 +5,6 @@ package gem
 package web
 
 import cats.effect._
-import cats.implicits._
 import gem.dao.DatabaseConfiguration
 import org.http4s._
 import org.http4s.server.Server

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -82,7 +82,7 @@ object Settings {
     val scalaJSReactSortable    = "0.1.1"
 
     // Scala libraries
-    val catsEffectVersion       = "1.1.0"
+    val catsEffectVersion       = "1.2.0"
     val catsVersion             = "1.5.0"
     val mouseVersion            = "0.20"
     val fs2Version              = "1.0.2"


### PR DESCRIPTION
This PR remove usages of `ExecutionContext` by `Timer[IO]` simplifying parts of the giapi code.
I also move some methods of `GiapicConfig` to the companion object