### PR TITLE
calcTotalExposureTime should be referentially transparent

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -19,7 +19,7 @@ trait InstrumentSystem[F[_]] extends System[F] {
   def observe(
       config: Config): SeqObserveF[F, ImageFileId, ObserveCommand.Result]
   //Expected total observe lapse, used to calculate timeout
-  def calcObserveTime(config: Config): Time
+  def calcObserveTime(config: Config): F[Time]
   def keywordsClient: KeywordsClient[F]
   def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress]
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -67,10 +67,10 @@ final case class Nifs[F[_]: LiftIO: Sync](controller: NifsController[IO], // TOD
         .flatMap(x => SeqActionF.embed(controller.observe(fileId, x)))
     }
 
-  override def calcObserveTime(config: Config): Time =
+  override def calcObserveTime(config: Config): F[Time] =
     getDCConfig(config)
-      .map(controller.calcTotalExposureTime)
-      .getOrElse(60.seconds)
+      .map(c => LiftIO[F].liftIO(controller.calcTotalExposureTime(c)))
+      .getOrElse(Sync[F].delay(60.seconds))
 
   override def keywordsClient: KeywordsClient[F] = this
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsController.scala
@@ -26,7 +26,7 @@ trait NifsController[F[_]] {
 
   def observeProgress(total: Time): fs2.Stream[F, Progress]
 
-  def calcTotalExposureTime(cfg: DCConfig): Time
+  def calcTotalExposureTime(cfg: DCConfig): F[Time]
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -48,8 +48,10 @@ final case class Niri(controller: NiriController, dhsClient: DhsClient[IO])
       .flatMap(controller.observe(fileId, _))
     }
 
-  override def calcObserveTime(config: Config): Time =
-    getDCConfig(config).map(controller.calcTotalExposureTime).getOrElse(60.seconds)
+  override def calcObserveTime(config: Config): IO[Time] =
+    getDCConfig(config)
+      .map(controller.calcTotalExposureTime)
+      .getOrElse(IO.pure(60.seconds))
 
   override def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime)
   : fs2.Stream[IO, Progress] = controller.observeProgress(total)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriController.scala
@@ -24,7 +24,7 @@ trait NiriController {
 
   def observeProgress(total: Time): fs2.Stream[IO, Progress]
 
-  def calcTotalExposureTime(cfg: DCConfig): Time
+  def calcTotalExposureTime(cfg: DCConfig): IO[Time]
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
@@ -300,7 +300,8 @@ object NiriControllerEpics extends NiriController {
   override def observeProgress(total: Time): fs2.Stream[IO, Progress] =
     ProgressUtil.countdown[IO](total, 0.seconds)
 
-  override def calcTotalExposureTime(cfg: DCConfig): Time = {
+  override def calcTotalExposureTime(cfg: DCConfig): IO[Time] = IO {
+    // TODO epicSys.minIntegration should return IO
     val MinIntTime = epicsSys.minIntegration.map(Seconds(_)).getOrElse(0.seconds)
 
     (cfg.exposureTime + MinIntTime) * cfg.coadds.toDouble


### PR DESCRIPTION
In `InstrumentSystem` the method `calcObserveTime` should IMHO return an `F[Time]`. This because for some instruments, in particular Niri and apprently Nifs we need to read an epics channel to calculate the observe time

Doing it this way respects referential transparency