### PR TITLE
SEQNG-902 Show the step state msg rather that the sequence step

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -145,7 +145,7 @@ object StepProgressCell {
       SeqexecStyles.configuringRow,
       <.div(
         SeqexecStyles.specialStateLabel,
-        props.state.show
+        props.step.show
       ),
       props.step match {
         case step: StandardStep =>


### PR DESCRIPTION
The message of a step should be the step state rather than the sequence. This leads to erroneous error messages

<img width="731" alt="seqexec - gn-eng20190226-2 2019-02-26 09-59-50" src="https://user-images.githubusercontent.com/3615303/53442413-4fa74b00-39ad-11e9-8910-4535450f1f3f.png">
