### PR TITLE
SEQNG-944 Use guider dependent threshold for guiding while offsetting.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentGuide.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentGuide.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import seqexec.model.enum.Instrument
+import squants.space.Length
+
+trait InstrumentGuide {
+  def instrument: Instrument
+  def oiOffsetGuideThreshold: Option[Length]
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -8,9 +8,11 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.server.keywords.KeywordsClient
 import edu.gemini.spModel.config2.Config
 import gem.enum.LightSinkName
-import squants.Time
+import seqexec.model.enum.Instrument
+import squants.{Length, Time}
 
 trait InstrumentSystem[F[_]] extends System[F] {
+  override val resource: Instrument
   // The name used for this instrument in the science fold configuration
   def sfName(config: Config): LightSinkName
   val contributorName: String
@@ -22,6 +24,7 @@ trait InstrumentSystem[F[_]] extends System[F] {
   def calcObserveTime(config: Config): F[Time]
   def keywordsClient: KeywordsClient[F]
   def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress]
+  val oiOffsetGuideThreshold: Option[Length] = None
 }
 
 object InstrumentSystem {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -11,7 +11,7 @@ import gem.enum.LightSinkName
 import seqexec.model.enum.Instrument
 import squants.{Length, Time}
 
-trait InstrumentSystem[F[_]] extends System[F] {
+trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
   override val resource: Instrument
   // The name used for this instrument in the science fold configuration
   def sfName(config: Config): LightSinkName
@@ -24,7 +24,8 @@ trait InstrumentSystem[F[_]] extends System[F] {
   def calcObserveTime(config: Config): F[Time]
   def keywordsClient: KeywordsClient[F]
   def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress]
-  val oiOffsetGuideThreshold: Option[Length] = None
+  override val oiOffsetGuideThreshold: Option[Length] = None
+  override def instrument: Instrument = resource
 }
 
 object InstrumentSystem {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -440,14 +440,14 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
   ): TrySeq[List[System[IO]]] = {
     stepType match {
       case CelestialObject(inst) => toInstrumentSys(inst).map{sys => sys :: List(
-          Tcs.fromConfig(systems.tcs, hasOI(inst).fold(allButGaos, allButGaosNorOi), None, systems.guideDb)(
+          Tcs.fromConfig(systems.tcs, hasOI(inst).fold(allButGaos, allButGaosNorOi), None, sys, systems.guideDb)(
             config,
             LightPath(TcsController.LightSource.Sky, sys.sfName(config)),
             extractWavelength(config)),
           Gcal(systems.gcal, site == Site.GS)
       ) }
       case FlatOrArc(inst)       => toInstrumentSys(inst).map{sys => sys :: List(
-          Tcs.fromConfig(systems.tcs, flatOrArcTcsSubsystems(inst), None, systems.guideDb)(
+          Tcs.fromConfig(systems.tcs, flatOrArcTcsSubsystems(inst), None, sys, systems.guideDb)(
             config,
             LightPath(TcsController.LightSource.GCAL, sys.sfName(config)),
             extractWavelength(config)),
@@ -459,7 +459,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
         altair <- Altair.fromConfig(config, systems.altair)
       } yield sys :: List(
           Tcs.fromConfig(systems.tcs, hasOI(inst).fold(allButGaos, allButGaosNorOi).add(Gaos),
-            altair.asLeft.some, systems.guideDb)(config,
+            altair.asLeft.some, sys, systems.guideDb)(config,
             LightPath(TcsController.LightSource.AO, sys.sfName(config)),
             extractWavelength(config)),
           Gcal(systems.gcal, site == Site.GS)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -7,26 +7,31 @@ import cats.data.{EitherT, Reader}
 import cats.effect.IO
 import cats.implicits._
 import fs2.Stream
+import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2._
 import edu.gemini.spModel.obscomp.InstConstants.{DARK_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import java.lang.{Double => JDouble}
+
 import gem.enum.LightSinkName
+
 import scala.concurrent.duration.{Duration, SECONDS}
-import seqexec.model.enum.{Instrument, Resource}
+import seqexec.model.enum.Instrument
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.flamingos2.Flamingos2Controller._
 import seqexec.server._
 import seqexec.server.keywords.{DhsClient, DhsInstrument, KeywordsClient}
+import squants.Length
+import squants.space.Arcseconds
 import squants.time.{Seconds, Time}
 
 final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsClient[IO]) extends DhsInstrument[IO] with InstrumentSystem[IO] {
 
   import Flamingos2._
 
-  override val resource: Resource = Instrument.F2
+  override val resource: Instrument = Instrument.F2
 
   override def sfName(config: Config): LightSinkName = LightSinkName.F2
 
@@ -60,6 +65,9 @@ final case class Flamingos2(f2Controller: Flamingos2Controller, dhsClient: DhsCl
 
   override def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[IO, Progress] = f2Controller
     .observeProgress(total)
+
+  // TODO Use different value if using electronic offsets
+  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 }
 
 object Flamingos2 {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -17,7 +17,7 @@ import gem.optics.Format
 
 import scala.concurrent.duration._
 import seqexec.model.dhs.ImageFileId
-import seqexec.model.enum.{Instrument, Resource}
+import seqexec.model.enum.Instrument
 import seqexec.server.ConfigUtilOps._
 import seqexec.server._
 import seqexec.server.keywords.{GdsClient, GdsInstrument, KeywordsClient}
@@ -33,7 +33,7 @@ final case class Ghost[F[_]: Sync](controller: GhostController[F])
 
   override val keywordsClient: KeywordsClient[F] = this
 
-  override val resource: Resource = Instrument.Ghost
+  override val resource: Instrument = Instrument.Ghost
 
   override def sfName(config: Config): LightSinkName = LightSinkName.Ghost
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -29,7 +29,6 @@ import seqexec.server._
 import squants.space.Length
 import squants.{Seconds, Time}
 import squants.space.LengthConversions._
-import squants.time.Time
 
 abstract class Gmos[T<:GmosController.SiteDependentTypes](controller: GmosController[T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends DhsInstrument[IO] with InstrumentSystem[IO] {
   import Gmos._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -4,29 +4,39 @@
 package seqexec.server.gmos
 
 import cats.effect.IO
-import seqexec.model.enum.{ Instrument, Resource }
+import cats.implicits._
+import seqexec.model.enum.Instrument
 import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.{GmosNorthController, NorthTypes, northConfigTypes}
 import seqexec.server.keywords.DhsClient
+import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.GmosNorthType
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+import squants.Length
+import squants.space.Arcseconds
 
 final case class GmosNorth(c: GmosNorthController, dhsClient: DhsClient[IO]) extends Gmos[NorthTypes](c,
   new SiteSpecifics[NorthTypes] {
     override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
-    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] = config.extractAs[NorthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
-    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] = config.extractAs[NorthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
-    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] = config.extractAs[NorthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
-    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] = config.extractAs[NorthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
+    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
+      config.extractAs[NorthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
+    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] =
+      config.extractAs[NorthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
+    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] =
+      config.extractAs[NorthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
+    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
+      config.extractAs[NorthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
   })(northConfigTypes) {
-  override val resource: Resource = Instrument.GmosN
+  override val resource: Instrument = Instrument.GmosN
   override val dhsInstrumentName: String = "GMOS-N"
+  // TODO Use different value if using electronic offsets
+  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 }
 
 object GmosNorth {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -4,29 +4,40 @@
 package seqexec.server.gmos
 
 import cats.effect.IO
-import seqexec.model.enum.{ Instrument, Resource }
+import cats.implicits._
+import seqexec.model.enum.Instrument
 import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.{GmosSouthController, SouthTypes, southConfigTypes}
 import seqexec.server.keywords.DhsClient
+import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.GmosSouthType
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+import squants.Length
+import squants.space.Arcseconds
 
 final case class GmosSouth(c: GmosSouthController, dhsClient: DhsClient[IO]) extends Gmos[SouthTypes](c,
   new SiteSpecifics[SouthTypes] {
     override val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
-    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] = config.extractAs[SouthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
-    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] = config.extractAs[SouthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
-    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] = config.extractAs[SouthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
-    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] = config.extractAs[SouthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
+    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
+      config.extractAs[SouthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
+    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] =
+      config.extractAs[SouthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
+    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] =
+      config.extractAs[SouthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
+    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] =
+      config.extractAs[SouthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
   })(southConfigTypes) {
-  override val resource: Resource = Instrument.GmosS
+  override val resource: Instrument = Instrument.GmosS
   override val dhsInstrumentName: String = "GMOS-S"
+
+  // TODO Use different value if using electronic offsets
+  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 }
 
 object GmosSouth {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -15,7 +15,7 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.{INSTRUMENT_KEY, OBSERVE_KEY}
 import java.lang.{Double => JDouble, Integer => JInt}
 
 import gem.enum.LightSinkName
-import seqexec.model.enum.{Instrument, Resource}
+import seqexec.model.enum.Instrument
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gnirs.GnirsController.{CCConfig, DCConfig, Other, ReadMode}
@@ -49,7 +49,7 @@ final case class Gnirs(controller: GnirsController, dhsClient: DhsClient[IO]) ex
       .map(controller.calcTotalExposureTime[IO])
       .getOrElse(IO.pure(60.seconds))
 
-  override val resource: Resource = Instrument.Gnirs
+  override val resource: Instrument = Instrument.Gnirs
 
   override def configure(config: Config): SeqAction[ConfigResult[IO]] =
     SeqAction.either(fromSequenceConfig(config)).flatMap(controller.applyConfig).as(ConfigResult(this))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -18,7 +18,6 @@ import fs2.Stream
 import gem.enum.LightSinkName
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
-import seqexec.model.enum.Resource
 import seqexec.server.ConfigUtilOps._
 import seqexec.server._
 import seqexec.server.gpi.GpiController._
@@ -45,7 +44,7 @@ final case class Gpi[F[_]: Sync: Timer](controller: GpiController[F])
 
   override val keywordsClient: KeywordsClient[F] = this
 
-  override val resource: Resource = Instrument.Gpi
+  override val resource: Instrument = Instrument.Gpi
 
   override def sfName(config: Config): LightSinkName = LightSinkName.Gpi
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -17,15 +17,15 @@ import edu.gemini.spModel.obscomp.InstConstants.FLAT_OBSERVE_TYPE
 import edu.gemini.spModel.obscomp.InstConstants.OBSERVE_TYPE_PROP
 import edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_KEY
 import gem.enum.LightSinkName
-import java.lang.{ Double => JDouble }
-import java.lang.{ Integer => JInt }
+import java.lang.{Double => JDouble}
+import java.lang.{Integer => JInt}
 import java.beans.PropertyDescriptor
+
 import shapeless.tag
 import shapeless.tag.@@
 import seqexec.server.ConfigUtilOps._
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
-import seqexec.model.enum.Resource
 import seqexec.server.ConfigUtilOps.ExtractFailure
 import seqexec.server.ConfigResult
 import seqexec.server.InstrumentSystem
@@ -41,7 +41,9 @@ import seqexec.server.InstrumentSystem.AbortObserveCmd
 import seqexec.server.InstrumentSystem.InfraredControl
 import seqexec.server.InstrumentSystem.StopObserveCmd
 import seqexec.server.nifs.NifsController._
-import squants.Time
+import seqexec.server.tcs.FOCAL_PLANE_SCALE
+import squants.space.Arcseconds
+import squants.{Length, Time}
 import squants.time.TimeConversions._
 
 final case class Nifs[F[_]: LiftIO: Sync](
@@ -86,9 +88,11 @@ final case class Nifs[F[_]: LiftIO: Sync](
   ): fs2.Stream[F, Progress] =
     controller.observeProgress(total).streamLiftIO
 
+  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
+
   override val dhsInstrumentName: String = "NIFS"
 
-  override val resource: Resource = Instrument.Nifs
+  override val resource: Instrument = Instrument.Nifs
 
   /**
     * Called to configure a system

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -14,16 +14,18 @@ import edu.gemini.spModel.obscomp.InstConstants.{BIAS_OBSERVE_TYPE, DARK_OBSERVE
 import edu.gemini.seqexec.server.niri.ReadMode
 import seqexec.server.ConfigUtilOps._
 import seqexec.model.dhs.ImageFileId
-import seqexec.model.enum.{Instrument, Resource}
+import seqexec.model.enum.Instrument
 import seqexec.server.ConfigUtilOps.ExtractFailure
 import seqexec.server.{ConfigResult, ConfigUtilOps, InstrumentSystem, ObserveCommand, Progress, SeqAction, SeqActionF, SeqObserveF, SeqexecFailure, TrySeq}
 import seqexec.server.keywords.{DhsClient, DhsInstrument, KeywordsClient}
+import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import java.lang.{Double => JDouble, Integer => JInt}
 
 import gem.enum.LightSinkName
 import seqexec.server.InstrumentSystem.{AbortObserveCmd, InfraredControl, StopObserveCmd}
 import seqexec.server.niri.NiriController._
-import squants.Time
+import squants.space.Arcseconds
+import squants.{Length, Time}
 import squants.time.TimeConversions._
 
 final case class Niri(controller: NiriController, dhsClient: DhsClient[IO])
@@ -56,11 +58,13 @@ final case class Niri(controller: NiriController, dhsClient: DhsClient[IO])
   override def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime)
   : fs2.Stream[IO, Progress] = controller.observeProgress(total)
 
+  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
+
   override val dhsInstrumentName: String = "NIRI"
 
   override val keywordsClient: KeywordsClient[IO] = this
 
-  override val resource: Resource = Instrument.Niri
+  override val resource: Instrument = Instrument.Niri
 
   /**
     * Called to configure a system

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -7,7 +7,7 @@ import cats._
 import cats.data.{NonEmptySet, OneAnd}
 import cats.effect.IO
 import cats.implicits._
-import seqexec.server.{InstrumentSystem, SeqAction}
+import seqexec.server.{InstrumentGuide, SeqAction}
 import edu.gemini.spModel.core.Wavelength
 import gem.enum.LightSinkName
 import squants.{Angle, Length}
@@ -375,7 +375,7 @@ object TcsController {
     gds: GuidersConfig,
     agc: AGConfig,
     gaos: Option[Either[AltairConfig, GemsConfig]],
-    inst: InstrumentSystem[IO]
+    inst: InstrumentGuide
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -7,7 +7,7 @@ import cats._
 import cats.data.{NonEmptySet, OneAnd}
 import cats.effect.IO
 import cats.implicits._
-import seqexec.server.SeqAction
+import seqexec.server.{InstrumentSystem, SeqAction}
 import edu.gemini.spModel.core.Wavelength
 import gem.enum.LightSinkName
 import squants.{Angle, Length}
@@ -199,7 +199,9 @@ object TcsController {
   sealed abstract class ProbeTrackingConfig(
     val follow: FollowOption,
     val getNodChop: NodChopTrackingConfig
-  )
+  ) {
+    def isActive: Boolean = follow === FollowOn && getNodChop =!= NodChopTrackingConfig.AllOff
+  }
   object ProbeTrackingConfig {
     case object Parked extends ProbeTrackingConfig(FollowOff, NodChopTrackingConfig.AllOff)
     case object Off extends ProbeTrackingConfig(FollowOff, NodChopTrackingConfig.AllOff)
@@ -341,7 +343,9 @@ object TcsController {
   }
 
   @Lenses
-  final case class GuiderConfig(tracking: ProbeTrackingConfig, detector: GuiderSensorOption)
+  final case class GuiderConfig(tracking: ProbeTrackingConfig, detector: GuiderSensorOption) {
+    val isActive: Boolean = tracking.isActive && detector === GuiderSensorOn
+  }
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object GuiderConfig {
@@ -370,23 +374,12 @@ object TcsController {
     tc:  TelescopeConfig,
     gds: GuidersConfig,
     agc: AGConfig,
-    gaos: Option[Either[AltairConfig, GemsConfig]]
+    gaos: Option[Either[AltairConfig, GemsConfig]],
+    inst: InstrumentSystem[IO]
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object TcsConfig
-
-  val defaultConfig = TcsConfig(
-    TelescopeGuideConfig(MountGuideOption.MountGuideOff, M1GuideOff, M2GuideOff),
-    TelescopeConfig(None, None),
-    GuidersConfig(
-      tag[P1Config](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff)),
-      Left(tag[P2Config](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff))),
-      tag[OIConfig](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff))
-    ),
-    AGConfig(LightPath(LightSource.Sky, LightSinkName.Ac), HrwfsConfig.Auto.some),
-    None
-  )
 
   sealed trait Subsystem extends Product with Serializable
   object Subsystem {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
@@ -95,19 +95,19 @@ object TcsControllerEpics extends TcsController {
     }
     else none
 
-  private val pwfs1GuiderControl: GuideControl = GuideControl(Subsystem.PWFS1, TcsEpics.instance.pwfs1Park,
+  private def pwfs1GuiderControl: GuideControl = GuideControl(Subsystem.PWFS1, TcsEpics.instance.pwfs1Park,
     TcsEpics.instance.pwfs1ProbeGuideCmd, TcsEpics.instance.pwfs1ProbeFollowCmd)
 
   private val setPwfs1Probe = setGuideProbe(pwfs1GuiderControl, (EpicsTcsConfig.pwfs1 ^|-> GuiderConfig.tracking).set)(
     _, _, _)
 
-  private val pwfs2GuiderControl: GuideControl = GuideControl(Subsystem.PWFS2, TcsEpics.instance.pwfs2Park,
+  private def pwfs2GuiderControl: GuideControl = GuideControl(Subsystem.PWFS2, TcsEpics.instance.pwfs2Park,
     TcsEpics.instance.pwfs2ProbeGuideCmd, TcsEpics.instance.pwfs2ProbeFollowCmd)
 
   private val setPwfs2Probe = setGuideProbe(pwfs2GuiderControl,
     v => EpicsTcsConfig.pwfs2OrAowfs.modify(_.leftMap(GuiderConfig.tracking.set(v))))(_, _, _)
 
-  private val oiwfsGuiderControl: GuideControl = GuideControl(Subsystem.OIWFS, TcsEpics.instance.oiwfsPark,
+  private def oiwfsGuiderControl: GuideControl = GuideControl(Subsystem.OIWFS, TcsEpics.instance.oiwfsPark,
     TcsEpics.instance.oiwfsProbeGuideCmd, TcsEpics.instance.oiwfsProbeFollowCmd)
 
   private val setOiwfsProbe = setGuideProbe(oiwfsGuiderControl, (EpicsTcsConfig.oiwfs ^|-> GuiderConfig.tracking).set)(
@@ -149,11 +149,11 @@ object TcsControllerEpics extends TcsController {
     }
   }
 
-  private val setPwfs1 = setGuiderWfs(TcsEpics.instance.pwfs1ObserveCmd, TcsEpics.instance.pwfs1StopObserveCmd)(_)
+  private lazy val setPwfs1 = setGuiderWfs(TcsEpics.instance.pwfs1ObserveCmd, TcsEpics.instance.pwfs1StopObserveCmd)(_)
 
-  private val setPwfs2 = setGuiderWfs(TcsEpics.instance.pwfs2ObserveCmd, TcsEpics.instance.pwfs2StopObserveCmd)(_)
+  private lazy val setPwfs2 = setGuiderWfs(TcsEpics.instance.pwfs2ObserveCmd, TcsEpics.instance.pwfs2StopObserveCmd)(_)
 
-  private val setOiwfs = setGuiderWfs(TcsEpics.instance.oiwfsObserveCmd, TcsEpics.instance.oiwfsStopObserveCmd)(_)
+  private lazy val setOiwfs = setGuiderWfs(TcsEpics.instance.oiwfsObserveCmd, TcsEpics.instance.oiwfsStopObserveCmd)(_)
 
   val BottomPort: Int = 1
   val InvalidPort: Int = 0
@@ -272,8 +272,8 @@ object TcsControllerEpics extends TcsController {
   private val tcsTimeout = Seconds(60)
   private val agTimeout = Seconds(60)
 
-  private val pwfs1OffsetThreshold = Arcseconds(0.01)/FOCAL_PLANE_SCALE
-  private val pwfs2OffsetThreshold = Arcseconds(0.01)/FOCAL_PLANE_SCALE
+  val pwfs1OffsetThreshold: Length = Arcseconds(0.01)/FOCAL_PLANE_SCALE
+  val pwfs2OffsetThreshold: Length = Arcseconds(0.01)/FOCAL_PLANE_SCALE
   private def aoOffsetThreshold(instrument: Instrument): Option[Length] = instrument match {
     case Instrument.Nifs  => (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
     case Instrument.Niri  => (Arcseconds(3.0)/FOCAL_PLANE_SCALE).some
@@ -294,7 +294,7 @@ object TcsControllerEpics extends TcsController {
         .option(pwfs2OffsetThreshold),
       demand.inst.oiOffsetGuideThreshold
         .filter(_ => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.OIWFS, M1Source.OIWFS) && demand.gds.oiwfs.isActive),
-      aoOffsetThreshold(demand.inst.resource)
+      aoOffsetThreshold(demand.inst.instrument)
         .filter(_ => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.GAOS, M1Source.GAOS) &&
           demand.gds.pwfs2OrAowfs.exists(_.isActive)
         )

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/TcsControllerEpicsSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/TcsControllerEpicsSpec.scala
@@ -1,0 +1,359 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import cats.implicits._
+import edu.gemini.spModel.core.Wavelength
+import gem.enum.LightSinkName.Gmos
+import org.scalatest.{FlatSpec, PrivateMethodTester}
+import org.scalatest.Matchers._
+import seqexec.model.enum.Instrument
+import seqexec.server.InstrumentGuide
+import seqexec.server.tcs.TcsController.LightSource.Sky
+import seqexec.server.tcs.TcsController.MountGuideOption.MountGuideOff
+import seqexec.server.tcs.TcsController._
+import seqexec.server.tcs.TcsControllerEpics.{AoFold, EpicsTcsConfig, InstrumentPorts}
+import shapeless.tag
+import squants.space._
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+class TcsControllerEpicsSpec extends FlatSpec with PrivateMethodTester {
+  import TcsControllerEpicsSpec._
+
+  private val baseCurrentStatus = EpicsTcsConfig(
+    Arcseconds(33.8),
+    FocalPlaneOffset(tag[OffsetX](Millimeters(0.0)), tag[OffsetY](Millimeters(0.0))),
+    Wavelength(Microns(400)),
+    GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
+    Left(GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)),
+    GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
+    TelescopeGuideConfig(MountGuideOff, M1GuideOff, M2GuideOff),
+    AoFold.Out,
+    None,
+    HrwfsPickupPosition.OUT,
+    InstrumentPorts(
+      flamingos2Port = 5,
+      ghostPort = 0,
+      gmosPort = 3,
+      gnirsPort = 0,
+      gpiPort = 0,
+      gsaoiPort = 1,
+      nifsPort = 0,
+      niriPort = 0
+    )
+  )
+
+  private val baseConfig = TcsConfig(
+    TelescopeGuideConfig(MountGuideOff, M1GuideOff, M2GuideOff),
+    TelescopeConfig(None, None),
+    GuidersConfig(
+      tag[P1Config](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)),
+      Left(tag[P2Config](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff))),
+      tag[OIConfig](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff))
+    ),
+    AGConfig(LightPath(Sky, Gmos), None),
+    None,
+    DummyInstrument(None)
+  )
+
+  private val mustPauseWhileOffsetting = PrivateMethod[Boolean]('mustPauseWhileOffsetting)
+
+  "TcsControllerEpics" should "not pause guiding if it is not necessary" in {
+    //No offset
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      baseConfig
+    ) shouldBe false
+
+    //Offset, but no guider in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+        InstrumentOffset(
+          tag[OffsetP](TcsControllerEpics.pwfs1OffsetThreshold * 2 * FOCAL_PLANE_SCALE),
+          tag[OffsetQ](Arcseconds(0.0))
+        ).some
+      )(baseConfig)
+    ) shouldBe false
+  }
+
+  it should "decide if it can keep PWFS1 guiding active when applying an offset" in {
+    //Big offset with PWFS1 in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](TcsControllerEpics.pwfs1OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).set(
+            M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.PWFS1))
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs1).set(
+            tag[P1Config](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            ))
+          )
+        ) (baseConfig)
+    ) shouldBe true
+
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](TcsControllerEpics.pwfs1OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m1Guide).set(
+            M1GuideOn(M1Source.PWFS1)
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs1).set(
+            tag[P1Config](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            ))
+          )
+        ) (baseConfig)
+    ) shouldBe true
+
+    //Small offset with PWFS1 in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](TcsControllerEpics.pwfs1OffsetThreshold / 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).set(
+            M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.PWFS1))
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs1).set(
+            tag[P1Config](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            ))
+          )
+        ) (baseConfig)
+    ) shouldBe false
+  }
+
+  it should "decide if it can keep PWFS2 guiding active when applying an offset" in {
+    //Big offset with PWFS2 in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](TcsControllerEpics.pwfs2OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).set(
+            M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.PWFS2))
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs2OrAowfs).set(Left(
+            tag[P2Config](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            )))
+          )
+      )(baseConfig)
+    ) shouldBe true
+
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](TcsControllerEpics.pwfs2OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m1Guide).set(
+            M1GuideOn(M1Source.PWFS2)
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs2OrAowfs).set(Left(
+            tag[P2Config](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            )))
+          )
+      )(baseConfig)
+    ) shouldBe true
+
+    //Small offset with PWFS2 in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](TcsControllerEpics.pwfs2OffsetThreshold / 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).set(
+            M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.PWFS2))
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs2OrAowfs).set(Left(
+            tag[P2Config](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            )))
+          )
+      )(baseConfig)
+    ) shouldBe false
+
+  }
+
+  it should "decide if it can keep OIWFS guiding active when applying an offset" in {
+    val threshold = Millimeters(1.0)
+
+    //Big offset with OIWFS in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](threshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).set(
+            M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.OIWFS))
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.oiwfs).set(
+            tag[OIConfig](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            ))
+          ) >>>
+          TcsConfig.inst.set(DummyInstrument(threshold.some))
+      )(baseConfig)
+    ) shouldBe true
+
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](threshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m1Guide).set(
+            M1GuideOn(M1Source.OIWFS)
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.oiwfs).set(
+            tag[OIConfig](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            ))
+          ) >>>
+          TcsConfig.inst.set(DummyInstrument(threshold.some))
+      )(baseConfig)
+    ) shouldBe true
+
+    //Small offset with OIWFS in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](threshold / 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).set(
+            M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.OIWFS))
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.oiwfs).set(
+            tag[OIConfig](GuiderConfig(
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn
+            ))
+          ) >>>
+          TcsConfig.inst.set(DummyInstrument(threshold.some))
+      )(baseConfig)
+    ) shouldBe false
+  }
+
+  // The test uses only NIRI, although the threshold can be different for each instrument. The reason is that the
+  // goal of the test is to check that it works in general, not to test for the specific threshold of every
+  // instrument.
+  it should "decide if it can keep Altair guiding active when applying an offset" in {
+    val niriAoThreshold = Arcseconds(3.0)
+    //Big offset with Altair in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](niriAoThreshold * 2.0),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).set(
+            M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.GAOS))
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs2OrAowfs).set(Right(
+            tag[AoGuide](
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal)
+            ))
+          ) >>>
+          TcsConfig.inst.set(DummyInstrument(none))
+      )(baseConfig)
+    ) shouldBe true
+
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](niriAoThreshold * 2.0),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m1Guide).set(
+            M1GuideOn(M1Source.GAOS)
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs2OrAowfs).set(Right(
+            tag[AoGuide](
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal)
+            ))
+          ) >>>
+          TcsConfig.inst.set(DummyInstrument(none))
+      )(baseConfig)
+    ) shouldBe true
+
+    //Small offset with Altair in use
+    TcsControllerEpics invokePrivate mustPauseWhileOffsetting(
+      baseCurrentStatus,
+      (
+        (TcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
+          InstrumentOffset(
+            tag[OffsetP](niriAoThreshold / 2.0),
+            tag[OffsetQ](Arcseconds(0.0))
+          ).some
+        ) >>>
+          (TcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).set(
+            M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.GAOS))
+          ) >>>
+          (TcsConfig.gds ^|-> GuidersConfig.pwfs2OrAowfs).set(Right(
+            tag[AoGuide](
+              ProbeTrackingConfig.On(NodChopTrackingConfig.Normal)
+            ))
+          ) >>>
+          TcsConfig.inst.set(DummyInstrument(none))
+      )(baseConfig)
+    ) shouldBe false
+
+  }
+
+}
+
+object TcsControllerEpicsSpec {
+  final case class DummyInstrument(threshold: Option[Length]) extends InstrumentGuide {
+    override val instrument: Instrument = Instrument.Niri
+
+    override def oiOffsetGuideThreshold: Option[Length] = threshold
+  }
+}


### PR DESCRIPTION
Offsets can be applied without interrupting guiding if they are small enough. This PR implements that, and makes the decision threshold depend on the guider used.