### PR TITLE
SEQNG-865 Fixed bug in reading the current science fold position

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFoldPositionCodex.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFoldPositionCodex.scala
@@ -21,11 +21,7 @@ private[server] object ScienceFoldPositionCodex {
   private val GCAL_PREFIX = "gcal2"
   private val PARK_POS = "park-pos"
 
-  val lightSink: Parser[LightSinkName] =
-    many(letter).map { cs =>
-      val sinkName = cs.mkString
-      LightSinkName.all.find(_.name === sinkName)
-    }.collect { case Some(lsn) => lsn }
+  val lightSink: Parser[LightSinkName] = LightSinkName.all.foldMap(x => string(x.name).as(x))
 
   def prefixed(p: String, s: LightSource): Parser[ScienceFold] =
     (string(p) ~> lightSink ~ int).map { case (ls, port) => Position(s, ls, port) }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -229,7 +229,14 @@ object TcsController {
 
     implicit val show: Show[HrwfsPickupPosition] = Show.fromToString
 
-    implicit val eq: Eq[HrwfsPickupPosition] = Eq.fromUniversalEquals
+    implicit val eq: Eq[HrwfsPickupPosition] = Eq.instance{
+      case (IN, IN)         => true
+      case (OUT, OUT)       => true
+      case (Parked, Parked) => true
+      case _                => false
+    }
+
+    def isInTheWay(h: HrwfsPickupPosition): Boolean = h === IN
   }
 
   sealed trait HrwfsConfig

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/ScienceFoldPositionCodexSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/ScienceFoldPositionCodexSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import ScienceFoldPositionCodex._
 import seqexec.server.EpicsCodex._
-import gem.enum.LightSinkName.{Gmos, Nifs, Gsaoi}
+import gem.enum.LightSinkName.{Gmos, Gsaoi, Nifs, Niri_f32, F2}
 import seqexec.server.tcs.TcsController.LightSource.{AO, GCAL, Sky}
 import seqexec.server.tcs.TcsControllerEpics.ScienceFold
 
@@ -19,7 +19,9 @@ class ScienceFoldPositionCodexSpec extends FlatSpec {
   private val ao2gmos3 = ("ao2gmos3", ScienceFold.Position(AO, Gmos, 3))
   private val gcal2nifs1 = ("gcal2nifs1", ScienceFold.Position(GCAL, Nifs, 1))
   private val gsaoi5 = ("gsaoi5", ScienceFold.Position(Sky, Gsaoi, 5))
-  private val testVals = List(ao2gmos3, gcal2nifs1, gsaoi5)
+  private val ao2niri32 = ("ao2nirif32p5", ScienceFold.Position(AO, Niri_f32, 5))
+  private val f21 = ("f21", ScienceFold.Position(Sky, F2, 1))
+  private val testVals = List(ao2gmos3, gcal2nifs1, gsaoi5, ao2niri32, f21)
 
   "ScienceFoldPositionCodex" should "properly decode EPICS strings into ScienceFold values" in {
 


### PR DESCRIPTION
Most of the work was already done in SEQNG-892. Before sending an AG configuration, the current science fold position and HR pickup mirror position are compared with the requested ones. If they are the same, no command is sent.
This PR fixes two things. The first one is that there was a bug in the code that decoded the current science fold position (it was failing if the instrument part of the position name had numbers in it)
The second fix is that the HR positions OUT and parked are now considered equivalent. The HR will not be moved if it is in the OUT position and the request is for park (or the other way around)