### PR TITLE
SEQNG-911: Subsystem button colors

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -728,6 +728,15 @@ body {
   display: flex;
 }
 
+.SeqexecStyles-completedIconCell {
+  justify-content: center;
+  min-width: 24px;
+  height: 100%;
+  align-items: center;
+  width: 100%;
+  display: flex;
+}
+
 .SeqexecStyles-errorCell {
   justify-content: center;
   min-width: 24px;
@@ -784,6 +793,10 @@ body {
 
 .SeqexecStyles-runningIcon {
   .queueText;
+}
+
+.SeqexecStyles-completedIcon {
+  .queueText
 }
 
 .SeqexecStyles-breakPointOnIcon {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -90,26 +90,27 @@ object actions {
   final case class RunFromFailed(id: Observation.Id, step: StepId)
       extends Action
 
-  final case class RunStarted(s:           Observation.Id) extends Action
-  final case class RunPaused(s:            Observation.Id) extends Action
-  final case class RunCancelPaused(s:      Observation.Id) extends Action
-  final case class RunSync(s:              Observation.Id) extends Action
-  final case class RunStartFailed(s:       Observation.Id) extends Action
-  final case class RunPauseFailed(s:       Observation.Id) extends Action
-  final case class RunCancelPauseFailed(s: Observation.Id) extends Action
-  final case class RunSyncFailed(s:        Observation.Id) extends Action
-  final case class RunStop(s:              Observation.Id) extends Action
-  final case class RunStopCompleted(s:     Observation.Id) extends Action
-  final case class RunStopFailed(s:        Observation.Id) extends Action
-  final case class ClearRunOnError(s:      Observation.Id) extends Action
-  final case class ClearOperations(s:      Observation.Id) extends Action
+  final case class  RunStarted(s:             Observation.Id) extends Action
+  final case class  RunPaused(s:              Observation.Id) extends Action
+  final case class  RunCancelPaused(s:        Observation.Id) extends Action
+  final case class  RunSync(s:                Observation.Id) extends Action
+  final case class  RunStartFailed(s:         Observation.Id) extends Action
+  final case class  RunPauseFailed(s:         Observation.Id) extends Action
+  final case class  RunCancelPauseFailed(s:   Observation.Id) extends Action
+  final case class  RunSyncFailed(s:          Observation.Id) extends Action
+  final case class  RunStop(s:                Observation.Id) extends Action
+  final case class  RunStopCompleted(s:       Observation.Id) extends Action
+  final case class  RunStopFailed(s:          Observation.Id) extends Action
+  final case class  ClearRunOnError(s:        Observation.Id) extends Action
+  final case class  ClearOperations(s:        Observation.Id) extends Action
   final case object ClearAllOperations                     extends Action
-  final case class RunAbort(s:             Observation.Id) extends Action
-  final case class RunAbortFailed(s:       Observation.Id) extends Action
-  final case class RunObsPause(s:          Observation.Id) extends Action
-  final case class RunObsResume(s:         Observation.Id) extends Action
-  final case class RunObsPauseFailed(s:    Observation.Id) extends Action
-  final case class RunObsResumeFailed(s:   Observation.Id) extends Action
+  final case class  ClearAllResouceOptions(s: Observation.Id) extends Action
+  final case class  RunAbort(s:               Observation.Id) extends Action
+  final case class  RunAbortFailed(s:         Observation.Id) extends Action
+  final case class  RunObsPause(s:            Observation.Id) extends Action
+  final case class  RunObsResume(s:           Observation.Id) extends Action
+  final case class  RunObsPauseFailed(s:      Observation.Id) extends Action
+  final case class  RunObsResumeFailed(s:     Observation.Id) extends Action
 
   // Queue actions
   final case class RequestAllSelectedSequences(qid: QueueId)                               extends Action

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -228,6 +228,9 @@ object SeqexecStyles {
   val runningIconCell: GStyle =
     GStyle.fromString("SeqexecStyles-runningIconCell")
 
+  val completedIconCell: GStyle =
+    GStyle.fromString("SeqexecStyles-completedIconCell")
+
   val errorCell: GStyle = GStyle.fromString("SeqexecStyles-errorCell")
 
   val skippedIconCell: GStyle =
@@ -244,6 +247,8 @@ object SeqexecStyles {
   val selectedIcon: GStyle = GStyle.fromString("SeqexecStyles-selectedIcon")
 
   val runningIcon: GStyle = GStyle.fromString("SeqexecStyles-runningIcon")
+
+  val completedIcon: GStyle = GStyle.fromString("SeqexecStyles-completedIcon")
 
   val breakPointOnIcon: GStyle =
     GStyle.fromString("SeqexecStyles-breakPointOnIcon")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -17,6 +17,7 @@ import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.raw.JsNumber
 import monocle.Lens
 import monocle.macros.GenLens
+
 import scala.scalajs.js
 import scala.math.min
 import react.common._
@@ -36,13 +37,12 @@ import seqexec.web.client.model.ModelOps._
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.circuit.StepsTableAndStatusFocus
 import seqexec.web.client.circuit.StepsTableFocus
-import seqexec.web.client.actions.UpdateStepTableState
-import seqexec.web.client.actions.UpdateSelectedStep
+import seqexec.web.client.actions.{ClearAllResouceOptions, UpdateSelectedStep, UpdateStepTableState}
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.components.TableContainer
 import seqexec.web.client.components.sequence.steps.OffsetFns._
 import seqexec.web.client.semanticui.elements.icon.Icon._
-import seqexec.web.client.semanticui.{ Size => SSize }
+import seqexec.web.client.semanticui.{Size => SSize}
 import seqexec.web.client.reusability._
 import react.virtualized._
 import web.client.style._
@@ -688,6 +688,8 @@ object StepsTable {
     b.props.obsId.map { id =>
       (SeqexecCircuit
         .dispatchCB(UpdateSelectedStep(id, i)) *>
+       SeqexecCircuit
+        .dispatchCB(ClearAllResouceOptions(id)) *>
         b.modState(State.selected.set(Some(i))) *>
         recomputeRowHeightsCB(min(b.state.selected.getOrElse(i), i)))
         .when(b.props

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
@@ -95,6 +95,7 @@ object StepIconCell {
     p.status match {
       case StepState.Running   => SeqexecStyles.runningIconCell
       case StepState.Skipped   => SeqexecStyles.skippedIconCell
+      case StepState.Completed => SeqexecStyles.completedIconCell
       case StepState.Failed(_) => SeqexecStyles.errorCell
       case _ if p.skip         => SeqexecStyles.skippedIconCell
       case _                   => SeqexecStyles.iconCell

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -60,14 +60,17 @@ object SubsystemControlCell {
           val inExecution =
             p.resourcesCalls
               .get(r)
-              .map(_ === ResourceRunOperation.ResourceRunInFlight)
-              .getOrElse(false)
+              .exists(_ === ResourceRunOperation.ResourceRunInFlight)
+          val completed =
+            p.resourcesCalls
+                .get(r)
+                .exists(_ === ResourceRunOperation.ResourceRunCompleted)
           Popup(
             Popup.Props("button", s"Configure ${r.show}"),
             Button(
               Button.Props(
                 size     = Size.Small,
-                color    = Some("blue"),
+                color    = if (inExecution) Some("yellow") else if (completed) Some("green") else Some("blue"),
                 disabled = inExecution,
                 labeled =
                   if (inExecution) Button.LeftLabeled else Button.NotLabeled,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -51,6 +51,13 @@ object SubsystemControlCell {
     loading     = true,
     extraStyles = List(SeqexecStyles.runningIcon))
 
+  // We want blue if the resource operation is idle or does not exist: these are equivalent cases.
+  private def buttonColor(op: Option[ResourceRunOperation]): Option[String] = op.map {
+    case ResourceRunOperation.ResourceRunIdle      => "blue"
+    case ResourceRunOperation.ResourceRunInFlight  => "yellow"
+    case ResourceRunOperation.ResourceRunCompleted => "green"
+  }.orElse(Some("blue"))
+
   private val component = ScalaComponent
     .builder[Props]("SubsystemControl")
     .render_P { p =>
@@ -61,16 +68,13 @@ object SubsystemControlCell {
             p.resourcesCalls
               .get(r)
               .exists(_ === ResourceRunOperation.ResourceRunInFlight)
-          val completed =
-            p.resourcesCalls
-                .get(r)
-                .exists(_ === ResourceRunOperation.ResourceRunCompleted)
+
           Popup(
             Popup.Props("button", s"Configure ${r.show}"),
             Button(
               Button.Props(
                 size     = Size.Small,
-                color    = if (inExecution) Some("yellow") else if (completed) Some("green") else Some("blue"),
+                color    = buttonColor(p.resourcesCalls.get(r)),
                 disabled = inExecution,
                 labeled =
                   if (inExecution) Button.LeftLabeled else Button.NotLabeled,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -75,7 +75,12 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
                                .set(StartFromOperation.StartFromInFlight)))
 
     case RunResourceComplete(id, _, r) =>
-      updated(value.markOperations(id, TabOperations.resourceRun(r).set(none)))
+      updated(
+        value.markOperations(
+          id,
+          TabOperations
+            .resourceRun(r).
+            set(ResourceRunOperation.ResourceRunCompleted.some)))
   }
 
   def handleOperationResult: PartialFunction[Any, ActionResult[M]] = {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -169,6 +169,9 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
 
     case ClearAllOperations =>
       updated(value.resetAllOperations)
+
+    case ClearAllResouceOptions(id) =>
+      updated(value.resetAllResourceOperations(id))
   }
 
   override def handle: PartialFunction[Any, ActionResult[M]] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -417,6 +417,9 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
   def resetAllOperations: SequencesOnDisplay =
     loadedIds.foldLeft(this)((sod, id) => sod.resetOperations(id))
 
+  def resetAllResourceOperations(id: Observation.Id): SequencesOnDisplay =
+    markOperations(id, TabOperations.clearResourceOperations)
+
   def selectStep(
     id:   Observation.Id,
     step: StepId

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
@@ -75,6 +75,7 @@ object SyncOperation {
 sealed trait ResourceRunOperation extends Product with Serializable
 object ResourceRunOperation {
   case object ResourceRunInFlight extends ResourceRunOperation
+  case object ResourceRunCompleted extends ResourceRunOperation
   case object ResourceRunIdle extends ResourceRunOperation
 
   implicit val eq: Eq[ResourceRunOperation] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
@@ -137,6 +137,10 @@ object TabOperations {
     r: Resource): Lens[TabOperations, Option[ResourceRunOperation]] =
     TabOperations.resourceRunRequested ^|-> at(r)
 
+  // Set the resource operations in the map to idle.
+  def clearResourceOperations: TabOperations => TabOperations =
+    TabOperations.resourceRunRequested.modify(_.map { case (r, _) => r -> ResourceRunOperation.ResourceRunIdle})
+
   val Default: TabOperations =
     TabOperations(
       RunOperation.RunIdle,

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -99,7 +99,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val arbResourceRunOperation: Arbitrary[ResourceRunOperation] =
     Arbitrary(
       Gen.oneOf(ResourceRunOperation.ResourceRunIdle,
-                ResourceRunOperation.ResourceRunInFlight))
+                ResourceRunOperation.ResourceRunInFlight,
+                ResourceRunOperation.ResourceRunCompleted))
 
   implicit val rruCogen: Cogen[ResourceRunOperation] =
     Cogen[String].contramap(_.productPrefix)


### PR DESCRIPTION
This PR changes the color of the subsystem buttons in an observation step, using:

- Blue: Idle / not configured.
- Yellow: Configuring.
- Green: Configured.

This is done by introducing a new state for subsystem configuration, namely `ResourceRunComplete`.

One thing I'm not entirely happy about is that when the table is first loaded, the map of resources to steps is an empty map; after that point, it becomes populated, and resources are moved to `ResourceRunIdle`.

One thought, given that I don't think we want to assume what resources are going to be used in advance: we use `Map.empty.withDefaultValue(ResourceRunOperation.ResourceRunIdle)` for the resource state map in `TabOperations.Default`. The issue with this is that the return from `SortedMap.withDefaultValue` is a `Map` instead of a `SortedMap` (although it will still be sorted: the underlying implementation remains a `SortedMap`).

I'm not entirely sure why we are using a `SortedMap` here: does it give us a significant advantage? In any case, the `SortedMap` is spread across a number of files (but as far as I can tell, not required), I'm not going to touch this until it's discussed further.

I'm including a video showing the change to this PR.

![seqng911](https://user-images.githubusercontent.com/8795653/56243290-3bf09a80-6068-11e9-882e-7b23eef84264.gif)
