### PR TITLE
SEQNG-967: Step configuration shows wrong values for optional parameters 

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
@@ -109,13 +109,19 @@ object ConfigUtilOps {
       implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, AO_SYSTEM_KEY / key).as[A]
 
+    private def sanitizeValue(s: Any): String = s match {
+      case x: edu.gemini.shared.util.immutable.Some[_] => s"${x.getValue}"
+      case _: edu.gemini.shared.util.immutable.None[_] => "None"
+      case _ => s"$s"
+    }
+
     // config syntax: cfg.toStepConfig
     def toStepConfig: StepConfig =
       c.itemEntries().groupBy(_.getKey.getRoot).map {
         case (subsystem, entries) =>
           SystemName.unsafeFromString(subsystem.getName) ->
             (entries.toList.map { e =>
-              (e.getKey.getPath, s"${e.getItemValue}")
+              (e.getKey.getPath, sanitizeValue(e.getItemValue))
             }(breakOut): Map[String, String])
       }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -11,6 +11,7 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
+import japgolly.scalajs.react.extra.Reusability
 import cats.implicits._
 import react.virtualized._
 import scala.scalajs.js
@@ -21,6 +22,7 @@ import seqexec.web.client.components.TableContainer
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.actions.UpdateStepsConfigTableState
 import web.client.table._
+import seqexec.web.client.reusability._
 
 object StepConfigTable {
   sealed trait TableColumn extends Product with Serializable
@@ -28,7 +30,8 @@ object StepConfigTable {
   case object ValueColumn extends TableColumn
 
   object TableColumn {
-    implicit val eq: Eq[TableColumn] = Eq.fromUniversalEquals
+    implicit val eq: Eq[TableColumn]             = Eq.fromUniversalEquals
+    implicit val reuse: Reusability[TableColumn] = Reusability.byRef
   }
 
   type Backend = RenderScope[Props, TableState[TableColumn], Unit]
@@ -50,6 +53,9 @@ object StepConfigTable {
         .lift(idx)
         .fold(SettingsRow.zero)(Function.tupled(SettingsRow.apply))
   }
+
+  implicit val propsReuse: Reusability[Props] =
+    Reusability.by(p => (p.settingsList, p.startState))
 
   // ScalaJS defined trait
   // scalastyle:off
@@ -181,6 +187,7 @@ object StepConfigTable {
         Table(settingsTableProps(b, size),
               b.state.columnBuilder(size, colBuilder(b, size)): _*)))
     )
+    .configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(p: Props): Unmounted[Props, TableState[TableColumn], Unit] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -116,7 +116,6 @@ object FilterCell {
         case Instrument.F2 =>
           instrumentFilterO
             .getOption(s)
-            .flatMap(enumerations.filter.F2Filter.get)
         case Instrument.Niri =>
           instrumentFilterO
             .getOption(s)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -13,6 +13,7 @@ import scala.collection.immutable.SortedMap
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.BatchExecState
 import seqexec.model.enum.Resource
+import seqexec.model.enum.SystemName
 import seqexec.model.Observer
 import seqexec.model.QueueId
 import seqexec.model.Step
@@ -58,6 +59,7 @@ package object reusability {
   implicit val stfReuse: Reusability[StepsTableAndStatusFocus] =
     Reusability.byEq
   implicit val tabSelReuse: Reusability[TabSelected] = Reusability.byRef
+  implicit val sysnReuse: Reusability[SystemName]    = Reusability.byRef
   implicit val sectReuse: Reusability[SectionVisibilityState] =
     Reusability.byRef
   implicit val potStateReuse: Reusability[PotState] = Reusability.byRef


### PR DESCRIPTION
Since anything can be stored on the mode sometimes we get weird objects from ocs2 `Some/None` types

![image (1)](https://user-images.githubusercontent.com/3615303/56070561-671c7680-5d56-11e9-998b-dcea94f97a4f.png)

This PR fixes this and also does a fix for F2 filters

After the fix we get:
<img width="892" alt="Seqexec - GS-2018B-Q-0-101 2019-04-12 18-44-30" src="https://user-images.githubusercontent.com/3615303/56070600-a0ed7d00-5d56-11e9-884a-75bec98c47a8.png">
