### PR TITLE
SEQNG-912: Support access to the guide route over plain http

### DIFF
--- a/app/seqexec-server-gn/src/main/resources/app.conf
+++ b/app/seqexec-server-gn/src/main/resources/app.conf
@@ -45,9 +45,10 @@ seqexec-engine {
         gpiGds = "simulated"
         gsaoi = "simulated"
         gws = "full"
-        nifs = "simulated"
+        nifs = "full"
         niri = "full"
         tcs = "full"
+        altair = "full"
     }
     odbNotifications = true
     odbQueuePollingInterval = 3 seconds

--- a/app/seqexec-server/src/main/resources/app.conf
+++ b/app/seqexec-server/src/main/resources/app.conf
@@ -50,6 +50,7 @@ seqexec-engine {
         nifs = "simulated"
         niri = "simulated"
         tcs = "simulated"
+        altair = "simulated"
     }
     odbNotifications = false
     tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gw=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"


### PR DESCRIPTION
We need to let the TCC call the guide route over http