### PR TITLE
SEQNG-948 Only enable AO target guide on relevant Altair modes.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
@@ -46,6 +46,14 @@ class Altair[F[_]: Sync] private (controller: AltairController[F],
   }
 
   def isFollowing: F[Option[Boolean]] = controller.isFollowing
+
+  def hasTarget(guide: AltairConfig): Boolean = guide match {
+    case Lgs(st, sf, _) => st || sf
+    case LgsWithOi      => false
+    case LgsWithP1      => false
+    case Ngs(_, _)      => true
+    case AltairOff      => false
+  }
 }
 
 object Altair {


### PR DESCRIPTION
This is to fix a bug where Seqexec was enabling guiding for the AO target in TCS, even for Altair modes without a guide target.