### PR TITLE
Convert some of the keyword collection to tagless final encoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -512,6 +512,7 @@ lazy val seqexec_server = project
   .settings(commonSettings: _*)
   .settings(
     addCompilerPlugin(Plugins.paradisePlugin),
+    addCompilerPlugin(Plugins.kindProjectorPlugin),
     libraryDependencies ++=
       Seq(Http4sCirce,
           Squants.value,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/GiapiInstrumentController.scala
@@ -23,7 +23,7 @@ abstract class GiapiInstrumentController[F[_]: Sync, CFG, C <: GiapiClient[F]] {
   private val Log = getLogger
 
   def client: C
-  def gdsClient: GdsClient
+  def gdsClient: GdsClient[F]
   def name: String
   def configuration(config: CFG): Configuration
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server
 
-import cats.effect.IO
 import fs2.Stream
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.keywords.KeywordsClient
@@ -21,7 +20,7 @@ trait InstrumentSystem[F[_]] extends System[F] {
       config: Config): SeqObserveF[F, ImageFileId, ObserveCommand.Result]
   //Expected total observe lapse, used to calculate timeout
   def calcObserveTime(config: Config): Time
-  def keywordsClient: KeywordsClient[IO]
+  def keywordsClient: KeywordsClient[F]
   def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress]
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -75,7 +75,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: TranslateSettings) {
 
   //scalastyle:off
   private def observe(config: Config, obsId: Observation.Id, inst: InstrumentSystem[IO],
-                      otherSys: List[System[IO]], headers: Reader[HeaderExtraData, List[Header]])
+                      otherSys: List[System[IO]], headers: Reader[HeaderExtraData, List[Header[IO]]])
                      (ctx: HeaderExtraData)
                      (implicit ev: Concurrent[IO]): Stream[IO, Result]
   = {
@@ -138,7 +138,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: TranslateSettings) {
                               tio: Timer[IO]
                    ): TrySeq[SequenceGen.StepGen] = {
     def buildStep(inst: InstrumentSystem[IO], sys: List[System[IO]],
-                  headers: Reader[HeaderExtraData, List[Header]]): SequenceGen.StepGen = {
+                  headers: Reader[HeaderExtraData, List[Header[IO]]]): SequenceGen.StepGen = {
       val initialStepExecutions: List[List[Action[IO]]] =
         if (i === 0)
           List(List(systems.odb.sequenceStart(obsId, "")
@@ -447,7 +447,7 @@ class SeqTranslate(site: Site, systems: Systems, settings: TranslateSettings) {
 
   private def calcInstHeader(config: Config, inst: Instrument)(
     implicit tio: Timer[IO]
-  ): TrySeq[Header] = {
+  ): TrySeq[Header[IO]] = {
     val tcsKReader = if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader
     inst match {
       case Instrument.F2     =>
@@ -460,9 +460,9 @@ class SeqTranslate(site: Site, systems: Systems, settings: TranslateSettings) {
         val gnirsReader = if(settings.gnirsKeywords) GnirsKeywordReaderImpl else GnirsKeywordReaderDummy
         toInstrumentSys(inst).map(GnirsHeader.header(_, gnirsReader, tcsKReader))
       case Instrument.Gpi    =>
-        toInstrumentSys(inst).map(GpiHeader.header(_, systems.gpi.gdsClient, tcsKReader, ObsKeywordReaderImpl(config, site)))
+        TrySeq(GpiHeader.header(systems.gpi.gdsClient, tcsKReader, ObsKeywordReaderImpl[IO](config, site)))
       case Instrument.Ghost  =>
-        GhostHeader.header().asRight
+        GhostHeader.header[IO].asRight
       case Instrument.Niri   =>
         val niriReader = if(settings.niriKeywords) NiriKeywordReaderImpl
                           else NiriKeywordReaderDummy
@@ -472,24 +472,24 @@ class SeqTranslate(site: Site, systems: Systems, settings: TranslateSettings) {
     }
   }
 
-  private def commonHeaders(config: Config, tcsSubsystems: List[TcsController.Subsystem], inst: InstrumentSystem[IO])(ctx: HeaderExtraData): Header =
+  private def commonHeaders(config: Config, tcsSubsystems: List[TcsController.Subsystem], inst: InstrumentSystem[IO])(ctx: HeaderExtraData): Header[IO] =
     new StandardHeader(
       inst,
       ObsKeywordReaderImpl(config, site),
       if (settings.tcsKeywords) TcsKeywordsReaderImpl else DummyTcsKeywordsReader,
-      StateKeywordsReader(ctx.conditions, ctx.operator, ctx.observer),
+      StateKeywordsReader[IO](ctx.conditions, ctx.operator, ctx.observer),
       tcsSubsystems
     )
 
-  private def gwsHeaders(i: InstrumentSystem[IO]): Header = GwsHeader.header(i,
+  private def gwsHeaders(i: InstrumentSystem[IO]): Header[IO] = GwsHeader.header(i,
     if (settings.gwsKeywords) GwsKeywordsReaderImpl else DummyGwsKeywordsReader)
 
-  private def gcalHeader(i: InstrumentSystem[IO]): Header = GcalHeader.header(i,
+  private def gcalHeader(i: InstrumentSystem[IO]): Header[IO] = GcalHeader.header(i,
     if (settings.gcalKeywords) GcalKeywordsReaderImpl else DummyGcalKeywordsReader )
 
   private def calcHeaders(config: Config, stepType: StepType)(
     implicit tio: Timer[IO]
-  ): TrySeq[Reader[HeaderExtraData, List[Header]]] = stepType match {
+  ): TrySeq[Reader[HeaderExtraData, List[Header[IO]]]] = stepType match {
     case CelestialObject(inst) => toInstrumentSys(inst) >>= { i =>
         calcInstHeader(config, inst).map(h => Reader(ctx => List(commonHeaders(config, all.toList, i)(ctx), gwsHeaders(i), h)))
       }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -59,9 +59,9 @@ class SeqexecEngine(httpClient: Client[IO], gpi: GpiClient[IO], ghost: GhostClie
     if (settings.odbNotifications) OdbProxy.OdbCommandsImpl[IO](new Peer(settings.odbHost, 8442, null))
     else new OdbProxy.DummyOdbCommands[IO])
 
-  val gpiGDS: GdsClient = GdsClient(settings.gpiGdsControl.command.fold(httpClient, GdsClient.alwaysOkClient), settings.gpiGDS)
+  val gpiGDS: GdsClient[IO] = GdsClient(settings.gpiGdsControl.command.fold(httpClient, GdsClient.alwaysOkClient), settings.gpiGDS)
 
-  val ghostGDS: GdsClient = GdsClient(settings.ghostControl.command.fold(httpClient, GdsClient.alwaysOkClient), settings.ghostGDS)
+  val ghostGDS: GdsClient[IO] = GdsClient(settings.ghostControl.command.fold(httpClient, GdsClient.alwaysOkClient), settings.ghostGDS)
 
   private val systems = SeqTranslate.Systems(
     odbProxy,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
@@ -3,26 +3,27 @@
 
 package seqexec.server.gcal
 
+import cats.Monad
 import gem.Observation
 import gem.enum.KeywordName
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.keywords._
-import seqexec.server.{InstrumentSystem, SeqAction}
+import seqexec.server.{InstrumentSystem, SeqActionF}
 
 object GcalHeader {
-  implicit def header[F[_]](inst: InstrumentSystem[F], gcalReader: GcalKeywordReader): Header =
-    new Header {
+  implicit def header[F[_]: Monad](inst: InstrumentSystem[F], gcalReader: GcalKeywordReader[F]): Header[F] =
+    new Header[F] {
       private val gcalKeywords = List(
-        buildString(gcalReader.getLamp.orDefault, KeywordName.GCALLAMP),
-        buildString(gcalReader.getFilter.orDefault, KeywordName.GCALFILT),
-        buildString(gcalReader.getDiffuser.orDefault, KeywordName.GCALDIFF),
-        buildString(gcalReader.getShutter.orDefault, KeywordName.GCALSHUT)
+        buildString[F](gcalReader.getLamp.orDefault, KeywordName.GCALLAMP),
+        buildString[F](gcalReader.getFilter.orDefault, KeywordName.GCALFILT),
+        buildString[F](gcalReader.getDiffuser.orDefault, KeywordName.GCALDIFF),
+        buildString[F](gcalReader.getShutter.orDefault, KeywordName.GCALSHUT)
       )
 
       override def sendBefore(obsId: Observation.Id,
-                              id: ImageFileId): SeqAction[Unit] =
+                              id: ImageFileId): SeqActionF[F, Unit] =
         sendKeywords(id, inst, gcalKeywords)
 
-      override def sendAfter(id: ImageFileId): SeqAction[Unit] = SeqAction(())
+      override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] = SeqActionF.void[F]
     }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
@@ -19,7 +19,7 @@ import seqexec.server.GiapiInstrumentController
 import seqexec.server.ghost.GhostController.GhostConfig
 
 final case class GhostController[F[_]: Sync](override val client: GhostClient[F],
-                                             override val gdsClient: GdsClient)
+                                             override val gdsClient: GdsClient[F])
   extends GiapiInstrumentController[F, GhostConfig, GhostClient[F]] {
 
   import GhostController._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostHeader.scala
@@ -3,21 +3,21 @@
 
 package seqexec.server.ghost
 
+import cats.Applicative
 import gem.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.SeqAction
+import seqexec.server.SeqActionF
 import seqexec.server.keywords._
 
 object GhostHeader {
 
-  def header(): Header =
-    new Header {
+  def header[F[_]: Applicative]: Header[F] =
+    new Header[F] {
       override def sendBefore(obsId: Observation.Id,
-                              id: ImageFileId): SeqAction[Unit] =
-        SeqAction.void
+                              id: ImageFileId): SeqActionF[F, Unit] =
+        SeqActionF.void[F]
 
-
-      override def sendAfter(id: ImageFileId): SeqAction[Unit] =
-        SeqAction.void
+      override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] =
+        SeqActionF.void[F]
     }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsKeywordReader.scala
@@ -3,89 +3,91 @@
 
 package seqexec.server.gnirs
 
+import cats.effect.IO
 import seqexec.server.SeqAction
+import seqexec.server.SeqActionF
 import seqexec.server.keywords._
 
-trait GnirsKeywordReader {
-  def getArrayId: SeqAction[String]
-  def getArrayType: SeqAction[String]
-  def getDetectorBias: SeqAction[Double]
-  def getFilter1: SeqAction[String]
-  def getFilterWheel1Pos: SeqAction[Int]
-  def getFilter2: SeqAction[String]
-  def getFilterWheel2Pos: SeqAction[Int]
-  def getCamera: SeqAction[String]
-  def getCameraPos: SeqAction[Int]
-  def getDecker: SeqAction[String]
-  def getDeckerPos: SeqAction[Int]
-  def getSlit: SeqAction[String]
-  def getSlitPos: SeqAction[Int]
-  def getPrism: SeqAction[String]
-  def getPrismPos: SeqAction[Int]
-  def getGrating: SeqAction[String]
-  def getGratingPos: SeqAction[Int]
-  def getGratingWavelength: SeqAction[Double]
-  def getGratingOrder: SeqAction[Int]
-  def getGratingTilt: SeqAction[Double]
-  def getFocus: SeqAction[String]
-  def getFocusPos: SeqAction[Int]
-  def getAcquisitionMirror: SeqAction[String]
-  def getWindowCover: SeqAction[String]
-  def getObsEpoch: SeqAction[Double]
+trait GnirsKeywordReader[F[_]] {
+  def getArrayId: SeqActionF[F, String]
+  def getArrayType: SeqActionF[F, String]
+  def getDetectorBias: SeqActionF[F, Double]
+  def getFilter1: SeqActionF[F, String]
+  def getFilterWheel1Pos: SeqActionF[F, Int]
+  def getFilter2: SeqActionF[F, String]
+  def getFilterWheel2Pos: SeqActionF[F, Int]
+  def getCamera: SeqActionF[F, String]
+  def getCameraPos: SeqActionF[F, Int]
+  def getDecker: SeqActionF[F, String]
+  def getDeckerPos: SeqActionF[F, Int]
+  def getSlit: SeqActionF[F, String]
+  def getSlitPos: SeqActionF[F, Int]
+  def getPrism: SeqActionF[F, String]
+  def getPrismPos: SeqActionF[F, Int]
+  def getGrating: SeqActionF[F, String]
+  def getGratingPos: SeqActionF[F, Int]
+  def getGratingWavelength: SeqActionF[F, Double]
+  def getGratingOrder: SeqActionF[F, Int]
+  def getGratingTilt: SeqActionF[F, Double]
+  def getFocus: SeqActionF[F, String]
+  def getFocusPos: SeqActionF[F, Int]
+  def getAcquisitionMirror: SeqActionF[F, String]
+  def getWindowCover: SeqActionF[F, String]
+  def getObsEpoch: SeqActionF[F, Double]
 }
 
-object GnirsKeywordReaderDummy extends GnirsKeywordReader {
-  override def getArrayId: SeqAction[String] = SeqAction(StrDefault)
-  override def getArrayType: SeqAction[String] = SeqAction(StrDefault)
-  override def getDetectorBias: SeqAction[Double] = SeqAction(DoubleDefault)
-  override def getFilter1: SeqAction[String] = SeqAction(StrDefault)
-  override def getFilterWheel1Pos: SeqAction[Int] = SeqAction(IntDefault)
-  override def getFilter2: SeqAction[String] = SeqAction(StrDefault)
-  override def getFilterWheel2Pos: SeqAction[Int] = SeqAction(IntDefault)
-  override def getCamera: SeqAction[String] = SeqAction(StrDefault)
-  override def getCameraPos: SeqAction[Int] = SeqAction(IntDefault)
-  override def getDecker: SeqAction[String] = SeqAction(StrDefault)
-  override def getDeckerPos: SeqAction[Int] = SeqAction(IntDefault)
-  override def getSlit: SeqAction[String] = SeqAction(StrDefault)
-  override def getSlitPos: SeqAction[Int] = SeqAction(IntDefault)
-  override def getPrism: SeqAction[String] = SeqAction(StrDefault)
-  override def getPrismPos: SeqAction[Int] = SeqAction(IntDefault)
-  override def getGrating: SeqAction[String] = SeqAction(StrDefault)
-  override def getGratingPos: SeqAction[Int] = SeqAction(IntDefault)
-  override def getGratingWavelength: SeqAction[Double] = SeqAction(DoubleDefault)
-  override def getGratingOrder: SeqAction[Int] = SeqAction(IntDefault)
-  override def getGratingTilt: SeqAction[Double] = SeqAction(DoubleDefault)
-  override def getFocus: SeqAction[String] = SeqAction(StrDefault)
-  override def getFocusPos: SeqAction[Int] = SeqAction(IntDefault)
-  override def getAcquisitionMirror: SeqAction[String] = SeqAction(StrDefault)
-  override def getWindowCover: SeqAction[String] = SeqAction(StrDefault)
-  override def getObsEpoch: SeqAction[Double] = SeqAction(DoubleDefault)
+object GnirsKeywordReaderDummy extends GnirsKeywordReader[IO] {
+  override def getArrayId: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getArrayType: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getDetectorBias: SeqActionF[IO, Double] = SeqAction(DoubleDefault)
+  override def getFilter1: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getFilterWheel1Pos: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getFilter2: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getFilterWheel2Pos: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getCamera: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getCameraPos: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getDecker: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getDeckerPos: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getSlit: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getSlitPos: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getPrism: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getPrismPos: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getGrating: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getGratingPos: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getGratingWavelength: SeqActionF[IO, Double] = SeqAction(DoubleDefault)
+  override def getGratingOrder: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getGratingTilt: SeqActionF[IO, Double] = SeqAction(DoubleDefault)
+  override def getFocus: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getFocusPos: SeqActionF[IO, Int] = SeqAction(IntDefault)
+  override def getAcquisitionMirror: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getWindowCover: SeqActionF[IO, String] = SeqAction(StrDefault)
+  override def getObsEpoch: SeqActionF[IO, Double] = SeqAction(DoubleDefault)
 }
 
-object GnirsKeywordReaderImpl extends GnirsKeywordReader {
-  override def getArrayId: SeqAction[String] = GnirsEpics.instance.arrayId.toSeqAction
-  override def getArrayType: SeqAction[String] = GnirsEpics.instance.arrayType.toSeqAction
-  override def getDetectorBias: SeqAction[Double] = GnirsEpics.instance.detBias.toSeqAction
-  override def getFilter1: SeqAction[String] = GnirsEpics.instance.filter1.toSeqAction
-  override def getFilterWheel1Pos: SeqAction[Int] = GnirsEpics.instance.filter1Eng.toSeqAction
-  override def getFilter2: SeqAction[String] = GnirsEpics.instance.filter2.toSeqAction
-  override def getFilterWheel2Pos: SeqAction[Int] = GnirsEpics.instance.filter2Eng.toSeqAction
-  override def getCamera: SeqAction[String] = GnirsEpics.instance.camera.toSeqAction
-  override def getCameraPos: SeqAction[Int] = GnirsEpics.instance.cameraEng.toSeqAction
-  override def getDecker: SeqAction[String] = GnirsEpics.instance.decker.toSeqAction
-  override def getDeckerPos: SeqAction[Int] = GnirsEpics.instance.deckerEng.toSeqAction
-  override def getSlit: SeqAction[String] = GnirsEpics.instance.slitWidth.toSeqAction
-  override def getSlitPos: SeqAction[Int] = GnirsEpics.instance.slitEng.toSeqAction
-  override def getPrism: SeqAction[String] = GnirsEpics.instance.prism.toSeqAction
-  override def getPrismPos: SeqAction[Int] = GnirsEpics.instance.prismEng.toSeqAction
-  override def getGrating: SeqAction[String] = GnirsEpics.instance.grating.toSeqAction
-  override def getGratingPos: SeqAction[Int] = GnirsEpics.instance.gratingEng.toSeqAction
-  override def getGratingWavelength: SeqAction[Double] = GnirsEpics.instance.centralWavelength.toSeqAction
-  override def getGratingOrder: SeqAction[Int] = GnirsEpics.instance.gratingOrder.toSeqAction
-  override def getGratingTilt: SeqAction[Double] = GnirsEpics.instance.gratingTilt.toSeqAction
-  override def getFocus: SeqAction[String] = GnirsEpics.instance.focus.toSeqAction
-  override def getFocusPos: SeqAction[Int] = GnirsEpics.instance.focusEng.toSeqAction
-  override def getAcquisitionMirror: SeqAction[String] = GnirsEpics.instance.acqMirror.toSeqAction
-  override def getWindowCover: SeqAction[String] = GnirsEpics.instance.cover.toSeqAction
-  override def getObsEpoch: SeqAction[Double] = GnirsEpics.instance.obsEpoch.toSeqAction
+object GnirsKeywordReaderImpl extends GnirsKeywordReader[IO] {
+  override def getArrayId: SeqActionF[IO, String] = GnirsEpics.instance.arrayId.toSeqAction
+  override def getArrayType: SeqActionF[IO, String] = GnirsEpics.instance.arrayType.toSeqAction
+  override def getDetectorBias: SeqActionF[IO, Double] = GnirsEpics.instance.detBias.toSeqAction
+  override def getFilter1: SeqActionF[IO, String] = GnirsEpics.instance.filter1.toSeqAction
+  override def getFilterWheel1Pos: SeqActionF[IO, Int] = GnirsEpics.instance.filter1Eng.toSeqAction
+  override def getFilter2: SeqActionF[IO, String] = GnirsEpics.instance.filter2.toSeqAction
+  override def getFilterWheel2Pos: SeqActionF[IO, Int] = GnirsEpics.instance.filter2Eng.toSeqAction
+  override def getCamera: SeqActionF[IO, String] = GnirsEpics.instance.camera.toSeqAction
+  override def getCameraPos: SeqActionF[IO, Int] = GnirsEpics.instance.cameraEng.toSeqAction
+  override def getDecker: SeqActionF[IO, String] = GnirsEpics.instance.decker.toSeqAction
+  override def getDeckerPos: SeqActionF[IO, Int] = GnirsEpics.instance.deckerEng.toSeqAction
+  override def getSlit: SeqActionF[IO, String] = GnirsEpics.instance.slitWidth.toSeqAction
+  override def getSlitPos: SeqActionF[IO, Int] = GnirsEpics.instance.slitEng.toSeqAction
+  override def getPrism: SeqActionF[IO, String] = GnirsEpics.instance.prism.toSeqAction
+  override def getPrismPos: SeqActionF[IO, Int] = GnirsEpics.instance.prismEng.toSeqAction
+  override def getGrating: SeqActionF[IO, String] = GnirsEpics.instance.grating.toSeqAction
+  override def getGratingPos: SeqActionF[IO, Int] = GnirsEpics.instance.gratingEng.toSeqAction
+  override def getGratingWavelength: SeqActionF[IO, Double] = GnirsEpics.instance.centralWavelength.toSeqAction
+  override def getGratingOrder: SeqActionF[IO, Int] = GnirsEpics.instance.gratingOrder.toSeqAction
+  override def getGratingTilt: SeqActionF[IO, Double] = GnirsEpics.instance.gratingTilt.toSeqAction
+  override def getFocus: SeqActionF[IO, String] = GnirsEpics.instance.focus.toSeqAction
+  override def getFocusPos: SeqActionF[IO, Int] = GnirsEpics.instance.focusEng.toSeqAction
+  override def getAcquisitionMirror: SeqActionF[IO, String] = GnirsEpics.instance.acqMirror.toSeqAction
+  override def getWindowCover: SeqActionF[IO, String] = GnirsEpics.instance.cover.toSeqAction
+  override def getObsEpoch: SeqActionF[IO, Double] = GnirsEpics.instance.obsEpoch.toSeqAction
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
@@ -92,7 +92,7 @@ object GpiLookupTables {
 }
 
 final case class GpiController[F[_]: Sync](override val client: GpiClient[F],
-                                           override val gdsClient: GdsClient)
+                                           override val gdsClient: GdsClient[F])
   extends GiapiInstrumentController[F, GpiConfig, GpiClient[F]] {
 
   import GpiController._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsKeywordReader.scala
@@ -3,31 +3,32 @@
 
 package seqexec.server.gws
 
-import seqexec.server.{EpicsHealth, SeqAction}
+import cats.effect.IO
+import seqexec.server.{EpicsHealth, SeqAction, SeqActionF}
 import seqexec.server.keywords._
 import squants.motion.{MetersPerSecond, Pressure, StandardAtmospheres}
 import squants.space.Degrees
 import squants.thermal.Celsius
 import squants.{Angle, Temperature, Velocity}
 
-trait GwsKeywordReader {
-  def getHealth: SeqAction[Option[EpicsHealth]]
+trait GwsKeywordReader[F[_]] {
+  def getHealth: SeqActionF[F, Option[EpicsHealth]]
 
-  def getTemperature: SeqAction[Option[Temperature]]
+  def getTemperature: SeqActionF[F, Option[Temperature]]
 
-  def getDewPoint: SeqAction[Option[Temperature]]
+  def getDewPoint: SeqActionF[F, Option[Temperature]]
 
-  def getAirPressure: SeqAction[Option[Pressure]]
+  def getAirPressure: SeqActionF[F, Option[Pressure]]
 
-  def getWindVelocity: SeqAction[Option[Velocity]]
+  def getWindVelocity: SeqActionF[F, Option[Velocity]]
 
-  def getWindDirection: SeqAction[Option[Angle]]
+  def getWindDirection: SeqActionF[F, Option[Angle]]
 
-  def getHumidity: SeqAction[Option[Double]]
+  def getHumidity: SeqActionF[F, Option[Double]]
 
 }
 
-object DummyGwsKeywordsReader extends GwsKeywordReader {
+object DummyGwsKeywordsReader extends GwsKeywordReader[IO] {
 
   override def getTemperature: SeqAction[Option[Temperature]] = Celsius(15.0).toSeqAction
 
@@ -44,7 +45,7 @@ object DummyGwsKeywordsReader extends GwsKeywordReader {
   override def getHealth: SeqAction[Option[EpicsHealth]] = (EpicsHealth.Good: EpicsHealth).toSeqAction
 }
 
-object GwsKeywordsReaderImpl extends GwsKeywordReader {
+object GwsKeywordsReaderImpl extends GwsKeywordReader[IO] {
 
   override def getTemperature: SeqAction[Option[Temperature]] = GwsEpics.instance.ambientT.toSeqActionO
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/Header.scala
@@ -5,12 +5,12 @@ package seqexec.server.keywords
 
 import gem.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.SeqAction
+import seqexec.server.SeqActionF
 
 /**
   * Header implementations know what headers sent before and after an observation
   */
-trait Header {
-  def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqAction[Unit]
-  def sendAfter(id: ImageFileId): SeqAction[Unit]
+trait Header[F[_]] {
+  def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqActionF[F, Unit]
+  def sendAfter(id: ImageFileId): SeqActionF[F, Unit]
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriHeader.scala
@@ -3,19 +3,19 @@
 
 package seqexec.server.niri
 
-import cats.effect.IO
+import cats.Monad
 import gem.Observation
 import gem.enum.KeywordName
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.keywords.{Header, buildDouble, buildString, _}
-import seqexec.server.{InstrumentSystem, SeqAction}
+import seqexec.server.{InstrumentSystem, SeqActionF}
 import seqexec.server.tcs.TcsKeywordsReader
 
 object NiriHeader {
   // scalastyle:off
-  def header(inst: InstrumentSystem[IO], instReader: NiriKeywordReader,
-             tcsKeywordsReader: TcsKeywordsReader): Header = new Header {
-    override def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqAction[Unit] =
+  def header[F[_]: Monad](inst: InstrumentSystem[F], instReader: NiriKeywordReader[F],
+             tcsKeywordsReader: TcsKeywordsReader[F]): Header[F] = new Header[F] {
+    override def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqActionF[F, Unit] =
       sendKeywords(id, inst, List(
         buildString(instReader.arrayId, KeywordName.ARRAYID),
         buildString(instReader.arrayType, KeywordName.ARRAYTYP),
@@ -53,7 +53,7 @@ object NiriHeader {
         buildDouble(instReader.setVoltage, KeywordName.VSET)
       ))
 
-    override def sendAfter(id: ImageFileId): SeqAction[Unit] =
+    override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] =
       sendKeywords(id, inst, List(
         buildDouble(instReader.detectorTemperature, KeywordName.A_TDETABS),
         buildDouble(instReader.mountTemperature, KeywordName.A_TMOUNT),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
@@ -3,44 +3,46 @@
 
 package seqexec.server.niri
 
+import cats.effect.IO
 import seqexec.server.SeqAction
+import seqexec.server.SeqActionF
 import seqexec.server.keywords._
 
-trait NiriKeywordReader {
-  def arrayId: SeqAction[String]
-  def arrayType: SeqAction[String]
-  def camera: SeqAction[String]
-  def coadds: SeqAction[Int]
-  def exposureTime: SeqAction[Double]
-  def filter1: SeqAction[String]
-  def filter2: SeqAction[String]
-  def filter3: SeqAction[String]
-  def focusName: SeqAction[String]
-  def focusPosition: SeqAction[Double]
-  def focalPlaneMask: SeqAction[String]
-  def beamSplitter: SeqAction[String]
-  def windowCover: SeqAction[String]
-  def framesPerCycle: SeqAction[Int]
-  def headerTiming: SeqAction[String]
-  def lnrs: SeqAction[Int]
-  def mode: SeqAction[String]
-  def numberDigitalAverage: SeqAction[Int]
-  def pupilViewer: SeqAction[String]
-  def detectorTemperature: SeqAction[Double]
-  def mountTemperature: SeqAction[Double]
-  def µcodeName: SeqAction[String]
-  def µcodeType: SeqAction[String]
-  def cl1VoltageDD: SeqAction[Double]
-  def cl2VoltageDD: SeqAction[Double]
-  def ucVoltage: SeqAction[Double]
-  def detectorVoltage: SeqAction[Double]
-  def cl1VoltageGG: SeqAction[Double]
-  def cl2VoltageGG: SeqAction[Double]
-  def setVoltage: SeqAction[Double]
-  def observationEpoch: SeqAction[Double]
+trait NiriKeywordReader[F[_]] {
+  def arrayId: SeqActionF[F, String]
+  def arrayType: SeqActionF[F, String]
+  def camera: SeqActionF[F, String]
+  def coadds: SeqActionF[F, Int]
+  def exposureTime: SeqActionF[F, Double]
+  def filter1: SeqActionF[F, String]
+  def filter2: SeqActionF[F, String]
+  def filter3: SeqActionF[F, String]
+  def focusName: SeqActionF[F, String]
+  def focusPosition: SeqActionF[F, Double]
+  def focalPlaneMask: SeqActionF[F, String]
+  def beamSplitter: SeqActionF[F, String]
+  def windowCover: SeqActionF[F, String]
+  def framesPerCycle: SeqActionF[F, Int]
+  def headerTiming: SeqActionF[F, String]
+  def lnrs: SeqActionF[F, Int]
+  def mode: SeqActionF[F, String]
+  def numberDigitalAverage: SeqActionF[F, Int]
+  def pupilViewer: SeqActionF[F, String]
+  def detectorTemperature: SeqActionF[F, Double]
+  def mountTemperature: SeqActionF[F, Double]
+  def µcodeName: SeqActionF[F, String]
+  def µcodeType: SeqActionF[F, String]
+  def cl1VoltageDD: SeqActionF[F, Double]
+  def cl2VoltageDD: SeqActionF[F, Double]
+  def ucVoltage: SeqActionF[F, Double]
+  def detectorVoltage: SeqActionF[F, Double]
+  def cl1VoltageGG: SeqActionF[F, Double]
+  def cl2VoltageGG: SeqActionF[F, Double]
+  def setVoltage: SeqActionF[F, Double]
+  def observationEpoch: SeqActionF[F, Double]
 }
 
-object NiriKeywordReaderDummy extends NiriKeywordReader {
+object NiriKeywordReaderDummy extends NiriKeywordReader[IO] {
   override def arrayId: SeqAction[String] = SeqAction(StrDefault)
   override def arrayType: SeqAction[String] = SeqAction(StrDefault)
   override def camera: SeqAction[String] = SeqAction(StrDefault)
@@ -74,7 +76,7 @@ object NiriKeywordReaderDummy extends NiriKeywordReader {
   override def observationEpoch: SeqAction[Double] = SeqAction(DoubleDefault)
 }
 
-object NiriKeywordReaderImpl extends NiriKeywordReader {
+object NiriKeywordReaderImpl extends NiriKeywordReader[IO] {
   val sys = NiriEpics.instance
   override def arrayId: SeqAction[String] = sys.arrayId.toSeqAction
   override def arrayType: SeqAction[String] = sys.arrayType.toSeqAction

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -170,6 +170,7 @@ package object server {
   object SeqActionF {
     def apply[F[_]: Sync, A](a: => A): SeqActionF[F, A]       = EitherT(Sync[F].delay(TrySeq(a)))
     def liftF[F[_]: Functor, A](a: => F[A]): SeqActionF[F, A] = EitherT.liftF(a)
+    def either[F[_]: Sync, A](a: => TrySeq[A]): SeqActionF[F, A] = EitherT(Sync[F].delay(a))
     def void[F[_]: Applicative]: SeqActionF[F, Unit]          = EitherT.liftF(Applicative[F].pure(()))
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsKeywordReader.scala
@@ -4,6 +4,7 @@
 package seqexec.server.tcs
 
 import cats.{Apply, Eq}
+import cats.effect.IO
 import cats.implicits._
 import gem.math.Angle
 import edu.gemini.spModel.core.Wavelength
@@ -11,7 +12,7 @@ import edu.gemini.spModel.core.Wavelength
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import monocle.Prism
-import seqexec.server.SeqAction
+import seqexec.server.SeqActionF
 import seqexec.server.keywords._
 import squants.space.{Angstroms, Meters}
 
@@ -40,326 +41,326 @@ object CRFollow {
 
 }
 
-trait TargetKeywordsReader {
-  def getRA: SeqAction[Option[Double]]
+trait TargetKeywordsReader[F[_]] {
+  def getRA: SeqActionF[F, Option[Double]]
 
-  def getDec: SeqAction[Option[Double]]
+  def getDec: SeqActionF[F, Option[Double]]
 
-  def getRadialVelocity: SeqAction[Option[Double]]
+  def getRadialVelocity: SeqActionF[F, Option[Double]]
 
-  def getParallax: SeqAction[Option[Double]]
+  def getParallax: SeqActionF[F, Option[Double]]
 
-  def getWavelength: SeqAction[Option[Wavelength]]
+  def getWavelength: SeqActionF[F, Option[Wavelength]]
 
-  def getEpoch: SeqAction[Option[Double]]
+  def getEpoch: SeqActionF[F, Option[Double]]
 
-  def getEquinox: SeqAction[Option[Double]]
+  def getEquinox: SeqActionF[F, Option[Double]]
 
-  def getFrame: SeqAction[Option[String]]
+  def getFrame: SeqActionF[F, Option[String]]
 
-  def getObjectName: SeqAction[Option[String]]
+  def getObjectName: SeqActionF[F, Option[String]]
 
-  def getProperMotionDec: SeqAction[Option[Double]]
+  def getProperMotionDec: SeqActionF[F, Option[Double]]
 
-  def getProperMotionRA: SeqAction[Option[Double]]
-
-}
-
-trait TcsKeywordsReader {
-  def getHourAngle: SeqAction[Option[String]]
-
-  def getLocalTime: SeqAction[Option[String]]
-
-  def getTrackingFrame: SeqAction[Option[String]]
-
-  def getTrackingEpoch: SeqAction[Option[Double]]
-
-  def getTrackingEquinox: SeqAction[Option[Double]]
-
-  def getTrackingDec: SeqAction[Option[Double]]
-
-  def getTrackingRA: SeqAction[Option[Double]]
-
-  def getElevation: SeqAction[Option[Double]]
-
-  def getAzimuth: SeqAction[Option[Double]]
-
-  def getCRPositionAngle: SeqAction[Option[Double]]
-
-  def getUT: SeqAction[Option[String]]
-
-  def getDate: SeqAction[Option[String]]
-
-  def getM2Baffle: SeqAction[Option[String]]
-
-  def getM2CentralBaffle: SeqAction[Option[String]]
-
-  def getST: SeqAction[Option[String]]
-
-  def getSFRotation: SeqAction[Option[Double]]
-
-  def getSFTilt: SeqAction[Option[Double]]
-
-  def getSFLinear: SeqAction[Option[Double]]
-
-  def getInstrumentPA: SeqAction[Option[Double]]
-
-  def getXOffset: SeqAction[Option[Double]]
-
-  def getYOffset: SeqAction[Option[Double]]
-
-  def getTrackingRAOffset: SeqAction[Option[Double]]
-
-  def getTrackingDecOffset: SeqAction[Option[Double]]
-
-  def getInstrumentAA: SeqAction[Option[Double]]
-
-  def getAOFoldName: SeqAction[Option[String]]
-
-  def getSourceATarget: TargetKeywordsReader
-
-  def getPwfs1Target: TargetKeywordsReader
-
-  def getPwfs2Target: TargetKeywordsReader
-
-  def getOiwfsTarget: TargetKeywordsReader
-
-  def getAowfsTarget: TargetKeywordsReader
-
-  def getGwfs1Target: TargetKeywordsReader
-
-  def getGwfs2Target: TargetKeywordsReader
-
-  def getGwfs3Target: TargetKeywordsReader
-
-  def getGwfs4Target: TargetKeywordsReader
-
-  def getAirMass: SeqAction[Option[Double]]
-
-  def getStartAirMass: SeqAction[Option[Double]]
-
-  def getEndAirMass: SeqAction[Option[Double]]
-
-  def getCarouselMode: SeqAction[Option[String]]
-
-  def getM2UserFocusOffset: SeqAction[Option[Double]]
-
-  def getParallacticAngle: SeqAction[Option[Angle]]
-
-  def getPwfs1Freq: SeqAction[Option[Double]]
-
-  def getPwfs2Freq: SeqAction[Option[Double]]
-
-  def getOiwfsFreq: SeqAction[Option[Double]]
-
-  def getGmosInstPort: SeqAction[Option[Int]]
-
-  def getGnirsInstPort: SeqAction[Option[Int]]
-
-  def getGpiInstPort: SeqAction[Option[Int]]
-
-  def getNiriInstPort: SeqAction[Option[Int]]
-
-  def getNifsInstPort: SeqAction[Option[Int]]
-
-  def getGsaoiInstPort: SeqAction[Option[Int]]
-
-  def getF2InstPort: SeqAction[Option[Int]]
-
-  def getCRFollow: SeqAction[Option[CRFollow]]
+  def getProperMotionRA: SeqActionF[F, Option[Double]]
 
 }
 
-object DummyTargetKeywordsReader extends TargetKeywordsReader {
+trait TcsKeywordsReader[F[_]] {
+  def getHourAngle: SeqActionF[F, Option[String]]
 
-  override def getRA: SeqAction[Option[Double]] = 0.0.toSeqAction
+  def getLocalTime: SeqActionF[F, Option[String]]
 
-  override def getDec: SeqAction[Option[Double]] = 0.0.toSeqAction
+  def getTrackingFrame: SeqActionF[F, Option[String]]
 
-  override def getRadialVelocity: SeqAction[Option[Double]] = 0.0.toSeqAction
+  def getTrackingEpoch: SeqActionF[F, Option[Double]]
 
-  override def getParallax: SeqAction[Option[Double]] = 0.0.toSeqAction
+  def getTrackingEquinox: SeqActionF[F, Option[Double]]
 
-  override def getWavelength: SeqAction[Option[Wavelength]] = Wavelength(Meters(0.0)).toSeqAction
+  def getTrackingDec: SeqActionF[F, Option[Double]]
 
-  override def getEpoch: SeqAction[Option[Double]] = 2000.0.toSeqAction
+  def getTrackingRA: SeqActionF[F, Option[Double]]
 
-  override def getEquinox: SeqAction[Option[Double]] = 2000.0.toSeqAction
+  def getElevation: SeqActionF[F, Option[Double]]
 
-  override def getFrame: SeqAction[Option[String]] = "FK5".toSeqAction
+  def getAzimuth: SeqActionF[F, Option[Double]]
 
-  override def getObjectName: SeqAction[Option[String]] = "Dummy".toSeqAction
+  def getCRPositionAngle: SeqActionF[F, Option[Double]]
 
-  override def getProperMotionDec: SeqAction[Option[Double]] = 0.0.toSeqAction
+  def getUT: SeqActionF[F, Option[String]]
 
-  override def getProperMotionRA: SeqAction[Option[Double]] = 0.0.toSeqAction
+  def getDate: SeqActionF[F, Option[String]]
+
+  def getM2Baffle: SeqActionF[F, Option[String]]
+
+  def getM2CentralBaffle: SeqActionF[F, Option[String]]
+
+  def getST: SeqActionF[F, Option[String]]
+
+  def getSFRotation: SeqActionF[F, Option[Double]]
+
+  def getSFTilt: SeqActionF[F, Option[Double]]
+
+  def getSFLinear: SeqActionF[F, Option[Double]]
+
+  def getInstrumentPA: SeqActionF[F, Option[Double]]
+
+  def getXOffset: SeqActionF[F, Option[Double]]
+
+  def getYOffset: SeqActionF[F, Option[Double]]
+
+  def getTrackingRAOffset: SeqActionF[F, Option[Double]]
+
+  def getTrackingDecOffset: SeqActionF[F, Option[Double]]
+
+  def getInstrumentAA: SeqActionF[F, Option[Double]]
+
+  def getAOFoldName: SeqActionF[F, Option[String]]
+
+  def getSourceATarget: TargetKeywordsReader[F]
+
+  def getPwfs1Target: TargetKeywordsReader[F]
+
+  def getPwfs2Target: TargetKeywordsReader[F]
+
+  def getOiwfsTarget: TargetKeywordsReader[F]
+
+  def getAowfsTarget: TargetKeywordsReader[F]
+
+  def getGwfs1Target: TargetKeywordsReader[F]
+
+  def getGwfs2Target: TargetKeywordsReader[F]
+
+  def getGwfs3Target: TargetKeywordsReader[F]
+
+  def getGwfs4Target: TargetKeywordsReader[F]
+
+  def getAirMass: SeqActionF[F, Option[Double]]
+
+  def getStartAirMass: SeqActionF[F, Option[Double]]
+
+  def getEndAirMass: SeqActionF[F, Option[Double]]
+
+  def getCarouselMode: SeqActionF[F, Option[String]]
+
+  def getM2UserFocusOffset: SeqActionF[F, Option[Double]]
+
+  def getParallacticAngle: SeqActionF[F, Option[Angle]]
+
+  def getPwfs1Freq: SeqActionF[F, Option[Double]]
+
+  def getPwfs2Freq: SeqActionF[F, Option[Double]]
+
+  def getOiwfsFreq: SeqActionF[F, Option[Double]]
+
+  def getGmosInstPort: SeqActionF[F, Option[Int]]
+
+  def getGnirsInstPort: SeqActionF[F, Option[Int]]
+
+  def getGpiInstPort: SeqActionF[F, Option[Int]]
+
+  def getNiriInstPort: SeqActionF[F, Option[Int]]
+
+  def getNifsInstPort: SeqActionF[F, Option[Int]]
+
+  def getGsaoiInstPort: SeqActionF[F, Option[Int]]
+
+  def getF2InstPort: SeqActionF[F, Option[Int]]
+
+  def getCRFollow: SeqActionF[F, Option[CRFollow]]
 
 }
 
-object DummyTcsKeywordsReader extends TcsKeywordsReader {
+object DummyTargetKeywordsReader extends TargetKeywordsReader[IO] {
 
-  override def getHourAngle: SeqAction[Option[String]] = "00:00:00".toSeqAction
+  override def getRA: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
 
-  override def getLocalTime: SeqAction[Option[String]] = "00:00:00".toSeqAction
+  override def getDec: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
 
-  override def getTrackingFrame: SeqAction[Option[String]] = "FK5".toSeqAction
+  override def getRadialVelocity: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
 
-  override def getTrackingEpoch: SeqAction[Option[Double]] = 0.0.toSeqAction
+  override def getParallax: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
 
-  override def getTrackingEquinox: SeqAction[Option[Double]] = 2000.0.toSeqAction
+  override def getWavelength: SeqActionF[IO, Option[Wavelength]] = Wavelength(Meters(0.0)).toSeqAction
 
-  override def getTrackingDec: SeqAction[Option[Double]] = 0.0.toSeqAction
+  override def getEpoch: SeqActionF[IO, Option[Double]] = 2000.0.toSeqAction
 
-  override def getTrackingRA: SeqAction[Option[Double]] = 0.0.toSeqAction
+  override def getEquinox: SeqActionF[IO, Option[Double]] = 2000.0.toSeqAction
 
-  override def getElevation: SeqAction[Option[Double]] = 0.0.toSeqAction
+  override def getFrame: SeqActionF[IO, Option[String]] = "FK5".toSeqAction
 
-  override def getAzimuth: SeqAction[Option[Double]] = 0.0.toSeqAction
+  override def getObjectName: SeqActionF[IO, Option[String]] = "Dummy".toSeqAction
 
-  override def getCRPositionAngle: SeqAction[Option[Double]] = 0.0.toSeqAction
+  override def getProperMotionDec: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
 
-  override def getUT: SeqAction[Option[String]] = "00:00:00".toSeqAction
+  override def getProperMotionRA: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
 
-  override def getDate: SeqAction[Option[String]] = LocalDate.now.format(DateTimeFormatter.ISO_LOCAL_DATE).toSeqAction
-
-  override def getM2Baffle: SeqAction[Option[String]] = "OUT".toSeqAction
-
-  override def getM2CentralBaffle: SeqAction[Option[String]] = "OUT".toSeqAction
-
-  override def getST: SeqAction[Option[String]] = "00:00:00".toSeqAction
-
-  override def getSFRotation: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getSFTilt: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getSFLinear: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getInstrumentPA: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getXOffset: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getYOffset: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getInstrumentAA: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getAOFoldName: SeqAction[Option[String]] = "OUT".toSeqAction
-
-  override def getSourceATarget: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getAirMass: SeqAction[Option[Double]] = 1.0.toSeqAction
-
-  override def getStartAirMass: SeqAction[Option[Double]] = 1.0.toSeqAction
-
-  override def getEndAirMass: SeqAction[Option[Double]] = 1.0.toSeqAction
-
-  override def getParallacticAngle: SeqAction[Option[Angle]] = Some(Angle.fromDoubleDegrees(0)).toSeqActionO
-
-  override def getTrackingRAOffset: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getTrackingDecOffset: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getPwfs1Target: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getPwfs2Target: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getOiwfsTarget: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getAowfsTarget: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getGwfs1Target: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getGwfs2Target: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getGwfs3Target: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getGwfs4Target: TargetKeywordsReader = DummyTargetKeywordsReader
-
-  override def getM2UserFocusOffset: SeqAction[Option[Double]] = 0.0.toSeqAction
-
-  override def getPwfs1Freq: SeqAction[Option[Double]] = -9999.0.toSeqAction
-
-  override def getPwfs2Freq: SeqAction[Option[Double]] = -9999.0.toSeqAction
-
-  override def getOiwfsFreq: SeqAction[Option[Double]] = -9999.0.toSeqAction
-
-  override def getCarouselMode: SeqAction[Option[String]] = "Basic".toSeqAction
-
-  override def getGmosInstPort: SeqAction[Option[Int]] = 0.toSeqAction
-
-  override def getGnirsInstPort: SeqAction[Option[Int]] = 0.toSeqAction
-
-  override def getGpiInstPort: SeqAction[Option[Int]] = 0.toSeqAction
-
-  override def getNiriInstPort: SeqAction[Option[Int]] = 0.toSeqAction
-
-  override def getNifsInstPort: SeqAction[Option[Int]] = 0.toSeqAction
-
-  override def getGsaoiInstPort: SeqAction[Option[Int]] = 0.toSeqAction
-
-  override def getF2InstPort: SeqAction[Option[Int]] = 0.toSeqAction
-
-  override def getCRFollow: SeqAction[Option[CRFollow]] = (CRFollow.Off: CRFollow).toSeqAction
 }
 
-object TcsKeywordsReaderImpl extends TcsKeywordsReader {
+object DummyTcsKeywordsReader extends TcsKeywordsReader[IO] {
 
-  override def getHourAngle: SeqAction[Option[String]] = TcsEpics.instance.hourAngle.toSeqActionO
+  override def getHourAngle: SeqActionF[IO, Option[String]] = "00:00:00".toSeqAction
 
-  override def getLocalTime: SeqAction[Option[String]] = TcsEpics.instance.localTime.toSeqActionO
+  override def getLocalTime: SeqActionF[IO, Option[String]] = "00:00:00".toSeqAction
 
-  override def getTrackingFrame: SeqAction[Option[String]] = TcsEpics.instance.trackingFrame.toSeqActionO
+  override def getTrackingFrame: SeqActionF[IO, Option[String]] = "FK5".toSeqAction
 
-  override def getTrackingEpoch: SeqAction[Option[Double]] = TcsEpics.instance.trackingEpoch.toSeqActionO
+  override def getTrackingEpoch: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getTrackingEquinox: SeqActionF[IO, Option[Double]] = 2000.0.toSeqAction
+
+  override def getTrackingDec: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getTrackingRA: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getElevation: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getAzimuth: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getCRPositionAngle: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getUT: SeqActionF[IO, Option[String]] = "00:00:00".toSeqAction
+
+  override def getDate: SeqActionF[IO, Option[String]] = LocalDate.now.format(DateTimeFormatter.ISO_LOCAL_DATE).toSeqAction
+
+  override def getM2Baffle: SeqActionF[IO, Option[String]] = "OUT".toSeqAction
+
+  override def getM2CentralBaffle: SeqActionF[IO, Option[String]] = "OUT".toSeqAction
+
+  override def getST: SeqActionF[IO, Option[String]] = "00:00:00".toSeqAction
+
+  override def getSFRotation: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getSFTilt: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getSFLinear: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getInstrumentPA: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getXOffset: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getYOffset: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getInstrumentAA: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getAOFoldName: SeqActionF[IO, Option[String]] = "OUT".toSeqAction
+
+  override def getSourceATarget: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getAirMass: SeqActionF[IO, Option[Double]] = 1.0.toSeqAction
+
+  override def getStartAirMass: SeqActionF[IO, Option[Double]] = 1.0.toSeqAction
+
+  override def getEndAirMass: SeqActionF[IO, Option[Double]] = 1.0.toSeqAction
+
+  override def getParallacticAngle: SeqActionF[IO, Option[Angle]] = Some(Angle.fromDoubleDegrees(0)).toSeqActionO
+
+  override def getTrackingRAOffset: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getTrackingDecOffset: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getPwfs1Target: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getPwfs2Target: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getOiwfsTarget: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getAowfsTarget: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getGwfs1Target: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getGwfs2Target: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getGwfs3Target: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getGwfs4Target: TargetKeywordsReader[IO] = DummyTargetKeywordsReader
+
+  override def getM2UserFocusOffset: SeqActionF[IO, Option[Double]] = 0.0.toSeqAction
+
+  override def getPwfs1Freq: SeqActionF[IO, Option[Double]] = -9999.0.toSeqAction
+
+  override def getPwfs2Freq: SeqActionF[IO, Option[Double]] = -9999.0.toSeqAction
+
+  override def getOiwfsFreq: SeqActionF[IO, Option[Double]] = -9999.0.toSeqAction
+
+  override def getCarouselMode: SeqActionF[IO, Option[String]] = "Basic".toSeqAction
+
+  override def getGmosInstPort: SeqActionF[IO, Option[Int]] = 0.toSeqAction
+
+  override def getGnirsInstPort: SeqActionF[IO, Option[Int]] = 0.toSeqAction
+
+  override def getGpiInstPort: SeqActionF[IO, Option[Int]] = 0.toSeqAction
+
+  override def getNiriInstPort: SeqActionF[IO, Option[Int]] = 0.toSeqAction
+
+  override def getNifsInstPort: SeqActionF[IO, Option[Int]] = 0.toSeqAction
+
+  override def getGsaoiInstPort: SeqActionF[IO, Option[Int]] = 0.toSeqAction
+
+  override def getF2InstPort: SeqActionF[IO, Option[Int]] = 0.toSeqAction
+
+  override def getCRFollow: SeqActionF[IO, Option[CRFollow]] = (CRFollow.Off: CRFollow).toSeqAction
+}
+
+object TcsKeywordsReaderImpl extends TcsKeywordsReader[IO] {
+
+  override def getHourAngle: SeqActionF[IO, Option[String]] = TcsEpics.instance.hourAngle.toSeqActionO
+
+  override def getLocalTime: SeqActionF[IO, Option[String]] = TcsEpics.instance.localTime.toSeqActionO
+
+  override def getTrackingFrame: SeqActionF[IO, Option[String]] = TcsEpics.instance.trackingFrame.toSeqActionO
+
+  override def getTrackingEpoch: SeqActionF[IO, Option[Double]] = TcsEpics.instance.trackingEpoch.toSeqActionO
 
   private def translateEpoch(v: Option[String]): Option[Double] = v.flatMap(x => Either.catchNonFatal { x.drop(1).toDouble }.toOption)
 
-  override def getTrackingEquinox: SeqAction[Option[Double]] = translateEpoch(TcsEpics.instance.trackingEquinox).toSeqActionO
+  override def getTrackingEquinox: SeqActionF[IO, Option[Double]] = translateEpoch(TcsEpics.instance.trackingEquinox).toSeqActionO
 
-  override def getTrackingDec: SeqAction[Option[Double]] = TcsEpics.instance.trackingDec.toSeqActionO
+  override def getTrackingDec: SeqActionF[IO, Option[Double]] = TcsEpics.instance.trackingDec.toSeqActionO
 
-  override def getTrackingRA: SeqAction[Option[Double]] = TcsEpics.instance.trackingRA.toSeqActionO
+  override def getTrackingRA: SeqActionF[IO, Option[Double]] = TcsEpics.instance.trackingRA.toSeqActionO
 
-  override def getElevation: SeqAction[Option[Double]] = TcsEpics.instance.elevation.toSeqActionO
+  override def getElevation: SeqActionF[IO, Option[Double]] = TcsEpics.instance.elevation.toSeqActionO
 
-  override def getAzimuth: SeqAction[Option[Double]] = TcsEpics.instance.azimuth.toSeqActionO
+  override def getAzimuth: SeqActionF[IO, Option[Double]] = TcsEpics.instance.azimuth.toSeqActionO
 
-  override def getCRPositionAngle: SeqAction[Option[Double]] = TcsEpics.instance.crPositionAngle.toSeqActionO
+  override def getCRPositionAngle: SeqActionF[IO, Option[Double]] = TcsEpics.instance.crPositionAngle.toSeqActionO
 
-  override def getUT: SeqAction[Option[String]] = TcsEpics.instance.ut.toSeqActionO
+  override def getUT: SeqActionF[IO, Option[String]] = TcsEpics.instance.ut.toSeqActionO
 
-  override def getDate: SeqAction[Option[String]] = TcsEpics.instance.date.toSeqActionO
+  override def getDate: SeqActionF[IO, Option[String]] = TcsEpics.instance.date.toSeqActionO
 
-  override def getM2Baffle: SeqAction[Option[String]] = TcsEpics.instance.m2Baffle.toSeqActionO
+  override def getM2Baffle: SeqActionF[IO, Option[String]] = TcsEpics.instance.m2Baffle.toSeqActionO
 
-  override def getM2CentralBaffle: SeqAction[Option[String]] = TcsEpics.instance.m2CentralBaffle.toSeqActionO
+  override def getM2CentralBaffle: SeqActionF[IO, Option[String]] = TcsEpics.instance.m2CentralBaffle.toSeqActionO
 
-  override def getST: SeqAction[Option[String]] = TcsEpics.instance.st.toSeqActionO
+  override def getST: SeqActionF[IO, Option[String]] = TcsEpics.instance.st.toSeqActionO
 
-  override def getSFRotation: SeqAction[Option[Double]] = TcsEpics.instance.sfRotation.toSeqActionO
+  override def getSFRotation: SeqActionF[IO, Option[Double]] = TcsEpics.instance.sfRotation.toSeqActionO
 
-  override def getSFTilt: SeqAction[Option[Double]] = TcsEpics.instance.sfTilt.toSeqActionO
+  override def getSFTilt: SeqActionF[IO, Option[Double]] = TcsEpics.instance.sfTilt.toSeqActionO
 
-  override def getSFLinear: SeqAction[Option[Double]] = TcsEpics.instance.sfLinear.toSeqActionO
+  override def getSFLinear: SeqActionF[IO, Option[Double]] = TcsEpics.instance.sfLinear.toSeqActionO
 
-  override def getInstrumentPA: SeqAction[Option[Double]] = TcsEpics.instance.instrPA.toSeqActionO
+  override def getInstrumentPA: SeqActionF[IO, Option[Double]] = TcsEpics.instance.instrPA.toSeqActionO
 
-  override def getGmosInstPort: SeqAction[Option[Int]] = TcsEpics.instance.gmosPort.toSeqActionO
+  override def getGmosInstPort: SeqActionF[IO, Option[Int]] = TcsEpics.instance.gmosPort.toSeqActionO
 
   private val xoffIndex = 6
   private val yoffIndex = 7
   private val focalPlaneScale = 1.611443804
 
-  override def getXOffset: SeqAction[Option[Double]] =
+  override def getXOffset: SeqActionF[IO, Option[Double]] =
     TcsEpics.instance.targetA.flatMap(v => v.lift(xoffIndex).map(_*focalPlaneScale)).toSeqActionO
 
-  override def getYOffset: SeqAction[Option[Double]] =
+  override def getYOffset: SeqActionF[IO, Option[Double]] =
     TcsEpics.instance.targetA.flatMap(v => v.lift(yoffIndex).map(_*focalPlaneScale)).toSeqActionO
 
   private val raoffIndex = 2
   private val decoffIndex = 3
   private val degreeToArcsec = 3600.0
 
-  override def getTrackingRAOffset: SeqAction[Option[Double]] = {
+  override def getTrackingRAOffset: SeqActionF[IO, Option[Double]] = {
     def angleRange(v: Double) = {
       val r = v % 360.0
       if (r<180.0) r + 360.0
@@ -371,88 +372,88 @@ object TcsKeywordsReaderImpl extends TcsKeywordsReader {
     TcsEpics.instance.targetA.flatMap(v => Apply[Option].ap2(Option(raOffset _))(v.lift(raoffIndex),v.lift(decoffIndex))).toSeqActionO
   }
 
-  override def getTrackingDecOffset: SeqAction[Option[Double]] =
+  override def getTrackingDecOffset: SeqActionF[IO, Option[Double]] =
     TcsEpics.instance.targetA.flatMap(v => v.lift(decoffIndex).map(Math.toDegrees(_) * degreeToArcsec)).toSeqActionO
 
-  override def getInstrumentAA: SeqAction[Option[Double]] = TcsEpics.instance.instrAA.toSeqActionO
+  override def getInstrumentAA: SeqActionF[IO, Option[Double]] = TcsEpics.instance.instrAA.toSeqActionO
 
-  override def getAOFoldName: SeqAction[Option[String]] = TcsEpics.instance.aoFoldPosition.toSeqActionO
+  override def getAOFoldName: SeqActionF[IO, Option[String]] = TcsEpics.instance.aoFoldPosition.toSeqActionO
 
-  private def target(t: TcsEpics.Target) = new TargetKeywordsReader {
+  private def target(t: TcsEpics.Target) = new TargetKeywordsReader[IO] {
 
-    override def getRA: SeqAction[Option[Double]] = SeqAction(t.ra)
+    override def getRA: SeqActionF[IO, Option[Double]] = t.ra.toSeqActionO
 
-    override def getDec: SeqAction[Option[Double]] = t.dec.toSeqActionO
+    override def getDec: SeqActionF[IO, Option[Double]] = t.dec.toSeqActionO
 
-    override def getRadialVelocity: SeqAction[Option[Double]] = t.radialVelocity.toSeqActionO
+    override def getRadialVelocity: SeqActionF[IO, Option[Double]] = t.radialVelocity.toSeqActionO
 
-    override def getParallax: SeqAction[Option[Double]] = t.parallax.toSeqActionO
+    override def getParallax: SeqActionF[IO, Option[Double]] = t.parallax.toSeqActionO
 
-    override def getWavelength: SeqAction[Option[Wavelength]] = t.centralWavelenght.map(v => Wavelength(Angstroms[Double](v))).toSeqActionO
+    override def getWavelength: SeqActionF[IO, Option[Wavelength]] = t.centralWavelenght.map(v => Wavelength(Angstroms[Double](v))).toSeqActionO
 
-    override def getEpoch: SeqAction[Option[Double]] = translateEpoch(t.epoch).toSeqActionO
+    override def getEpoch: SeqActionF[IO, Option[Double]] = translateEpoch(t.epoch).toSeqActionO
 
-    override def getEquinox: SeqAction[Option[Double]] = translateEpoch(t.equinox).toSeqActionO
+    override def getEquinox: SeqActionF[IO, Option[Double]] = translateEpoch(t.equinox).toSeqActionO
 
-    override def getFrame: SeqAction[Option[String]] = t.frame.toSeqActionO
+    override def getFrame: SeqActionF[IO, Option[String]] = t.frame.toSeqActionO
 
-    override def getObjectName: SeqAction[Option[String]] = t.objectName.toSeqActionO
+    override def getObjectName: SeqActionF[IO, Option[String]] = t.objectName.toSeqActionO
 
-    override def getProperMotionDec: SeqAction[Option[Double]] = t.properMotionDec.toSeqActionO
+    override def getProperMotionDec: SeqActionF[IO, Option[Double]] = t.properMotionDec.toSeqActionO
 
-    override def getProperMotionRA: SeqAction[Option[Double]] = t.properMotionRA.toSeqActionO
+    override def getProperMotionRA: SeqActionF[IO, Option[Double]] = t.properMotionRA.toSeqActionO
   }
 
-  override def getSourceATarget: TargetKeywordsReader = target(TcsEpics.instance.sourceATarget)
+  override def getSourceATarget: TargetKeywordsReader[IO] = target(TcsEpics.instance.sourceATarget)
 
-  override def getAirMass: SeqAction[Option[Double]] =  TcsEpics.instance.airmass.toSeqActionO
+  override def getAirMass: SeqActionF[IO, Option[Double]] =  TcsEpics.instance.airmass.toSeqActionO
 
-  override def getStartAirMass: SeqAction[Option[Double]] = TcsEpics.instance.airmassStart.toSeqActionO
+  override def getStartAirMass: SeqActionF[IO, Option[Double]] = TcsEpics.instance.airmassStart.toSeqActionO
 
-  override def getEndAirMass: SeqAction[Option[Double]] = TcsEpics.instance.airmassEnd.toSeqActionO
+  override def getEndAirMass: SeqActionF[IO, Option[Double]] = TcsEpics.instance.airmassEnd.toSeqActionO
 
-  override def getParallacticAngle: SeqAction[Option[Angle]] = TcsEpics.instance.parallacticAngle.toSeqActionO
+  override def getParallacticAngle: SeqActionF[IO, Option[Angle]] = TcsEpics.instance.parallacticAngle.toSeqActionO
 
-  override def getPwfs1Target: TargetKeywordsReader = target(TcsEpics.instance.pwfs1Target)
+  override def getPwfs1Target: TargetKeywordsReader[IO] = target(TcsEpics.instance.pwfs1Target)
 
-  override def getPwfs2Target: TargetKeywordsReader = target(TcsEpics.instance.pwfs2Target)
+  override def getPwfs2Target: TargetKeywordsReader[IO] = target(TcsEpics.instance.pwfs2Target)
 
-  override def getOiwfsTarget: TargetKeywordsReader = target(TcsEpics.instance.oiwfsTarget)
+  override def getOiwfsTarget: TargetKeywordsReader[IO] = target(TcsEpics.instance.oiwfsTarget)
 
-  override def getAowfsTarget: TargetKeywordsReader = target(TcsEpics.instance.pwfs2Target)
+  override def getAowfsTarget: TargetKeywordsReader[IO] = target(TcsEpics.instance.pwfs2Target)
 
-  override def getGwfs1Target: TargetKeywordsReader = target(TcsEpics.instance.gwfs1Target)
+  override def getGwfs1Target: TargetKeywordsReader[IO] = target(TcsEpics.instance.gwfs1Target)
 
-  override def getGwfs2Target: TargetKeywordsReader = target(TcsEpics.instance.gwfs2Target)
+  override def getGwfs2Target: TargetKeywordsReader[IO] = target(TcsEpics.instance.gwfs2Target)
 
-  override def getGwfs3Target: TargetKeywordsReader = target(TcsEpics.instance.gwfs3Target)
+  override def getGwfs3Target: TargetKeywordsReader[IO] = target(TcsEpics.instance.gwfs3Target)
 
-  override def getGwfs4Target: TargetKeywordsReader = target(TcsEpics.instance.gwfs4Target)
+  override def getGwfs4Target: TargetKeywordsReader[IO] = target(TcsEpics.instance.gwfs4Target)
 
-  override def getM2UserFocusOffset: SeqAction[Option[Double]] = TcsEpics.instance.m2UserFocusOffset.toSeqActionO
+  override def getM2UserFocusOffset: SeqActionF[IO, Option[Double]] = TcsEpics.instance.m2UserFocusOffset.toSeqActionO
 
   private def calcFrequency(t: Double): Double = if (t > 0.0) 1.0 / t else -9999.0
 
-  override def getPwfs1Freq: SeqAction[Option[Double]] = TcsEpics.instance.pwfs1IntegrationTime.map(calcFrequency).toSeqActionO
+  override def getPwfs1Freq: SeqActionF[IO, Option[Double]] = TcsEpics.instance.pwfs1IntegrationTime.map(calcFrequency).toSeqActionO
 
-  override def getPwfs2Freq: SeqAction[Option[Double]] = TcsEpics.instance.pwfs2IntegrationTime.map(calcFrequency).toSeqActionO
+  override def getPwfs2Freq: SeqActionF[IO, Option[Double]] = TcsEpics.instance.pwfs2IntegrationTime.map(calcFrequency).toSeqActionO
 
-  override def getOiwfsFreq: SeqAction[Option[Double]] = TcsEpics.instance.oiwfsIntegrationTime.map(calcFrequency).toSeqActionO
+  override def getOiwfsFreq: SeqActionF[IO, Option[Double]] = TcsEpics.instance.oiwfsIntegrationTime.map(calcFrequency).toSeqActionO
 
-  override def getCarouselMode: SeqAction[Option[String]] = TcsEpics.instance.carouselMode.toSeqActionO
+  override def getCarouselMode: SeqActionF[IO, Option[String]] = TcsEpics.instance.carouselMode.toSeqActionO
 
-  override def getGnirsInstPort: SeqAction[Option[Int]] = TcsEpics.instance.gnirsPort.toSeqActionO
+  override def getGnirsInstPort: SeqActionF[IO, Option[Int]] = TcsEpics.instance.gnirsPort.toSeqActionO
 
-  override def getGpiInstPort: SeqAction[Option[Int]] = TcsEpics.instance.gpiPort.toSeqActionO
+  override def getGpiInstPort: SeqActionF[IO, Option[Int]] = TcsEpics.instance.gpiPort.toSeqActionO
 
-  override def getNiriInstPort: SeqAction[Option[Int]] = TcsEpics.instance.niriPort.toSeqActionO
+  override def getNiriInstPort: SeqActionF[IO, Option[Int]] = TcsEpics.instance.niriPort.toSeqActionO
 
-  override def getNifsInstPort: SeqAction[Option[Int]] = TcsEpics.instance.nifsPort.toSeqActionO
+  override def getNifsInstPort: SeqActionF[IO, Option[Int]] = TcsEpics.instance.nifsPort.toSeqActionO
 
-  override def getGsaoiInstPort: SeqAction[Option[Int]] = TcsEpics.instance.gsaoiPort.toSeqActionO
+  override def getGsaoiInstPort: SeqActionF[IO, Option[Int]] = TcsEpics.instance.gsaoiPort.toSeqActionO
 
-  override def getF2InstPort: SeqAction[Option[Int]] = TcsEpics.instance.f2Port.toSeqActionO
+  override def getF2InstPort: SeqActionF[IO, Option[Int]] = TcsEpics.instance.f2Port.toSeqActionO
 
-  override def getCRFollow: SeqAction[Option[CRFollow]] =
+  override def getCRFollow: SeqActionF[IO, Option[CRFollow]] =
     TcsEpics.instance.crFollow.flatMap(CRFollow.fromInt.getOption).toSeqActionO
 }


### PR DESCRIPTION
This PR converts a big chunk of the code related to keywords to tagless final encoding.
It started with one line change that cascaded through a bunch of code

Ideally we'd change `SeqActionF[F, A]` for `F[A]` but that is a much bigger change