### PR TITLE
Added GMOS config lenses

### DIFF
--- a/modules/core/shared/src/main/scala/gem/config/GmosConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/GmosConfig.scala
@@ -310,7 +310,7 @@ object GmosConfig {
       )
 
     implicit val EqualGmosCcdReadout: Eq[GmosCcdReadout] =
-      Eq.by(c => (c.xBinning, c.yBinning, c.ampCount, c.ampReadMode))
+      Eq.by(c => (c.xBinning, c.yBinning, c.ampCount, c.ampGain, c.ampReadMode))
 
   }
 

--- a/modules/core/shared/src/main/scala/gem/config/GmosConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/GmosConfig.scala
@@ -3,11 +3,14 @@
 
 package gem.config
 
-import cats.Eq
 import gem.enum._
+import gem.instances.time._
 import gem.math.{ Offset, Wavelength }
+
+import cats.{ Eq, Order }
+import cats.implicits._
 import java.time.Duration
-import monocle.macros.Lenses
+import monocle._
 
 /**
  * Additional type hierarchy over the low-level GMOS enums.
@@ -24,7 +27,7 @@ object GmosConfig {
     assert(detectorRows > 0, s"detectorRows must be > 0, not $detectorRows")
   }
 
-  object GmosShuffleOffset {
+  object GmosShuffleOffset extends GmosShuffleOffsetOptics {
 
     /** Constructs the shuffle offset with the given number of detector rows,
       * provided it is a positive number.
@@ -51,6 +54,14 @@ object GmosConfig {
       Eq.fromUniversalEquals
   }
 
+  trait GmosShuffleOffsetOptics {
+
+    /** @group Optics */
+    val detectorRows: Getter[GmosShuffleOffset, Int] =
+      Getter(_.detectorRows)
+
+  }
+
   /** The number of nod-and-shuffle cycles, which must be at least 1. This class
     * essentially provides a newtype for Int.
     */
@@ -60,7 +71,7 @@ object GmosConfig {
     assert(toInt > 0, s"toInt must be > 0, not $toInt")
   }
 
-  object GmosShuffleCycles {
+  object GmosShuffleCycles extends GmosShuffleCyclesOptics {
 
     /** Default non-and-shuffle cycles, which is 1. */
     val Default: GmosShuffleCycles =
@@ -84,6 +95,14 @@ object GmosConfig {
       Eq.fromUniversalEquals
   }
 
+  trait GmosShuffleCyclesOptics {
+
+    /** @group Optics */
+    val shuffleCycles: Getter[GmosShuffleCycles, Int] =
+      Getter(_.toInt)
+
+  }
+
   // TODO: there are many ways to misconfigure Nod And Shuffle.  Some of these
   // ways can be caught in a companion object constructor, and some cannot, or
   // at least cannot easily.  In the first category, we should definitly check
@@ -102,7 +121,7 @@ object GmosConfig {
     cycles:  GmosShuffleCycles
   )
 
-  object GmosNodAndShuffle {
+  object GmosNodAndShuffle extends GmosNodAndShuffleOptics {
     val Default: GmosNodAndShuffle =
       GmosNodAndShuffle(
         Offset.Zero,
@@ -115,6 +134,31 @@ object GmosConfig {
     implicit val EqualGmosNodAndShuffle: Eq[GmosNodAndShuffle] =
       Eq.fromUniversalEquals
   }
+
+  trait GmosNodAndShuffleOptics {
+
+    /** @group Optics */
+    val posA: Lens[GmosNodAndShuffle, Offset] =
+      Lens[GmosNodAndShuffle, Offset](_.posA)(a => _.copy(posA = a))
+
+    /** @group Optics */
+    val posB: Lens[GmosNodAndShuffle, Offset] =
+      Lens[GmosNodAndShuffle, Offset](_.posB)(a => _.copy(posB = a))
+
+    /** @group Optics */
+    val eOffset: Lens[GmosNodAndShuffle, GmosEOffsetting] =
+      Lens[GmosNodAndShuffle, GmosEOffsetting](_.eOffset)(a => _.copy(eOffset = a))
+
+    /** @group Optics */
+    val shuffle: Lens[GmosNodAndShuffle, GmosShuffleOffset] =
+      Lens[GmosNodAndShuffle, GmosShuffleOffset](_.shuffle)(a => _.copy(shuffle = a))
+
+    /** @group Optics */
+    val cycles: Lens[GmosNodAndShuffle, GmosShuffleCycles] =
+      Lens[GmosNodAndShuffle, GmosShuffleCycles](_.cycles)(a => _.copy(cycles = a))
+
+  }
+
 
   /** GMOS custom ROI entry definition. */
   sealed abstract case class GmosCustomRoiEntry(
@@ -162,7 +206,7 @@ object GmosConfig {
     }
   }
 
-  object GmosCustomRoiEntry {
+  object GmosCustomRoiEntry extends GmosCustomRoiEntryOptics {
 
     def fromDescription(xMin: Short, yMin: Short, xRange: Short, yRange: Short): Option[GmosCustomRoiEntry] =
       if ((xMin > 0) && (yMin > 0) && (xRange > 0) && (yRange > 0))
@@ -174,13 +218,34 @@ object GmosConfig {
       fromDescription(xMin, yMin, xRange, yRange)
         .getOrElse(sys.error(s"All custom ROI fields must be > 0 in GmosCustomRoi.unsafeFromDefinition($xMin, $yMin, $xRange, $yRange)"))
 
-    implicit val EqualGmosCustomRoiEntry: Eq[GmosCustomRoiEntry] =
-      Eq.fromUniversalEquals
+    implicit val OrderGmosCustomRoiEntry: Order[GmosCustomRoiEntry] =
+      Order.by(c => (c.xMin, c.yMin, c.xRange, c.yRange))
+
+  }
+
+  trait GmosCustomRoiEntryOptics {
+
+    /** @group Optics */
+    val xMin: Getter[GmosCustomRoiEntry, Short] =
+      Getter(_.xMin)
+
+    /** @group Optics */
+    val yMin: Getter[GmosCustomRoiEntry, Short] =
+      Getter(_.yMin)
+
+    /** @group Optics */
+    val xRange: Getter[GmosCustomRoiEntry, Short] =
+      Getter(_.xRange)
+
+    /** @group Optics */
+    val yRange: Getter[GmosCustomRoiEntry, Short] =
+      Getter(_.yRange)
+
   }
 
   /** Shared static configuration for both GMOS-N and GMOS-S.
     */
-  @Lenses final case class GmosCommonStaticConfig(
+  final case class GmosCommonStaticConfig(
     detector:      GmosDetector,
     mosPreImaging: MosPreImaging,
     nodAndShuffle: Option[GmosNodAndShuffle],
@@ -188,7 +253,8 @@ object GmosConfig {
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  object GmosCommonStaticConfig {
+  object GmosCommonStaticConfig extends GmosCommonStaticConfigOptics {
+
     val Default: GmosCommonStaticConfig =
       GmosCommonStaticConfig(
         GmosDetector.HAMAMATSU,
@@ -196,6 +262,30 @@ object GmosConfig {
         None,
         Set.empty[GmosCustomRoiEntry]
       )
+
+    implicit val EqGmosCommonStaticConfig: Eq[GmosCommonStaticConfig] =
+      Eq.by(c => (c.detector, c.mosPreImaging, c.nodAndShuffle, c.customRois))
+
+  }
+
+  trait GmosCommonStaticConfigOptics {
+
+    /** @group Optics */
+    val detector: Lens[GmosCommonStaticConfig, GmosDetector] =
+      Lens[GmosCommonStaticConfig, GmosDetector](_.detector)(a => _.copy(detector = a))
+
+    /** @group Optics */
+    val mosPreImaging: Lens[GmosCommonStaticConfig, MosPreImaging] =
+      Lens[GmosCommonStaticConfig, MosPreImaging](_.mosPreImaging)(a => _.copy(mosPreImaging = a))
+
+    /** @group Optics */
+    val nodAndShuffle: Lens[GmosCommonStaticConfig, Option[GmosNodAndShuffle]] =
+      Lens[GmosCommonStaticConfig, Option[GmosNodAndShuffle]](_.nodAndShuffle)(a => _.copy(nodAndShuffle = a))
+
+    /** @group Optics */
+    val customRois: Lens[GmosCommonStaticConfig, Set[GmosCustomRoiEntry]] =
+      Lens[GmosCommonStaticConfig, Set[GmosCustomRoiEntry]](_.customRois)(a => _.copy(customRois = a))
+
   }
 
   /** Parameters that determine GMOS CCD readout.
@@ -208,7 +298,8 @@ object GmosConfig {
     ampReadMode: GmosAmpReadMode
   )
 
-  object GmosCcdReadout {
+  object GmosCcdReadout extends GmosCcdReadoutOptics {
+
     val Default: GmosCcdReadout =
       GmosCcdReadout(
         GmosXBinning.One,
@@ -217,6 +308,34 @@ object GmosConfig {
         GmosAmpGain.Low,
         GmosAmpReadMode.Slow
       )
+
+    implicit val EqualGmosCcdReadout: Eq[GmosCcdReadout] =
+      Eq.by(c => (c.xBinning, c.yBinning, c.ampCount, c.ampReadMode))
+
+  }
+
+  trait GmosCcdReadoutOptics {
+
+    /** @group Optics */
+    val xBinning: Lens[GmosCcdReadout, GmosXBinning] =
+      Lens[GmosCcdReadout, GmosXBinning](_.xBinning)(a => _.copy(xBinning = a))
+
+    /** @group Optics */
+    val yBinning: Lens[GmosCcdReadout, GmosYBinning] =
+      Lens[GmosCcdReadout, GmosYBinning](_.yBinning)(a => _.copy(yBinning = a))
+
+    /** @group Optics */
+    val ampCount: Lens[GmosCcdReadout, GmosAmpCount] =
+      Lens[GmosCcdReadout, GmosAmpCount](_.ampCount)(a => _.copy(ampCount = a))
+
+    /** @group Optics */
+    val ampGain: Lens[GmosCcdReadout, GmosAmpGain] =
+      Lens[GmosCcdReadout, GmosAmpGain](_.ampGain)(a => _.copy(ampGain = a))
+
+    /** @group Optics */
+    val ampReadMode: Lens[GmosCcdReadout, GmosAmpReadMode] =
+      Lens[GmosCcdReadout, GmosAmpReadMode](_.ampReadMode)(a => _.copy(ampReadMode = a))
+
   }
 
   /** Shared dynamic configuration for both GMOS-N and GMOS-S.
@@ -228,7 +347,8 @@ object GmosConfig {
     roi:          GmosRoi
   )
 
-  object GmosCommonDynamicConfig {
+  object GmosCommonDynamicConfig extends GmosCommonDynamicConfigOptics {
+
     val Default: GmosCommonDynamicConfig =
       GmosCommonDynamicConfig(
         GmosCcdReadout.Default,
@@ -236,6 +356,30 @@ object GmosConfig {
         Duration.ofSeconds(300),
         GmosRoi.FullFrame
       )
+
+    implicit val EqualGmosCommonDynamicConfig: Eq[GmosCommonDynamicConfig] =
+      Eq.by(c => (c.ccdReadout, c.dtaxOffset, c.exposureTime, c.roi))
+
+  }
+
+  trait GmosCommonDynamicConfigOptics {
+
+    /** @group Optics */
+    val ccdReadout: Lens[GmosCommonDynamicConfig, GmosCcdReadout] =
+      Lens[GmosCommonDynamicConfig, GmosCcdReadout](_.ccdReadout)(a => _.copy(ccdReadout = a))
+
+    /** @group Optics */
+    val dtaxOffset: Lens[GmosCommonDynamicConfig, GmosDtax] =
+      Lens[GmosCommonDynamicConfig, GmosDtax](_.dtaxOffset)(a => _.copy(dtaxOffset = a))
+
+    /** @group Optics */
+    val exposureTime: Lens[GmosCommonDynamicConfig, Duration] =
+      Lens[GmosCommonDynamicConfig, Duration](_.exposureTime)(a => _.copy(exposureTime = a))
+
+    /** @group Optics */
+    val roi: Lens[GmosCommonDynamicConfig, GmosRoi] =
+      Lens[GmosCommonDynamicConfig, GmosRoi](_.roi)(a => _.copy(roi = a))
+
   }
 
   /** Custom mask definition, which is available as an alternative to using a
@@ -246,6 +390,25 @@ object GmosConfig {
     maskDefinitionFilename: String,
     slitWidth:              GmosCustomSlitWidth
   )
+
+  object GmosCustomMask extends GmosCustomMaskOptics {
+
+    implicit val EqualGmosCustomMask: Eq[GmosCustomMask] =
+      Eq.by(c => (c.maskDefinitionFilename, c.slitWidth))
+
+  }
+
+  trait GmosCustomMaskOptics {
+
+    /** @group Optics */
+    val maskDefinitionFilename: Lens[GmosCustomMask, String] =
+      Lens[GmosCustomMask, String](_.maskDefinitionFilename)(a => _.copy(maskDefinitionFilename = a))
+
+    /** @gropu Optics */
+    val slitWidth: Lens[GmosCustomMask, GmosCustomSlitWidth] =
+      Lens[GmosCustomMask, GmosCustomSlitWidth](_.slitWidth)(a => _.copy(slitWidth = a))
+
+  }
 
   /** GMOS grating configuration, parameterized on the disperser type.  These
     * are grouped because they only apply when using a grating.  That is, all
@@ -259,4 +422,27 @@ object GmosConfig {
     order:      GmosDisperserOrder,
     wavelength: Wavelength
   )
+
+  object GmosGrating extends GmosGratingOptics {
+
+    implicit def EqualGmosGrating[D: Eq]: Eq[GmosGrating[D]] =
+      Eq.by(g => (g.disperser, g.order, g.wavelength))
+
+  }
+
+  trait GmosGratingOptics {
+
+    /** @group Optics */
+    def disperser[D]: Lens[GmosGrating[D], D] =
+      Lens[GmosGrating[D], D](_.disperser)(a => _.copy(disperser = a))
+
+    /** @group Optics */
+    def order[D]: Lens[GmosGrating[D], GmosDisperserOrder] =
+      Lens[GmosGrating[D], GmosDisperserOrder](_.order)(a => _.copy(order = a))
+
+    /** @group Optics */
+    def wavelength[D]: Lens[GmosGrating[D], Wavelength] =
+      Lens[GmosGrating[D], Wavelength](_.wavelength)(a => _.copy(wavelength = a))
+
+  }
 }

--- a/modules/core/shared/src/main/scala/gem/config/StaticConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/StaticConfig.scala
@@ -5,7 +5,8 @@ package gem
 package config
 
 import cats.Eq
-import gem.enum.{GmosNorthStageMode, GmosSouthStageMode, GnirsWellDepth, MosPreImaging}
+import cats.implicits._
+import gem.enum._
 import monocle.Lens
 import monocle.macros.Lenses
 
@@ -41,7 +42,7 @@ object StaticConfig {
 
   import GmosConfig._
 
-  @Lenses final case class GmosN(
+  final case class GmosN(
     common:    GmosCommonStaticConfig,
     stageMode: GmosNorthStageMode
   ) extends StaticConfig
@@ -55,39 +56,64 @@ object StaticConfig {
         GmosNorthStageMode.FollowXy
       )
 
+    implicit val EqualGmosN: Eq[GmosN] =
+      Eq.by(g => (g.common, g.stageMode))
+
   }
 
   trait GmosNorthLenses { this: GmosN.type =>
 
-    lazy val customRois: Lens[GmosN, Set[GmosCustomRoiEntry]] =
-      common ^|-> GmosCommonStaticConfig.customRois
+    /** @group Optics */
+    val common: Lens[GmosN, GmosCommonStaticConfig] =
+      Lens[GmosN, GmosCommonStaticConfig](_.common)(a => _.copy(common = a))
 
-    lazy val nodAndShuffle: Lens[GmosN, Option[GmosNodAndShuffle]] =
-      common ^|-> GmosCommonStaticConfig.nodAndShuffle
+    /** @group Optics */
+    val stageMode: Lens[GmosN, GmosNorthStageMode] =
+      Lens[GmosN, GmosNorthStageMode](_.stageMode)(a => _.copy(stageMode = a))
+
+    /** @group Optics */
+    val customRois: Lens[GmosN, Set[GmosCustomRoiEntry]] =
+      common composeLens GmosCommonStaticConfig.customRois
+
+    /** @group Optics */
+    val nodAndShuffle: Lens[GmosN, Option[GmosNodAndShuffle]] =
+      common composeLens GmosCommonStaticConfig.nodAndShuffle
 
   }
 
-  @Lenses final case class GmosS(
+  final case class GmosS(
     common:    GmosCommonStaticConfig,
     stageMode: GmosSouthStageMode
   ) extends StaticConfig
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object GmosS extends GmosSouthLenses {
+
     val Default: GmosS =
       GmosS(
         GmosCommonStaticConfig.Default,
         GmosSouthStageMode.FollowXyz
       )
+
+    implicit val EqualGmosS: Eq[GmosS] =
+      Eq.by(g => (g.common, g.stageMode))
   }
 
   trait GmosSouthLenses { this: GmosS.type =>
 
+    /** @group Optics */
+    val common: Lens[GmosS, GmosCommonStaticConfig] =
+      Lens[GmosS, GmosCommonStaticConfig](_.common)(a => _.copy(common = a))
+
+    /** @group Optics */
+    val stageMode: Lens[GmosS, GmosSouthStageMode] =
+      Lens[GmosS, GmosSouthStageMode](_.stageMode)(a => _.copy(stageMode = a))
+
     lazy val customRois: Lens[GmosS, Set[GmosCustomRoiEntry]] =
-      common ^|-> GmosCommonStaticConfig.customRois
+      common composeLens GmosCommonStaticConfig.customRois
 
     lazy val nodAndShuffle: Lens[GmosS, Option[GmosNodAndShuffle]] =
-      common ^|-> GmosCommonStaticConfig.nodAndShuffle
+      common composeLens GmosCommonStaticConfig.nodAndShuffle
   }
 
   @Lenses final case class Gnirs(

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTime.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTime.scala
@@ -13,7 +13,6 @@ import org.scalacheck.Arbitrary._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.{Duration => SDuration}
 import java.time._
-import java.time.temporal.ChronoUnit
 
 // Arbitrary but resonable dates and times.
 trait ArbTime {
@@ -78,12 +77,7 @@ trait ArbTime {
     }
 
   implicit val arbDuration: Arbitrary[Duration] =
-    Arbitrary {
-      for {
-        a <- Gen.choose(-10000L, 10000L)
-        u <- Gen.oneOf(ChronoUnit.values.filterNot(_.isDurationEstimated))
-      } yield Duration.of(a, u)
-    }
+    Arbitrary(Gen.posNum[Long].map(Duration.ofMillis))
 
   implicit val arbSDuration: Arbitrary[SDuration] = Arbitrary {
     for {

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTime.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTime.scala
@@ -100,6 +100,9 @@ trait ArbTime {
   implicit val cogLocalDate: Cogen[LocalDate] =
     Cogen[(Int, Int)].contramap(d => (d.getYear, d.getDayOfYear))
 
+  implicit val cogDuration: Cogen[Duration] =
+    Cogen[(Long,Int)].contramap(d => (d.getSeconds, d.getNano))
+
   implicit val cogTimestamp: Cogen[Timestamp] =
     Cogen[Instant].contramap(_.toInstant)
 

--- a/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
@@ -16,12 +16,16 @@ import gem.math.{ Offset, Wavelength }
 
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
 
 import java.time.Duration
 
 trait Arbitraries {
+
   import ArbEnumerated._
   import ArbOffset._
+  import ArbTime._
+  import ArbWavelength._
 
 
   // Surely this is already defined somewhere?
@@ -43,9 +47,6 @@ trait Arbitraries {
 
   implicit val arbCoAdds: Arbitrary[CoAdds] =
     Arbitrary(Gen.posNum[Short].map(CoAdds.fromShort.unsafeGet))
-
-  implicit val arbDuration: Arbitrary[Duration] =
-    Arbitrary(Gen.posNum[Long].map(Duration.ofMillis))
 
   implicit val arbMosPreImaging: Arbitrary[MosPreImaging] =
     Arbitrary(
@@ -72,8 +73,14 @@ trait Arbitraries {
   implicit val arbGmosShuffleOffset =
     Arbitrary(Gen.posNum[Int].map(GmosConfig.GmosShuffleOffset.unsafeFromRowCount))
 
+  implicit val cogGmosShuffleOffset: Cogen[GmosConfig.GmosShuffleOffset] =
+    Cogen[Int].contramap(_.detectorRows)
+
   implicit val arbGmosShuffleCycles =
     Arbitrary(Gen.posNum[Int].map(GmosConfig.GmosShuffleCycles.unsafeFromCycleCount))
+
+  implicit val cogGmosShuffleCycles: Cogen[GmosConfig.GmosShuffleCycles] =
+    Cogen[Int].contramap(_.toInt)
 
   implicit val arbGmosNodAndShuffle =
     Arbitrary(
@@ -86,6 +93,10 @@ trait Arbitraries {
       } yield GmosConfig.GmosNodAndShuffle(a, b, e, o, c)
     )
 
+  implicit val cogGmosNodAndShuffle: Cogen[GmosConfig.GmosNodAndShuffle] =
+    Cogen[(Offset, Offset, GmosEOffsetting, GmosShuffleOffset, GmosShuffleCycles)]
+      .contramap(n => (n.posA, n.posB, n.eOffset, n.shuffle, n.cycles))
+
   implicit val arbGmosCustomRoiEntry =
     Arbitrary(
       for {
@@ -95,6 +106,9 @@ trait Arbitraries {
         yRng <- Gen.posNum[Short]
       } yield GmosConfig.GmosCustomRoiEntry.unsafeFromDescription(xMin, yMin, xRng, yRng)
     )
+
+  implicit val cogGmosCustomRoiEntry: Cogen[GmosConfig.GmosCustomRoiEntry] =
+    Cogen[(Short, Short, Short, Short)].contramap(c => (c.xMin, c.yMin, c.xRange, c.yRange))
 
   implicit val arbGmosCommonStaticConfig =
     Arbitrary(
@@ -106,6 +120,10 @@ trait Arbitraries {
         r <- Gen.listOfN(c, arbitrary[GmosConfig.GmosCustomRoiEntry])
       } yield GmosConfig.GmosCommonStaticConfig(d, p, n, r.toSet)
     )
+
+  implicit val cogGmosCommonStaticConfig: Cogen[GmosConfig.GmosCommonStaticConfig] =
+    Cogen[(GmosDetector, MosPreImaging, Option[GmosConfig.GmosNodAndShuffle], List[GmosConfig.GmosCustomRoiEntry])]
+      .contramap(c => (c.detector, c.mosPreImaging, c.nodAndShuffle, c.customRois.toList))
 
   val genGmosNorthStatic: Gen[StaticConfig.GmosN] =
     for {
@@ -142,6 +160,12 @@ trait Arbitraries {
       case Visitor    => genVisitorStatic
     }
   }
+
+  implicit val arbGmosNStaticConfig: Arbitrary[StaticConfig.GmosN] =
+    Arbitrary(genGmosNorthStatic)
+
+  implicit val arbGmosSStaticConfig: Arbitrary[StaticConfig.GmosS] =
+    Arbitrary(genGmosSouthStatic)
 
   implicit val arbStaticConfig: Arbitrary[StaticConfig] =
     Arbitrary(arbitrary[Instrument].flatMap(genStaticConfigOf))
@@ -187,6 +211,10 @@ trait Arbitraries {
       } yield GmosConfig.GmosCcdReadout(x, y, c, g, r)
     }
 
+  implicit val cogGmosCcdReadout: Cogen[GmosConfig.GmosCcdReadout] =
+    Cogen[(GmosXBinning, GmosYBinning, GmosAmpCount, GmosAmpGain, GmosAmpReadMode)]
+      .contramap(c => (c.xBinning, c.yBinning, c.ampCount, c.ampGain, c.ampReadMode))
+
   implicit val arbGmosCommonDynamic =
     Arbitrary {
       for {
@@ -197,6 +225,10 @@ trait Arbitraries {
       } yield GmosConfig.GmosCommonDynamicConfig(c, d, e, r)
     }
 
+  implicit val cogGmosCommonDynamic: Cogen[GmosConfig.GmosCommonDynamicConfig] =
+    Cogen[(GmosCcdReadout, GmosDtax, Duration, GmosRoi)]
+      .contramap(c => (c.ccdReadout, c.dtaxOffset, c.exposureTime, c.roi))
+
   implicit val arbGmosCustomMask =
     Arbitrary {
       for {
@@ -204,6 +236,9 @@ trait Arbitraries {
         w <- arbitrary[GmosCustomSlitWidth]
       } yield GmosConfig.GmosCustomMask(m, w)
     }
+
+  implicit val cogGmosCustomMask: Cogen[GmosConfig.GmosCustomMask] =
+    Cogen[(String, GmosCustomSlitWidth)].contramap(g => (g.maskDefinitionFilename, g.slitWidth))
 
   implicit val arbGmosNorthGrating =
     Arbitrary {
@@ -214,6 +249,10 @@ trait Arbitraries {
       } yield GmosConfig.GmosGrating(d, o, w)
     }
 
+  implicit val cogGmosNorthGrating: Cogen[GmosConfig.GmosGrating[GmosNorthDisperser]] =
+    Cogen[(GmosNorthDisperser, GmosDisperserOrder, Wavelength)]
+      .contramap(g => (g.disperser, g.order, g.wavelength))
+
   implicit val arbGmosSouthGrating =
     Arbitrary {
       for {
@@ -222,6 +261,10 @@ trait Arbitraries {
         w <- Gen.choose(3000, 12000).map(Wavelength.fromAngstroms.unsafeGet)
       } yield GmosConfig.GmosGrating(d, o, w)
     }
+
+  implicit val cogGmosSouthGrating: Cogen[GmosConfig.GmosGrating[GmosSouthDisperser]] =
+    Cogen[(GmosSouthDisperser, GmosDisperserOrder, Wavelength)]
+      .contramap(g => (g.disperser, g.order, g.wavelength))
 
   val genGmosNorthDynamic: Gen[DynamicConfig.GmosN] =
     for {
@@ -274,6 +317,12 @@ trait Arbitraries {
       case Visitor    => genVisitorDynamic
     }
   }
+
+  implicit val arbGmosNDynamicConfig: Arbitrary[DynamicConfig.GmosN] =
+    Arbitrary(genGmosNorthDynamic)
+
+  implicit val arbGmosSDynamicConfig: Arbitrary[DynamicConfig.GmosS] =
+    Arbitrary(genGmosSouthDynamic)
 
   implicit val arbDynamicConfig: Arbitrary[DynamicConfig] =
     Arbitrary(arbitrary[Instrument].flatMap(genDynamicConfigOf))

--- a/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
@@ -164,8 +164,16 @@ trait Arbitraries {
   implicit val arbGmosNStaticConfig: Arbitrary[StaticConfig.GmosN] =
     Arbitrary(genGmosNorthStatic)
 
+  implicit val cogGmosNStaticConfig: Cogen[StaticConfig.GmosN] =
+    Cogen[(GmosCommonStaticConfig, GmosNorthStageMode)]
+      .contramap(g => (g.common, g.stageMode))
+
   implicit val arbGmosSStaticConfig: Arbitrary[StaticConfig.GmosS] =
     Arbitrary(genGmosSouthStatic)
+
+  implicit val cogGmosSStaticConfig: Cogen[StaticConfig.GmosS] =
+    Cogen[(GmosCommonStaticConfig, GmosSouthStageMode)]
+      .contramap(g => (g.common, g.stageMode))
 
   implicit val arbStaticConfig: Arbitrary[StaticConfig] =
     Arbitrary(arbitrary[Instrument].flatMap(genStaticConfigOf))
@@ -321,8 +329,16 @@ trait Arbitraries {
   implicit val arbGmosNDynamicConfig: Arbitrary[DynamicConfig.GmosN] =
     Arbitrary(genGmosNorthDynamic)
 
+  implicit val cogGmosNDynamicConfig: Cogen[DynamicConfig.GmosN] =
+    Cogen[(GmosConfig.GmosCommonDynamicConfig, Option[GmosConfig.GmosGrating[GmosNorthDisperser]], Option[GmosNorthFilter], Option[Either[GmosConfig.GmosCustomMask, GmosNorthFpu]])]
+      .contramap(g => (g.common, g.grating, g.filter, g.fpu))
+
   implicit val arbGmosSDynamicConfig: Arbitrary[DynamicConfig.GmosS] =
     Arbitrary(genGmosSouthDynamic)
+
+  implicit val cogGmosSDynamicConfig: Cogen[DynamicConfig.GmosS] =
+    Cogen[(GmosConfig.GmosCommonDynamicConfig, Option[GmosConfig.GmosGrating[GmosSouthDisperser]], Option[GmosSouthFilter], Option[Either[GmosConfig.GmosCustomMask, GmosSouthFpu]])]
+      .contramap(g => (g.common, g.grating, g.filter, g.fpu))
 
   implicit val arbDynamicConfig: Arbitrary[DynamicConfig] =
     Arbitrary(arbitrary[Instrument].flatMap(genDynamicConfigOf))

--- a/modules/core/shared/src/test/scala/gem/config/DynamicConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/DynamicConfigSpec.scala
@@ -5,6 +5,7 @@ package gem.config
 
 import gem.arb._
 
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import monocle.law.discipline._
 import org.scalacheck.Arbitrary._
@@ -16,6 +17,8 @@ final class DynamicConfigSpec extends CatsSuite with Arbitraries {
   import ArbEnumerated._
   import ArbWavelength._
 
+  checkAll("GmosN", EqTests[GmosN].eqv)
+
   checkAll("GmosN.common",  LensTests(GmosN.common ))
   checkAll("GmosN.grating", LensTests(GmosN.grating))
   checkAll("GmosN.filter",  LensTests(GmosN.filter))
@@ -25,6 +28,8 @@ final class DynamicConfigSpec extends CatsSuite with Arbitraries {
   checkAll("GmosN.wavelength", OptionalTests(GmosN.wavelength))
   checkAll("GmosN.builtinFpu", OptionalTests(GmosN.builtinFpu))
   checkAll("GmosN.customMask", OptionalTests(GmosN.customMask))
+
+  checkAll("GmosS", EqTests[GmosS].eqv)
 
   checkAll("GmosS.common",  LensTests(GmosS.common ))
   checkAll("GmosS.grating", LensTests(GmosS.grating))

--- a/modules/core/shared/src/test/scala/gem/config/DynamicConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/DynamicConfigSpec.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import gem.arb._
+
+import cats.tests.CatsSuite
+import monocle.law.discipline._
+import org.scalacheck.Arbitrary._
+
+import DynamicConfig.{ GmosN, GmosS }
+
+final class DynamicConfigSpec extends CatsSuite with Arbitraries {
+
+  import ArbEnumerated._
+  import ArbWavelength._
+
+  checkAll("GmosN.common",  LensTests(GmosN.common ))
+  checkAll("GmosN.grating", LensTests(GmosN.grating))
+  checkAll("GmosN.filter",  LensTests(GmosN.filter))
+  checkAll("GmosN.fpu",     LensTests(GmosN.fpu))
+
+  checkAll("GmosN.disperser",  OptionalTests(GmosN.disperser))
+  checkAll("GmosN.wavelength", OptionalTests(GmosN.wavelength))
+  checkAll("GmosN.builtinFpu", OptionalTests(GmosN.builtinFpu))
+  checkAll("GmosN.customMask", OptionalTests(GmosN.customMask))
+
+  checkAll("GmosS.common",  LensTests(GmosS.common ))
+  checkAll("GmosS.grating", LensTests(GmosS.grating))
+  checkAll("GmosS.filter",  LensTests(GmosS.filter))
+  checkAll("GmosS.fpu",     LensTests(GmosS.fpu))
+
+  checkAll("GmosS.disperser",  OptionalTests(GmosS.disperser))
+  checkAll("GmosS.wavelength", OptionalTests(GmosS.wavelength))
+  checkAll("GmosS.builtinFpu", OptionalTests(GmosS.builtinFpu))
+  checkAll("GmosS.customMask", OptionalTests(GmosS.customMask))
+
+}

--- a/modules/core/shared/src/test/scala/gem/config/GmosConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/GmosConfigSpec.scala
@@ -7,6 +7,7 @@ import gem.arb._
 import gem.enum.GmosNorthDisperser
 import gem.instances.time._
 
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import monocle.law.discipline._
 
@@ -20,6 +21,13 @@ final class GmosConfigSpec extends CatsSuite with Arbitraries {
   import ArbWavelength._
 
   // Laws
+
+  checkAll("GmosCcdReadout",          EqTests[GmosCcdReadout].eqv)
+  checkAll("GmosCommonDynamicConfig", EqTests[GmosCommonDynamicConfig].eqv)
+  checkAll("GmosCommonStaticConfig",  EqTests[GmosCommonStaticConfig].eqv)
+  checkAll("GmosCustomMask",          EqTests[GmosCustomMask].eqv)
+  checkAll("GmosCustomRoiEntry",      OrderTests[GmosCustomRoiEntry].order)
+  checkAll("GmosGrating",             EqTests[GmosGrating[GmosNorthDisperser]].eqv)
 
   checkAll("GmosNodAndShuffle.posA",    LensTests(GmosNodAndShuffle.posA))
   checkAll("GmosNodAndShuffle.posB",    LensTests(GmosNodAndShuffle.posB))

--- a/modules/core/shared/src/test/scala/gem/config/GmosConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/GmosConfigSpec.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import gem.arb._
+import gem.enum.GmosNorthDisperser
+import gem.instances.time._
+
+import cats.tests.CatsSuite
+import monocle.law.discipline._
+
+import GmosConfig._
+
+final class GmosConfigSpec extends CatsSuite with Arbitraries {
+
+  import ArbEnumerated._
+  import ArbOffset._
+  import ArbTime._
+  import ArbWavelength._
+
+  // Laws
+
+  checkAll("GmosNodAndShuffle.posA",    LensTests(GmosNodAndShuffle.posA))
+  checkAll("GmosNodAndShuffle.posB",    LensTests(GmosNodAndShuffle.posB))
+  checkAll("GmosNodAndShuffle.eOffset", LensTests(GmosNodAndShuffle.eOffset))
+  checkAll("GmosNodAndShuffle.shuffle", LensTests(GmosNodAndShuffle.shuffle))
+  checkAll("GmosNodAndShuffle.cycles",  LensTests(GmosNodAndShuffle.cycles))
+
+  checkAll("GmosCommonStaticConfig.detector",      LensTests(GmosCommonStaticConfig.detector))
+  checkAll("GmosCommonStaticConfig.mosPreImaging", LensTests(GmosCommonStaticConfig.mosPreImaging))
+  checkAll("GmosCommonStaticConfig.nodAndShuffle", LensTests(GmosCommonStaticConfig.nodAndShuffle))
+  checkAll("GmosCommonStaticConfig.customRois",    LensTests(GmosCommonStaticConfig.customRois))
+
+  checkAll("GmosCcdReadout.xBinning",    LensTests(GmosCcdReadout.xBinning))
+  checkAll("GmosCcdReadout.yBinning",    LensTests(GmosCcdReadout.yBinning))
+  checkAll("GmosCcdReadout.ampCount",    LensTests(GmosCcdReadout.ampCount))
+  checkAll("GmosCcdReadout.ampReadMode", LensTests(GmosCcdReadout.ampReadMode))
+
+  checkAll("GmosCommonDynamicConfig.ccdReadout",   LensTests(GmosCommonDynamicConfig.ccdReadout))
+  checkAll("GmosCommonDynamicConfig.dtaxOffset",   LensTests(GmosCommonDynamicConfig.dtaxOffset))
+  checkAll("GmosCommonDynamicConfig.exposureTime", LensTests(GmosCommonDynamicConfig.exposureTime))
+  checkAll("GmosCommonDynamicConfig.roi",          LensTests(GmosCommonDynamicConfig.roi))
+
+  checkAll("GmosCustomMask.maskDefinitionFilename", LensTests(GmosCustomMask.maskDefinitionFilename))
+  checkAll("GmosCustomMask.slitWidth",              LensTests(GmosCustomMask.slitWidth))
+
+  checkAll("GmosGrating.disperser",  LensTests(GmosGrating.disperser[GmosNorthDisperser]))
+  checkAll("GmosGrating.order",      LensTests(GmosGrating.order[GmosNorthDisperser]))
+  checkAll("GmosGrating.wavelength", LensTests(GmosGrating.wavelength[GmosNorthDisperser]))
+
+}

--- a/modules/core/shared/src/test/scala/gem/config/StaticConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/StaticConfigSpec.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import gem.arb._
+
+import cats.tests.CatsSuite
+import monocle.law.discipline._
+import org.scalacheck.Arbitrary._
+
+import StaticConfig.{ GmosN, GmosS }
+
+final class StaticConfigSpec extends CatsSuite with Arbitraries {
+
+  import ArbEnumerated._
+
+  checkAll("GmosN.common",        LensTests(GmosN.common))
+  checkAll("GmosN.stageMode",     LensTests(GmosN.stageMode))
+  checkAll("GmosN.customRois",    LensTests(GmosN.customRois))
+  checkAll("GmosN.nodAndShuffle", LensTests(GmosN.nodAndShuffle))
+
+  checkAll("GmosS.common",        LensTests(GmosS.common))
+  checkAll("GmosS.stageMode",     LensTests(GmosS.stageMode))
+  checkAll("GmosS.customRois",    LensTests(GmosS.customRois))
+  checkAll("GmosS.nodAndShuffle", LensTests(GmosS.nodAndShuffle))
+
+}

--- a/modules/core/shared/src/test/scala/gem/config/StaticConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/StaticConfigSpec.scala
@@ -5,6 +5,7 @@ package gem.config
 
 import gem.arb._
 
+import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import monocle.law.discipline._
 import org.scalacheck.Arbitrary._
@@ -15,10 +16,14 @@ final class StaticConfigSpec extends CatsSuite with Arbitraries {
 
   import ArbEnumerated._
 
+  checkAll("GmosN", EqTests[GmosN].eqv)
+
   checkAll("GmosN.common",        LensTests(GmosN.common))
   checkAll("GmosN.stageMode",     LensTests(GmosN.stageMode))
   checkAll("GmosN.customRois",    LensTests(GmosN.customRois))
   checkAll("GmosN.nodAndShuffle", LensTests(GmosN.nodAndShuffle))
+
+  checkAll("GmosS", EqTests[GmosS].eqv)
 
   checkAll("GmosS.common",        LensTests(GmosS.common))
   checkAll("GmosS.stageMode",     LensTests(GmosS.stageMode))


### PR DESCRIPTION
This PR adds lenses to GMOS config, both static and dynamic.  Ultimately the goal is to use these lenses to simplify sequence generation but I'll need a few more lenses/prisms in `Step` to get there. A few questions that I anticipate:

* Why write them out manually instead of using `@Lenses` or `GenLens`?

I'm not married to this but I thought I'd try it when @tpolecat mentioned he preferred it that way.  Because I wrote them out manually, I felt obligated to write out the tests as well which revealed missing `Eq`, `Order`, `Arbitrary`, and `Cogen` instances and a problem with arbitrary `Duration`.  So that seemed worthwhile in the end.

* Why not use the weathervane operators like `^|->`?

I don't like them and can't remember them.  `composeLens` seems a lot clearer to me.  If there is a consensus about it I'll switch though.

* Why only `Getter` instances for `GmosShuffleOffset.detectorRows`, etc.?

Because `detectorRows` is constrained to be a positive int, you can't make a normal `Lens[GmosShuffleOffset, Int]` because the setter might not work.  I can make a `Prism[Int, GmosShuffleOffset]` but that doesn't compose with anything that contains a `GmosShuffleOffset`.  Maybe there's a correct way to do this, idk.