### PR TITLE
SEQNG-907 Use a shorter request timeout for the http client

### DIFF
--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -17,7 +17,6 @@ import java.util.concurrent.{ExecutorService, Executors}
 import knobs.{Resource => _, _}
 import mouse.all._
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
-import org.http4s.util.threads.threadFactory
 import org.http4s.client.asynchttpclient.AsyncHttpClient
 import org.http4s.client.Client
 import org.http4s.HttpRoutes
@@ -241,13 +240,8 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
     }
 
   // Override the default client config
-  val clientConfig = new DefaultAsyncHttpClientConfig.Builder()
-    .setMaxConnectionsPerHost(200)
-    .setMaxConnections(400)
+  val clientConfig = new DefaultAsyncHttpClientConfig.Builder(AsyncHttpClient.defaultConfig)
     .setRequestTimeout(5000) // Change the timeout to 5 seconds
-    .setThreadFactory(threadFactory(name = { i =>
-      s"http4s-async-http-client-worker-${i}"
-    }))
     .build()
 
   def engineIO(httpClient: Client[IO], guideConfigDb: GuideConfigDb[IO], collector: CollectorRegistry): Resource[IO, SeqexecEngine] =

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -14,9 +14,10 @@ import gem.enum.Site
 import io.prometheus.client.CollectorRegistry
 import java.nio.file.{Path => FilePath}
 import java.util.concurrent.{ExecutorService, Executors}
-
 import knobs.{Resource => _, _}
 import mouse.all._
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.http4s.util.threads.threadFactory
 import org.http4s.client.asynchttpclient.AsyncHttpClient
 import org.http4s.client.Client
 import org.http4s.HttpRoutes
@@ -29,7 +30,6 @@ import org.http4s.server.Server
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import org.http4s.syntax.kleisli._
 import org.log4s._
-
 import scala.concurrent.ExecutionContext
 import seqexec.model.events._
 import seqexec.server
@@ -240,7 +240,17 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
       Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
     }
 
-    def engineIO(httpClient: Client[IO], guideConfigDb: GuideConfigDb[IO], collector: CollectorRegistry): Resource[IO, SeqexecEngine] =
+  // Override the default client config
+  val clientConfig = new DefaultAsyncHttpClientConfig.Builder()
+    .setMaxConnectionsPerHost(200)
+    .setMaxConnections(400)
+    .setRequestTimeout(5000) // Change the timeout to 5 seconds
+    .setThreadFactory(threadFactory(name = { i =>
+      s"http4s-async-http-client-worker-${i}"
+    }))
+    .build()
+
+  def engineIO(httpClient: Client[IO], guideConfigDb: GuideConfigDb[IO], collector: CollectorRegistry): Resource[IO, SeqexecEngine] =
       for {
         cfg          <- Resource.liftF(config)
         _            <- Resource.liftF(logEngineStart)
@@ -276,7 +286,7 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
     val r: Resource[IO, ExitCode] =
       for {
         _      <- Resource.liftF(configLog) // Initialize log before the engine is setup
-        cli    <- AsyncHttpClient.resource[IO]()
+        cli    <- AsyncHttpClient.resource[IO](clientConfig)
         inq    <- Resource.liftF(Queue.bounded[IO, executeEngine.EventType](10))
         out    <- Resource.liftF(Topic[IO, SeqexecEvent](NullEvent))
         cr     <- Resource.liftF(IO(new CollectorRegistry))


### PR DESCRIPTION
The default timeout for the http client is 60s which is too long for example when connecting to the DHS. This reduces the timeout to 5s but the actual amount is subject to testing