### PR TITLE
Header tagless style

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -3,6 +3,7 @@
 
 package seqexec.server.flamingos2
 
+import cats.Applicative
 import cats.data.EitherT
 import cats.effect.IO
 import cats.effect.Sync
@@ -30,7 +31,7 @@ import cats.implicits._
 object Flamingos2Header {
   def header[F[_]: Sync](inst: InstrumentSystem[F], f2ObsReader: Flamingos2Header.ObsKeywordsReader[F], tcsKeywordsReader: TcsKeywordsReader[F]): Header[F] =
     new Header[F] {
-      override def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqActionF[F, Unit] =  {
+      override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =  {
         sendKeywords(id, inst, List(
           buildBoolean(f2ObsReader.getPreimage.map(_.toBoolean), KeywordName.PREIMAGE),
           buildString(SeqActionF(LocalDate.now.format(DateTimeFormatter.ISO_LOCAL_DATE)), KeywordName.DATE_OBS),
@@ -48,7 +49,7 @@ object Flamingos2Header {
         )
       }
 
-      override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] = SeqActionF.void
+      override def sendAfter(id: ImageFileId): F[Unit] = Applicative[F].unit
     }
 
   trait ObsKeywordsReader[F[_]] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
@@ -3,12 +3,13 @@
 
 package seqexec.server.gcal
 
+import cats.Applicative
 import cats.effect.Sync
 import gem.Observation
 import gem.enum.KeywordName
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.keywords._
-import seqexec.server.{InstrumentSystem, SeqActionF}
+import seqexec.server.InstrumentSystem
 
 object GcalHeader {
   implicit def header[F[_]: Sync](inst: InstrumentSystem[F], gcalReader: GcalKeywordReader[F]): Header[F] =
@@ -21,9 +22,9 @@ object GcalHeader {
       )
 
       override def sendBefore(obsId: Observation.Id,
-                              id: ImageFileId): SeqActionF[F, Unit] =
+                              id: ImageFileId): F[Unit] =
         sendKeywords(id, inst, gcalKeywords)
 
-      override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] = SeqActionF.void[F]
+      override def sendAfter(id: ImageFileId): F[Unit] = Applicative[F].unit
     }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostHeader.scala
@@ -6,7 +6,6 @@ package seqexec.server.ghost
 import cats.Applicative
 import gem.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.SeqActionF
 import seqexec.server.keywords._
 
 object GhostHeader {
@@ -14,10 +13,10 @@ object GhostHeader {
   def header[F[_]: Applicative]: Header[F] =
     new Header[F] {
       override def sendBefore(obsId: Observation.Id,
-                              id: ImageFileId): SeqActionF[F, Unit] =
-        SeqActionF.void[F]
+                              id: ImageFileId): F[Unit] =
+        Applicative[F].unit
 
-      override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] =
-        SeqActionF.void[F]
+      override def sendAfter(id: ImageFileId): F[Unit] =
+        Applicative[F].unit
     }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
@@ -24,7 +24,7 @@ object GmosHeader {
   // scalastyle:off
   def header[F[_]: Sync](inst: InstrumentSystem[F], gmosObsReader: GmosHeader.ObsKeywordsReader[F], gmosReader: GmosHeader.InstKeywordsReader[F], tcsKeywordsReader: TcsKeywordsReader[F]): Header[F] =
     new Header[F] {
-      override def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqActionF[F, Unit] = {
+      override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] = {
         sendKeywords(id, inst, List(
           buildInt32(tcsKeywordsReader.getGmosInstPort.orDefault, KeywordName.INPORT),
           buildString(gmosReader.ccName, KeywordName.GMOSCC),
@@ -61,7 +61,7 @@ object GmosHeader {
       private val InBeam: Int = 0
       private def readMaskName: SeqActionF[F, String] = gmosReader.maskLoc.flatMap{v => if(v === InBeam) gmosReader.maskName else SeqActionF("None")}
 
-      override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] = {
+      override def sendAfter(id: ImageFileId): F[Unit] = {
         sendKeywords(id, inst, List(
           buildInt32(gmosReader.maskId, KeywordName.MASKID),
           buildString(readMaskName, KeywordName.MASKNAME),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
@@ -10,11 +10,10 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.server.keywords._
 import seqexec.server.InstrumentSystem
 import seqexec.server.tcs.TcsKeywordsReader
-import seqexec.server.SeqActionF
 
 object GnirsHeader {
   def header[F[_]: Sync](inst: InstrumentSystem[F], gnirsReader: GnirsKeywordReader[F], tcsReader: TcsKeywordsReader[F]): Header[F] = new Header[F] {
-    override def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqActionF[F, Unit] =
+    override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
       sendKeywords(id, inst, List(
         buildInt32(tcsReader.getGnirsInstPort.orDefault, KeywordName.INPORT),
         buildString(gnirsReader.getArrayId, KeywordName.ARRAYID),
@@ -46,7 +45,7 @@ object GnirsHeader {
         buildDouble(gnirsReader.getDetectorBias, KeywordName.DETBIAS)
       ) )
 
-    override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] =
+    override def sendAfter(id: ImageFileId): F[Unit] =
       sendKeywords(id, inst, List(
         buildString(tcsReader.getUT.orDefault, KeywordName.UTEND),
         buildDouble(gnirsReader.getObsEpoch, KeywordName.OBSEPOCH)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
@@ -3,11 +3,12 @@
 
 package seqexec.server.gpi
 
+import cats.Applicative
 import cats.effect.Sync
+import cats.implicits._
 import gem.Observation
 import gem.enum.KeywordName
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.SeqActionF
 import seqexec.server.keywords._
 import seqexec.server.tcs.TcsKeywordsReader
 import seqexec.server.tcs.CRFollow
@@ -20,7 +21,7 @@ object GpiHeader {
              obsKeywordsReader: ObsKeywordsReader[F]): Header[F] =
     new Header[F] {
       override def sendBefore(obsId: Observation.Id,
-                              id: ImageFileId): SeqActionF[F, Unit] = {
+                              id: ImageFileId): F[Unit] = {
         val ks = GdsInstrument.bundleKeywords(
           List(
             buildDouble(tcsKeywordsReader.getParallacticAngle
@@ -39,7 +40,7 @@ object GpiHeader {
         ks.flatMap(gdsClient.openObservation(obsId, id, _))
       }
 
-      override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] =
-        SeqActionF.void[F]
+      override def sendAfter(id: ImageFileId): F[Unit] =
+        Applicative[F].unit
     }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClient.scala
@@ -4,7 +4,6 @@
 package seqexec.server.keywords
 
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.SeqActionF
 
 /**
   * Defines the interface for dhs client, with methods, e.g. to request image creation
@@ -13,12 +12,12 @@ trait DhsClient[F[_]] {
   /**
     * Requests the DHS to create an image returning the obs id if applicable
     */
-  def createImage(p: DhsClient.ImageParameters): SeqActionF[F, ImageFileId]
+  def createImage(p: DhsClient.ImageParameters): F[ImageFileId]
 
   /**
     * Set the keywords for an image
     */
-  def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): SeqActionF[F, Unit]
+  def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): F[Unit]
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GdsClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GdsClient.scala
@@ -6,6 +6,7 @@ package seqexec.server.keywords
 import cats.effect.IO
 import cats.effect.Timer
 import cats.effect.Effect
+import cats.Functor
 import cats.implicits._
 import gem.Observation
 import org.http4s.client.Client
@@ -24,7 +25,7 @@ import seqexec.server.SeqexecFailure
 /**
   * Gemini Data service client
   */
-final case class GdsClient[F[_]: Effect: cats.Functor](base: Client[F], gdsUri: Uri)(implicit timer: Timer[F])//, ae: ApplicativeError[F, SeqexecFailure])
+final case class GdsClient[F[_]: Effect: Functor](base: Client[F], gdsUri: Uri)(implicit timer: Timer[F])
     extends Http4sClientDsl[F] {
 
   @SuppressWarnings(Array("org.wartremover.warts.Var"))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/Header.scala
@@ -5,12 +5,11 @@ package seqexec.server.keywords
 
 import gem.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.SeqActionF
 
 /**
   * Header implementations know what headers sent before and after an observation
   */
 trait Header[F[_]] {
-  def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqActionF[F, Unit]
-  def sendAfter(id: ImageFileId): SeqActionF[F, Unit]
+  def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit]
+  def sendAfter(id: ImageFileId): F[Unit]
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsHeader.scala
@@ -6,7 +6,6 @@ package seqexec.server.nifs
 import cats.Applicative
 import gem.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.SeqActionF
 import seqexec.server.keywords._
 
 object NifsHeader {
@@ -14,10 +13,10 @@ object NifsHeader {
   def header[F[_]: Applicative]: Header[F] =
     new Header[F] {
       override def sendBefore(obsId: Observation.Id,
-                              id: ImageFileId): SeqActionF[F, Unit] =
-        SeqActionF.void[F]
+                              id: ImageFileId): F[Unit] =
+        Applicative[F].unit
 
-      override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] =
-        SeqActionF.void[F]
+      override def sendAfter(id: ImageFileId): F[Unit] =
+        Applicative[F].unit
     }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriHeader.scala
@@ -8,14 +8,14 @@ import gem.Observation
 import gem.enum.KeywordName
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.keywords.{Header, buildDouble, buildString, _}
-import seqexec.server.{InstrumentSystem, SeqActionF}
+import seqexec.server.InstrumentSystem
 import seqexec.server.tcs.TcsKeywordsReader
 
 object NiriHeader {
   // scalastyle:off
   def header[F[_]: Sync](inst: InstrumentSystem[F], instReader: NiriKeywordReader[F],
              tcsKeywordsReader: TcsKeywordsReader[F]): Header[F] = new Header[F] {
-    override def sendBefore(obsId: Observation.Id, id: ImageFileId): SeqActionF[F, Unit] =
+    override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
       sendKeywords(id, inst, List(
         buildString(instReader.arrayId, KeywordName.ARRAYID),
         buildString(instReader.arrayType, KeywordName.ARRAYTYP),
@@ -53,7 +53,7 @@ object NiriHeader {
         buildDouble(instReader.setVoltage, KeywordName.VSET)
       ))
 
-    override def sendAfter(id: ImageFileId): SeqActionF[F, Unit] =
+    override def sendAfter(id: ImageFileId): F[Unit] =
       sendKeywords(id, inst, List(
         buildDouble(instReader.detectorTemperature, KeywordName.A_TDETABS),
         buildDouble(instReader.mountTemperature, KeywordName.A_TMOUNT),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
@@ -42,6 +42,7 @@ trait NiriKeywordReader[F[_]] {
   def observationEpoch: SeqActionF[F, Double]
 }
 
+// This could be NiriKeywordReader[Id] but it requires changes upstream
 object NiriKeywordReaderDummy extends NiriKeywordReader[IO] {
   override def arrayId: SeqAction[String] = SeqAction(StrDefault)
   override def arrayType: SeqAction[String] = SeqAction(StrDefault)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -194,7 +194,7 @@ package object server {
     def either[F[_]: Sync, A](a: => TrySeq[A]): SeqActionF[F, A] =
       EitherT(Sync[F].delay(a))
     def void[F[_]: Applicative]: SeqActionF[F, Unit] =
-      EitherT.liftF(Applicative[F].pure(()))
+      EitherT.liftF(Applicative[F].unit)
   }
 
   implicit class StreamIOOps[A](s: Stream[IO, A]) {
@@ -208,7 +208,13 @@ package object server {
   }
 
   implicit class EitherTFailureOps[F[_]: MonadError[?[_], Throwable], A](s: EitherT[F, SeqexecFailure, A]) {
-    def liftF: F[A] = s.value.flatMap(_.liftTo[F])
+    def liftF: F[A] =
+      s.value.flatMap(_.liftTo[F])
+  }
+
+  implicit class IOOps[F[_]: LiftIO, A](ioa: IO[A]) {
+    def embed: SeqActionF[F, A] =
+      SeqActionF.embed(ioa)
   }
 
   // This assumes that there is only one instance of e in l

--- a/modules/seqexec/server/src/test/scala/seqexec/server/keywords/DhsClientSimSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/keywords/DhsClientSimSpec.scala
@@ -11,17 +11,14 @@ import seqexec.server.keywords.DhsClient.Permanent
 
 class DhsClientSimSpec extends FlatSpec with Matchers {
   "DhsClientSim" should "produce data labels for today" in {
-      DhsClientSim[IO](LocalDate.of(2016, 4, 15)).createImage(DhsClient.ImageParameters(Permanent, Nil)).value.unsafeRunSync() should matchPattern {
-        case Right("S20160415S0001") =>
+      DhsClientSim[IO](LocalDate.of(2016, 4, 15)).createImage(DhsClient.ImageParameters(Permanent, Nil)).unsafeRunSync() should matchPattern {
+        case "S20160415S0001" =>
       }
     }
   it should "accept keywords" in {
     val client = DhsClientSim[IO](LocalDate.of(2016, 4, 15))
-    client.createImage(DhsClient.ImageParameters(Permanent, Nil)).value.unsafeRunSync().fold(
-      _ => fail(),
-      id => client.setKeywords(id, KeywordBag(Int32Keyword(KeywordName.TELESCOP, 10)), finalFlag = true).value.unsafeRunSync() should matchPattern {
-        case Right(()) =>
-      }
-    )
+    client.createImage(DhsClient.ImageParameters(Permanent, Nil)).flatMap { id =>
+      client.setKeywords(id, KeywordBag(Int32Keyword(KeywordName.TELESCOP, 10)), finalFlag = true)
+    }.unsafeRunSync() shouldEqual (())
   }
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/keywords/GdsClientSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/keywords/GdsClientSpec.scala
@@ -4,7 +4,6 @@
 package seqexec.server.keywords
 
 import cats.tests.CatsSuite
-import org.http4s.Uri._
 import scala.xml.XML
 
 @SuppressWarnings(Array("org.wartremover.warts.Throw"))
@@ -12,7 +11,7 @@ final class GdsClientSpec extends CatsSuite {
   test("GDSClient should reject bad responses") {
     val xml = XML.load(getClass.getResource("/gds-bad-resp.xml"))
     GdsClient
-      .checkError(xml, uri("http://localhost:8888/xmlrpc"))
+      .parseError(xml)
       .isLeft shouldEqual true
   }
 }


### PR DESCRIPTION
This is a largish PR that (hopefully) simplifies the Headers using `F[A]` rather than `SeqActionF[F, A]`. There are some tricky business related to error handling but I think this preserves the current semantics

Some notes:
* This has been thoroughly tested with GPI and the behaviour is correct
* I could have changed the existing `KeywordReaders` but i didn't want to make more noise
* NifsHeader will however use the new style

@jluhrs Should we test this with the DHS?
