### PR TITLE
SEQNG-903: Update smartgcal less often

### DIFF
--- a/app/seqexec-server/src/main/resources/update_smartgcal
+++ b/app/seqexec-server/src/main/resources/update_smartgcal
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -X POST http://localhost:9090/smartgcal/refresh

--- a/build.sbt
+++ b/build.sbt
@@ -705,6 +705,10 @@ lazy val app_seqexec_server = preventPublication(project.in(file("app/seqexec-se
     mappings in Universal += {
       val jar = (packageBin in Compile).value
       jar -> ("lib/" + jar.getName)
+    },
+    mappings in Universal += {
+      val f = (resourceDirectory in Compile).value / "update_smartgcal"
+      f -> ("bin/" + f.getName)
     }
   )
 

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SmartGcalRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SmartGcalRoutes.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.server.http4s
+
+import cats.effect.IO
+import cats.implicits._
+import org.http4s._
+import org.http4s.dsl.io._
+
+import edu.gemini.spModel.core.Peer
+import edu.gemini.spModel.gemini.calunit.smartgcal.CalibrationProviderHolder
+import edu.gemini.spModel.smartgcal.provider.CalibrationProviderImpl
+import edu.gemini.spModel.smartgcal.repository.CalibrationUpdater
+import edu.gemini.spModel.smartgcal.repository.CalibrationFileCache
+import edu.gemini.spModel.smartgcal.repository.CalibrationRemoteRepository
+import java.nio.file.Paths
+
+/**
+  * Rest Endpoints for SmartGceal
+  */
+class SmartGcalRoutes(smartGCalHost: String, smartGCalLocation: String) {
+
+  val peer       = new Peer(smartGCalHost, 8443, edu.gemini.spModel.core.Site.GS)
+  val calService = new CalibrationRemoteRepository(peer.host, peer.port)
+  val cachedRepo = new CalibrationFileCache(Paths.get(smartGCalLocation).toFile)
+  val provider   = new CalibrationProviderImpl(cachedRepo)
+  CalibrationProviderHolder.setProvider(provider)
+  CalibrationUpdater.instance.addListener(provider)
+  CalibrationUpdater.instance.start(cachedRepo, calService, Int.MaxValue)
+
+  val publicService: HttpRoutes[IO] = HttpRoutes.of {
+
+    case POST -> Root / "refresh" =>
+      IO(CalibrationUpdater.instance.updateNowInBackground()) *>
+        Ok("Smart GCal Refresh started")
+
+  }
+
+  def service: HttpRoutes[IO] = publicService
+}


### PR DESCRIPTION
We have noted that smartgcal updates, every 1h, may interfere with sequence execution. Besides, the data doesn't change often enough to need this frequent updates

This PR removes this auto update and adds an http endpoint to manually trigger the update

A cronjob will be setup on the seqexec hosts to daily update smartgcal files during the day giving the options for users to manually trigger if needed