### PR TITLE
SEQNG-942 Keep frozen probes in following state.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Tcs.scala
@@ -137,7 +137,7 @@ object Tcs {
   implicit class GuideWithOps(guideWith: StandardGuideOptions.Value) {
     val toProbeTracking: ProbeTrackingConfig = guideWith match {
       case StandardGuideOptions.Value.park => ProbeTrackingConfig.Parked
-      case StandardGuideOptions.Value.freeze => ProbeTrackingConfig.Off
+      case StandardGuideOptions.Value.freeze => ProbeTrackingConfig.Frozen
       case StandardGuideOptions.Value.guide => ProbeTrackingConfig.On(NodChopTrackingConfig.Normal)
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
@@ -108,10 +108,9 @@ object TcsConfigRetriever {
   ).value
 
   private def calcProbeTrackingConfig(f: FollowOption, t: NodChopTrackingConfig): ProbeTrackingConfig = (f, t) match {
-    case (_, NodChopTrackingConfig.AllOff)            => ProbeTrackingConfig.Off
-    case (FollowOn, NodChopTrackingConfig.Normal)     => ProbeTrackingConfig.On(NodChopTrackingConfig.Normal)
-    case (FollowOn, v: NodChopTrackingConfig.Special) => ProbeTrackingConfig.On(v)
-    case _                                            => ProbeTrackingConfig.Off
+    case (FollowOff, _)                            => ProbeTrackingConfig.Off
+    case (FollowOn, NodChopTrackingConfig.AllOff)  => ProbeTrackingConfig.Frozen
+    case (FollowOn, v:ActiveNodChopTracking)       => ProbeTrackingConfig.On(v)
   }
 
   implicit private val decodeFollowOption: DecodeEpicsValue[String, FollowOption] = DecodeEpicsValue((s: String)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -204,12 +204,14 @@ object TcsController {
     case object Parked extends ProbeTrackingConfig(FollowOff, NodChopTrackingConfig.AllOff)
     case object Off extends ProbeTrackingConfig(FollowOff, NodChopTrackingConfig.AllOff)
     final case class On(ndconfig: ActiveNodChopTracking) extends ProbeTrackingConfig(FollowOn, ndconfig)
+    case object Frozen extends ProbeTrackingConfig(FollowOn, NodChopTrackingConfig.AllOff)
 
     implicit val onEq: Eq[On] = Eq.by(_.ndconfig)
 
     implicit val eq: Eq[ProbeTrackingConfig] = Eq.instance{
       case (Parked, Parked)   => true
       case (Off, Off)         => true
+      case (Frozen, Frozen)   => true
       case (a@On(_), b@On(_)) => a === b
       case _                  => false
     }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
@@ -80,7 +80,8 @@ object TcsControllerEpics extends TcsController {
         d match {
           case ProbeTrackingConfig.Parked => (c =!= ProbeTrackingConfig.Parked).option(guideControl.parkCmd.mark)
           case ProbeTrackingConfig.On(_) |
-               ProbeTrackingConfig.Off    => (c.follow =!= d.follow)
+               ProbeTrackingConfig.Off   |
+               ProbeTrackingConfig.Frozen => (c.follow =!= d.follow)
             .option(guideControl.followCmd.setFollowState(encode(d.follow)))
         }
       ).collect{ case Some(x) => x }


### PR DESCRIPTION
Probes follow demands depending on two settings. The nod/chop guide configuration tells TCS when to send demands to the probes. The follow state tells the probe to follow such demands. When a big offset is applied, probes are frozen: they stay in their last position, and don't move. In this case, Seqexec was setting all nod/chop values to Off, and follow to Off. The last one was unnecessary, but also should have been inocuos. It ended up that it was causing problems with OIWFS, so I changed the code to not turn follow Off when freezing a probe (which is the behavior of the Tcl Seqexec)