### PR TITLE
SEQNG-950 Handle several border cases enabling action buttons on them

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
@@ -88,7 +88,7 @@ trait ModelLenses {
       case e @ ConditionsUpdated(_)            => e.copy(view = q)
       case e @ StepSkipMarkChanged(_)          => e.copy(view = q)
       case e @ SequencePauseRequested(_)       => e.copy(view = q)
-      case e @ SequencePauseCanceled(_)        => e.copy(view = q)
+      case e @ SequencePauseCanceled(_, _)     => e.copy(view = q)
       case e @ SequenceRefreshed(_, _)         => e.copy(view = q)
       case e @ ActionStopRequested(_)          => e.copy(view = q)
       case e @ SequenceError(_, _)             => e.copy(view = q)

--- a/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
@@ -234,12 +234,13 @@ object events {
       Eq.by(_.view)
   }
 
-  final case class SequencePauseCanceled(view: SequencesQueue[SequenceView])
+  final case class SequencePauseCanceled(obsId: Observation.Id,
+                                         view:  SequencesQueue[SequenceView])
       extends SeqexecModelUpdate
 
   object SequencePauseCanceled {
     implicit lazy val equal: Eq[SequencePauseCanceled] =
-      Eq.by(_.view)
+      Eq.by(x => (x.obsId, x.view))
   }
 
   final case class SequenceRefreshed(view:     SequencesQueue[SequenceView],

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -63,7 +63,10 @@ trait SequenceEventsArbitraries extends ArbTime {
     arbitrary[SequencesQueue[SequenceView]].map(SequencePauseRequested.apply)
   }
   implicit val spcArb = Arbitrary[SequencePauseCanceled] {
-    arbitrary[SequencesQueue[SequenceView]].map(SequencePauseCanceled.apply)
+    for {
+      i <- arbitrary[Observation.Id]
+      s <- arbitrary[SequencesQueue[SequenceView]]
+    } yield SequencePauseCanceled(i, s)
   }
   implicit val srfArb = Arbitrary[SequenceRefreshed] {
     for {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -944,7 +944,7 @@ object SeqexecEngine extends SeqexecConfiguration {
       case engine.UserCommandResponse(ue, _, uev) => ue match {
         case engine.Start(_, _, _, _)      => SequenceStart(svs)
         case engine.Pause(_, _)            => SequencePauseRequested(svs)
-        case engine.CancelPause(_, _)      => SequencePauseCanceled(svs)
+        case engine.CancelPause(id, _)     => SequencePauseCanceled(id, svs)
         case engine.Breakpoint(_, _, _, _) => StepBreakpointChanged(svs)
         case engine.SkipMark(_, _, _, _)   => StepSkipMarkChanged(svs)
         case engine.Poll(cid)              => SequenceRefreshed(svs, cid)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -96,10 +96,12 @@ object actions {
   final case class RunStopCompleted(s:     Observation.Id) extends Action
   final case class RunStopFailed(s:        Observation.Id) extends Action
   final case class ClearRunOnError(s:      Observation.Id) extends Action
+  final case class ClearOperations(s:      Observation.Id) extends Action
+  final case object ClearAllOperations                     extends Action
   final case class RunAbort(s:             Observation.Id) extends Action
   final case class RunAbortFailed(s:       Observation.Id) extends Action
   final case class RunObsPause(s:          Observation.Id) extends Action
-  final case class RunObsResume(s:          Observation.Id) extends Action
+  final case class RunObsResume(s:         Observation.Id) extends Action
   final case class RunObsPauseFailed(s:    Observation.Id) extends Action
   final case class RunObsResumeFailed(s:   Observation.Id) extends Action
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -73,7 +73,7 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
 
   def handleOperationResult: PartialFunction[Any, ActionResult[M]] = {
     case RunStarted(_) | RunStop(_) | RunAbort(_) | RunObsPause(_) |
-        RunObsResume(_) =>
+        RunObsResume(_) | RunPaused(_) | RunCancelPaused(_) =>
       noChange
 
     case RunSync(id) =>
@@ -140,6 +140,12 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
 
     case ClearRunOnError(id) =>
       updated(value.resetOperations(id))
+
+    case ClearOperations(id) =>
+      updated(value.resetOperations(id))
+
+    case ClearAllOperations =>
+      updated(value.resetAllOperations)
   }
 
   override def handle: PartialFunction[Any, ActionResult[M]] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/SequenceDisplayHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/SequenceDisplayHandler.scala
@@ -40,12 +40,12 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus])
 
   }
 
-  def handleCalTabObserver: PartialFunction[Any, ActionResult[M]] = {
+  private def handleCalTabObserver: PartialFunction[Any, ActionResult[M]] = {
     case UpdateCalTabObserver(o) =>
       updatedL(SequencesFocus.sod.modify(_.updateCalTabObserver(o)))
   }
 
-  def handleShowHideStep: PartialFunction[Any, ActionResult[M]] = {
+  private def handleShowHideStep: PartialFunction[Any, ActionResult[M]] = {
     case ShowPreviewStepConfig(i, id, step) =>
       val seq = SequencesQueue
         .queueItemG[SequenceView](_.id === id)
@@ -67,12 +67,12 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus])
 
   }
 
-  def handleClean: PartialFunction[Any, ActionResult[M]] = {
+  private def handleClean: PartialFunction[Any, ActionResult[M]] = {
     case CleanSequences =>
-      updatedL(SequencesFocus.sod.modify(_.cleanAll))
+      noChange
   }
 
-  def handleLoadFailed: PartialFunction[Any, ActionResult[M]] = {
+  private def handleLoadFailed: PartialFunction[Any, ActionResult[M]] = {
     case SequenceLoadFailed(id) =>
       updatedL(SequencesFocus.sod.modify(_.loadingFailed(id)))
   }
@@ -81,5 +81,6 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus])
     List(handleSelectSequenceDisplay,
          handleShowHideStep,
          handleLoadFailed,
+         handleClean,
          handleCalTabObserver).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -414,6 +414,9 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
   def resetOperations(id: Observation.Id): SequencesOnDisplay =
     markOperations(id, _ => TabOperations.Default)
 
+  def resetAllOperations: SequencesOnDisplay =
+    loadedIds.foldLeft(this)((sod, id) => sod.resetOperations(id))
+
   def selectStep(
     id:   Observation.Id,
     step: StepId


### PR DESCRIPTION
The action buttons on the UI are disabled while an action is happening. they should be enabled when an action completes but there are a few edge cases where it isn't happening

This PR fixes several of them