### PR TITLE
More config lenses

### DIFF
--- a/modules/core/shared/src/main/scala/gem/config/TelescopeConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/TelescopeConfig.scala
@@ -6,6 +6,11 @@ package config
 
 import gem.math.Offset
 
+import cats.Order
+import cats.implicits._
+import monocle._
+
+
 /**
  * Additional configuration information for [[gem.Step.Science Science]] steps.
  * @group Configurations
@@ -14,6 +19,22 @@ final case class TelescopeConfig(p: Offset.P, q: Offset.Q) {
   def offset: Offset = Offset(p, q)
 }
 
-object TelescopeConfig extends ((Offset.P, Offset.Q) => TelescopeConfig) {
+object TelescopeConfig extends ((Offset.P, Offset.Q) => TelescopeConfig) with TelescopeConfigOptics {
   val Zero: TelescopeConfig = TelescopeConfig(Offset.P.Zero, Offset.Q.Zero)
+
+  implicit val OrderTelescopeConfig: Order[TelescopeConfig] =
+    Order.by(t => (t.p, t.q))
+
+}
+
+trait TelescopeConfigOptics {
+
+  /** @group Optics */
+  val p: Lens[TelescopeConfig, Offset.P] =
+    Lens[TelescopeConfig, Offset.P](_.p)(a => _.copy(p = a))
+
+  /** @group Optics */
+  val q: Lens[TelescopeConfig, Offset.Q] =
+    Lens[TelescopeConfig, Offset.Q](_.q)(a => _.copy(q = a))
+
 }

--- a/modules/core/shared/src/test/scala/gem/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/Arbitraries.scala
@@ -17,6 +17,7 @@ import org.scalacheck.Arbitrary._
 import scala.collection.immutable.TreeMap
 
 trait Arbitraries extends gem.config.Arbitraries {
+  import ArbGcalConfig._
   import ArbEnumerated._
   import ArbTargetEnvironment._
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbCoAdds.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbCoAdds.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.syntax.prism._
+
+import org.scalacheck.{ Arbitrary, Cogen, Gen }
+
+trait ArbCoAdds {
+
+  implicit val arbCoAdds: Arbitrary[CoAdds] =
+    Arbitrary(Gen.posNum[Short].map(CoAdds.fromShort.unsafeGet))
+
+  implicit val cogCoAdds: Cogen[CoAdds] =
+    Cogen[Short].contramap(_.toShort)
+
+}
+
+object ArbCoAdds extends ArbCoAdds

--- a/modules/core/shared/src/test/scala/gem/arb/ArbGcalConfig.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbGcalConfig.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.config.GcalConfig
+import gem.config.GcalConfig.{GcalArcs, GcalLamp}
+import gem.enum._
+
+import cats.data.NonEmptySet
+import cats.laws.discipline.arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{ Arbitrary, Cogen, Gen }
+
+import java.time.Duration
+
+trait ArbGcalConfig {
+
+  import ArbCoAdds._
+  import ArbEnumerated._
+  import ArbTime._
+
+  implicit val arbGcalArcs: Arbitrary[GcalArcs] =
+    Arbitrary {
+      for {
+        a  <- arbitrary[GcalArc]
+        as <- Gen.someOf(GcalArc.all)
+      } yield GcalArcs.of(a, as.toList: _*)
+    }
+
+  implicit val cogGcalArcs: Cogen[GcalArcs] =
+    Cogen[NonEmptySet[GcalArc]].contramap(_.arcs)
+
+  implicit val arbGcalLamp: Arbitrary[GcalLamp] =
+    Arbitrary(Gen.oneOf(
+      arbitrary[GcalContinuum].map(Left(_)),
+      arbitrary[GcalArcs     ].map(Right(_))
+    ))
+
+  implicit val arbGcalConfig: Arbitrary[GcalConfig] =
+    Arbitrary {
+      for {
+        l <- arbitrary[GcalLamp    ]
+        f <- arbitrary[GcalFilter  ]
+        d <- arbitrary[GcalDiffuser]
+        s <- arbitrary[GcalShutter ]
+        e <- arbitrary[Duration    ]
+        c <- arbitrary[CoAdds      ]
+      } yield GcalConfig(l, f, d, s, e, c)
+    }
+
+  implicit val cogGcalConfig: Cogen[GcalConfig] =
+    Cogen[(GcalLamp, GcalFilter, GcalDiffuser, GcalShutter, Duration, CoAdds)]
+      .contramap(g => (g.lamp, g.filter, g.diffuser, g.shutter, g.exposureTime, g.coadds))
+
+}
+
+object ArbGcalConfig extends ArbGcalConfig

--- a/modules/core/shared/src/test/scala/gem/arb/ArbStep.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbStep.scala
@@ -7,26 +7,20 @@ package arb
 import gem.enum.SmartGcalType
 import gem.Step
 import gem.config.{ DynamicConfig, GcalConfig, TelescopeConfig }
-import gem.math.Offset
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
 
 trait ArbStep extends Arbitraries {
   import ArbEnumerated._
-  import ArbOffset._
-
-  val genTelescopeConfig: Gen[TelescopeConfig] =
-    for {
-      p <- arbitrary[Offset.P]
-      q <- arbitrary[Offset.Q]
-    } yield TelescopeConfig(p, q)
+  import ArbGcalConfig._
+  import ArbTelescopeConfig._
 
   val genBase: Gen[Step.Base] =
     Gen.oneOf(
       Gen.const(Step.Base.Bias),
       Gen.const(Step.Base.Dark),
       arbitrary[GcalConfig].map(Step.Base.Gcal(_)),
-      genTelescopeConfig.map(Step.Base.Science(_)),
+      arbitrary[TelescopeConfig].map(Step.Base.Science(_)),
       arbitrary[SmartGcalType].map(Step.Base.SmartGcal)
     )
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTelescopeConfig.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTelescopeConfig.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.config.TelescopeConfig
+import gem.math.Offset
+
+import org.scalacheck.{ Arbitrary, Cogen }
+import org.scalacheck.Arbitrary.arbitrary
+
+trait ArbTelescopeConfig {
+
+  import ArbOffset._
+
+  implicit val arbTelescopeConfig: Arbitrary[TelescopeConfig] =
+    Arbitrary {
+      arbitrary[Offset].map(o => TelescopeConfig(o.p, o.q))
+    }
+
+  implicit val cogTelescopeConfig: Cogen[TelescopeConfig] =
+    Cogen[(Offset.P, Offset.Q)].contramap(t => (t.p, t.q))
+
+}
+
+object ArbTelescopeConfig extends ArbTelescopeConfig

--- a/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
+++ b/modules/core/shared/src/test/scala/gem/config/Arbitraries.scala
@@ -8,7 +8,6 @@ import cats._
 import gem.CoAdds
 import gem.arb._
 import gem.config.F2Config.F2FpuChoice
-import gem.config.GcalConfig.{GcalArcs, GcalLamp}
 import gem.config.GmosConfig._
 import gem.enum._
 import gem.enum.Instrument._
@@ -22,6 +21,7 @@ import java.time.Duration
 
 trait Arbitraries {
 
+  import ArbCoAdds._
   import ArbEnumerated._
   import ArbOffset._
   import ArbTime._
@@ -44,9 +44,6 @@ trait Arbitraries {
     def pure[A](a: A): Gen[A] =
       Gen.const(a)
   }
-
-  implicit val arbCoAdds: Arbitrary[CoAdds] =
-    Arbitrary(Gen.posNum[Short].map(CoAdds.fromShort.unsafeGet))
 
   implicit val arbMosPreImaging: Arbitrary[MosPreImaging] =
     Arbitrary(
@@ -343,31 +340,4 @@ trait Arbitraries {
   implicit val arbDynamicConfig: Arbitrary[DynamicConfig] =
     Arbitrary(arbitrary[Instrument].flatMap(genDynamicConfigOf))
 
-  // GcalConfig
-
-  implicit val arbGcalArcs: Arbitrary[GcalArcs] =
-    Arbitrary {
-      for {
-        a  <- arbitrary[GcalArc]
-        as <- Gen.someOf(GcalArc.all)
-      } yield GcalArcs.of(a, as.toList: _*)
-    }
-
-  implicit val arbGcalLamp: Arbitrary[GcalLamp] =
-    Arbitrary(Gen.oneOf(
-      arbitrary[GcalContinuum].map(Left(_)),
-      arbitrary[GcalArcs     ].map(Right(_))
-    ))
-
-  implicit val arbGcalConfig: Arbitrary[GcalConfig] =
-    Arbitrary {
-      for {
-        l <- arbitrary[GcalLamp    ]
-        f <- arbitrary[GcalFilter  ]
-        d <- arbitrary[GcalDiffuser]
-        s <- arbitrary[GcalShutter ]
-        e <- arbitrary[Duration    ]
-        c <- arbitrary[CoAdds      ]
-      } yield GcalConfig(l, f, d, s, e, c)
-    }
 }

--- a/modules/core/shared/src/test/scala/gem/config/GcalConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/GcalConfigSpec.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package config
+
+import gem.arb._
+import gem.config.GcalConfig.GcalArcs
+import gem.instances.time._
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+import cats.laws.discipline.arbitrary._
+import monocle.law.discipline._
+
+
+final class GcalConfigSpec extends CatsSuite {
+
+  import ArbCoAdds._
+  import ArbEnumerated._
+  import ArbGcalConfig._
+  import ArbTime._
+
+  checkAll("GcalArcs",   EqTests[GcalArcs].eqv)
+  checkAll("GcalConfig", EqTests[GcalConfig].eqv)
+
+  checkAll("GcalArcs.arcs", LensTests(GcalArcs.arcs))
+
+  checkAll("GcalConfig.lamp",         LensTests(GcalConfig.lamp))
+  checkAll("GcalConfig.filter",       LensTests(GcalConfig.filter))
+  checkAll("GcalConfig.diffuser",     LensTests(GcalConfig.diffuser))
+  checkAll("GcalConfig.shutter",      LensTests(GcalConfig.shutter))
+  checkAll("GcalConfig.exposureTime", LensTests(GcalConfig.exposureTime))
+  checkAll("GcalConfig.coadds",       LensTests(GcalConfig.coadds))
+  checkAll("GcalConfig.continuum",    OptionalTests(GcalConfig.continuum))
+  checkAll("GcalConfig.arcs",         OptionalTests(GcalConfig.arcs))
+
+}

--- a/modules/core/shared/src/test/scala/gem/config/TelescopeConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/TelescopeConfigSpec.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import gem.arb._
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+import monocle.law.discipline._
+
+
+final class TelescopeConfigSpec extends CatsSuite {
+
+  import ArbTelescopeConfig._
+  import ArbOffset._
+
+  checkAll("TelescopeConfig", OrderTests[TelescopeConfig].order)
+
+  checkAll("TelescopeConfig.p", LensTests(TelescopeConfig.p))
+  checkAll("TelescopeConfig.q", LensTests(TelescopeConfig.q))
+
+}

--- a/modules/json/src/test/scala/gem/json/instances/CoAddsJsonSpec.scala
+++ b/modules/json/src/test/scala/gem/json/instances/CoAddsJsonSpec.scala
@@ -5,12 +5,14 @@ package gem.json.instances
 
 import cats.tests.CatsSuite
 import gem.CoAdds
-import gem.config.Arbitraries
+import gem.arb.ArbCoAdds
 import io.circe.testing.CodecTests
 import io.circe.testing.instances._
 
-final class CoAddsJsonSpec extends CatsSuite with Arbitraries {
+final class CoAddsJsonSpec extends CatsSuite {
   import coadds._
+
+  import ArbCoAdds._
 
   checkAll("CoAdds", CodecTests[CoAdds].unserializableCodec)
 

--- a/modules/json/src/test/scala/gem/json/instances/GcalConfigJsonSpec.scala
+++ b/modules/json/src/test/scala/gem/json/instances/GcalConfigJsonSpec.scala
@@ -3,13 +3,17 @@
 
 package gem.json.instances
 
+import gem.arb.ArbGcalConfig
+
 import cats.tests.CatsSuite
 import gem.config._
 import io.circe.testing.CodecTests
 import io.circe.testing.instances._
 
-final class GcalConfigJsonSpec extends CatsSuite with Arbitraries {
+final class GcalConfigJsonSpec extends CatsSuite {
   import gcalconfig._
+
+  import ArbGcalConfig._
 
   checkAll("GcalConfig", CodecTests[GcalConfig].unserializableCodec)
 


### PR DESCRIPTION
Adds lenses for `GcalConfig` and `TelescopeConfig` along with a few `Eq` and one `Order` instance. Along the way I'm moving stuff out of `gem.Arbitraries` and `gem.config.Arbitraries` in favor of specific instances in `gem.arb`.