### PR TITLE
SEQNG-823 Properly display single resource configuration errors

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/Notification.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Notification.scala
@@ -36,11 +36,8 @@ object Notification {
         s"Cannot select sequence '${sid.format}' for instrument '${ins.label}",
         "Possibly another sequence is being executed on the same instrument"
       )
-    case RequestFailed(msg) =>
-      List(
-        s"Request to the seqexec server failed:",
-        msg
-      )
+    case RequestFailed(msgs) =>
+      s"Request to the seqexec server failed:" :: msgs
   }
 }
 
@@ -61,9 +58,9 @@ object InstrumentInUse {
 }
 
 // Notification that a request to the backend failed
-final case class RequestFailed(msg: String) extends Notification
+final case class RequestFailed(msgs: List[String]) extends Notification
 
 object RequestFailed {
   implicit lazy val eq: Eq[RequestFailed] =
-    Eq.by(_.msg)
+    Eq.by(_.msgs)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/SingleActionOp.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/SingleActionOp.scala
@@ -19,13 +19,13 @@ object SingleActionOp {
     extends SingleActionOp
   final case class Completed(sid: Observation.Id, stepId: StepId, resource: Resource)
     extends SingleActionOp
-  final case class Error(sid: Observation.Id, stepId: StepId, resource: Resource)
+  final case class Error(sid: Observation.Id, stepId: StepId, resource: Resource, msg: String)
     extends SingleActionOp
 
   implicit val equal: Eq[SingleActionOp] = Eq.instance {
     case (Started(a, c, e), Started(b, d, f))     => a === b && c === d && e === f
     case (Completed(a, c, e), Completed(b, d, f)) => a === b && c === d && e === f
-    case (Error(a, c, e), Error(b, d, f))         => a === b && c === d && e === f
-    case _                                  => false
+    case (Error(a, c, e, g), Error(b, d, f, h))   => a === b && c === d && e === f && g === h
+    case _                                        => false
   }
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -381,11 +381,11 @@ trait SeqexecModelArbitraries extends ArbObservation {
     Cogen[Observation.Id].contramap(_.sid)
 
   implicit val rfArb = Arbitrary[RequestFailed] {
-    Gen.alphaStr.map(RequestFailed.apply)
+    arbitrary[List[String]].map(RequestFailed.apply)
   }
 
   implicit val rfCogen: Cogen[RequestFailed] =
-    Cogen[String].contramap(_.msg)
+    Cogen[List[String]].contramap(_.msgs)
 
   implicit val inArb = Arbitrary[InstrumentInUse] {
     for {
@@ -547,12 +547,13 @@ trait SeqexecModelArbitraries extends ArbObservation {
         o <- arbitrary[Observation.Id]
         s <- arbitrary[StepId]
         r <- arbitrary[Resource]
-      } yield SingleActionOp.Error(o, s, r)
+        m <- arbitrary[String]
+      } yield SingleActionOp.Error(o, s, r, m)
     }
 
   implicit val saoErrorCogen: Cogen[SingleActionOp.Error] =
-    Cogen[(Observation.Id, StepId, Resource)]
-      .contramap(x => (x.sid, x.stepId, x.resource))
+    Cogen[(Observation.Id, StepId, Resource, String)]
+      .contramap(x => (x.sid, x.stepId, x.resource, x.msg))
 
   implicit val saoArb = Arbitrary[SingleActionOp] {
     for {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -891,8 +891,8 @@ object SeqexecEngine extends SeqexecConfiguration {
           svs)
         case engine.SingleRunCompleted(c, _) =>
           singleActionEvent[SingleActionOp.Completed](c, qState, SingleActionOp.Completed)
-        case engine.SingleRunFailed(c, _)   =>
-          singleActionEvent[SingleActionOp.Error](c, qState, SingleActionOp.Error)
+        case engine.SingleRunFailed(c, r)   =>
+          singleActionEvent[SingleActionOp.Error](c, qState, SingleActionOp.Error.apply(_, _, _, r.msg))
       }
     }
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -80,7 +80,8 @@ object actions {
       extends Action
   final case class RunResourceFailed(id:       Observation.Id,
                                      step:     StepId,
-                                     resource: Resource)
+                                     resource: Resource,
+                                     msg:      String)
       extends Action
 
   final case class RunStarted(s:           Observation.Id) extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -70,7 +70,7 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
     case RunSyncFailed(id) =>
       val msg = s"Failed to sync sequence ${id.format}"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updated(value.markOperations(
                 id,
                 TabOperations.syncRequested.set(SyncOperation.SyncIdle)),
@@ -79,16 +79,16 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
     case RunPauseFailed(id) =>
       val msg = s"Failed to pause sequence ${id.format}"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updated(value.markOperations(
                 id,
                 TabOperations.pauseRequested.set(PauseOperation.PauseIdle)),
               notification)
 
-    case RunResourceFailed(id, _, r) =>
-      val msg = s"Failed to run ${r.show} for sequence ${id.format}"
+    case RunResourceFailed(id, _, r, m) =>
+      val msg = s"Failed to configure ${r.show} for sequence ${id.format}"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg, m)))))
       updated(value.markOperations(id, TabOperations.resourceRun(r).set(none)),
               notification)
   }
@@ -99,7 +99,5 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
   }
 
   override def handle: PartialFunction[Any, ActionResult[M]] =
-    List(handleRequestOperation,
-         handleOperationResult,
-         handleSelectedStep).combineAll
+    List(handleRequestOperation, handleOperationResult, handleSelectedStep).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/QueueOperationsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/QueueOperationsHandler.scala
@@ -106,7 +106,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     case AllDayCalFailed(qid) =>
       val msg = s"Failed to add all day cal sequences"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updatedLE(
         CalibrationQueues.addDayCalL(qid).set(AddDayCalOperation.AddDayCalIdle),
         notification)
@@ -114,7 +114,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     case ClearAllCalFailed(qid) =>
       val msg = s"Failed to clear the cal sequences"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updatedLE(CalibrationQueues
                   .clearAllCalL(qid)
                   .set(ClearAllCalOperation.ClearAllCalIdle),
@@ -123,14 +123,14 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     case RunCalFailed(qid) =>
       val msg = s"Failed to execute the cal queue"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updatedLE(CalibrationQueues.runCalL(qid).set(RunCalOperation.RunCalIdle),
                 notification)
 
     case StopCalFailed(qid) =>
       val msg = s"Failed to stop queue execution"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updatedLE(
         CalibrationQueues.stopCalL(qid).set(StopCalOperation.StopCalIdle),
         notification)
@@ -140,7 +140,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     case RemoveSeqCalFailed(qid, id) =>
       val msg = s"Failed to remove sequence ${id.format} from the queue"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updatedLE(CalibrationQueues.modifyOrAddSeqOps(
                   qid,
                   id,
@@ -150,7 +150,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     case MoveCalFailed(qid, id) =>
       val msg = s"Failed to move sequence ${id.format} on the queue"
       val notification = Effect(
-        Future(RequestFailedNotification(RequestFailed(msg))))
+        Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updatedLE(CalibrationQueues.modifyOrAddSeqOps(
                   qid,
                   id,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/RemoteRequestsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/RemoteRequestsHandler.scala
@@ -119,7 +119,11 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
           id,
           SeqexecWebClient.runResource(step, resource),
           (id: Observation.Id) => RunResource(id, step, resource),
-          (id: Observation.Id) => RunResourceFailed(id, step, resource)
+          (id: Observation.Id) =>
+            RunResourceFailed(id,
+                              step,
+                              resource,
+                              s"Http call to configure ${resource.show} failed")
         ))
   }
 


### PR DESCRIPTION
This PR supports showing errors when configuring a single resource:

![seqexec - gs-2018b-q-0-96 2019-02-04 11-28-51](https://user-images.githubusercontent.com/3615303/52221672-6b24a780-2880-11e9-8014-8e61b5369cad.png)
