### PR TITLE
SEQNG-922: Support NIRI's way to run observations

### DIFF
--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -723,7 +723,11 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
 
         @Override
         public CaObserveSenderImpl.ApplyState onCarValChange(final CarStateGeneric val) {
-            return new CaObserveSenderImpl.WaitApplyPreset(cm, val, carClid, observeState);
+            if ((carState == null || carState.isIdle()) && val.isBusy() && carClid > 0) {
+                return new CaObserveSenderImpl.WaitApplyIdle(cm, carClid, val, observeState);
+            } else {
+                return new CaObserveSenderImpl.WaitApplyPreset(cm, val, carClid, observeState);
+            }
         }
 
         @Override

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
@@ -331,7 +331,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     assert(observe.applyState().isIdle())
   }
 
-  ignore("NIRI normal observation") {
+  test("NIRI normal observation") {
     val context: CAJContext = mock[CAJContext]
     (context.addContextExceptionListener _).expects(*).returns(()).repeat(5)
     (context.addContextMessageListener _).expects(*).returns(()).repeat(5)


### PR DESCRIPTION
NIRI's observations aren't running properly after the last change to the ACM's state machine. This should fix it by handling the case where apply val changes after the clid