### PR TITLE
SEQNG-963: Smarter selection of the next step

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
@@ -23,6 +23,7 @@ final case class StepsTableFocus(id:                  Observation.Id,
                                  stepConfigDisplayed: Option[Int],
                                  nextStepToRun:       Option[StepId],
                                  selectedStep:        Option[StepId],
+                                 runningStep:         Option[RunningStep],
                                  isPreview:           Boolean,
                                  tableState:          TableState[StepsTable.TableColumn],
                                  tabOperations:       TabOperations)
@@ -39,6 +40,7 @@ object StepsTableFocus {
          x.stepConfigDisplayed,
          x.nextStepToRun,
          x.selectedStep,
+         x.runningStep,
          x.isPreview,
          x.tableState,
          x.tabOperations))
@@ -60,6 +62,7 @@ object StepsTableFocus {
             sequence.nextStepToRun,
             tab.selectedStep
               .orElse(sequence.nextStepToRun), // start with the nextstep selected
+            sequence.runningStep,
             tab.isPreview,
             tab.tableState,
             tab.tabOperations

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -552,10 +552,11 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         n  <- arbitrary[Option[Int]]
         e  <- arbitrary[Option[Int]]
         se <- arbitrary[Option[StepId]]
+        rs <- arbitrary[Option[RunningStep]]
         p  <- arbitrary[Boolean]
         ts <- arbitrary[TableState[StepsTable.TableColumn]]
         to <- arbitrary[TabOperations]
-      } yield StepsTableFocus(id, i, ss, s, n, e, se, p, ts, to)
+      } yield StepsTableFocus(id, i, ss, s, n, e, se, rs, p, ts, to)
     }
 
   implicit val sstCogen: Cogen[StepsTableFocus] =


### PR DESCRIPTION
The steps table shows the running subsystems buttons when the user selects a row. However when a sequence is running the selection is not updated. This is clearer when you pause in a breakpoint, there the sequence stops but the next step to be executed is not selected and the subsystems button doesn't show up until you click

this PR tracks the running sequence and updates thus showing the subsystem buttons right away:

![image](https://user-images.githubusercontent.com/3615303/55244359-d145ff00-521f-11e9-8512-6bd3fed6d596.png)
