### PR TITLE
SEQNG-934 Fixed issue with TCS in position

### DIFF
--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaWindowStabilizer.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaWindowStabilizer.java
@@ -47,6 +47,7 @@ public class CaWindowStabilizer<T> implements CaAttribute<T> {
     }
 
     private synchronized void onValChange(T val) {
+
         if (val != null && val != lastVal) {
             if (timeoutFuture != null) {
                 timeoutFuture.cancel(true);
@@ -65,7 +66,7 @@ public class CaWindowStabilizer<T> implements CaAttribute<T> {
     private synchronized void onTimeout() {
         timeoutFuture = null;
         filteredVal = lastVal;
-        notifier.notifyValueChange(Arrays.asList(filteredVal));
+        notifier.notifyValueChange(values());
     }
 
     void unbind() {
@@ -97,7 +98,10 @@ public class CaWindowStabilizer<T> implements CaAttribute<T> {
 
     @Override
     public List<T> values() {
-        return Arrays.asList(filteredVal);
+        if(filteredVal != null)
+            return Arrays.asList(filteredVal);
+        else
+            return Arrays.asList();
     }
 
     @Override
@@ -141,6 +145,11 @@ public class CaWindowStabilizer<T> implements CaAttribute<T> {
     @Override
     public void removeListener(CaAttributeListener<T> listener) {
         notifier.removeListener(listener);
+    }
+
+    public CaWindowStabilizer<T> reset() {
+        filteredVal = lastVal = null;
+        return this;
     }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
@@ -46,8 +46,8 @@ object TcsControllerEpics extends TcsController {
 
   implicit private val encodeNodChopOption: EncodeEpicsValue[NodChopTrackingOption, String] =
     EncodeEpicsValue {
-      case NodChopTrackingOption.NodChopTrackingOn  => "on"
-      case NodChopTrackingOption.NodChopTrackingOff => "off"
+      case NodChopTrackingOption.NodChopTrackingOn  => "On"
+      case NodChopTrackingOption.NodChopTrackingOff => "Off"
     }
 
   private def setProbeTrackingConfig(s: TcsEpics.ProbeGuideCmd)(c: ProbeTrackingConfig): SeqAction[Unit] = for {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
@@ -364,17 +364,17 @@ final class TcsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, Stri
 
   private val tcsStabilizeTime = 1.seconds
 
-  private val filteredInPositionAttr: CaAttribute[String] = new CaWindowStabilizer[String](inPositionAttr, java.time.Duration.ofMillis(tcsStabilizeTime.toMillis))
+  private val filteredInPositionAttr: CaWindowStabilizer[String] = new CaWindowStabilizer[String](inPositionAttr, java.time.Duration.ofMillis(tcsStabilizeTime.toMillis))
   def filteredInPosition:F[Option[String]] = safeAttribute(filteredInPositionAttr)
 
   // This functions returns a Task that, when run, will wait up to `timeout`
   // seconds for the TCS in-position flag to set to TRUE
-  def waitInPosition(timeout: Time): SeqAction[Unit] = waitForValue(filteredInPositionAttr, "TRUE", timeout,
+  def waitInPosition(timeout: Time): SeqAction[Unit] = waitForValue(filteredInPositionAttr.reset, "TRUE", timeout,
     "TCS inposition flag")
 
   private val agStabilizeTime = 1.seconds
 
-  private val filteredAGInPositionAttr: CaAttribute[java.lang.Double] = new CaWindowStabilizer[java.lang.Double](agInPositionAttr, java.time.Duration.ofMillis(agStabilizeTime.toMillis))
+  private val filteredAGInPositionAttr: CaWindowStabilizer[java.lang.Double] = new CaWindowStabilizer[java.lang.Double](agInPositionAttr, java.time.Duration.ofMillis(agStabilizeTime.toMillis))
   def filteredAGInPosition: F[Option[Double]] = safeAttributeSDouble(filteredAGInPositionAttr)
 
   // `waitAGInPosition` works like `waitInPosition`, but for the AG in-position flag.
@@ -383,7 +383,7 @@ final class TcsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, Stri
    */
   private val AGSettleTime = 1100.milliseconds
   def waitAGInPosition(timeout: Time): SeqAction[Unit] = SeqAction(Thread.sleep(AGSettleTime.toMilliseconds.toLong)) *>
-    waitForValue[java.lang.Double](filteredAGInPositionAttr, 1.0, timeout, "AG inposition flag")
+    waitForValue[java.lang.Double](filteredAGInPositionAttr.reset, 1.0, timeout, "AG inposition flag")
 
   def hourAngle: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("ha"))
 


### PR DESCRIPTION
The problem was that the in position value was filtered to remove spurious changes. That introduces a delay in the changes (the input has to be stable for XX seconds before the output changes). The problem is that when Seqexec checked the filtered value, it had not yet changed to "false" because of that delay.