### PR TITLE
SEQNG-697: Sync the sequence when loading

### DIFF
--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -59,7 +59,7 @@ class SeqexecCommandRoutes(auth:       AuthenticationService,
 
     case POST -> Root / ObsIdVar(obsId) / "sync" as _ =>
       for {
-        u <- se.load(inputQueue, obsId)
+        u <- se.sync(inputQueue, obsId)
         resp <- u.fold(_ => NotFound(s"Not found sequence $obsId"),
                        _ => Ok(s"Sync requested for ${obsId.format}"))
       } yield resp


### PR DESCRIPTION
It would be useful to do a sync of the sequence when it is loaded. This way you get a fresh representation of the sequence

This PR does that on the backend