### PR TITLE
SEQNG-124 Sequences can be started from arbitrary step.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -92,8 +92,9 @@ package server {
   final case class UpdateQueueRemove(qid: QueueId, seqs: List[Observation.Id], pos: List[Int]) extends SeqEvent
   final case class UpdateQueueMoved(qid: QueueId, cid: ClientId, oid: Observation.Id, pos: Int) extends SeqEvent
   final case class UpdateQueueClear(qid: QueueId) extends SeqEvent
-  final case class StartSysConfig(sid: Observation.Id, stepIs: StepId, res: Resource)
-    extends SeqEvent
+  final case class StartSysConfig(sid: Observation.Id, stepIs: StepId, res: Resource) extends SeqEvent
+  final case class Busy(sid: Observation.Id, cid: ClientId) extends SeqEvent
+  case object SequenceStart extends SeqEvent
   case object NullSeqEvent extends SeqEvent
 
   sealed trait ControlStrategy

--- a/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
@@ -115,6 +115,15 @@ object TestCommon {
     )))
   )
 
+  def sequenceNSteps(id: Observation.Id, n: Int): SequenceGen = SequenceGen(
+    id,
+    "",
+    Instrument.F2,
+    List.range(1, n).map(SequenceGen.PendingStepGen(_, Map(), Set.empty, SequenceGen.StepActionsGen(List(),
+      Map(), _ => List(List(pendingAction(Instrument.F2)))
+    )))
+  )
+
   def sequenceWithResources(id: Observation.Id, ins: Instrument, resources: Set[Resource]): SequenceGen = SequenceGen(
     id,
     "",
@@ -126,7 +135,7 @@ object TestCommon {
         )
       ),
       SequenceGen.PendingStepGen(
-        1, Map(), resources, SequenceGen.StepActionsGen(List(), resources.map(r => r ->pendingAction(r)).toMap,
+        2, Map(), resources, SequenceGen.StepActionsGen(List(), resources.map(r => r ->pendingAction(r)).toMap,
           _ =>List()
         )
       )

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -39,6 +39,12 @@ class SeqexecCommandRoutes(auth:       AuthenticationService,
         resp <- Ok(s"Started sequence $obsId")
       } yield resp
 
+    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "startFrom" / ClientIDVar(clientId) as _ =>
+      for {
+        _    <- se.startFrom(inputQueue, obsId, stepId, clientId)
+        resp <- Ok(s"Started sequence $obsId from step $stepId")
+      } yield resp
+
     case POST -> Root / ObsIdVar(obsId) / "pause" as user =>
       for {
         _    <- se.requestPause(inputQueue, obsId, user)


### PR DESCRIPTION
This PR modifies the back end to provide the ability to start a sequence from an arbitrary step. This is a feature already present in the old Tcl Seqexec. The implementation uses existing features. It marks all steps preceding the selected one as to be skipped (excluding already completed steps), and then runs the sequence.