### PR TITLE
Rename toSeqAction to toSeqActionDefault

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -76,9 +76,9 @@ object Flamingos2Header {
   }
 
   object InstKeywordReaderImpl extends InstKeywordsReader[IO] {
-    override def getHealth: SeqActionF[IO, String] = Flamingos2Epics.instance.health.toSeqAction
+    override def getHealth: SeqActionF[IO, String] = Flamingos2Epics.instance.health.toSeqActionDefault
 
-    override def getState: SeqActionF[IO, String] = Flamingos2Epics.instance.state.toSeqAction
+    override def getState: SeqActionF[IO, String] = Flamingos2Epics.instance.state.toSeqActionDefault
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
@@ -211,46 +211,46 @@ object GmosHeader {
 
     object InstKeywordReaderImpl extends InstKeywordsReader[IO] {
 
-      override def ccName: SeqAction[String] = GmosEpics.instance.ccName.toSeqAction
-      override def maskId: SeqAction[Int] = GmosEpics.instance.maskId.toSeqAction
-      override def maskName: SeqAction[String] = GmosEpics.instance.fpu.toSeqAction
-      override def maskType: SeqAction[Int] = GmosEpics.instance.maskType.toSeqAction
-      override def maskLoc: SeqAction[Int] = GmosEpics.instance.inBeam.toSeqAction
-      override def filter1: SeqAction[String] = GmosEpics.instance.filter1.toSeqAction
-      override def filter2: SeqAction[String] = GmosEpics.instance.filter2.toSeqAction
-      override def filter1Id: SeqAction[Int] = GmosEpics.instance.filter1Id.toSeqAction
-      override def filter2Id: SeqAction[Int] = GmosEpics.instance.filter2Id.toSeqAction
-      override def grating: SeqAction[String] = GmosEpics.instance.disperser.toSeqAction
-      override def gratingId: SeqAction[Int] = GmosEpics.instance.disperserId.toSeqAction
-      override def gratingWavelength: SeqAction[Double] = GmosEpics.instance.gratingWavel.toSeqAction
-      override def gratingAdjustedWavelength: SeqAction[Double] = GmosEpics.instance.disperserWavel.toSeqAction
-      override def gratingOrder: SeqAction[Int] = GmosEpics.instance.disperserOrder.toSeqAction
-      override def gratingTilt: SeqAction[Double] = GmosEpics.instance.gratingTilt.toSeqAction
+      override def ccName: SeqAction[String] = GmosEpics.instance.ccName.toSeqActionDefault
+      override def maskId: SeqAction[Int] = GmosEpics.instance.maskId.toSeqActionDefault
+      override def maskName: SeqAction[String] = GmosEpics.instance.fpu.toSeqActionDefault
+      override def maskType: SeqAction[Int] = GmosEpics.instance.maskType.toSeqActionDefault
+      override def maskLoc: SeqAction[Int] = GmosEpics.instance.inBeam.toSeqActionDefault
+      override def filter1: SeqAction[String] = GmosEpics.instance.filter1.toSeqActionDefault
+      override def filter2: SeqAction[String] = GmosEpics.instance.filter2.toSeqActionDefault
+      override def filter1Id: SeqAction[Int] = GmosEpics.instance.filter1Id.toSeqActionDefault
+      override def filter2Id: SeqAction[Int] = GmosEpics.instance.filter2Id.toSeqActionDefault
+      override def grating: SeqAction[String] = GmosEpics.instance.disperser.toSeqActionDefault
+      override def gratingId: SeqAction[Int] = GmosEpics.instance.disperserId.toSeqActionDefault
+      override def gratingWavelength: SeqAction[Double] = GmosEpics.instance.gratingWavel.toSeqActionDefault
+      override def gratingAdjustedWavelength: SeqAction[Double] = GmosEpics.instance.disperserWavel.toSeqActionDefault
+      override def gratingOrder: SeqAction[Int] = GmosEpics.instance.disperserOrder.toSeqActionDefault
+      override def gratingTilt: SeqAction[Double] = GmosEpics.instance.gratingTilt.toSeqActionDefault
       override def gratingStep: SeqAction[Double] =
         // Set the value to the epics channel if inBeam is    1
-        GmosEpics.instance.reqGratingMotorSteps.filter(_ => GmosEpics.instance.disperserInBeam === Some(1)).toSeqAction
-      override def dtaX: SeqAction[Double] = GmosEpics.instance.dtaX.toSeqAction
-      override def dtaY: SeqAction[Double] = GmosEpics.instance.dtaY.toSeqAction
-      override def dtaZ: SeqAction[Double] = GmosEpics.instance.dtaZ.toSeqAction
-      override def dtaZst: SeqAction[Double] = GmosEpics.instance.dtaZStart.toSeqAction
-      override def dtaZen: SeqAction[Double] = GmosEpics.instance.dtaZEnd.toSeqAction
-      override def dtaZme: SeqAction[Double] = GmosEpics.instance.dtaZMean.toSeqAction
-      override def stageMode: SeqAction[String] = GmosEpics.instance.stageMode.toSeqAction
-      override def adcMode: SeqAction[String] = GmosEpics.instance.adcMode.toSeqAction
-      override def dcName: SeqAction[String] = GmosEpics.instance.dcName.toSeqAction
-      override def detectorType: SeqAction[String] = GmosEpics.instance.detectorType.toSeqAction
-      override def detectorId: SeqAction[String] = GmosEpics.instance.detectorId.toSeqAction
+        GmosEpics.instance.reqGratingMotorSteps.filter(_ => GmosEpics.instance.disperserInBeam === Some(1)).toSeqActionDefault
+      override def dtaX: SeqAction[Double] = GmosEpics.instance.dtaX.toSeqActionDefault
+      override def dtaY: SeqAction[Double] = GmosEpics.instance.dtaY.toSeqActionDefault
+      override def dtaZ: SeqAction[Double] = GmosEpics.instance.dtaZ.toSeqActionDefault
+      override def dtaZst: SeqAction[Double] = GmosEpics.instance.dtaZStart.toSeqActionDefault
+      override def dtaZen: SeqAction[Double] = GmosEpics.instance.dtaZEnd.toSeqActionDefault
+      override def dtaZme: SeqAction[Double] = GmosEpics.instance.dtaZMean.toSeqActionDefault
+      override def stageMode: SeqAction[String] = GmosEpics.instance.stageMode.toSeqActionDefault
+      override def adcMode: SeqAction[String] = GmosEpics.instance.adcMode.toSeqActionDefault
+      override def dcName: SeqAction[String] = GmosEpics.instance.dcName.toSeqActionDefault
+      override def detectorType: SeqAction[String] = GmosEpics.instance.detectorType.toSeqActionDefault
+      override def detectorId: SeqAction[String] = GmosEpics.instance.detectorId.toSeqActionDefault
       // TODO Exposure changes with N&S
-      override def exposureTime: SeqAction[Double] = GmosEpics.instance.reqExposureTime.map(_.toDouble).toSeqAction
-      override def adcUsed: SeqAction[Int] = GmosEpics.instance.adcUsed.toSeqAction
-      override def adcPrismEntSt: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleStart.toSeqAction
-      override def adcPrismEntEnd: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleEnd.toSeqAction
-      override def adcPrismEntMe: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleMean.toSeqAction
-      override def adcPrismExtSt: SeqAction[Double] = GmosEpics.instance.adcPrismExitAngleStart.toSeqAction
-      override def adcPrismExtEnd: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleEnd.toSeqAction
-      override def adcPrismExtMe: SeqAction[Double] = GmosEpics.instance.adcPrismExitAngleEnd.toSeqAction
-      override def adcWavelength1: SeqAction[Double] = GmosEpics.instance.adcExitLowerWavel.toSeqAction
-      override def adcWavelength2: SeqAction[Double] = GmosEpics.instance.adcExitUpperWavel.toSeqAction
+      override def exposureTime: SeqAction[Double] = GmosEpics.instance.reqExposureTime.map(_.toDouble).toSeqActionDefault
+      override def adcUsed: SeqAction[Int] = GmosEpics.instance.adcUsed.toSeqActionDefault
+      override def adcPrismEntSt: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleStart.toSeqActionDefault
+      override def adcPrismEntEnd: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleEnd.toSeqActionDefault
+      override def adcPrismEntMe: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleMean.toSeqActionDefault
+      override def adcPrismExtSt: SeqAction[Double] = GmosEpics.instance.adcPrismExitAngleStart.toSeqActionDefault
+      override def adcPrismExtEnd: SeqAction[Double] = GmosEpics.instance.adcPrismEntryAngleEnd.toSeqActionDefault
+      override def adcPrismExtMe: SeqAction[Double] = GmosEpics.instance.adcPrismExitAngleEnd.toSeqActionDefault
+      override def adcWavelength1: SeqAction[Double] = GmosEpics.instance.adcExitLowerWavel.toSeqActionDefault
+      override def adcWavelength2: SeqAction[Double] = GmosEpics.instance.adcExitUpperWavel.toSeqActionDefault
       // The TCL code does some verifications to ensure the value is not negative
       override def detNRoi: SeqAction[Int] = SeqAction(GmosEpics.instance.roiNumUsed.filter(_ > 0).getOrElse(0))
       override def roiValues: Map[Int, RoiValues[IO]] =
@@ -259,10 +259,10 @@ object GmosHeader {
           roi = GmosEpics.instance.rois.get(i)
         } yield roi.map { r =>
             i ->
-              RoiValues(r.ccdXstart.toSeqAction, r.ccdXsize.toSeqAction, r.ccdYstart.toSeqAction, r.ccdYsize.toSeqAction)
+              RoiValues(r.ccdXstart.toSeqActionDefault, r.ccdXsize.toSeqActionDefault, r.ccdYstart.toSeqActionDefault, r.ccdYsize.toSeqActionDefault)
           }).toList.collect { case Some(x) => x }.toMap
-      override def aExpCount: SeqAction[Int] = GmosEpics.instance.aExpCount.toSeqAction
-      override def bExpCount: SeqAction[Int] = GmosEpics.instance.aExpCount.toSeqAction
+      override def aExpCount: SeqAction[Int] = GmosEpics.instance.aExpCount.toSeqActionDefault
+      override def bExpCount: SeqAction[Int] = GmosEpics.instance.aExpCount.toSeqActionDefault
       override def isADCInUse: Boolean =
         GmosEpics.instance.adcUsed.forall(_ === 1)
     }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsKeywordReader.scala
@@ -65,29 +65,29 @@ object GnirsKeywordReaderDummy extends GnirsKeywordReader[IO] {
 }
 
 object GnirsKeywordReaderImpl extends GnirsKeywordReader[IO] {
-  override def getArrayId: SeqActionF[IO, String] = GnirsEpics.instance.arrayId.toSeqAction
-  override def getArrayType: SeqActionF[IO, String] = GnirsEpics.instance.arrayType.toSeqAction
-  override def getDetectorBias: SeqActionF[IO, Double] = GnirsEpics.instance.detBias.toSeqAction
-  override def getFilter1: SeqActionF[IO, String] = GnirsEpics.instance.filter1.toSeqAction
-  override def getFilterWheel1Pos: SeqActionF[IO, Int] = GnirsEpics.instance.filter1Eng.toSeqAction
-  override def getFilter2: SeqActionF[IO, String] = GnirsEpics.instance.filter2.toSeqAction
-  override def getFilterWheel2Pos: SeqActionF[IO, Int] = GnirsEpics.instance.filter2Eng.toSeqAction
-  override def getCamera: SeqActionF[IO, String] = GnirsEpics.instance.camera.toSeqAction
-  override def getCameraPos: SeqActionF[IO, Int] = GnirsEpics.instance.cameraEng.toSeqAction
-  override def getDecker: SeqActionF[IO, String] = GnirsEpics.instance.decker.toSeqAction
-  override def getDeckerPos: SeqActionF[IO, Int] = GnirsEpics.instance.deckerEng.toSeqAction
-  override def getSlit: SeqActionF[IO, String] = GnirsEpics.instance.slitWidth.toSeqAction
-  override def getSlitPos: SeqActionF[IO, Int] = GnirsEpics.instance.slitEng.toSeqAction
-  override def getPrism: SeqActionF[IO, String] = GnirsEpics.instance.prism.toSeqAction
-  override def getPrismPos: SeqActionF[IO, Int] = GnirsEpics.instance.prismEng.toSeqAction
-  override def getGrating: SeqActionF[IO, String] = GnirsEpics.instance.grating.toSeqAction
-  override def getGratingPos: SeqActionF[IO, Int] = GnirsEpics.instance.gratingEng.toSeqAction
-  override def getGratingWavelength: SeqActionF[IO, Double] = GnirsEpics.instance.centralWavelength.toSeqAction
-  override def getGratingOrder: SeqActionF[IO, Int] = GnirsEpics.instance.gratingOrder.toSeqAction
-  override def getGratingTilt: SeqActionF[IO, Double] = GnirsEpics.instance.gratingTilt.toSeqAction
-  override def getFocus: SeqActionF[IO, String] = GnirsEpics.instance.focus.toSeqAction
-  override def getFocusPos: SeqActionF[IO, Int] = GnirsEpics.instance.focusEng.toSeqAction
-  override def getAcquisitionMirror: SeqActionF[IO, String] = GnirsEpics.instance.acqMirror.toSeqAction
-  override def getWindowCover: SeqActionF[IO, String] = GnirsEpics.instance.cover.toSeqAction
-  override def getObsEpoch: SeqActionF[IO, Double] = GnirsEpics.instance.obsEpoch.toSeqAction
+  override def getArrayId: SeqActionF[IO, String] = GnirsEpics.instance.arrayId.toSeqActionDefault
+  override def getArrayType: SeqActionF[IO, String] = GnirsEpics.instance.arrayType.toSeqActionDefault
+  override def getDetectorBias: SeqActionF[IO, Double] = GnirsEpics.instance.detBias.toSeqActionDefault
+  override def getFilter1: SeqActionF[IO, String] = GnirsEpics.instance.filter1.toSeqActionDefault
+  override def getFilterWheel1Pos: SeqActionF[IO, Int] = GnirsEpics.instance.filter1Eng.toSeqActionDefault
+  override def getFilter2: SeqActionF[IO, String] = GnirsEpics.instance.filter2.toSeqActionDefault
+  override def getFilterWheel2Pos: SeqActionF[IO, Int] = GnirsEpics.instance.filter2Eng.toSeqActionDefault
+  override def getCamera: SeqActionF[IO, String] = GnirsEpics.instance.camera.toSeqActionDefault
+  override def getCameraPos: SeqActionF[IO, Int] = GnirsEpics.instance.cameraEng.toSeqActionDefault
+  override def getDecker: SeqActionF[IO, String] = GnirsEpics.instance.decker.toSeqActionDefault
+  override def getDeckerPos: SeqActionF[IO, Int] = GnirsEpics.instance.deckerEng.toSeqActionDefault
+  override def getSlit: SeqActionF[IO, String] = GnirsEpics.instance.slitWidth.toSeqActionDefault
+  override def getSlitPos: SeqActionF[IO, Int] = GnirsEpics.instance.slitEng.toSeqActionDefault
+  override def getPrism: SeqActionF[IO, String] = GnirsEpics.instance.prism.toSeqActionDefault
+  override def getPrismPos: SeqActionF[IO, Int] = GnirsEpics.instance.prismEng.toSeqActionDefault
+  override def getGrating: SeqActionF[IO, String] = GnirsEpics.instance.grating.toSeqActionDefault
+  override def getGratingPos: SeqActionF[IO, Int] = GnirsEpics.instance.gratingEng.toSeqActionDefault
+  override def getGratingWavelength: SeqActionF[IO, Double] = GnirsEpics.instance.centralWavelength.toSeqActionDefault
+  override def getGratingOrder: SeqActionF[IO, Int] = GnirsEpics.instance.gratingOrder.toSeqActionDefault
+  override def getGratingTilt: SeqActionF[IO, Double] = GnirsEpics.instance.gratingTilt.toSeqActionDefault
+  override def getFocus: SeqActionF[IO, String] = GnirsEpics.instance.focus.toSeqActionDefault
+  override def getFocusPos: SeqActionF[IO, Int] = GnirsEpics.instance.focusEng.toSeqActionDefault
+  override def getAcquisitionMirror: SeqActionF[IO, String] = GnirsEpics.instance.acqMirror.toSeqActionDefault
+  override def getWindowCover: SeqActionF[IO, String] = GnirsEpics.instance.cover.toSeqActionDefault
+  override def getObsEpoch: SeqActionF[IO, Double] = GnirsEpics.instance.obsEpoch.toSeqActionDefault
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -227,7 +227,8 @@ package object keywords {
   }
 
   implicit class A2SeqAction[A: DefaultHeaderValue](val v: Option[A]) {
-    def toSeqAction: SeqAction[A] = SeqAction(v.orDefault)
+    // Convert to a SeqAction or use the default
+    def toSeqActionDefault: SeqAction[A] = SeqAction(v.orDefault)
   }
 
   implicit class SeqActionOption2SeqAction[A: DefaultHeaderValue](

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
@@ -78,28 +78,28 @@ object NiriKeywordReaderDummy extends NiriKeywordReader[IO] {
 
 object NiriKeywordReaderImpl extends NiriKeywordReader[IO] {
   val sys = NiriEpics.instance
-  override def arrayId: SeqAction[String] = sys.arrayId.toSeqAction
-  override def arrayType: SeqAction[String] = sys.arrayType.toSeqAction
-  override def camera: SeqAction[String] = sys.camera.toSeqAction
-  override def coadds: SeqAction[Int] = sys.coadds.toSeqAction
-  override def exposureTime: SeqAction[Double] = sys.integrationTime.toSeqAction
-  override def filter1: SeqAction[String] = sys.filter1.toSeqAction
-  override def filter2: SeqAction[String] = sys.filter2.toSeqAction
-  override def filter3: SeqAction[String] = sys.filter3.toSeqAction
-  override def focusName: SeqAction[String] = sys.focus.toSeqAction
-  override def focusPosition: SeqAction[Double] = sys.focusPosition.toSeqAction
-  override def focalPlaneMask: SeqAction[String] = sys.mask.toSeqAction
-  override def beamSplitter: SeqAction[String] = sys.beamSplitter.toSeqAction
-  override def windowCover: SeqAction[String] = sys.windowCover.toSeqAction
-  override def framesPerCycle: SeqAction[Int] = sys.framesPerCycle.toSeqAction
-  override def headerTiming: SeqAction[String] = sys.hdrTiming.toSeqAction.map{
+  override def arrayId: SeqAction[String] = sys.arrayId.toSeqActionDefault
+  override def arrayType: SeqAction[String] = sys.arrayType.toSeqActionDefault
+  override def camera: SeqAction[String] = sys.camera.toSeqActionDefault
+  override def coadds: SeqAction[Int] = sys.coadds.toSeqActionDefault
+  override def exposureTime: SeqAction[Double] = sys.integrationTime.toSeqActionDefault
+  override def filter1: SeqAction[String] = sys.filter1.toSeqActionDefault
+  override def filter2: SeqAction[String] = sys.filter2.toSeqActionDefault
+  override def filter3: SeqAction[String] = sys.filter3.toSeqActionDefault
+  override def focusName: SeqAction[String] = sys.focus.toSeqActionDefault
+  override def focusPosition: SeqAction[Double] = sys.focusPosition.toSeqActionDefault
+  override def focalPlaneMask: SeqAction[String] = sys.mask.toSeqActionDefault
+  override def beamSplitter: SeqAction[String] = sys.beamSplitter.toSeqActionDefault
+  override def windowCover: SeqAction[String] = sys.windowCover.toSeqActionDefault
+  override def framesPerCycle: SeqAction[Int] = sys.framesPerCycle.toSeqActionDefault
+  override def headerTiming: SeqAction[String] = sys.hdrTiming.toSeqActionDefault.map{
     case 1 => "BEFORE"
     case 2 => "AFTER"
     case 3 => "BOTH"
     case _ => "INDEF"
   }
-  override def lnrs: SeqAction[Int] = sys.lnrs.toSeqAction
-  override def mode: SeqAction[String] = sys.mode.toSeqAction.map{
+  override def lnrs: SeqAction[Int] = sys.lnrs.toSeqActionDefault
+  override def mode: SeqAction[String] = sys.mode.toSeqActionDefault.map{
     case 0 => "STARE"
     case 1 => "SEP"
     case 2 => "CHOP"
@@ -107,24 +107,24 @@ object NiriKeywordReaderImpl extends NiriKeywordReader[IO] {
     case 4 => "TEST"
     case _ => "INDEF"
   }
-  override def numberDigitalAverage: SeqAction[Int] = sys.digitalAverageCount.toSeqAction
-  override def pupilViewer: SeqAction[String] = sys.pupilViewer.toSeqAction
-  override def detectorTemperature: SeqAction[Double] = sys.detectorTemp.toSeqAction
-  override def mountTemperature: SeqAction[Double] = sys.mountTemp.toSeqAction
-  override def µcodeName: SeqAction[String] = sys.µcodeName.toSeqAction
-  override def µcodeType: SeqAction[String] = sys.µcodeType.toSeqAction.map{
+  override def numberDigitalAverage: SeqAction[Int] = sys.digitalAverageCount.toSeqActionDefault
+  override def pupilViewer: SeqAction[String] = sys.pupilViewer.toSeqActionDefault
+  override def detectorTemperature: SeqAction[Double] = sys.detectorTemp.toSeqActionDefault
+  override def mountTemperature: SeqAction[Double] = sys.mountTemp.toSeqActionDefault
+  override def µcodeName: SeqAction[String] = sys.µcodeName.toSeqActionDefault
+  override def µcodeType: SeqAction[String] = sys.µcodeType.toSeqActionDefault.map{
     case 1 => "RRD"
     case 2 => "RDD"
     case 3 => "RD"
     case 4 => "SRB"
     case _ => "INDEF"
   }
-  override def cl1VoltageDD: SeqAction[Double] = sys.vddCl1.toSeqAction
-  override def cl2VoltageDD: SeqAction[Double] = sys.vddCl2.toSeqAction
-  override def ucVoltage: SeqAction[Double] = sys.vddUc.toSeqAction
-  override def detectorVoltage: SeqAction[Double] = sys.detectorVDetBias.toSeqAction
-  override def cl1VoltageGG: SeqAction[Double] = sys.vggCl1.toSeqAction
-  override def cl2VoltageGG: SeqAction[Double] = sys.vggCl2.toSeqAction
-  override def setVoltage: SeqAction[Double] = sys.detectorVSetBias.toSeqAction
-  override def observationEpoch: SeqAction[Double] = sys.obsEpoch.toSeqAction
+  override def cl1VoltageDD: SeqAction[Double] = sys.vddCl1.toSeqActionDefault
+  override def cl2VoltageDD: SeqAction[Double] = sys.vddCl2.toSeqActionDefault
+  override def ucVoltage: SeqAction[Double] = sys.vddUc.toSeqActionDefault
+  override def detectorVoltage: SeqAction[Double] = sys.detectorVDetBias.toSeqActionDefault
+  override def cl1VoltageGG: SeqAction[Double] = sys.vggCl1.toSeqActionDefault
+  override def cl2VoltageGG: SeqAction[Double] = sys.vggCl2.toSeqActionDefault
+  override def setVoltage: SeqAction[Double] = sys.detectorVSetBias.toSeqActionDefault
+  override def observationEpoch: SeqAction[Double] = sys.obsEpoch.toSeqActionDefault
 }


### PR DESCRIPTION
The method name `toSeqAction` is a bit misleading as it not only converts a value to `SeqAction` but also defaults if the value is empty

This confused me quite a bit so I'm proposing to rename it