### PR TITLE
SEQNG-867: Reduce verbosity of AsyncHttpClient

### DIFF
--- a/modules/seqexec/web/server/src/main/resources/logback.xml
+++ b/modules/seqexec/web/server/src/main/resources/logback.xml
@@ -60,6 +60,9 @@
         <logger name="org.apache.activemq" level="INFO">
             <appender-ref ref="ASYNC500" />
         </logger>
+        <logger name="io.netty" level="INFO">
+            <appender-ref ref="ASYNC500" />
+        </logger>
 
     </then>
     <else>
@@ -71,6 +74,9 @@
         </appender>
 
         <logger name="org.apache.activemq" level="INFO">
+            <appender-ref ref="STDOUT" />
+        </logger>
+        <logger name="io.netty" level="INFO">
             <appender-ref ref="STDOUT" />
         </logger>
 


### PR DESCRIPTION
AsyncHttpClient emits lots of info to debug polluting the logs. This PR limits logs to INFO or above