### PR TITLE
SEQNG-928: Protect reading odb observations

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -13,6 +13,7 @@ import cats.effect.{ConcurrentEffect, ContextShift, IO, Sync, Timer}
 import cats.implicits._
 import monocle.Monocle._
 import monocle.Optional
+import edu.gemini.seqexec.odb.SeqFailure
 import edu.gemini.epics.acm.CaService
 import gem.Observation
 import gem.enum.Site
@@ -102,7 +103,9 @@ class SeqexecEngine(httpClient: Client[IO], gpi: GpiClient[IO], ghost: GhostClie
   private val odbLoader = new ODBSequencesLoader(odbProxy, translator)
 
   def sync(q: EventQueue, seqId: Observation.Id): IO[Either[SeqexecFailure, Unit]] =
-    q.enqueue(Stream.emits(odbLoader.loadEvents(seqId))).map(_.asRight).compile.last.attempt.map(_.bimap(SeqexecFailure.SeqexecException.apply, _ => ()))
+    odbLoader.loadEvents(seqId).flatMap{ e =>
+      q.enqueue(Stream.emits(e)).map(_.asRight).compile.last.attempt.map(_.bimap(SeqexecFailure.SeqexecException.apply, _ => ()))
+    }
 
   // TODO: this is too much guessing. We should have proper tracking of systems' state.
   def failedInstruments(st: EngineState): Set[Resource] = st.sequences.values.toList.mapFilter(s =>
@@ -203,19 +206,23 @@ class SeqexecEngine(httpClient: Client[IO], gpi: GpiClient[IO], ghost: GhostClie
 
   def requestRefresh(q: EventQueue, clientId: ClientId): IO[Unit] = q.enqueue1(Event.poll(clientId))
 
-  def seqQueueRefreshStream: Stream[IO, executeEngine.EventType] = {
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Throw"))
+  def seqQueueRefreshStream: Stream[IO, Either[SeqexecFailure, executeEngine.EventType]] = {
     val fd = Duration(settings.odbQueuePollingInterval.toSeconds, TimeUnit.SECONDS)
-    Stream.fixedDelay[IO](fd).evalMap(_ => odbProxy.queuedSequences.value).map { x =>
-      Event.getState[executeEngine.ConcreteTypes](st =>
-        x.map(odbLoader.refreshSequenceList(_)(st)).valueOr(r =>
-          List(Event.logWarningMsg(SeqexecFailure.explain(r)))
-        ).some.filter(_.nonEmpty).map(Stream.emits(_).covary[IO])
-      )
+    Stream.fixedDelay[IO](fd).evalMap(_ => odbProxy.queuedSequences).flatMap { x =>
+      Stream.emit(Event.getState[executeEngine.ConcreteTypes]{st =>
+        Stream.eval(odbLoader.refreshSequenceList(x)(st)).flatMap(Stream.emits).some
+      }.asRight)
+    }.handleErrorWith {
+      case e: SeqFailure =>
+        Stream.emit(SeqexecFailure.OdbSeqError(e).asLeft)
+      case e: Exception =>
+        Stream.emit(SeqexecFailure.SeqexecException(e).asLeft)
     }
   }
 
   def eventStream(q: EventQueue): Stream[IO, SeqexecEvent] = {
-    stream(q.dequeue.mergeHaltBoth(seqQueueRefreshStream))(EngineState.default).flatMap(x =>
+    stream(q.dequeue.mergeHaltBoth(seqQueueRefreshStream.rethrow))(EngineState.default).flatMap(x =>
       Stream.eval(notifyODB(x))).flatMap {
         case (ev, qState) =>
           val sequences = qState.sequences.values.map(viewSequence).toList

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -214,10 +214,14 @@ class SeqexecEngine(httpClient: Client[IO], gpi: GpiClient[IO], ghost: GhostClie
         Stream.eval(odbLoader.refreshSequenceList(x)(st)).flatMap(Stream.emits).some
       }.asRight)
     }.handleErrorWith {
-      case e: SeqFailure =>
-        Stream.emit(SeqexecFailure.OdbSeqError(e).asLeft)
-      case e: Exception =>
-        Stream.emit(SeqexecFailure.SeqexecException(e).asLeft)
+      case _: SeqFailure =>
+        Stream.eval(IO(sys.exit(-1)))
+        // The line below vill do graceful exit when https://github.com/typelevel/cats-effect/issues/487 ges fixed
+        // Stream.emit(SeqexecFailure.OdbSeqError(e).asLeft)
+      case _: Exception =>
+        Stream.eval(IO(sys.exit(-1)))
+        // The line below vill do graceful exit when https://github.com/typelevel/cats-effect/issues/487 ges fixed
+        // Stream.emit(SeqexecFailure.SeqexecException(e).asLeft)
     }
   }
 

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -241,7 +241,7 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
   }
 
   def logError: PartialFunction[Throwable, IO[Unit]] = {
-    case e: Exception => IO.apply { logger.error(e)("Seqexec global error handler") }
+    case e: Exception => IO(logger.error(e)("Seqexec global error handler")) *> IO(sys.exit(-1))
   }
 
   /** Reads the configuration and launches the web server */
@@ -305,7 +305,7 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
         _      <- webServerIO(inq, out, engine, gcdb, cr, bec)
         _      <- Resource.liftF(engine.eventStream(inq).through(out.publish).compile.drain.start)
         _      <- Resource.liftF(logDone)
-        // _      <- Resource.liftF(f.join.onError(logError)) // We need to join to catch uncaught errors
+        _      <- Resource.liftF(f.join.onError(logError)) // We need to join to catch uncaught errors
       } yield ExitCode.Success
 
     r.use(_ => IO.never)

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -35,6 +35,7 @@ import seqexec.model.events._
 import seqexec.server
 import seqexec.server.tcs.GuideConfigDb
 import seqexec.server.{ControlStrategy, SeqexecConfiguration, SeqexecEngine, SeqexecMetrics, executeEngine}
+import seqexec.server.SeqexecFailure
 import seqexec.web.server.OcsBuildInfo
 import seqexec.web.server.logging.AppenderForClients
 import seqexec.web.server.security.{AuthenticationConfig, AuthenticationService, LDAPConfig}
@@ -210,10 +211,6 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
     logger.info(banner + msg)
   }
 
-  def logDone: IO[Unit] = IO {
-    logger.info("Seqexec completed")
-  }
-
   // We need to manually update the configuration of the logging subsystem
   // to support capturing log messages and forward them to the clients
   def logToClients(out: Topic[IO, SeqexecEvent]): IO[Appender[ILoggingEvent]] = IO.apply {
@@ -240,7 +237,11 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
     asyncAppender
   }
 
+  // Logger of error of last resort.
+  // Once https://github.com/typelevel/cats-effect/issues/487 is fixed we
+  // could remove the sys.exit calls
   def logError: PartialFunction[Throwable, IO[Unit]] = {
+    case e: SeqexecFailure => IO(logger.error(e)(s"Seqexec global error handler ${SeqexecFailure.explain(e)}")) *> IO(sys.exit(-1))
     case e: Exception => IO(logger.error(e)("Seqexec global error handler")) *> IO(sys.exit(-1))
   }
 
@@ -303,9 +304,9 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
         gcdb   <- Resource.liftF(GuideConfigDb.newDb[IO])
         engine <- engineIO(cli, gcdb, cr)
         _      <- webServerIO(inq, out, engine, gcdb, cr, bec)
-        _      <- Resource.liftF(engine.eventStream(inq).through(out.publish).compile.drain.start)
-        _      <- Resource.liftF(logDone)
-        _      <- Resource.liftF(f.join.onError(logError)) // We need to join to catch uncaught errors
+        _      <- Resource.liftF(engine.eventStream(inq).through(out.publish).compile.drain.onError(logError).start)
+        // The line below vill do graceful exit when https://github.com/typelevel/cats-effect/issues/487 ges fixed
+        // _      <- Resource.liftF(f.join) // We need to join to catch uncaught errors
       } yield ExitCode.Success
 
     r.use(_ => IO.never)


### PR DESCRIPTION
We've seen several times the session queue being empty. Some experiments demonstrate that if there is an exception when reading the odb sequences the stream that polls the odb dies. In that case the seqexec keeps running but there are no sequences

I want that if this happens (some error on the odb reading process) happens we log and kill the seqexec. While it may seem drastic it will ensure we fix any problems and note it right away

I tried to make the code exit gracefully but a `cats-effect` bug https://github.com/typelevel/cats-effect/issues/487 makes it harder, having to resort to `sys.exit`. When the bug is fixed this can be revisited