### PR TITLE
SEQNG-937 Don't enable beam C guiding.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -153,9 +153,11 @@ object TcsController {
         NodChopTrackingOff
     }
 
+    // Beam C is never used on normal configuration, and setting it to On would cause problems because no other tool
+    // (TCC, Tcs engineering screens) can change it.
     object Normal extends ActiveNodChopTracking {
       def get(nodchop: NodChop): NodChopTrackingOption =
-        NodChopTrackingOption.fromBoolean(nodchop.nod === nodchop.chop)
+        NodChopTrackingOption.fromBoolean(nodchop.nod =!= Beam.C && nodchop.nod === nodchop.chop)
     }
 
     final case class Special(s: OneAnd[List, NodChop]) extends ActiveNodChopTracking {


### PR DESCRIPTION
Seqexec left the TCS in an unrecoverable state after enabling guiding. The issue is that it was enabling guiding for beam C, but neither the TCC nor the TCS dm screens consider that option. The end result was that TCC would not turn off the beam C guiding when changing guiders, which resulted in TCS complaining because the previous guider was left as still in use.