### PR TITLE
SEQNG-925 Fixed reading of current SF position.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -36,7 +36,7 @@ import seqexec.server.gcal._
 import seqexec.server.gmos.{GmosHeader, GmosNorth, GmosSouth}
 import seqexec.server.gws.{DummyGwsKeywordsReader, GwsHeader, GwsKeywordsReaderImpl}
 import seqexec.server.tcs._
-import seqexec.server.tcs.TcsController.ScienceFoldPosition
+import seqexec.server.tcs.TcsController.LightPath
 import seqexec.server.gnirs._
 import seqexec.server.niri._
 import seqexec.server.nifs._
@@ -437,16 +437,16 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
   ): TrySeq[List[System[IO]]] = {
     stepType match {
       case CelestialObject(inst) => toInstrumentSys(inst).map{sys => sys :: List(
-          Tcs.fromConfig(systems.tcs, (hasOI(inst)).fold(allButGaos, allButGaosNorOi), None, systems.guideDb)(
+          Tcs.fromConfig(systems.tcs, hasOI(inst).fold(allButGaos, allButGaosNorOi), None, systems.guideDb)(
             config,
-            ScienceFoldPosition.Position(TcsController.LightSource.Sky, sys.sfName(config)),
+            LightPath(TcsController.LightSource.Sky, sys.sfName(config)),
             extractWavelength(config)),
           Gcal(systems.gcal, site == Site.GS)
       ) }
       case FlatOrArc(inst)       => toInstrumentSys(inst).map{sys => sys :: List(
           Tcs.fromConfig(systems.tcs, flatOrArcTcsSubsystems(inst), None, systems.guideDb)(
             config,
-            ScienceFoldPosition.Position(TcsController.LightSource.GCAL, sys.sfName(config)),
+            LightPath(TcsController.LightSource.GCAL, sys.sfName(config)),
             extractWavelength(config)),
           Gcal(systems.gcal, site == Site.GS)
       ) }
@@ -457,7 +457,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
       } yield sys :: List(
           Tcs.fromConfig(systems.tcs, hasOI(inst).fold(allButGaos, allButGaosNorOi).add(Gaos),
             altair.asLeft.some, systems.guideDb)(config,
-            ScienceFoldPosition.Position(TcsController.LightSource.Sky, sys.sfName(config)),
+            LightPath(TcsController.LightSource.Sky, sys.sfName(config)),
             extractWavelength(config)),
           Gcal(systems.gcal, site == Site.GS)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFoldPositionCodex.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFoldPositionCodex.scala
@@ -4,61 +4,46 @@
 package seqexec.server.tcs
 
 import cats.implicits._
-import mouse.boolean._
+import mouse.string._
 import gem.enum.LightSinkName
 import seqexec.server.EpicsCodex.{DecodeEpicsValue, EncodeEpicsValue}
-import seqexec.server.tcs.TcsController.{LightSource, ScienceFoldPosition}
-import seqexec.server.tcs.TcsControllerEpics.InstrumentPorts
+import seqexec.server.tcs.TcsController.LightSource
+import seqexec.server.tcs.TcsControllerEpics.ScienceFold.{Parked, Position}
+import seqexec.server.tcs.TcsControllerEpics.ScienceFold
 
 // Decoding and encoding the science fold position require some common definitions, therefore I
 // put them inside an object
 private[server] object ScienceFoldPositionCodex {
 
   import LightSource._
-  import ScienceFoldPosition._
 
   private val AO_PREFIX = "ao2"
   private val GCAL_PREFIX = "gcal2"
   private val PARK_POS = "park-pos"
 
-  val BottomPort: Int = 1
-  val InvalidPort: Int = 0
-
-  def portFromSinkName(ports: InstrumentPorts)(n: LightSinkName): Option[Int] = {
-    val port = n match {
-      case LightSinkName.Gmos |
-           LightSinkName.Gmos_Ifu => ports.gmosPort
-      case LightSinkName.Niri_f6 |
-           LightSinkName.Niri_f14 |
-           LightSinkName.Niri_f32 => ports.niriPort
-      case LightSinkName.Nifs     => ports.nifsPort
-      case LightSinkName.Gnirs    => ports.gnirsPort
-      case LightSinkName.F2       => ports.flamingos2Port
-      case LightSinkName.Gpi      => ports.gpiPort
-      case LightSinkName.Ghost    => ports.ghostPort
-      case LightSinkName.Gsaoi    => ports.gsaoiPort
-      case LightSinkName.Ac |
-           LightSinkName.Hr       => BottomPort
-      case LightSinkName.Phoenix |
-           LightSinkName.Visitor  => InvalidPort
-    }
-    (port =!= InvalidPort).option(port)
-  }
-
   private def findSinkInSFName(str: String): Option[LightSinkName] =
     LightSinkName.all.find(i => str.startsWith(i.name))
 
-  implicit val decodeScienceFoldPosition: DecodeEpicsValue[String, Option[ScienceFoldPosition]] = DecodeEpicsValue(
+  private def findPortInSFName(str: String): Option[Int] = str.parseIntOption
+
+  implicit val decodeScienceFold: DecodeEpicsValue[String, Option[ScienceFold]] = DecodeEpicsValue(
     (t: String) => if (t.startsWith(PARK_POS)) Parked.some
-    else if (t.startsWith(AO_PREFIX))
-      findSinkInSFName(t.substring(AO_PREFIX.length)).map(Position(AO, _))
-    else if (t.startsWith(GCAL_PREFIX))
-      findSinkInSFName(t.substring(GCAL_PREFIX.length)).map(Position(GCAL, _))
-    else findSinkInSFName(t).map(Position(Sky, _))
+    else if (t.startsWith(AO_PREFIX)) for {
+      sink <- findSinkInSFName(t.substring(AO_PREFIX.length))
+      port <- findPortInSFName(t.substring(AO_PREFIX.length + sink.name.length))
+    } yield Position(AO, sink, port)
+    else if (t.startsWith(GCAL_PREFIX)) for {
+      sink <- findSinkInSFName(t.substring(GCAL_PREFIX.length))
+      port <- findPortInSFName(t.substring(GCAL_PREFIX.length + sink.name.length))
+    } yield Position(GCAL, sink, port)
+    else for {
+      sink <- findSinkInSFName(t)
+      port <- findPortInSFName(t.substring(sink.name.length))
+    } yield Position(Sky, sink, port)
   )
 
-  def encodeScienceFoldPosition(port: Int): EncodeEpicsValue[Position, String] = EncodeEpicsValue((a: Position) => {
-    val instAGName = a.sink.name + port.toString
+  implicit val encodeScienceFold: EncodeEpicsValue[Position, String] = EncodeEpicsValue((a: Position) => {
+    val instAGName = a.sink.name + a.port.toString
 
     a.source match {
       case Sky => instAGName
@@ -66,4 +51,5 @@ private[server] object ScienceFoldPositionCodex {
       case GCAL => GCAL_PREFIX + instAGName
     }
   })
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFoldPositionCodex.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFoldPositionCodex.scala
@@ -4,7 +4,7 @@
 package seqexec.server.tcs
 
 import cats.implicits._
-import mouse.string._
+import atto._, Atto._
 import gem.enum.LightSinkName
 import seqexec.server.EpicsCodex.{DecodeEpicsValue, EncodeEpicsValue}
 import seqexec.server.tcs.TcsController.LightSource
@@ -21,35 +21,32 @@ private[server] object ScienceFoldPositionCodex {
   private val GCAL_PREFIX = "gcal2"
   private val PARK_POS = "park-pos"
 
-  private def findSinkInSFName(str: String): Option[LightSinkName] =
-    LightSinkName.all.find(i => str.startsWith(i.name))
+  val lightSink: Parser[LightSinkName] =
+    many(letter).map { cs =>
+      val sinkName = cs.mkString
+      LightSinkName.all.find(_.name === sinkName)
+    }.collect { case Some(lsn) => lsn }
 
-  private def findPortInSFName(str: String): Option[Int] = str.parseIntOption
+  def prefixed(p: String, s: LightSource): Parser[ScienceFold] =
+    (string(p) ~> lightSink ~ int).map { case (ls, port) => Position(s, ls, port) }
+
+  val park: Parser[ScienceFold] =
+    (string(PARK_POS) <~ many(anyChar)).as(Parked)
 
   implicit val decodeScienceFold: DecodeEpicsValue[String, Option[ScienceFold]] = DecodeEpicsValue(
-    (t: String) => if (t.startsWith(PARK_POS)) Parked.some
-    else if (t.startsWith(AO_PREFIX)) for {
-      sink <- findSinkInSFName(t.substring(AO_PREFIX.length))
-      port <- findPortInSFName(t.substring(AO_PREFIX.length + sink.name.length))
-    } yield Position(AO, sink, port)
-    else if (t.startsWith(GCAL_PREFIX)) for {
-      sink <- findSinkInSFName(t.substring(GCAL_PREFIX.length))
-      port <- findPortInSFName(t.substring(GCAL_PREFIX.length + sink.name.length))
-    } yield Position(GCAL, sink, port)
-    else for {
-      sink <- findSinkInSFName(t)
-      port <- findPortInSFName(t.substring(sink.name.length))
-    } yield Position(Sky, sink, port)
-  )
+    (t: String) =>
+      (park | prefixed(AO_PREFIX, AO) | prefixed(GCAL_PREFIX, GCAL) | prefixed("", Sky)).parseOnly(t).option  )
 
   implicit val encodeScienceFold: EncodeEpicsValue[Position, String] = EncodeEpicsValue((a: Position) => {
     val instAGName = a.sink.name + a.port.toString
 
     a.source match {
-      case Sky => instAGName
-      case AO => AO_PREFIX + instAGName
+      case Sky  => instAGName
+      case AO   => AO_PREFIX + instAGName
       case GCAL => GCAL_PREFIX + instAGName
     }
   })
+
+
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
@@ -116,7 +116,7 @@ final case class Tcs private (tcsController: TcsController,
             config.guideWithOI)
           )
         ),
-        AGConfig(config.scienceFoldPosition, HrwfsConfig.Auto.some),
+        AGConfig(config.lightPath, HrwfsConfig.Auto.some),
         c.gaosGuide
       )
     }
@@ -155,7 +155,7 @@ object Tcs {
     guideWithAO: Option[StandardGuideOptions.Value],
     offsetA: Option[InstrumentOffset],
     wavelA: Option[Wavelength],
-    scienceFoldPosition: ScienceFoldPosition
+    lightPath: LightPath
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
@@ -163,7 +163,7 @@ object Tcs {
 
   def fromConfig(controller: TcsController, subsystems: NonEmptySet[Subsystem], gaos: Option[Either[Altair[IO],
     Gems[IO]]], guideConfigDb: GuideConfigDb[IO])(
-    config: Config, scienceFoldPosition: ScienceFoldPosition, observingWavelength: Option[Wavelength]
+                  config: Config, lightPath: LightPath, observingWavelength: Option[Wavelength]
   ): Tcs = {
 
     val gwp1 = config.extractAs[StandardGuideOptions.Value](TELESCOPE_KEY / GUIDE_WITH_PWFS1_PROP).toOption
@@ -182,7 +182,7 @@ object Tcs {
       gwao,
       (offsetp, offsetq).mapN(InstrumentOffset(_, _)),
       observingWavelength,
-      scienceFoldPosition
+      lightPath
     )
 
     Tcs(controller, subsystems, gaos, guideConfigDb)(tcsSeqCfg)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -254,21 +254,13 @@ object TcsController {
     implicit val eq: Eq[LightSource] =  Eq.fromUniversalEquals
   }
 
-  /** Data type for science fold position. */
-  sealed trait ScienceFoldPosition
-  object ScienceFoldPosition {
-    case object Parked extends ScienceFoldPosition
-    final case class Position(source: LightSource, sink: LightSinkName) extends ScienceFoldPosition
+  /* Data type for science fold position. */
+  final case class LightPath(source: LightSource, sink: LightSinkName)
+  object LightPath {
 
-    implicit val show: Show[ScienceFoldPosition] = Show.fromToString
+    implicit val show: Show[LightPath] = Show.fromToString
 
-    implicit val positionEq: Eq[Position] = Eq.by(x => (x.source, x.sink))
-
-    implicit val eq: Eq[ScienceFoldPosition] = Eq.instance{
-      case (Parked, Parked)                     => true
-      case (a@Position(_, _), b@Position(_, _)) => a === b
-      case _                                    => false
-    }
+    implicit val positionEq: Eq[LightPath] = Eq.by(x => (x.source, x.sink))
   }
 
   /** Enumerated type for offloading of tip/tilt corrections from M2 to mount. */
@@ -368,7 +360,7 @@ object TcsController {
     implicit val pwfs1Eq: Eq[GuiderConfig@@P1Config] = Eq[GuiderConfig].contramap(identity)
   }
 
-  final case class AGConfig(sfPos: ScienceFoldPosition, hrwfs: Option[HrwfsConfig])
+  final case class AGConfig(sfPos: LightPath, hrwfs: Option[HrwfsConfig])
 
   @Lenses
   final case class TcsConfig(
@@ -390,7 +382,7 @@ object TcsController {
       Left(tag[P2Config](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff))),
       tag[OIConfig](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff))
     ),
-    AGConfig(ScienceFoldPosition.Parked, HrwfsConfig.Auto.some),
+    AGConfig(LightPath(LightSource.Sky, LightSinkName.Ac), HrwfsConfig.Auto.some),
     None
   )
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/ScienceFoldPositionCodexSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/ScienceFoldPositionCodexSpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import ScienceFoldPositionCodex._
+import seqexec.server.EpicsCodex._
+import gem.enum.LightSinkName.{Gmos, Nifs, Gsaoi}
+import seqexec.server.tcs.TcsController.LightSource.{AO, GCAL, Sky}
+import seqexec.server.tcs.TcsControllerEpics.ScienceFold
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+class ScienceFoldPositionCodexSpec extends FlatSpec {
+
+  private val invalid = "Invalid"
+  private val parked = ("park-pos.", ScienceFold.Parked)
+  private val ao2gmos3 = ("ao2gmos3", ScienceFold.Position(AO, Gmos, 3))
+  private val gcal2nifs1 = ("gcal2nifs1", ScienceFold.Position(GCAL, Nifs, 1))
+  private val gsaoi5 = ("gsaoi5", ScienceFold.Position(Sky, Gsaoi, 5))
+  private val testVals = List(ao2gmos3, gcal2nifs1, gsaoi5)
+
+  "ScienceFoldPositionCodex" should "properly decode EPICS strings into ScienceFold values" in {
+
+    testVals.foreach{
+      case (s, v) => decode[String, Option[ScienceFold]](s) shouldBe Some(v)
+    }
+
+    decode[String, Option[ScienceFold]](invalid) shouldBe None
+
+    decode[String, Option[ScienceFold]](parked._1) shouldBe Some(parked._2)
+
+  }
+  it should "properly encode Position values into EPICS strings" in {
+
+    decode[String, Option[ScienceFold]](invalid) shouldBe None
+
+    testVals.foreach{
+      case (s, v) => encode[ScienceFold.Position, String](v) shouldBe s
+    }
+
+  }
+
+}


### PR DESCRIPTION
Reading of the science fold position would sometimes cause an error. It is OK if the error was that it couldn't read an EPICS channel, but in most cases, the error was caused because it could not transform the read position into a certain type, which is not OK. The type used was designed to represent positions that make sense for a given observation, but missed other posible values of the science fold position.
The solution introduces a new type to represent the real science fold position.