### PR TITLE
SEQNG-909 Simulate gnirs progress bar

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -45,8 +45,9 @@ final case class Gnirs(controller: GnirsController, dhsClient: DhsClient[IO]) ex
     }
 
   override def calcObserveTime(config: Config): IO[Time] =
-    IO((extractExposureTime(config), extractCoadds(config))
-      .mapN(_ * _.toDouble).getOrElse(10000.seconds))
+    getDCConfig(config)
+      .map(controller.calcTotalExposureTime[IO])
+      .getOrElse(IO.pure(60.seconds))
 
   override val resource: Resource = Instrument.Gnirs
 


### PR DESCRIPTION
Though GNIRS exposes a channel with the time left for an exposition in practice it is always 0
Thus we need to simulate the progress