### PR TITLE
SEQNG-952 Consistently sort the subsystems

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -81,7 +81,10 @@ object StepProgressCell {
       ),
       <.div(
         SeqexecStyles.subsystems,
-        step.configStatus.map(Function.tupled(statusLabel)).toTagMod
+        step.configStatus
+          .sortBy(_._1)
+          .map(Function.tupled(statusLabel))
+          .toTagMod
       )
     )
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -31,18 +31,18 @@ import web.client.style._
   */
 object SubsystemControlCell {
   final case class Props(
-                          id:             Observation.Id,
-                          stepId:         Int,
-                          resources:      List[Resource],
-                          resourcesCalls: SortedMap[Resource, ResourceRunOperation])
+    id:             Observation.Id,
+    stepId:         Int,
+    resources:      List[Resource],
+    resourcesCalls: SortedMap[Resource, ResourceRunOperation])
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   def requestResourceCall(
-                           id:     Observation.Id,
-                           stepId: StepId,
-                           r:      Resource
-                         )(e:      ReactEvent): Callback =
+    id:     Observation.Id,
+    stepId: StepId,
+    r:      Resource
+  )(e:      ReactEvent): Callback =
     e.preventDefaultCB *> e.stopPropagationCB *>
       SeqexecCircuit.dispatchCB(RequestResourceRun(id, stepId, r))
 
@@ -56,7 +56,7 @@ object SubsystemControlCell {
     .render_P { p =>
       <.div(
         SeqexecStyles.notInMobile,
-        p.resources.map { r =>
+        p.resources.sorted.map { r =>
           val inExecution =
             p.resourcesCalls
               .get(r)


### PR DESCRIPTION
This is a small bug fix. The subsystem buttons should be sorted consistently

Before:
![Seqexec - GS-2018B-Q-0-71 2019-03-28 14-55-24](https://user-images.githubusercontent.com/3615303/55181939-7652d000-516b-11e9-86e4-3c14d1ecb325.png)

After:
![image](https://user-images.githubusercontent.com/3615303/55181972-87034600-516b-11e9-8b37-6946a1934b1b.png)
