### PR TITLE
SEQNG-890: Show system buttons after an error

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -197,6 +197,8 @@ object StepProgressCell {
       case (_, StandardStep(i, _, StepState.Paused, _, _, _, _, _))
           if props.stepSelected(i) =>
         stepSubsystemControl(props)
+      case (_, StandardStep(_, _, StepState.Failed(_), _, _, _, _, _)) =>
+        stepSubsystemControl(props)
       case _ =>
         <.p(SeqexecStyles.componentLabel, props.step.show)
     }


### PR DESCRIPTION
Tiny bug fix. Show system buttons after an error

![seqexec - gs-2018b-q-0-76 2019-02-21 16-24-51](https://user-images.githubusercontent.com/3615303/53215623-93890180-35f5-11e9-9bfe-2dcab58a5547.png)
