### PR TITLE
SEQNG-939 First batch of Altair bugfixes

### DIFF
--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaWindowStabilizer.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaWindowStabilizer.java
@@ -148,7 +148,14 @@ public class CaWindowStabilizer<T> implements CaAttribute<T> {
     }
 
     public CaWindowStabilizer<T> reset() {
-        filteredVal = lastVal = null;
+        filteredVal = null;
+        //Restart the timer
+        if (timeoutFuture != null) {
+            timeoutFuture.cancel(true);
+        }
+        timeoutFuture = executor.schedule(() -> CaWindowStabilizer.this.onTimeout(),
+            settleTime.toMillis(), TimeUnit.MILLISECONDS);
+
         return this;
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
@@ -38,8 +38,8 @@ class Altair[F[_]: Sync] private (controller: AltairController[F],
 
   def usesOI(guide: AltairConfig): Boolean = guide match {
     case LgsWithOi |
-         Ngs(true) => true
-    case _         => false
+         Ngs(true, _) => true
+    case _            => false
   }
 
   def isFollowing: F[Option[Boolean]] = controller.isFollowing

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairController.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.implicits._
 import seqexec.server.tcs.Gaos.{PauseCondition, ResumeCondition}
 import squants.Time
+import squants.space.Length
 
 trait AltairController[F[_]] {
   import AltairController._
@@ -26,8 +27,8 @@ object AltairController {
   sealed trait AltairConfig
 
   case object AltairOff extends AltairConfig
-  final case class Ngs(blend: Boolean) extends AltairConfig
-  final case class Lgs(strap: Boolean, sfo: Boolean) extends AltairConfig
+  final case class Ngs(blend: Boolean, starPos: (Length, Length)) extends AltairConfig
+  final case class Lgs(strap: Boolean, sfo: Boolean, starPos: (Length, Length)) extends AltairConfig
   case object LgsWithP1 extends AltairConfig
   case object LgsWithOi extends AltairConfig
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
@@ -133,7 +133,7 @@ object TcsConfigRetriever {
     for {
       useAo <- getStatusVal(TcsEpics.instance.useAo, "use AO flag")
       aoFol <- getStatusVal(getAoFollow, "AO follow state").map(_.fold(FollowOn, FollowOff))
-      prk   <- getStatusVal(TcsEpics.instance.oiParked, "OIWFS parked state")
+      prk   <- getStatusVal(TcsEpics.instance.p2Parked, "PWFS2 parked state")
       trk   <- getStatusVal(getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig), "PWFS2 tracking configuration")
       fol   <- getStatusVal(TcsEpics.instance.p2FollowS.map(_.map(decode[String, FollowOption])), "PWFS2 follow state")
       wfs   <- getStatusVal(TcsEpics.instance.pwfs2On.map(_.map(decode[BinaryYesNo, GuiderSensorOption])), "PWFS2 detector")
@@ -141,7 +141,7 @@ object TcsConfigRetriever {
             else Left(GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs))
 
   private def getOiwfs: SeqAction[GuiderConfig] = for {
-    prk <- getStatusVal(TcsEpics.instance.p1Parked, "OIWFS parked state")
+    prk <- getStatusVal(TcsEpics.instance.oiParked, "OIWFS parked state")
     trk <- getStatusVal(getNodChopTrackingConfig(TcsEpics.instance.oiwfsProbeGuideConfig), "OIWFS tracking configuration")
     fol <- getStatusVal(TcsEpics.instance.oiFollowS.map(_.map(decode[String, FollowOption])), "OIWFS follow state")
     wfs <- getStatusVal(TcsEpics.instance.oiwfsOn.map(_.map(decode[BinaryYesNo, GuiderSensorOption])), "OIWFS detector")

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSpec.scala
@@ -13,6 +13,7 @@ import seqexec.server.altair.AltairController.Lgs
 import seqexec.server.tcs.TcsController.ComaOption.{ComaOff, ComaOn}
 import seqexec.server.tcs.TcsController.MountGuideOption.{MountGuideOff, MountGuideOn}
 import seqexec.server.tcs.TcsController.{M1GuideOn, M1Source, M2GuideOn, TelescopeGuideConfig, TipTiltSource}
+import squants.space.Millimeters
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 final class GuideConfigDbSpec extends FlatSpec {
@@ -65,7 +66,9 @@ final class GuideConfigDbSpec extends FlatSpec {
         "sfoOn": true,
         "useOI": false,
         "useP1": false,
-        "oiBlend": false
+        "oiBlend": false,
+        "aogsx": -5.0,
+        "aogsy": 3.0
       }
     }
   }
@@ -76,7 +79,7 @@ final class GuideConfigDbSpec extends FlatSpec {
       M1GuideOn(M1Source.PWFS1),
       M2GuideOn(ComaOn, Set(TipTiltSource.PWFS1))
     ),
-    Some(Left(Lgs(strap = true, sfo = true)))
+    Some(Left(Lgs(strap = true, sfo = true, starPos = (Millimeters(-5.0), Millimeters(3.0)))))
   )
 
   "GuideConfigDb" should "provide decoders" in {


### PR DESCRIPTION
* Predicting the next AO target position before applying an offset requires to know the current value but retrieving it at each step is unreliable. Instead, now TCC captures the position when the Altair is enabled, and passes it to Seqexec.
* Fixed a bug where Altair was not enabled if was not disabled in the same step (it would fail to restart after an unguided step)
* In Altair, check the current status to decide if it necessary to send a command.
* Fixed some typos in the code the retrieves the current P2 and OI configuration from TCS.