### PR TITLE
Step Lenses

### DIFF
--- a/modules/core/shared/src/main/scala/gem/Step.scala
+++ b/modules/core/shared/src/main/scala/gem/Step.scala
@@ -3,9 +3,12 @@
 
 package gem
 
-import cats.Eq
 import gem.config._
 import gem.enum.SmartGcalType
+
+import cats.Eq
+import cats.implicits._
+import monocle._
 
 sealed trait Step {
   def dynamicConfig: DynamicConfig
@@ -16,32 +19,140 @@ object Step {
 
   // TODO: better name for this
   sealed trait Base
-  object Base {
+
+  object Base extends BaseOptics {
+
     final case object Bias extends Base
     final case object Dark extends Base
     final case class  Gcal(gcal: GcalConfig) extends Base
     final case class  Science(telescope: TelescopeConfig) extends Base
     final case class  SmartGcal(smartGcalType: SmartGcalType) extends Base
+
+    implicit val EqBias: Eq[Bias.type] =
+      Eq.allEqual
+
+    implicit val EqDark: Eq[Dark.type] =
+      Eq.allEqual
+
+    object Gcal extends GcalOptics {
+
+      implicit val EqGcal: Eq[Gcal] =
+        Eq.by(_.gcal)
+
+    }
+
+    trait GcalOptics {
+
+      /** @group Optics */
+      val gcal: Lens[Gcal, GcalConfig] =
+        Lens[Gcal, GcalConfig](_.gcal)(a => _.copy(gcal = a))
+
+    }
+
+    object Science extends ScienceOptics {
+
+      implicit val EqScience: Eq[Science] =
+        Eq.by(_.telescope)
+
+    }
+
+    trait ScienceOptics {
+
+      /** @group Optics */
+      val telescope: Lens[Science, TelescopeConfig] =
+        Lens[Science, TelescopeConfig](_.telescope)(a => _.copy(telescope = a))
+
+    }
+
+    object SmartGcal extends SmartGcalOptics {
+
+      implicit val EqSmartGcal: Eq[SmartGcal] =
+        Eq.by(_.smartGcalType)
+
+    }
+
+    trait SmartGcalOptics {
+
+      /** @group Optics */
+      val smartGcalType: Lens[SmartGcal, SmartGcalType] =
+        Lens[SmartGcal, SmartGcalType](_.smartGcalType)(a => _.copy(smartGcalType = a))
+
+    }
+
+    implicit val EqBase: Eq[Base] =
+      Eq.instance {
+        case (a: Bias.type, b: Bias.type) => a === b
+        case (a: Dark.type, b: Dark.type) => a === b
+        case (a: Gcal,      b: Gcal     ) => a === b
+        case (a: Science,   b: Science  ) => a === b
+        case (a: SmartGcal, b: SmartGcal) => a === b
+        case _                            => false
+      }
   }
 
-  sealed case class Phoenix(dynamicConfig: DynamicConfig.Phoenix, base: Base) extends Step
-  sealed case class Michelle(dynamicConfig: DynamicConfig.Michelle, base: Base) extends Step
-  sealed case class Gnirs(dynamicConfig: DynamicConfig.Gnirs, base: Base) extends Step
-  sealed case class Niri(dynamicConfig: DynamicConfig.Niri, base: Base) extends Step
-  sealed case class Trecs(dynamicConfig: DynamicConfig.Trecs, base: Base) extends Step
-  sealed case class Nici(dynamicConfig: DynamicConfig.Nici, base: Base) extends Step
-  sealed case class Nifs(dynamicConfig: DynamicConfig.Nifs, base: Base) extends Step
-  sealed case class Gpi(dynamicConfig: DynamicConfig.Gpi, base: Base) extends Step
-  sealed case class Gsaoi(dynamicConfig: DynamicConfig.Gsaoi, base: Base) extends Step
-  sealed case class GmosS(dynamicConfig: DynamicConfig.GmosS, base: Base) extends Step
+  trait BaseOptics {
+
+    /** @group Optics */
+    val gcalConfig: Prism[Base, GcalConfig] =
+      Prism.partial[Base, GcalConfig] { case Base.Gcal(c) => c }(Base.Gcal(_))
+
+    /** @group Optics */
+    val telescopeConfig: Prism[Base, TelescopeConfig] =
+      Prism.partial[Base, TelescopeConfig] { case Base.Science(c) => c }(Base.Science(_))
+
+    /** @group Optics */
+    val smartGcalType: Prism[Base, SmartGcalType] =
+      Prism.partial[Base, SmartGcalType] { case Base.SmartGcal(t) => t }(Base.SmartGcal(_))
+
+  }
+
   sealed case class AcqCam(dynamicConfig: DynamicConfig.AcqCam, base: Base) extends Step
-  sealed case class GmosN(dynamicConfig: DynamicConfig.GmosN, base: Base) extends Step
   sealed case class Bhros(dynamicConfig: DynamicConfig.Bhros, base: Base) extends Step
-  sealed case class Visitor(dynamicConfig: DynamicConfig.Visitor, base: Base) extends Step
   sealed case class Flamingos2(dynamicConfig: DynamicConfig.Flamingos2, base: Base) extends Step
   sealed case class Ghost(dynamicConfig: DynamicConfig.Ghost, base: Base) extends Step
+  sealed case class Gpi(dynamicConfig: DynamicConfig.Gpi, base: Base) extends Step
+  sealed case class GmosN(dynamicConfig: DynamicConfig.GmosN, base: Base) extends Step
+  sealed case class GmosS(dynamicConfig: DynamicConfig.GmosS, base: Base) extends Step
+  sealed case class Gnirs(dynamicConfig: DynamicConfig.Gnirs, base: Base) extends Step
+  sealed case class Gsaoi(dynamicConfig: DynamicConfig.Gsaoi, base: Base) extends Step
+  sealed case class Michelle(dynamicConfig: DynamicConfig.Michelle, base: Base) extends Step
+  sealed case class Nici(dynamicConfig: DynamicConfig.Nici, base: Base) extends Step
+  sealed case class Nifs(dynamicConfig: DynamicConfig.Nifs, base: Base) extends Step
+  sealed case class Niri(dynamicConfig: DynamicConfig.Niri, base: Base) extends Step
+  sealed case class Phoenix(dynamicConfig: DynamicConfig.Phoenix, base: Base) extends Step
+  sealed case class Trecs(dynamicConfig: DynamicConfig.Trecs, base: Base) extends Step
+  sealed case class Visitor(dynamicConfig: DynamicConfig.Visitor, base: Base) extends Step
 
-  implicit val EqStep: Eq[Step] =
-    Eq.fromUniversalEquals
+
+  object GmosN extends GmosNOptics
+
+  trait GmosNOptics {
+
+    /** @group Optics */
+    val dynamicConfig: Lens[Step.GmosN, DynamicConfig.GmosN] =
+      Lens[GmosN, DynamicConfig.GmosN](_.dynamicConfig)(a => _.copy(dynamicConfig = a))
+
+    /** @group Optics */
+    val base: Lens[GmosN, Base] =
+      Lens[GmosN, Base](_.base)(a => _.copy(base = a))
+
+  }
+
+  object GmosS extends GmosSOptics
+
+  trait GmosSOptics {
+
+    /** @group Optics */
+    val dynamicConfig: Lens[Step.GmosS, DynamicConfig.GmosS] =
+      Lens[GmosS, DynamicConfig.GmosS](_.dynamicConfig)(a => _.copy(dynamicConfig = a))
+
+    /** @group Optics */
+    val base: Lens[GmosS, Base] =
+      Lens[GmosS, Base](_.base)(a => _.copy(base = a))
+
+  }
+
+  implicit def EqStep[S <: Step]: Eq[S] =
+    Eq.by(s => (s.dynamicConfig, s.base))
 
 }

--- a/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
+++ b/modules/core/shared/src/main/scala/gem/config/DynamicConfig.scala
@@ -6,6 +6,7 @@ package config
 
 import gem.CoAdds
 import gem.enum._
+import gem.instances.time._
 import gem.math.Wavelength
 
 import cats.Eq
@@ -51,6 +52,11 @@ object DynamicConfig {
       Step.AcqCam(this, b)
   }
 
+  object AcqCam {
+    implicit val EqAcqCam: Eq[AcqCam] =
+      Eq.allEqual
+  }
+
   /**
    * Dynamic configuration for bHROS (retired).
    * @group Constructors
@@ -58,6 +64,11 @@ object DynamicConfig {
   final case class Bhros() extends DynamicConfig {
     def toStep(b: Step.Base): Step.Bhros =
       Step.Bhros(this, b)
+  }
+
+  object Bhros {
+    implicit val EqBhros: Eq[Bhros] =
+      Eq.allEqual
   }
 
   /**
@@ -69,6 +80,11 @@ object DynamicConfig {
       Step.Ghost(this, b)
   }
 
+  object Ghost {
+    implicit val EqGhost: Eq[Ghost] =
+      Eq.allEqual
+  }
+
   /**
    * Dynamic configuration for GPI.
    * @group Constructors
@@ -76,6 +92,11 @@ object DynamicConfig {
   final case class Gpi() extends DynamicConfig {
     def toStep(b: Step.Base): Step.Gpi =
       Step.Gpi(this, b)
+  }
+
+  object Gpi {
+    implicit val EqGpi: Eq[Gpi] =
+      Eq.allEqual
   }
 
   /**
@@ -87,6 +108,11 @@ object DynamicConfig {
       Step.Gsaoi(this, b)
   }
 
+  object Gsaoi {
+    implicit val EqGsaoi: Eq[Gsaoi] =
+      Eq.allEqual
+  }
+
   /**
    * Dynamic configuration for Michelle (retired).
    * @group Constructors
@@ -94,6 +120,11 @@ object DynamicConfig {
   final case class Michelle() extends DynamicConfig {
     def toStep(b: Step.Base): Step.Michelle =
       Step.Michelle(this, b)
+  }
+
+  object Michelle {
+    implicit val EqMichelle: Eq[Michelle] =
+      Eq.allEqual
   }
 
   /**
@@ -105,6 +136,11 @@ object DynamicConfig {
       Step.Nici(this, b)
   }
 
+  object Nici {
+    implicit val EqNici: Eq[Nici] =
+      Eq.allEqual
+  }
+
   /**
    * Dynamic configuration for NIFS.
    * @group Constructors
@@ -112,6 +148,11 @@ object DynamicConfig {
   final case class Nifs() extends DynamicConfig {
     def toStep(b: Step.Base): Step.Nifs =
       Step.Nifs(this, b)
+  }
+
+  object Nifs {
+    implicit val EqNifs: Eq[Nifs] =
+      Eq.allEqual
   }
 
   /**
@@ -123,6 +164,11 @@ object DynamicConfig {
       Step.Niri(this, b)
   }
 
+  object Niri {
+    implicit val EqNiri: Eq[Niri] =
+      Eq.allEqual
+  }
+
   /**
    * Dynamic configuration for Phoenix.
    * @group Constructors
@@ -130,6 +176,11 @@ object DynamicConfig {
   final case class Phoenix() extends DynamicConfig {
     def toStep(b: Step.Base): Step.Phoenix =
       Step.Phoenix(this, b)
+  }
+
+  object Phoenix {
+    implicit val EqPhoenix: Eq[Phoenix] =
+      Eq.allEqual
   }
 
   /**
@@ -141,6 +192,11 @@ object DynamicConfig {
       Step.Trecs(this, b)
   }
 
+  object Trecs {
+    implicit val EqTrecs: Eq[Trecs] =
+      Eq.allEqual
+  }
+
   /**
    * Dynamic configuration for visitor instruments.
    * @group Constructors
@@ -150,6 +206,10 @@ object DynamicConfig {
       Step.Visitor(this, b)
   }
 
+  object Visitor {
+    implicit val EqVisitor: Eq[Visitor] =
+      Eq.allEqual
+  }
 
   /**
    * Dynamic configuration for FLAMINGOS-2.
@@ -177,6 +237,17 @@ object DynamicConfig {
     val Default: Flamingos2 =
       Flamingos2(None, java.time.Duration.ZERO, F2Filter.Open,
          None, F2LyotWheel.F16, F2ReadMode.Bright, F2WindowCover.Close)
+
+    implicit val EqFlamingos2: Eq[Flamingos2] =
+      Eq.by(f => (
+        f.disperser,
+        f.exposureTime,
+        f.filter,
+        f.fpu,
+        f.lyotWheel,
+        f.readMode,
+        f.windowCover
+      ))
   }
 
   /**
@@ -214,7 +285,7 @@ object DynamicConfig {
     val Default: GmosN =
       GmosN(GmosConfig.GmosCommonDynamicConfig.Default, None, None, None)
 
-    implicit val EqualGmosN: Eq[GmosN] =
+    implicit val EqGmosN: Eq[GmosN] =
       Eq.by(g => (g.common, g.grating, g.filter, g.fpu))
 
   }
@@ -295,7 +366,7 @@ object DynamicConfig {
     val Default: GmosS =
       GmosS(GmosConfig.GmosCommonDynamicConfig.Default, None, None, None)
 
-    implicit val EqualGmosS: Eq[GmosS] =
+    implicit val EqGmosS: Eq[GmosS] =
       Eq.by(g => (g.common, g.grating, g.filter, g.fpu))
 
   }
@@ -393,9 +464,42 @@ object DynamicConfig {
       GnirsReadMode.Bright,
       Wavelength.fromAngstroms.unsafeGet(22000)
     )
+
+    implicit val EqGnirs: Eq[Gnirs] =
+      Eq.by(g => (
+        g.acquisitionMirror,
+        g.camera,
+        g.coadds,
+        g.decker,
+        g.disperser,
+        g.exposureTime,
+        g.filter,
+        g.fpu,
+        g.prism,
+        g.readMode,
+        g.wavelength
+      ))
   }
 
   implicit val EqDynamicConfig: Eq[DynamicConfig] =
-    Eq.fromUniversalEquals // TODO: ensure this is ok
+    Eq.instance {
+      case (a: AcqCam,     b: AcqCam    ) => a === b
+      case (a: Bhros,      b: Bhros     ) => a === b
+      case (a: Flamingos2, b: Flamingos2) => a === b
+      case (a: Ghost,      b: Ghost     ) => a === b
+      case (a: Gpi,        b: Gpi       ) => a === b
+      case (a: GmosN,      b: GmosN     ) => a === b
+      case (a: GmosS,      b: GmosS     ) => a === b
+      case (a: Gnirs,      b: Gnirs     ) => a === b
+      case (a: Gsaoi,      b: Gsaoi     ) => a === b
+      case (a: Michelle,   b: Michelle  ) => a === b
+      case (a: Nici,       b: Nici      ) => a === b
+      case (a: Nifs,       b: Nifs      ) => a === b
+      case (a: Niri,       b: Niri      ) => a === b
+      case (a: Phoenix,    b: Phoenix   ) => a === b
+      case (a: Trecs,      b: Trecs     ) => a === b
+      case (a: Visitor,    b: Visitor   ) => a === b
+      case _                              => false
+    }
 
 }

--- a/modules/core/shared/src/test/scala/gem/StepSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/StepSpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.arb._
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import monocle.law.discipline._
+
+
+final class StepSpec extends CatsSuite {
+
+  import ArbEnumerated._
+  import ArbGcalConfig._
+  import ArbGmos._
+  import ArbStep._
+  import ArbTelescopeConfig._
+
+  checkAll("Step.Base",           EqTests[Step.Base          ].eqv)
+  checkAll("Step.Base.Bias",      EqTests[Step.Base.Bias.type].eqv)
+  checkAll("Step.Base.Dark",      EqTests[Step.Base.Dark.type].eqv)
+  checkAll("Step.Base.Gcal",      EqTests[Step.Base.Gcal     ].eqv)
+  checkAll("Step.Base.Science",   EqTests[Step.Base.Science  ].eqv)
+  checkAll("Step.Base.SmartGcal", EqTests[Step.Base.SmartGcal].eqv)
+
+  checkAll("Step.Base.gcalConfig",      PrismTests(Step.Base.gcalConfig))
+  checkAll("Step.Base.telescopeConfig", PrismTests(Step.Base.telescopeConfig))
+  checkAll("Step.Base.smartGcalType",   PrismTests(Step.Base.smartGcalType))
+
+  checkAll("Step.Base.Gcal.gcal",               LensTests(Step.Base.Gcal.gcal))
+  checkAll("Step.Base.Science.telescope",       LensTests(Step.Base.Science.telescope))
+  checkAll("Step.Base.SmartGcal.smartGcalType", LensTests(Step.Base.SmartGcal.smartGcalType))
+
+  checkAll("Step.GmosN", EqTests[Step.GmosN].eqv)
+
+  checkAll("Step.GmosN.dynamicConfig", LensTests(Step.GmosN.dynamicConfig))
+  checkAll("Step.GmosN.base",          LensTests(Step.GmosN.base))
+
+  checkAll("Step.GmosS", EqTests[Step.GmosS].eqv)
+
+  checkAll("Step.GmosS.dynamicConfig", LensTests(Step.GmosS.dynamicConfig))
+  checkAll("Step.GmosS.base",          LensTests(Step.GmosS.base))
+
+}

--- a/modules/core/shared/src/test/scala/gem/arb/ArbFlamingos2.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbFlamingos2.scala
@@ -7,7 +7,7 @@ import gem.config.F2Config.F2FpuChoice
 import gem.config.{DynamicConfig, StaticConfig}
 import gem.enum._
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Cogen, Gen}
 
 import java.time.Duration
 
@@ -29,6 +29,9 @@ trait ArbFlamingos2 {
                 arbitrary[F2Fpu].map(F2FpuChoice.Builtin(_)))
     }
 
+  implicit val cogF2FpuChoice: Cogen[F2FpuChoice] =
+    Cogen[Option[F2Fpu]].contramap(_.toBuiltin)
+
   implicit val arbFlamingos2Dynamic: Arbitrary[DynamicConfig.Flamingos2] =
     Arbitrary {
       for {
@@ -41,6 +44,18 @@ trait ArbFlamingos2 {
         w <- arbitrary[F2WindowCover]
       } yield DynamicConfig.Flamingos2(d, e, f, u, l, r, w)
     }
+
+  implicit val cogFlamingos2Dynamic: Cogen[DynamicConfig.Flamingos2] =
+    Cogen[(Option[F2Disperser], Duration, F2Filter, Option[F2FpuChoice], F2LyotWheel, F2ReadMode, F2WindowCover)]
+      .contramap(f => (
+        f.disperser,
+        f.exposureTime,
+        f.filter,
+        f.fpu,
+        f.lyotWheel,
+        f.readMode,
+        f.windowCover
+      ))
 
 }
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbGnirs.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbGnirs.scala
@@ -10,7 +10,7 @@ import gem.math.Wavelength
 
 import java.time.Duration
 
-import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.{ Arbitrary, Cogen }
 import org.scalacheck.Arbitrary.arbitrary
 
 
@@ -20,6 +20,7 @@ trait ArbGnirs {
   import ArbCoAdds._
   import ArbEnumerated._
   import ArbTime._
+  import ArbWavelength._
 
   // Static Config
 
@@ -42,9 +43,25 @@ trait ArbGnirs {
         h <- arbitrary[Either[GnirsFpuOther, GnirsFpuSlit]]
         i <- arbitrary[GnirsPrism]
         j <- arbitrary[GnirsReadMode]
-        k <- Gen.choose(1000, 120000).map(Wavelength.fromAngstroms.unsafeGet)
+        k <- arbitrary[Wavelength]
       } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j, k)
     }
+
+  implicit val cogGnirsDynamic: Cogen[DynamicConfig.Gnirs] =
+    Cogen[(GnirsAcquisitionMirror, GnirsCamera, CoAdds, GnirsDecker, GnirsDisperser, Duration, GnirsFilter, Either[GnirsFpuOther, GnirsFpuSlit], GnirsPrism, GnirsReadMode, Wavelength)]
+      .contramap(g => (
+        g.acquisitionMirror,
+        g.camera,
+        g.coadds,
+        g.decker,
+        g.disperser,
+        g.exposureTime,
+        g.filter,
+        g.fpu,
+        g.prism,
+        g.readMode,
+        g.wavelength
+      ))
 
 }
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbStep.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbStep.scala
@@ -5,7 +5,7 @@ package gem
 package arb
 
 import gem.enum.{Instrument, SmartGcalType}
-import gem.config.{GcalConfig, TelescopeConfig}
+import gem.config.{DynamicConfig, GcalConfig, TelescopeConfig}
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
 
@@ -13,19 +13,62 @@ trait ArbStep {
 
   import ArbEnumerated._
   import ArbGcalConfig._
+  import ArbGmos._
   import ArbDynamicConfig._
   import ArbTelescopeConfig._
+
+  import Step.Base._
+
+  implicit val arbStepBaseBias: Arbitrary[Bias.type] =
+    Arbitrary(Gen.const(Bias))
+
+  implicit val cogStepBaseBias: Cogen[Bias.type] =
+    Cogen[Unit].contramap(Function.const(()))
+
+  implicit val arbStepBaseDark: Arbitrary[Dark.type] =
+    Arbitrary(Gen.const(Dark))
+
+  implicit val cogStepBaseDark: Cogen[Dark.type] =
+    Cogen[Unit].contramap(Function.const(()))
+
+  implicit val arbStepBaseGcal: Arbitrary[Gcal] =
+    Arbitrary(arbitrary[GcalConfig].map(Gcal(_)))
+
+  implicit val cogStepBaseGcal: Cogen[Gcal] =
+    Cogen[GcalConfig].contramap(_.gcal)
+
+  implicit val arbStepBaseScience: Arbitrary[Science] =
+    Arbitrary(arbitrary[TelescopeConfig].map(Science(_)))
+
+  implicit val cogStepBaseScience: Cogen[Science] =
+    Cogen[TelescopeConfig].contramap(_.telescope)
+
+  implicit val arbStepBaseSmartGcal: Arbitrary[SmartGcal] =
+    Arbitrary(arbitrary[SmartGcalType].map(SmartGcal(_)))
+
+  implicit val cogStepBaseSmartGcal: Cogen[SmartGcal] =
+    Cogen[SmartGcalType].contramap(_.smartGcalType)
 
   implicit val arbStepBase: Arbitrary[Step.Base] =
     Arbitrary {
       Gen.oneOf(
-        Gen.const(Step.Base.Bias),
-        Gen.const(Step.Base.Dark),
-        arbitrary[GcalConfig].map(Step.Base.Gcal(_)),
-        arbitrary[TelescopeConfig].map(Step.Base.Science(_)),
-        arbitrary[SmartGcalType].map(Step.Base.SmartGcal)
+        arbitrary[Bias.type],
+        arbitrary[Dark.type],
+        arbitrary[Gcal     ],
+        arbitrary[Science  ],
+        arbitrary[SmartGcal]
       )
     }
+
+  implicit val cogStepBase: Cogen[Step.Base] =
+    Cogen[(Option[Bias.type], Option[Dark.type], Option[Gcal], Option[Science], Option[SmartGcal])]
+      .contramap {
+        case Bias         => (Some(Bias), None,       None,    None,    None   )
+        case Dark         => (None,       Some(Dark), None,    None,    None   )
+        case b: Gcal      => (None,       None,       Some(b), None,    None   )
+        case b: Science   => (None,       None,       None,    Some(b), None   )
+        case b: SmartGcal => (None,       None,       None,    None,    Some(b))
+      }
 
   def genStepOf(i: Instrument): Gen[Step] =
     for {
@@ -35,6 +78,29 @@ trait ArbStep {
 
   implicit val arbStep: Arbitrary[Step] =
     Arbitrary(arbitrary[Instrument].flatMap(genStepOf))
+
+  implicit val arbStepGmosN: Arbitrary[Step.GmosN] =
+    Arbitrary {
+      for {
+        d <- arbitrary[DynamicConfig.GmosN]
+        b <- arbitrary[Step.Base]
+      } yield Step.GmosN(d, b)
+    }
+
+  implicit val cogStepGmosN: Cogen[Step.GmosN] =
+    Cogen[(DynamicConfig.GmosN, Step.Base)].contramap(g => (g.dynamicConfig, g.base))
+
+  implicit val arbStepGmosS: Arbitrary[Step.GmosS] =
+    Arbitrary {
+      for {
+        d <- arbitrary[DynamicConfig.GmosS]
+        b <- arbitrary[Step.Base]
+      } yield Step.GmosS(d, b)
+    }
+
+  implicit val cogStepGmosS: Cogen[Step.GmosS] =
+    Cogen[(DynamicConfig.GmosS, Step.Base)].contramap(g => (g.dynamicConfig, g.base))
+
 
   def genSequenceOf(i: Instrument): Gen[List[Step]] =
     for {

--- a/modules/core/shared/src/test/scala/gem/config/F2ConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/F2ConfigSpec.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import gem.arb._
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+
+
+final class F2ConfigSpec extends CatsSuite {
+
+  import ArbEnumerated._
+  import ArbFlamingos2._
+
+  checkAll("DynamicConfig.Flamingos2", EqTests[DynamicConfig.Flamingos2].eqv)
+
+}

--- a/modules/core/shared/src/test/scala/gem/config/GnirsConfigSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/config/GnirsConfigSpec.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.config
+
+import gem.arb._
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+
+
+final class GnirsConfigSpec extends CatsSuite {
+
+  import ArbEnumerated._
+  import ArbGnirs._
+
+  checkAll("DynamicConfig.Gnirs", EqTests[DynamicConfig.Gnirs].eqv)
+
+}


### PR DESCRIPTION
This PR adds some Lenses, Prisms, and `Eq` instances for `Step` and its friends.  For context, in order to do sequence generation I’ll need to set up a `Step.GmosN` (for example) and then modify it repeatedly to form a sequence.  Doing it without all of the optics I’ve now added was going to be brutal.

Nevertheless I can’t help but feel I’ve driven into a ditch in this one.  I’ll point out a few specific concerns in comments.