### PR TITLE
SEQNG-959 Implemented GSAOI Epics code.

### DIFF
--- a/modules/acm/src/main/java/edu/gemini/epics/acm/ApplySenderWithResource.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/ApplySenderWithResource.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package edu.gemini.epics.acm;
+
+interface ApplySenderWithResource extends CaApplySender, CaResource {
+}

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -18,7 +18,7 @@ import edu.gemini.epics.api.ChannelListener;
 import gov.aps.jca.CAException;
 import gov.aps.jca.TimeoutException;
 
-final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements CaApplySender {
+final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements ApplySenderWithResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(CaApplySenderImpl.class
             .getName());
@@ -122,7 +122,8 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ca
         return car.getEpicsName();
     }
 
-    void unbind() {
+    @Override
+    public void unbind() {
 
         executor.shutdown();
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandSenderImpl.java
@@ -19,7 +19,9 @@ import edu.gemini.epics.impl.EpicsWriterImpl;
 import gov.aps.jca.CAException;
 import gov.aps.jca.TimeoutException;
 
-final class CaCommandSenderImpl implements CaCommandSender {
+interface CommandSenderWithResource extends CaCommandSender, CaResource {}
+
+final class CaCommandSenderImpl implements CommandSenderWithResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(CaCommandSenderImpl.class.getName());
 
@@ -67,6 +69,7 @@ final class CaCommandSenderImpl implements CaCommandSender {
     @Override
     public CaApplySender getApplySender() { return apply; }
 
+    @Override
     public void unbind() {
         assert (epicsWriter != null);
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Created by jluhrs on 10/17/17.
  */
-public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements CaApplySender {
+public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements ApplySenderWithResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(CaObserveSenderImpl.class.getName());
     private static final String CAD_MARK_SUFFIX = ".MARK";
@@ -159,7 +159,8 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
         return car.getEpicsName();
     }
 
-    void unbind() {
+    @Override
+    public void unbind() {
 
         executor.shutdown();
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaResource.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaResource.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package edu.gemini.epics.acm;
+
+interface CaResource {
+    void unbind();
+}

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -44,7 +44,7 @@ public final class CaService {
     private final Map<String, ApplySenderWithResource> applySenders;
     private final Map<String, ApplySenderWithResource> observeSenders;
     private final Map<String, CommandSenderWithResource> commandSenders;
-    private final Map<String, TaskControlWithResoource> taskControlSenders;
+    private final Map<String, TaskControlWithResource> taskControlSenders;
     static private String addrList = "";
     static private Duration ioTimeout = Duration.ofSeconds(1);
     static private CaService theInstance;
@@ -430,7 +430,7 @@ public final class CaService {
             throws CAException {
         CaTaskControl a = taskControlSenders.get(name);
         if(a == null) {
-            TaskControlWithResoource b = new CaTaskControlImpl(name, recordName, description, epicsService);
+            TaskControlWithResource b = new CaTaskControlImpl(name, recordName, description, epicsService);
             taskControlSenders.put(name, b);
             return b;
         } else {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -40,11 +40,11 @@ public final class CaService {
 
     private static final String EPICS_CA_ADDR_LIST = "EPICS_CA_ADDR_LIST";
     private EpicsService epicsService;
-    private final Map<String, CaStatusAcceptorImpl> statusAcceptors;
-    private final Map<String, CaApplySenderImpl> applySenders;
-    private final Map<String, CaObserveSenderImpl> observeSenders;
-    private final Map<String, CaCommandSenderImpl> commandSenders;
-    private final Map<String, CaTaskControlImpl> taskControlSenders;
+    private final Map<String, StatusAcceptorWithResource> statusAcceptors;
+    private final Map<String, ApplySenderWithResource> applySenders;
+    private final Map<String, ApplySenderWithResource> observeSenders;
+    private final Map<String, CommandSenderWithResource> commandSenders;
+    private final Map<String, TaskControlWithResoource> taskControlSenders;
     static private String addrList = "";
     static private Duration ioTimeout = Duration.ofSeconds(1);
     static private CaService theInstance;
@@ -114,15 +114,15 @@ public final class CaService {
     public void unbind() {
         assert (epicsService != null);
 
-        statusAcceptors.values().forEach(CaStatusAcceptorImpl::unbind);
+        statusAcceptors.values().forEach(CaResource::unbind);
 
-        applySenders.values().forEach(CaApplySenderImpl::unbind);
+        applySenders.values().forEach(CaResource::unbind);
 
-        observeSenders.values().forEach(CaObserveSenderImpl::unbind);
+        observeSenders.values().forEach(CaResource::unbind);
 
-        commandSenders.values().forEach(CaCommandSenderImpl::unbind);
+        commandSenders.values().forEach(CaResource::unbind);
 
-        taskControlSenders.values().forEach(CaTaskControlImpl::unbind);
+        taskControlSenders.values().forEach(CaResource::unbind);
 
         epicsService.stopService();
         epicsService = null;
@@ -140,13 +140,14 @@ public final class CaService {
      * @return the status acceptor.
      */
     public CaStatusAcceptor createStatusAcceptor(String name, String description) {
-        CaStatusAcceptorImpl sa = statusAcceptors.get(name);
-        if (sa == null) {
-            sa = new CaStatusAcceptorImpl(name, description, epicsService);
-            statusAcceptors.put(name, sa);
+        CaStatusAcceptor a = statusAcceptors.get(name);
+        if (a == null) {
+            StatusAcceptorWithResource b = new CaStatusAcceptorImpl(name, description, epicsService);
+            statusAcceptors.put(name, b);
+            return b;
+        } else {
+            return a;
         }
-
-        return sa;
     }
 
     public CaStatusAcceptor createStatusAcceptor(String name) {
@@ -178,22 +179,26 @@ public final class CaService {
      *            optional description for the apply sender.
      * @return the apply sender.
      * @throws CAException
+     *            Error in the Channel Access library.
      */
     public CaApplySender createApplySender(String name, String applyRecord,
             String carRecord, Boolean gem5, String description) throws CAException {
-        CaApplySenderImpl apply = applySenders.get(name);
-        if (apply == null) {
+        CaApplySender a = applySenders.get(name);
+        if (a == null) {
+            ApplySenderWithResource b;
             if(gem5) {
-                apply = new CaApplySenderImpl<>(name, applyRecord, carRecord,
+                b = new CaApplySenderImpl<>(name, applyRecord, carRecord,
                         description, CarStateGEM5.class, epicsService);
             }
             else {
-                apply = new CaApplySenderImpl<>(name, applyRecord, carRecord,
+                b = new CaApplySenderImpl<>(name, applyRecord, carRecord,
                         description, CarState.class, epicsService);
             }
-            applySenders.put(name, apply);
+            applySenders.put(name, b);
+            return b;
+        } else {
+            return a;
         }
-        return apply;
     }
 
     public CaApplySender createApplySender(String name, String applyRecord,
@@ -211,31 +216,85 @@ public final class CaService {
      *            the name of the EPICS apply record.
      * @param carRecord
      *            the name of the EPICS CAR record associated with the apply.
+     * @param observeCarRecord
+     *            the name of the EPICS CAR record for the observe state.
+     * @param gem5
+     *            CAR record uses GEM5 definition.
+     * @param stopCmdRecord
+     *            the name of the EPICS CAD for the stop command.
+     * @param abortCmdRecord
+     *            the name of the EPICS CAD for the abort command.
      * @param description
      *            optional description for the apply sender.
      * @return the apply sender.
      * @throws CAException
+     *            Error in the Channel Access library.
      */
     public CaApplySender createObserveSender(String name, String applyRecord,
             String carRecord, String observeCarRecord, Boolean gem5, String stopCmdRecord, String abortCmdRecord, String description) throws CAException {
-        CaObserveSenderImpl observe = observeSenders.get(name);
-        if (observe == null) {
+        CaApplySender a = observeSenders.get(name);
+        if (a == null) {
+            ApplySenderWithResource b;
             if(gem5) {
-                observe = new CaObserveSenderImpl(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
+                b = new CaObserveSenderImpl<CarStateGEM5>(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
                         description, CarStateGEM5.class, epicsService);
             }
             else  {
-                observe = new CaObserveSenderImpl(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
+                b = new CaObserveSenderImpl<CarState>(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
                         description, CarState.class, epicsService);
             }
-            observeSenders.put(name, observe);
+            observeSenders.put(name, b);
+            return b;
+        } else {
+            return a;
         }
-        return observe;
     }
 
     public CaApplySender createObserveSender(String name, String applyRecord,
             String carRecord, String observeCarRecord, Boolean gem5) throws CAException {
         return createObserveSender(name, applyRecord, carRecord, observeCarRecord, gem5, null, null, null);
+    }
+
+    /**
+     * Creates an apply sender specialized for Observe commands. If the apply sender already exists, it returns the
+     * existing object.
+     *
+     * @param name
+     *            the name of the new apply sender.
+     * @param applyRecord
+     *            the name of the EPICS apply record.
+     * @param carRecord
+     *            the name of the EPICS observe CAR record.
+     * @param gem5
+     *            CAR record uses GEM5 definition.
+     * @param stopCmdRecord
+     *            the name of the EPICS CAD for the stop command.
+     * @param abortCmdRecord
+     *            the name of the EPICS CAD for the abort command.
+     * @param description
+     *            optional description for the apply sender.
+     * @return the apply sender.
+     * @throws CAException
+     *            Error in the Channel Access library.
+     */
+    public CaApplySender createObserveSender(String name, String applyRecord,
+                                             String carRecord, Boolean gem5, String stopCmdRecord, String abortCmdRecord, String description) throws CAException {
+        CaApplySender a = observeSenders.get(name);
+        if (a == null) {
+            ApplySenderWithResource b;
+            if(gem5) {
+                b = new CaSimpleObserveSenderImpl<CarStateGEM5>(name, applyRecord, carRecord, stopCmdRecord, abortCmdRecord,
+                        description, CarStateGEM5.class, epicsService);
+            }
+            else  {
+                b = new CaSimpleObserveSenderImpl<CarState>(name, applyRecord, carRecord, stopCmdRecord, abortCmdRecord,
+                        description, CarState.class, epicsService);
+            }
+            observeSenders.put(name, b);
+            return b;
+        } else {
+            return a;
+        }
     }
 
     /**
@@ -266,13 +325,15 @@ public final class CaService {
      */
     public CaCommandSender createCommandSender(String name,
             CaApplySender apply, String cadName, String description) {
-        CaCommandSenderImpl cs = commandSenders.get(name);
-        if (cs == null) {
-            cs = new CaCommandSenderImpl(name, apply, description,
+        CaCommandSender a = commandSenders.get(name);
+        if (a == null) {
+            CommandSenderWithResource b = new CaCommandSenderImpl(name, apply, description,
                     epicsService, cadName);
-            commandSenders.put(name, cs);
+            commandSenders.put(name, b);
+            return b;
+        } else {
+            return a;
         }
-        return cs;
     }
 
     public CaCommandSender createCommandSender(String name,
@@ -325,7 +386,7 @@ public final class CaService {
      * @param name the name of the command sender to destroy.
      */
     public void destroyCommandSender(String name) {
-        CaCommandSenderImpl cs = commandSenders.remove(name);
+        CaResource cs = commandSenders.remove(name);
         if (cs != null) {
             cs.unbind();
         }
@@ -338,7 +399,7 @@ public final class CaService {
      * @param name the name of the apply sender to destroy.
      */
     public void destroyApplySender(String name) {
-        CaApplySenderImpl apply = applySenders.remove(name);
+        CaResource apply = applySenders.remove(name);
         if (apply != null) {
             apply.unbind();
         }
@@ -351,7 +412,7 @@ public final class CaService {
      * @param name the name of the status acceptor to destroy.
      */
     public void destroyStatusAcceptor(String name) {
-        CaStatusAcceptorImpl sa = statusAcceptors.remove(name);
+        CaResource sa = statusAcceptors.remove(name);
         if (sa != null) {
             sa.unbind();
         }
@@ -363,16 +424,18 @@ public final class CaService {
      * @param recordName the name of the EPICS record
      * @param description the description of the record.
      * @return the TaskControlSender
-     * @throws CAException
+     * @throws CAException Error in the Channel Access library.
      */
     public CaTaskControl createTaskControlSender(String name, String recordName, String description)
             throws CAException {
-        CaTaskControlImpl t = taskControlSenders.get(name);
-        if(t == null) {
-            t = new CaTaskControlImpl(name, recordName, description, epicsService);
-            taskControlSenders.put(name, t);
+        CaTaskControl a = taskControlSenders.get(name);
+        if(a == null) {
+            TaskControlWithResoource b = new CaTaskControlImpl(name, recordName, description, epicsService);
+            taskControlSenders.put(name, b);
+            return b;
+        } else {
+            return a;
         }
-        return t;
     }
 
     /**
@@ -389,7 +452,7 @@ public final class CaService {
      * @param name the name of the <code>TaskControlSender</code>
      */
     public void destroyTaskControlSender(String name) {
-        CaTaskControlImpl t = taskControlSenders.remove(name);
+        CaResource t = taskControlSenders.remove(name);
         if(t != null) {
             t.unbind();
         }

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaSimpleObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaSimpleObserveSenderImpl.java
@@ -1,0 +1,775 @@
+/*
+ * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package edu.gemini.epics.acm;
+
+import edu.gemini.epics.EpicsReader;
+import edu.gemini.epics.EpicsService;
+import edu.gemini.epics.ReadOnlyClientEpicsChannel;
+import edu.gemini.epics.api.ChannelListener;
+import edu.gemini.epics.impl.EpicsReaderImpl;
+import gov.aps.jca.CAException;
+import gov.aps.jca.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * Class to handle observe commands in instruments were there is no CAR for the apply. In those cases, The observe CAR
+ * handles all the command state.
+ */
+public class CaSimpleObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements ApplySenderWithResource {
+    private static final Logger LOG = LoggerFactory.getLogger(CaSimpleObserveSenderImpl.class.getName());
+    private static final String CAD_MARK_SUFFIX = ".MARK";
+
+    private final String name;
+    private final String description;
+
+    private final CaApplyRecord apply;
+    private final CaCarRecord<C> car;
+    private final ReadOnlyClientEpicsChannel<Short> abortMark;
+    private final ReadOnlyClientEpicsChannel<Short> stopMark;
+
+    private final short MRK_PRESET = 2;
+    private final short MRK_IDLE = 0;
+
+    private final Boolean trace = false;
+
+    private long timeout;
+    private TimeUnit timeoutUnit;
+    private ScheduledExecutorService executor;
+    private ScheduledFuture<?> timeoutFuture;
+    private final ChannelListener<Integer> valListener;
+    private ChannelListener<Integer> carClidListener;
+    private ChannelListener<C> carValListener;
+    private ChannelListener<Short> abortMarkListener;
+    private ChannelListener<Short> stopMarkListener;
+    private CaSimpleObserveSenderImpl.ApplyState currentState;
+
+    CaSimpleObserveSenderImpl(
+            final String name,
+            final String applyRecord,
+            final String carRecord,
+            final String stopCmd,
+            final String abortCmd,
+            final String description,
+            final Class<C> carClass,
+            final EpicsService epicsService) throws CAException {
+        super();
+        this.name = name;
+        this.description = description;
+        this.currentState = idleState;
+
+        EpicsReader epicsReader = new EpicsReaderImpl(epicsService);
+
+        apply = new CaApplyRecord(applyRecord, epicsService);
+        // apply.VAL int > 0
+        apply.registerValListener(valListener = (String arg0, List<Integer> newVals) -> {
+            if (newVals != null && !newVals.isEmpty()) {
+                CaSimpleObserveSenderImpl.this.onApplyValChange(newVals.get(0));
+            }
+        });
+
+        car = new CaCarRecord<C>(carRecord, carClass, epicsService);
+        // applyC.CLID int > 0
+        car.registerClidListener(carClidListener = (String arg0, List<Integer> newVals) -> {
+            if (newVals != null && !newVals.isEmpty()) {
+                CaSimpleObserveSenderImpl.this.onCarClidChange(newVals.get(0));
+            }
+        });
+        // applyC.VAL BUSY/IDLE
+        car.registerValListener(carValListener = (String arg0, List<C> newVals) -> {
+            if (newVals != null && !newVals.isEmpty()) {
+                CaSimpleObserveSenderImpl.this.onCarValChange(newVals.get(0));
+            }
+        });
+
+        ReadOnlyClientEpicsChannel<Short> stopMark = null;
+        if (stopCmd != null && stopCmd.length() > 0) {
+            try {
+                stopMark = epicsReader.getShortChannel(stopCmd + CAD_MARK_SUFFIX);
+            } catch(Throwable e) {
+                LOG.warn(e.getMessage());
+            }
+            if (stopMark != null) {
+                stopMark.registerListener(stopMarkListener = (String arg0, List<Short> newVals) -> {
+                    if (newVals != null && !newVals.isEmpty()) {
+                        CaSimpleObserveSenderImpl.this.onStopMarkChange(newVals.get(0));
+                    }
+                });
+            }
+        } else {
+            stopMark = null;
+        }
+        this.stopMark = stopMark;
+
+        ReadOnlyClientEpicsChannel<Short> abortMark = null;
+        if (abortCmd != null && abortCmd.length() > 0) {
+            try {
+                abortMark = epicsReader.getShortChannel(abortCmd + CAD_MARK_SUFFIX);
+            } catch(Throwable e) {
+                LOG.warn(e.getMessage());
+            }
+            if (abortMark != null) {
+                abortMark.registerListener(abortMarkListener = (String arg0, List<Short> newVals) -> {
+                    if (newVals != null && !newVals.isEmpty()) {
+                        CaSimpleObserveSenderImpl.this.onAbortMarkChange(newVals.get(0));
+                    }
+                });
+            }
+        } else {
+            abortMark = null;
+        }
+        this.abortMark = abortMark;
+
+        executor = new ScheduledThreadPoolExecutor(2);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getApply() {
+        return apply.getEpicsName();
+    }
+
+    @Override
+    public String getCAR() {
+        return car.getEpicsName();
+    }
+
+    @Override
+    public void unbind() {
+
+        executor.shutdown();
+
+        try {
+            apply.unregisterValListener(valListener);
+        } catch (CAException e) {
+            LOG.warn(e.getMessage());
+        }
+        try {
+            car.unregisterClidListener(carClidListener);
+        } catch (CAException e) {
+            LOG.warn(e.getMessage());
+        }
+        try {
+            car.unregisterValListener(carValListener);
+        } catch (CAException e) {
+            LOG.warn(e.getMessage());
+        }
+        if (stopMark != null) {
+            try {
+                stopMark.unRegisterListener(stopMarkListener);
+            } catch (CAException e) {
+                LOG.warn(e.getMessage());
+            }
+        }
+        if (abortMark != null) {
+            try {
+                abortMark.unRegisterListener(abortMarkListener);
+            } catch (CAException e) {
+                LOG.warn(e.getMessage());
+            }
+        }
+
+        apply.unbind();
+        car.unbind();
+    }
+
+    @Override
+    public synchronized CaCommandMonitor post() {
+        CaCommandMonitorImpl cm = new CaCommandMonitorImpl();
+        if (!currentState.equals(idleState)) {
+            failCommand(cm, new CaCommandInProgress());
+        } else {
+            currentState = new CaSimpleObserveSenderImpl.WaitApplyPreset(cm);
+
+            try {
+                apply.setDir(CadDirective.START);
+            } catch (CAException | TimeoutException e) {
+                failCommand(cm, e);
+            }
+
+            if (timeout > 0) {
+                timeoutFuture = executor.schedule(() ->  CaSimpleObserveSenderImpl.this.onTimeout(), timeout, timeoutUnit);
+            }
+        }
+
+        return cm;
+    }
+
+    @Override
+    public CaCommandMonitor postWait() throws InterruptedException {
+        CaCommandMonitor cm = post();
+        cm.waitDone();
+        return cm;
+    }
+
+    @Override
+    public CaCommandMonitor postCallback(final CaCommandListener callback) {
+        CaCommandMonitor cm = post();
+        cm.setCallback(callback);
+        return cm;
+    }
+
+    // Used on a FSM tracking the state of apply
+    protected interface ApplyState {
+        String signature();
+
+        CaSimpleObserveSenderImpl.ApplyState onApplyValChange(final Integer val);
+
+        CaSimpleObserveSenderImpl.ApplyState onCarValChange(final CarStateGeneric carState);
+
+        CaSimpleObserveSenderImpl.ApplyState onCarClidChange(final Integer val);
+
+        default CaSimpleObserveSenderImpl.ApplyState onStopMarkChange(final Short val) {
+            return this;
+        }
+
+        default CaSimpleObserveSenderImpl.ApplyState onAbortMarkChange(final Short val) {
+            return this;
+        }
+
+        default boolean isIdle() {
+            return false;
+        }
+
+        CaSimpleObserveSenderImpl.ApplyState onTimeout();
+    }
+
+
+    // Initial state before any channel has changed
+    protected static final class IdleState implements ApplyState {
+        IdleState() { }
+
+        @Override
+        public String signature() { return "idleState"; }
+
+        @Override
+        public CaSimpleObserveSenderImpl.ApplyState onApplyValChange(final Integer val) {
+            return this;
+        }
+
+        @Override
+        public CaSimpleObserveSenderImpl.ApplyState onCarValChange(final CarStateGeneric carState) {
+            return this;
+        }
+
+        @Override
+        public CaSimpleObserveSenderImpl.ApplyState onCarClidChange(final Integer val) { return this; }
+
+        @Override
+        public CaSimpleObserveSenderImpl.ApplyState onTimeout() {
+            return this;
+        }
+
+        @Override
+        public boolean isIdle() {
+            return true;
+        }
+
+
+    }
+
+    private static IdleState idleState = new IdleState();
+
+    // In this state we wait for clid to change
+    private final class WaitApplyPreset implements CaSimpleObserveSenderImpl.ApplyState {
+        final CaCommandMonitorImpl cm;
+        final CarStateGeneric carState;
+        final Integer carClid;
+
+        WaitApplyPreset(final CaCommandMonitorImpl cm) {
+            this.cm = cm;
+            this.carState = null;
+            this.carClid = null;
+        }
+
+        private WaitApplyPreset(
+                final CaCommandMonitorImpl cm,
+                final CarStateGeneric carState,
+                final Integer carClid) {
+            this.cm = cm;
+            this.carState = carState;
+            this.carClid = carClid;
+        }
+
+        @Override
+        public String signature() {
+            return "WaitApplyPreset(carState = " + carState + ", carClid = " + carClid + ")";
+        }
+
+        @Override
+        public CaSimpleObserveSenderImpl.ApplyState onApplyValChange(final Integer val) {
+            if (val > 0) {
+                if (val.equals(carClid) && carState != null) {
+                    if (carState.isError()) {
+                        failCommandWithCarError(cm);
+                        return idleState;
+                    } else if (carState.isBusy()) {
+                        return new CaSimpleObserveSenderImpl.WaitApplyBusy(cm, val, carState);
+                    }
+                }
+                return new CaSimpleObserveSenderImpl.WaitApplyBusy(cm, val, carState);
+            } else {
+                failCommandWithApplyError(cm);
+                return idleState;
+            }
+        }
+
+        @Override
+        public CaSimpleObserveSenderImpl.ApplyState onCarValChange(final CarStateGeneric val) {
+            if ((carState == null || carState.isIdle()) && val.isBusy() && carClid != null && carClid > 0) {
+                return new CaSimpleObserveSenderImpl.WaitObserveCompleted(cm, carClid);
+            } else {
+                return new CaSimpleObserveSenderImpl.WaitApplyPreset(cm, val, carClid);
+            }
+        }
+
+        @Override
+        public CaSimpleObserveSenderImpl.ApplyState onCarClidChange(final Integer val) {
+            return new CaSimpleObserveSenderImpl.WaitApplyPreset(cm, carState, val);
+        }
+
+        @Override
+        public CaSimpleObserveSenderImpl.ApplyState onTimeout() {
+            failCommand(cm, new TimeoutException());
+            return idleState;
+        }
+
+    }
+
+    // In this stat we wait for applyC to turn to busy
+    private final class WaitApplyBusy implements ApplyState {
+        final CaCommandMonitorImpl cm;
+        final int clid;
+        final CarStateGeneric carState;
+
+        WaitApplyBusy(
+                final CaCommandMonitorImpl cm,
+                final int clid,
+                final CarStateGeneric carState) {
+            this.cm = cm;
+            this.clid = clid;
+            this.carState = carState;
+        }
+
+        @Override
+        public String signature() {
+            return "WaitApplyBusy(clid = " + clid + ")";
+        }
+
+        @Override
+        public ApplyState onApplyValChange(final Integer val) {
+            if (val == clid) {
+                return this;
+            } else {
+                failCommand(cm, new CaCommandPostError(
+                        "Another command was triggered in apply record "
+                                + apply.getEpicsName()));
+                return idleState;
+            }
+        }
+
+        @Override
+        public ApplyState onCarValChange(final CarStateGeneric val) {
+            if (val.isBusy()) {
+                return new WaitObserveCompleted(cm, clid);
+            }
+            else if (val.isError()) {
+                failCommandWithCarError(cm);
+                return idleState;
+            }
+            else {
+                return this;
+            }
+        }
+
+        @Override
+        public ApplyState onCarClidChange(final Integer val) {
+            if (val == clid) {
+                return this;
+            } else {
+                failCommand(cm, new CaCommandPostError(
+                        "Another command was triggered in apply record "
+                                + apply.getEpicsName()));
+                return idleState;
+            }
+        }
+
+        @Override
+        public ApplyState onTimeout() {
+            failCommand(cm, new TimeoutException());
+            return idleState;
+        }
+
+    }
+
+    private final class WaitObserveCompleted implements ApplyState {
+        final CaCommandMonitorImpl cm;
+        final int clid;
+        final short stopMark;
+        final short abortMark;
+
+        WaitObserveCompleted(
+                final CaCommandMonitorImpl cm,
+                final int clid) {
+            this.cm = cm;
+            this.clid = clid;
+            this.stopMark = MRK_IDLE;
+            this.abortMark = MRK_IDLE;
+        }
+
+        WaitObserveCompleted(
+                final CaCommandMonitorImpl cm,
+                final int clid,
+                short stop,
+                short abort) {
+            this.cm = cm;
+            this.clid = clid;
+            this.stopMark = stop;
+            this.abortMark = abort;
+        }
+
+        @Override
+        public String signature() {
+            return "WaitObserveCompleted(clid = " + clid + ")";
+        }
+
+        @Override
+        public ApplyState onApplyValChange(final Integer val) {
+            if (val >= clid) {
+                return new WaitObserveCompleted(cm, val, stopMark, abortMark);
+            } else {
+                failCommand(cm, new CaCommandPostError(
+                        "Another command was triggered in apply record " + apply.getEpicsName()
+                ));
+                return idleState;
+            }
+        }
+
+        @Override
+        public ApplyState onCarValChange(final CarStateGeneric val) {
+            if (val != null) {
+                if (val.isError()) {
+                    failCommandWithCarError(cm);
+                    return idleState;
+                }
+                if (val.isIdle()) {
+                    succedCommand(cm);
+                    return idleState;
+                }
+                if (val.isPaused()) {
+                    pauseCommand(cm);
+                    return idleState;
+                }
+            }
+            return this;
+        }
+
+
+        @Override
+        public ApplyState onCarClidChange(final Integer val) {
+            if (val >= clid) {
+                return new WaitObserveCompleted(cm, val);
+            }
+            else {
+                failCommand(cm, new CaCommandPostError(
+                        "Another command was triggered in apply record "
+                                + apply.getEpicsName()));
+                return idleState;
+            }
+        }
+
+        @Override
+        public ApplyState onTimeout() {
+            failCommand(cm, new TimeoutException());
+            return idleState;
+        }
+
+        @Override
+        public ApplyState onStopMarkChange(Short val) {
+            if(stopMark == MRK_PRESET && val == MRK_IDLE) {
+                return new WaitStopCompleted(cm, clid);
+            } else {
+                return new WaitObserveCompleted(cm, clid, val, abortMark);
+            }
+        }
+
+        @Override
+        public ApplyState onAbortMarkChange(Short val) {
+            if(abortMark == MRK_PRESET && val == MRK_IDLE) {
+                return new WaitAbortCompletion(cm);
+            } else {
+                return new WaitObserveCompleted(cm, clid, stopMark, val);
+            }
+        }
+    }
+    private final class WaitStopCompleted implements ApplyState {
+        final CaCommandMonitorImpl cm;
+        final int clid;
+
+        WaitStopCompleted(CaCommandMonitorImpl cm, int clid) {
+            this.cm = cm;
+            this.clid = clid;
+        }
+
+        @Override
+        public String signature() {
+            return "WaitStopCompleted( clid = " + clid + ", stopMark = " + stopMark + ", abortMark" + abortMark + ")";
+        }
+
+        @Override
+        public ApplyState onApplyValChange(final Integer val) {
+            if (val >= clid) {
+                return new WaitStopCompleted(cm, val);
+            } else {
+                failCommand(cm, new CaCommandPostError(
+                        "Another command was triggered in apply record " + apply.getEpicsName()
+                ));
+                return idleState;
+            }
+        }
+
+        @Override
+        public ApplyState onCarClidChange(final Integer val) {
+            if (val >= clid) {
+                return new WaitStopCompleted(cm, val);
+            }
+            else {
+                failCommand(cm, new CaCommandPostError(
+                        "Another command was triggered in apply record "
+                                + apply.getEpicsName()));
+                return idleState;
+            }
+        }
+
+        @Override
+        public ApplyState onCarValChange(CarStateGeneric val) {
+            if(val.isIdle()) {
+                failCommand(cm, new CaObserveStopped());
+                return idleState;
+            }
+            else if(val.isError()) {
+                failCommandWithCarError(cm);
+                return idleState;
+            }
+            else if(val.isPaused()) {
+                pauseCommand(cm);
+                return idleState;
+            }
+            else {
+                return this;
+            }
+        }
+
+        @Override
+        public ApplyState onTimeout() {
+            failCommand(cm, new TimeoutException());
+            return idleState;
+        }
+
+        @Override
+        public ApplyState onStopMarkChange(Short val) {
+            return this;
+        }
+
+        @Override
+        public ApplyState onAbortMarkChange(Short val) {
+            return this;
+        }
+
+    }
+
+    private final class WaitAbortCompletion implements ApplyState {
+        final CaCommandMonitorImpl cm;
+
+        WaitAbortCompletion(CaCommandMonitorImpl cm) {
+            this.cm = cm;
+        }
+
+        @Override
+        public String signature() {
+            return "WaitAbortCompletion( stopMark = " + stopMark + ", abortMark" + abortMark + ")";
+        }
+
+        @Override
+        public ApplyState onApplyValChange(Integer val) {
+            return this;
+        }
+
+        @Override
+        public ApplyState onCarValChange(CarStateGeneric val)  {
+            return this;
+        }
+
+        @Override
+        public ApplyState onCarClidChange(Integer val) { return this; }
+
+        @Override
+        public ApplyState onTimeout() {
+            failCommand(cm, new TimeoutException());
+            return idleState;
+        }
+
+        @Override
+        public ApplyState onStopMarkChange(Short val) {
+            return this;
+        }
+
+        @Override
+        public ApplyState onAbortMarkChange(Short val) {
+            return this;
+        }
+
+    }
+
+    protected synchronized void onApplyValChange(final Integer val) {
+        if (val != null) {
+            ApplyState oldState = currentState;
+            currentState = currentState.onApplyValChange(val);
+            if (currentState.equals(idleState) && timeoutFuture != null) {
+                timeoutFuture.cancel(true);
+                timeoutFuture = null;
+            }
+            if (trace) LOG.debug("onApplyValChange(" + val + "): " + oldState.signature() + " -> " + currentState.signature());
+        }
+    }
+
+    protected synchronized void onCarClidChange(final Integer val) {
+        if (val != null) {
+            ApplyState oldState = currentState;
+            currentState = currentState.onCarClidChange(val);
+            if (currentState.equals(idleState) && timeoutFuture != null) {
+                timeoutFuture.cancel(true);
+                timeoutFuture = null;
+            }
+            if (trace) LOG.debug("onCarClidChange(" + val + "): " + oldState.signature() + " -> " + currentState.signature());
+        }
+    }
+
+    protected synchronized void onCarValChange(final C carState) {
+        if (carState != null) {
+            ApplyState oldState = currentState;
+            currentState = currentState.onCarValChange(carState);
+            if (currentState.equals(idleState) && timeoutFuture != null) {
+                timeoutFuture.cancel(true);
+                timeoutFuture = null;
+            }
+            if (trace) LOG.debug("onCarValChange(" + carState + "): " + oldState.signature() + " -> " + currentState.signature());
+        }
+    }
+
+    protected synchronized void onStopMarkChange(final Short val) {
+        if (val != null) {
+            ApplyState oldState = currentState;
+            currentState = currentState.onStopMarkChange(val);
+            if (currentState.equals(idleState) && timeoutFuture != null) {
+                timeoutFuture.cancel(true);
+                timeoutFuture = null;
+            }
+            if (trace) LOG.debug("onStopMarkChange(" + val + "): " + oldState.signature() + " -> " + currentState.signature());
+        }
+    }
+
+    protected synchronized void onAbortMarkChange(final Short val) {
+        if (val != null) {
+            ApplyState oldState = currentState;
+            currentState = currentState.onAbortMarkChange(val);
+            if (currentState.equals(idleState) && timeoutFuture != null) {
+                timeoutFuture.cancel(true);
+                timeoutFuture = null;
+            }
+            if (trace) LOG.debug("onAbortMarkChange(" + val + "): " + oldState.signature() + " -> " + currentState.signature());
+        }
+    }
+
+    protected synchronized void onTimeout() {
+        timeoutFuture = null;
+        ApplyState oldState = currentState;
+        currentState = currentState.onTimeout();
+        if (trace) LOG.debug("onTimeout: " + oldState.signature() + " -> " + currentState.signature());
+    }
+
+    protected ApplyState applyState() {
+        return currentState;
+    }
+
+    @Override
+    public synchronized boolean isActive() {
+        return !currentState.equals(idleState);
+    }
+
+    @Override
+    public synchronized void setTimeout(long timeout, TimeUnit timeUnit) {
+        this.timeout = timeout;
+        this.timeoutUnit = timeUnit;
+    }
+
+    private void succedCommand(final CaCommandMonitorImpl cm) {
+        executor.execute(() -> cm.completeSuccess());
+    }
+
+    private void pauseCommand(final CaCommandMonitorImpl cm) {
+        executor.execute(() -> cm.completePause());
+    }
+
+    private void failCommand(final CaCommandMonitorImpl cm, final Exception ex) {
+        executor.execute(() -> cm.completeFailure(ex));
+    }
+
+    private void failCommandWithApplyError(final CaCommandMonitorImpl cm) {
+        // I found that if I try to read OMSS or MESS from the same thread that
+        // is processing a channel notifications, the reads fails with a
+        // timeout. But it works if the read is done later from another thread.
+        executor.execute(() -> {
+            String msg = null;
+            try {
+                msg = apply.getMessValue();
+            } catch (CAException | TimeoutException e) {
+                LOG.warn(e.getMessage());
+            }
+            cm.completeFailure(new CaCommandError(msg));
+        } );
+    }
+
+    private void failCommandWithCarError(final CaCommandMonitorImpl cm) {
+        // I found that if I try to read OMSS or MESS from the same thread that
+        // is processing a channel notifications, the reads fails with a
+        // timeout. But it works if the read is done later from another thread.
+        executor.execute(() -> {
+            String msg = null;
+            try {
+                msg = car.getOmssValue();
+            } catch (CAException | TimeoutException e) {
+                LOG.warn(e.getMessage());
+            }
+            cm.completeFailure(new CaCommandError(msg));
+        } );
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void clear() throws TimeoutException {
+        try {
+            apply.setDir(CadDirective.CLEAR);
+        } catch (CAException e) {
+            LOG.warn(e.getMessage());
+        }
+    }
+
+}

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorImpl.java
@@ -17,7 +17,9 @@ import edu.gemini.epics.EpicsReader;
 import edu.gemini.epics.impl.EpicsReaderImpl;
 import gov.aps.jca.CAException;
 
-final class CaStatusAcceptorImpl implements CaStatusAcceptor {
+interface StatusAcceptorWithResource extends CaStatusAcceptor, CaResource {}
+
+final class CaStatusAcceptorImpl implements StatusAcceptorWithResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(CaStatusAcceptorImpl.class.getName());
 
@@ -285,6 +287,7 @@ final class CaStatusAcceptorImpl implements CaStatusAcceptor {
         return shortAttributes.get(name);
     }
 
+    @Override
     public void unbind() {
         assert (epicsReader != null);
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlImpl.java
@@ -21,7 +21,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-public class CaTaskControlImpl implements CaTaskControl {
+interface TaskControlWithResoource extends CaTaskControl, CaResource {}
+
+public class CaTaskControlImpl implements TaskControlWithResoource {
     private static final Logger LOG = LoggerFactory.getLogger(CaTaskControlImpl.class.getName());
 
     private final String name;
@@ -243,6 +245,7 @@ public class CaTaskControlImpl implements CaTaskControl {
         return cm;
     }
 
+    @Override
     public void unbind() {
 
         executor.shutdown();

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlImpl.java
@@ -21,9 +21,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-interface TaskControlWithResoource extends CaTaskControl, CaResource {}
+interface TaskControlWithResource extends CaTaskControl, CaResource {}
 
-public class CaTaskControlImpl implements TaskControlWithResoource {
+public class CaTaskControlImpl implements TaskControlWithResource {
     private static final Logger LOG = LoggerFactory.getLogger(CaTaskControlImpl.class.getName());
 
     private final String name;

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
@@ -3,9 +3,12 @@
 
 package edu.gemini.epics.acm
 
+import java.util.concurrent.TimeUnit
+
 import com.cosylab.epics.caj.CAJContext
 import edu.gemini.epics.EpicsService
 import java.util.concurrent.atomic.AtomicInteger
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 
@@ -18,7 +21,7 @@ import org.scalatest._
   * care about the state of the channels. Instead we want to only observe
   * the state transitions
   */
-@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.PublicInference"))
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.PublicInference", "org.wartremover.warts.IsInstanceOf"))
 final class ObserveStateSpec extends FunSuite with MockFactory {
 
   test("NIFS normal observation") {
@@ -45,7 +48,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
       classOf[CarState],
       epicsService)
     // Start idle
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     val observeErrorCount = new AtomicInteger()
     val observePauseCount = new AtomicInteger()
@@ -71,28 +74,28 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // OBSERVE goes BUSY
     // VAL change
     observe.onApplyValChange(359)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(359)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
 
     // OBSERVE goes IDLE
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.IDLE)
     // And we are done and IDLE
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(359)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.IDLE)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     // TODO fix these when the channels are correctly mocked
     // assert(observeErrorCount.get() === 1)
@@ -124,7 +127,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
       classOf[CarState],
       epicsService)
     // Start idle
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     val observeErrorCount = new AtomicInteger()
     val observePauseCount = new AtomicInteger()
@@ -150,52 +153,53 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // OBSERVE goes BUSY
     // VAL change
     observe.onApplyValChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Another VAL change
     observe.onApplyValChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Apply goes IDLE
     observe.onCarValChange(CarState.IDLE)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
 
     // OBSERVE goes IDLE
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.IDLE)
     // And we are done and IDLE
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
+    l.waitDone(1, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // ENDOBSERVE
     // CAR CLID change
     observe.onApplyValChange(4168)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4168)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     observe.onApplyValChange(4168)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4168)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.IDLE)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     // TODO fix these when the channels are correctly mocked
     // assert(observeErrorCount.get() === 0)
@@ -227,7 +231,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
       classOf[CarState],
       epicsService)
     // Start idle
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     // Post an observe
     // TODO mock the epics channel to test the listener
@@ -237,48 +241,48 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // OBSERVE goes BUSY
     // VAL change
     observe.onApplyValChange(4170)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4170)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Another VAL change
     observe.onApplyValChange(4170)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4170)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Apply goes IDLE
     observe.onCarValChange(CarState.IDLE)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
 
     // PAUSE observations
     observe.onApplyValChange(4171)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4171)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Another VAL change
     observe.onApplyValChange(4171)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.PAUSED)
     // We are now idle
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4171)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.IDLE)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     // Resume the observation
     observe.post()
@@ -286,49 +290,49 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // RESUME OBSERVE
     observe.onApplyValChange(4172)
     // TODO Fix why this is idle here, it should be busy
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4172)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Another VAL change
     observe.onApplyValChange(4172)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4172)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Apply goes IDLE
     observe.onCarValChange(CarState.IDLE)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
 
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.IDLE)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     // ENDOBSERVE
     // CAR CLID change
     observe.onApplyValChange(4173)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4173)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     observe.onApplyValChange(4173)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4173)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.IDLE)
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
   }
 
   test("NIRI normal observation") {
@@ -355,37 +359,37 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
       classOf[CarState],
       epicsService)
     // Start idle
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
     // Post an observe
     observe.post()
 
     // OBSERVE
     // OBSERVE goes BUSY
     observe.onObserveCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(365)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
 
     // Apply VAL change
     observe.onApplyValChange(365)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(365)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.IDLE)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
 
     // OBSERVE goes IDLE
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.IDLE)
     // And we are done and IDLE
     // FIXME This is not working
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
   }
 
   test("GMOS observation with an error case 1") {
@@ -412,7 +416,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
       classOf[CarState],
       epicsService)
     // Start idle
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     // Post an observe
     observe.post()
@@ -421,31 +425,31 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // OBSERVE goes BUSY
     // VAL change
     observe.onApplyValChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Another VAL change
     observe.onApplyValChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Apply goes IDLE
     observe.onCarValChange(CarState.IDLE)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
 
     // OBSERVE goes ERROR
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.ERROR)
     // We should capture the error and go IDLE
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
   }
 
   test("GMOS observation with an error case 2") {
@@ -472,7 +476,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
       classOf[CarState],
       epicsService)
     // Start idle
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
 
     // Post an observe
     observe.post()
@@ -481,19 +485,187 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // OBSERVE goes BUSY
     // VAL change
     observe.onApplyValChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR CLID change
     observe.onCarClidChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // CAR VAL change
     observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Another VAL change
     observe.onApplyValChange(4167)
-    assert(!observe.applyState().isIdle())
+    assert(!observe.applyState().isIdle)
     // Observe CAR goes directly to error
     observe.onObserveCarValChange(CarState.ERROR)
     // We should capture the error and go IDLE
-    assert(observe.applyState().isIdle())
+    assert(observe.applyState().isIdle)
   }
+
+  test("GSAOI normal observation") {
+    val context: CAJContext = mock[CAJContext]
+    (context.addContextExceptionListener _).expects(*).returns(()).repeat(4)
+    (context.addContextMessageListener _).expects(*).returns(()).repeat(4)
+    (context.pendIO _).expects(*).returns(()).repeat(1 to 6)
+    // We just return null as we don't need the channels and don't want to mock them
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.DIR").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.VAL").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.MESS").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.CLID").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.VAL").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.OMSS").returns(null)
+    val epicsService = new EpicsService(context)
+    val observe = new CaSimpleObserveSenderImpl(
+      "gsaoi::observeCmd",
+      "gsaoi:dc:obsapply",
+      "gsaoi:dc:observeC",
+      "gsaoi:dc:stop",
+      "gsaoi:dc:abort",
+      "GSAOI Observe",
+      classOf[CarState],
+      epicsService)
+    // Start idle
+    assert(observe.applyState().isIdle)
+
+    // Post an observe
+    val l = observe.post()
+
+    // VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+    // Another VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    // Apply goes IDLE
+    observe.onCarValChange(CarState.IDLE)
+    // And we are done and IDLE
+    assert(observe.applyState().isIdle)
+    l.waitDone(1, TimeUnit.SECONDS)
+    assert(l.isDone)
+
+  }
+
+  // TODO Enable the following tests after SEQNG-978 is done
+  ignore("GSAOI stopped observation") {
+    val context: CAJContext = mock[CAJContext]
+    (context.addContextExceptionListener _).expects(*).returns(()).repeat(4)
+    (context.addContextMessageListener _).expects(*).returns(()).repeat(4)
+    (context.pendIO _).expects(*).returns(()).repeat(1 to 6)
+    // We just return null as we don't need the channels and don't want to mock them
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.DIR").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.VAL").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.MESS").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.CLID").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.VAL").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.OMSS").returns(null)
+    val epicsService = new EpicsService(context)
+    val observe = new CaSimpleObserveSenderImpl(
+      "gsaoi::observeCmd",
+      "gsaoi:dc:obsapply",
+      "gsaoi:dc:observeC",
+      "gsaoi:dc:stop",
+      "gsaoi:dc:abort",
+      "GSAOI Observe",
+      classOf[CarState],
+      epicsService)
+    // Start idle
+    assert(observe.applyState().isIdle)
+
+    // Post an observe
+    val l = observe.post()
+
+    // VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+    // Another VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    observe.onStopMarkChange(1.toShort)
+    assert(!observe.applyState().isIdle)
+    observe.onStopMarkChange(2.toShort)
+    assert(!observe.applyState().isIdle)
+    observe.onStopMarkChange(0.toShort)
+    assert(!observe.applyState().isIdle)
+    // Apply goes IDLE
+    observe.onCarValChange(CarState.IDLE)
+    // And we are done and IDLE
+    assert(observe.applyState().isIdle)
+    l.waitDone(1, TimeUnit.SECONDS)
+    assert(l.error.isInstanceOf[CaObserveStopped])
+  }
+
+  ignore("GSAOI aborted observation") {
+    val context: CAJContext = mock[CAJContext]
+    (context.addContextExceptionListener _).expects(*).returns(()).repeat(4)
+    (context.addContextMessageListener _).expects(*).returns(()).repeat(4)
+    (context.pendIO _).expects(*).returns(()).repeat(1 to 6)
+    // We just return null as we don't need the channels and don't want to mock them
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.DIR").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.VAL").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.MESS").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.CLID").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.VAL").returns(null)
+    (context.createChannel(_: String)).expects("gsaoi:dc:observeC.OMSS").returns(null)
+    val epicsService = new EpicsService(context)
+    val observe = new CaSimpleObserveSenderImpl(
+      "gsaoi::observeCmd",
+      "gsaoi:dc:obsapply",
+      "gsaoi:dc:observeC",
+      "gsaoi:dc:stop",
+      "gsaoi:dc:abort",
+      "GSAOI Observe",
+      classOf[CarState],
+      epicsService)
+    // Start idle
+    assert(observe.applyState().isIdle)
+
+    // Post an observe
+    val l = observe.post()
+
+    // VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+    // Another VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    observe.onAbortMarkChange(1.toShort)
+    assert(!observe.applyState().isIdle)
+    observe.onAbortMarkChange(2.toShort)
+    assert(!observe.applyState().isIdle)
+    observe.onAbortMarkChange(0.toShort)
+    assert(!observe.applyState().isIdle)
+    // Apply goes IDLE
+    observe.onCarValChange(CarState.IDLE)
+    // And we are done and IDLE
+    assert(observe.applyState().isIdle)
+    l.waitDone(1, TimeUnit.SECONDS)
+    assert(l.error.isInstanceOf[CaObserveAborted])
+  }
+
 }

--- a/modules/seqexec/server/src/main/java/edu/gemini/seqexec/server/gsaoi/DhsConnected.java
+++ b/modules/seqexec/server/src/main/java/edu/gemini/seqexec/server/gsaoi/DhsConnected.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package edu.gemini.seqexec.server.gsaoi;
+
+public enum DhsConnected {
+    Yes,
+    No
+}

--- a/modules/seqexec/server/src/main/resources/Gsaoi.xml
+++ b/modules/seqexec/server/src/main/resources/Gsaoi.xml
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Records xmlns="http://www.gemini.edu/CaSchema">
+    <Top name="gsaoi">gsaoi</Top>
+    <Apply name="gsaoi::dcapply">
+        <top>gsaoi</top>
+        <apply>dc:seqObsApply</apply>
+        <car>dc:seqObsC</car>
+        <description>DC Primary Apply Record</description>
+        <command name="gsaoi::dcconfig">
+            <description>Setup a DC Configuration</description>
+            <parameter name="numberOfFowSamples">
+                <channel>dc:seqObs.D</channel>
+                <type>INTEGER</type>
+                <description>Number of fowler samples</description>
+            </parameter>
+            <parameter name="readMode">
+                <channel>dc:seqObs.A</channel>
+                <type>STRING</type>
+                <description>Read mode (DCS|FOWLER|SINGLE)</description>
+            </parameter>
+            <parameter name="exposureTime">
+                <channel>dc:seqObs.F</channel>
+                <type>DOUBLE</type>
+                <description>Period between sample sets</description>
+            </parameter>
+            <parameter name="roi">
+                <channel>dc:seqObs.H</channel>
+                <type>STRING</type>
+                <description>Region of interest</description>
+            </parameter>
+            <parameter name="resetDelay">
+                <channel>dc:seqObs.C</channel>
+                <type>DOUBLE</type>
+                <description>Reset delay</description>
+            </parameter>
+            <parameter name="numberOfResets">
+                <channel>dc:seqObs.B</channel>
+                <type>INTEGER</type>
+                <description>Number of resets</description>
+            </parameter>
+            <parameter name="coadds">
+                <channel>dc:seqObs.E</channel>
+                <type>INTEGER</type>
+                <description>Number of coadds</description>
+            </parameter>
+            <parameter name="numberOfRefSamples">
+                <channel>dc:seqObs.G</channel>
+                <type>INTEGER</type>
+                <description>Number of reference samples</description>
+            </parameter>
+        </command>
+    </Apply>
+    <Apply name="gsaoi::ccapply">
+        <top>gsaoi</top>
+        <apply>cc:apply</apply>
+        <car>cc:applyC</car>
+        <description>IS Primary Apply Record</description>
+        <command name="gsaoi::config">
+            <description>Setup a Configuration</description>
+            <parameter name="filter">
+                <channel>cc:vfiltSel.A</channel>
+                <type>STRING</type>
+                <description>Filter</description>
+            </parameter>
+            <parameter name="utilWheel">
+                <channel>cc:utilSel.A</channel>
+                <type>STRING</type>
+                <description>Utility Wheel		</description>
+            </parameter>
+            <parameter name="windowCover">
+                <channel>cc:covSel.A</channel>
+                <type>STRING</type>
+                <description>Window Cover</description>
+            </parameter>
+        </command>
+    </Apply>
+    <Apply name="gsaoi::obsapply">
+        <top>gsaoi</top>
+        <apply>dc:stateApply</apply>
+        <car>dc:observeC</car>
+        <description>DC Observe Apply Record</description>
+        <command name="gsaoi::continue">
+            <record>dc:continue</record>
+            <description>Continue observation</description>
+        </command>
+        <command name="gsaoi::stop">
+            <record>dc:stop</record>
+            <description>Stop observation</description>
+        </command>
+        <command name="gsaoi::endObserve">
+            <record>dc:endObserve</record>
+            <description>End Observe</description>
+        </command>
+        <command name="gsaoi::abort">
+            <record>dc:abort</record>
+            <description>Abort observation</description>
+        </command>
+        <command name="gsaoi::pause">
+            <record>dc:pause</record>
+            <description>Pause observation</description>
+        </command>
+        <command name="gsaoi::observe">
+            <description>Observe</description>
+            <parameter name="label">
+                <channel>dc:observe.A</channel>
+                <type>STRING</type>
+                <description>DHS data label</description>
+            </parameter>
+            <parameter name="comment">
+                <channel>dc:observe.C</channel>
+                <type>STRING</type>
+                <description>Comment</description>
+            </parameter>
+            <parameter name="type">
+                <channel>dc:observe.B</channel>
+                <type>STRING</type>
+                <description>Image type (IMAGE|DARK|FLAT|ARC|BIAS)</description>
+            </parameter>
+        </command>
+    </Apply>
+    <Status name="gsaoi::status">
+        <top>gsaoi</top>
+        <description>gsaoi status</description>
+        <attribute name="lowerFilter">
+            <channel>sad:cc:lfwName</channel>
+            <type>STRING</type>
+            <description>Lower filter wheel current position (by name)</description>
+        </attribute>
+        <attribute name="windowCover">
+            <channel>sad:cc:covName</channel>
+            <type>STRING</type>
+            <description>Window cover current position (by name)</description>
+        </attribute>
+        <attribute name="filter">
+            <channel>sad:cc:vfiltName</channel>
+            <type>STRING</type>
+            <description>Virtual filter wheel current position (by name)</description>
+        </attribute>
+        <attribute name="upperFilter">
+            <channel>sad:cc:ufwName</channel>
+            <type>STRING</type>
+            <description>Upper filter wheel current position (by name)</description>
+        </attribute>
+        <attribute name="utilWheel">
+            <channel>sad:cc:utilName</channel>
+            <type>STRING</type>
+            <description>Utility wheel current position (by name)</description>
+        </attribute>
+        <attribute name="DSPTIMBV">
+            <channel>sad:dc:DSPVer</channel>
+            <type>STRING</type>
+            <description>Version of DSP code for SDSU timing board</description>
+        </attribute>
+        <attribute name="CWSTEMP">
+            <channel>eng:tmpC1Tmp</channel>
+            <type>DOUBLE</type>
+            <description>Cold work surface temperature</description>
+        </attribute>
+        <attribute name="BUNITS">
+            <channel>sad:dc:bunit</channel>
+            <type>STRING</type>
+            <description>Units of quantity read from detector array (e.g. “ADU” or “Volts/S”)</description>
+        </attribute>
+        <attribute name="CVERPOS">
+            <channel>sad:cc:covEngPos</channel>
+            <type>INTEGER</type>
+            <description>The utility wheel position in real-world units (position number)</description>
+        </attribute>
+        <attribute name="DCHLTH">
+            <channel>sad:dc:health</channel>
+            <type>STRING</type>
+            <description>Detector Controller health [GOOD | WARNING | BAD]</description>
+        </attribute>
+        <attribute name="FILT2CAR">
+            <channel>sad:cc:lfwHealth</channel>
+            <type>STRING</type>
+            <description>Combined lower filter wheel CAR state [GOOD|BAD]</description>
+        </attribute>
+        <attribute name="DCSIM">
+            <channel>sad:dc:simMode</channel>
+            <type>STRING</type>
+            <description>Simulation mode [NONE | FULL | FAST | VSM]</description>
+        </attribute>
+        <attribute name="DSPTIMBN">
+            <channel>sad:dc:timingDSP</channel>
+            <type>STRING</type>
+            <description>Name of DSP code for SDSU timing board</description>
+        </attribute>
+        <attribute name="READDLAY">
+            <channel>sad:dc:obs_readIntvl</channel>
+            <type>DOUBLE</type>
+            <description>Read interval</description>
+        </attribute>
+        <attribute name="DETTEMP">
+            <channel>eng:tmpC3Tmp</channel>
+            <type>DOUBLE</type>
+            <description>Detector temperature</description>
+        </attribute>
+        <attribute name="FILT1CAR">
+            <channel>sad:cc:ufwHealth</channel>
+            <type>STRING</type>
+            <description>Combined upper filter wheel CAR state [GOOD|BAD]</description>
+        </attribute>
+        <attribute name="DEWPRES">
+            <channel>eng:pressure</channel>
+            <type>DOUBLE</type>
+            <description>Dewar pressure</description>
+        </attribute>
+        <attribute name="ELAPSED">
+            <channel>sad:dc:elapsed</channel>
+            <type>DOUBLE</type>
+            <description>Total elapsed time in current data set observation</description>
+        </attribute>
+        <attribute name="FILT2POS">
+            <channel>sad:cc:lfwEngPos</channel>
+            <type>INTEGER</type>
+            <description>The position of the lower filter wheel in real-world units (position number)</description>
+        </attribute>
+        <attribute name="RSTDLAY">
+            <channel>sad:dc:obs_resetDelay</channel>
+            <type>DOUBLE</type>
+            <description>Time delay to allow detector to reset</description>
+        </attribute>
+        <attribute name="DETHTEMP">
+            <channel>eng:tmpC4Tmp</channel>
+            <type>DOUBLE</type>
+            <description>Detector-housing temperature</description>
+        </attribute>
+        <attribute name="UTLWPOS">
+            <channel>sad:cc:utilEngPos</channel>
+            <type>INTEGER</type>
+            <description>The utility wheel position in real-world units (position number)</description>
+        </attribute>
+        <attribute name="UTLWCAR">
+            <channel>sad:cc:utilHealth</channel>
+            <type>STRING</type>
+            <description>Combined utility wheel CAR state [GOOD|BAD]</description>
+        </attribute>
+        <attribute name="CVERCAR">
+            <channel>sad:cc:covHealth</channel>
+            <type>STRING</type>
+            <description>Combined utility wheel CAR state [GOOD|BAD]</description>
+        </attribute>
+        <attribute name="FILT1POS">
+            <channel>sad:cc:ufwEngPos</channel>
+            <type>INTEGER</type>
+            <description>The position of the upper filter wheel in real-world units (position number)</description>
+        </attribute>
+        <attribute name="EXPMODE">
+            <channel>sad:dc:obs_expMode</channel>
+            <type>STRING</type>
+            <description>Read mode [DESTRUCTIVE|NONDESTRUCTIVE]</description>
+        </attribute>
+        <attribute name="DCNAME">
+            <channel>sad:dc:name</channel>
+            <type>STRING</type>
+            <description>Detector Controller name</description>
+        </attribute>
+        <attribute name="DSPPCIN">
+            <channel>sad:dc:intfDSP</channel>
+            <type>STRING</type>
+            <description>Name of DSP code for SDSU PCI board</description>
+        </attribute>
+        <attribute name="READTIME">
+            <channel>sad:dc:obs_readTime</channel>
+            <type>DOUBLE</type>
+            <description>Read time</description>
+        </attribute>
+        <attribute name="exposureTime">
+            <channel>sad:dc:obs_exposedRQ</channel>
+            <type>DOUBLE</type>
+            <description>Exposure time requested</description>
+        </attribute>
+        <attribute name="numberOfResets">
+            <channel>sad:dc:obs_nresets</channel>
+            <type>INTEGER</type>
+            <description>Number of resets</description>
+        </attribute>
+        <attribute name="readMode">
+            <channel>sad:dc:obs_readMode</channel>
+            <type>STRING</type>
+            <description>Read mode (0=dcs, 1=fowler, 2=linear, 3=linear) </description>
+        </attribute>
+        <attribute name="numberOfFowSamples">
+            <channel>sad:dc:obs_nfowler</channel>
+            <type>INTEGER</type>
+            <description>Number of fowler samples  </description>
+        </attribute>
+        <attribute name="coadds">
+            <channel>sad:dc:obs_ncoadds</channel>
+            <type>INTEGER</type>
+            <description>Number of coadds</description>
+        </attribute>
+        <attribute name="exposedTime">
+            <channel>sad:dc:obs_exposed</channel>
+            <type>DOUBLE</type>
+            <description>Time exposed</description>
+        </attribute>
+<!--        <attribute name="dhsConnected">-->
+<!--            <channel>sad:dc:dhsConnO</channel>-->
+<!--            <type>STRING</type>-->
+<!--            <description>dhs connection</description>-->
+<!--        </attribute>-->
+        <attribute name="timeMode">
+            <channel>sad:dc:obs_timeMode</channel>
+            <type>STRING</type>
+            <description>Which variable (0=exposure time, 1=period, 2=nr of periods) to calculate</description>
+        </attribute>
+        <attribute name="countdown">
+            <channel>sad:dc:s_obs_timeLeft</channel>
+            <type>DOUBLE</type>
+            <description>countdown</description>
+        </attribute>
+    </Status>
+</Records>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -35,6 +35,7 @@ import seqexec.server.gmos.{GmosControllerSim, GmosEpics, GmosNorthControllerEpi
 import seqexec.server.gnirs.{GnirsControllerEpics, GnirsControllerSim, GnirsEpics}
 import seqexec.server.gpi.GpiController
 import seqexec.server.gpi.GpiStatusApply
+import seqexec.server.gsaoi.GsaoiEpics
 import seqexec.server.gsaoi.GsaoiControllerSim
 import seqexec.server.niri.{NiriControllerEpics, NiriControllerSim, NiriEpics}
 import seqexec.server.nifs.{NifsControllerEpics, NifsControllerSim, NifsEpics}
@@ -799,7 +800,7 @@ object SeqexecEngine extends SeqexecConfiguration {
 
     // More instruments to be added to the list here
     val epicsInstruments = site match {
-      case Site.GS => List((f2Control, Flamingos2Epics), (gmosControl, GmosEpics))
+      case Site.GS => List((f2Control, Flamingos2Epics), (gmosControl, GmosEpics), (gsaoiControl, GsaoiEpics))
       case Site.GN => List((gmosControl, GmosEpics), (gnirsControl, GnirsEpics),
         (niriControl, NiriEpics), (nifsControl, NifsEpics)
       )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiEpics.scala
@@ -1,0 +1,182 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.gsaoi
+
+import cats.effect.{IO, Sync}
+import edu.gemini.epics.acm.{CaApplySender, CaAttribute, CaCommandSender, CaParameter, CaService}
+import edu.gemini.seqexec.server.gsaoi.DhsConnected
+import seqexec.server.{EpicsCommandF, EpicsSystem, ObserveCommandF}
+import seqexec.server.EpicsCommand.setParameterF
+import seqexec.server.EpicsUtil.{safeAttribute, safeAttributeSDouble, safeAttributeSInt}
+import java.lang.{Double => JDouble}
+
+import org.log4s.{Logger, getLogger}
+
+class GsaoiEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String]) {
+
+  val GsaoiTop = tops.getOrElse("gsaoi", "gsaoi:")
+
+  object dcConfigCmd extends EpicsCommandF {
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gsaoi::dcconfig"))
+
+    val fowlerSamples: Option[CaParameter[Integer]] = cs.map(_.getInteger("numberOfFowSamples"))
+    def setFowlerSamples(v: Int): F[Unit] = setParameterF(fowlerSamples, Integer.valueOf(v))
+
+    val readMode: Option[CaParameter[String]] = cs.map(_.getString("readMode"))
+    def setReadMode(v: String): F[Unit] = setParameterF(readMode, v)
+
+    val exposureTime: Option[CaParameter[JDouble]] = cs.map(_.getDouble("exposureTime"))
+    def setExposureTime(v: Double): F[Unit] = setParameterF(exposureTime, JDouble.valueOf(v))
+
+    val roi: Option[CaParameter[String]] = cs.map(_.getString("roi"))
+    def setRoi(v: String): F[Unit] = setParameterF(roi, v)
+
+    val resetDelay: Option[CaParameter[JDouble]] = cs.map(_.getDouble("resetDelay"))
+    def setResetDelay(v: Double): F[Unit] = setParameterF(resetDelay, JDouble.valueOf(v))
+
+    val numberOfResets: Option[CaParameter[Integer]] = cs.map(_.getInteger("numberOfResets"))
+    def setNumberOfResets(v: Int): F[Unit] = setParameterF(numberOfResets, Integer.valueOf(v))
+
+    val coadds: Option[CaParameter[Integer]] = cs.map(_.getInteger("coadds"))
+    def setNumberOfCoadds(v: Int): F[Unit] = setParameterF(coadds, Integer.valueOf(v))
+
+    val referenceSamples: Option[CaParameter[Integer]] = cs.map(_.getInteger("numberOfRefSamples"))
+    def setReferenceSamples(v: Int): F[Unit] = setParameterF(referenceSamples, Integer.valueOf(v))
+
+  }
+
+  object ccConfigCmd extends EpicsCommandF {
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gsaoi::config"))
+
+    val filter: Option[CaParameter[String]] = cs.map(_.getString("filter"))
+    def setFilter(v: String): F[Unit] = setParameterF(filter, v)
+
+    val utilWheel: Option[CaParameter[String]] = cs.map(_.getString("utilWheel"))
+    def setUtilWheel(v: String): F[Unit] = setParameterF(utilWheel, v)
+
+    val windowCover: Option[CaParameter[String]] = cs.map(_.getString("windowCover"))
+    def setWindowCover(v: String): F[Unit] = setParameterF(windowCover, v)
+
+  }
+
+  private val observeAS: Option[CaApplySender] = Option(epicsService.createObserveSender(
+    "gsaoi::observeCmd", s"${GsaoiTop}dc:stateApply",s"${GsaoiTop}dc:observeC",
+    false, s"${GsaoiTop}dc:stop", s"${GsaoiTop}dc:abort", ""))
+
+  object stopCmd extends EpicsCommandF {
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gsaoi::stop"))
+  }
+
+  object abortCmd extends EpicsCommandF {
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gsaoi::abort"))
+  }
+
+  object observeCmd extends ObserveCommandF {
+    override protected val cs: Option[CaCommandSender] = Option(
+      epicsService.getCommandSender("gsaoi::observe"))
+    override protected val os: Option[CaApplySender] = observeAS
+
+    private val label: Option[CaParameter[String]] = cs.map(_.getString("label"))
+    def setLabel(v: String): F[Unit] = setParameterF(label, v)
+  }
+
+  object endObserveCmd extends EpicsCommandF {
+    override val cs: Option[CaCommandSender] = Option(
+      epicsService.getCommandSender("gsaoi::endObserve"))
+  }
+
+  val status = epicsService.getStatusAcceptor("gsaoi::status")
+
+  def windowCover: F[Option[String]] = safeAttribute(status.getStringAttribute("windowCover"))
+
+  def lowerFilter: F[Option[String]] = safeAttribute(status.getStringAttribute("lowerFilter"))
+
+  def filter: F[Option[String]] = safeAttribute(status.getStringAttribute("filter"))
+
+  def upperFilter: F[Option[String]] = safeAttribute(status.getStringAttribute("upperFilter"))
+
+  def utilWheel: F[Option[String]] = safeAttribute(status.getStringAttribute("utilWheel"))
+
+  def dspCodeVersion: F[Option[String]] =  safeAttribute(status.getStringAttribute("DSPTIMBV"))
+
+  def coldworkSurfaceTemperature: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("CWSTEMP"))
+
+  def bUnits: F[Option[String]] = safeAttribute(status.getStringAttribute("BUNITS"))
+
+  def windowCoverEngPos: F[Option[Int]] = safeAttributeSInt(status.getIntegerAttribute("CVERPOS"))
+
+  def dcHealth: F[Option[String]] = safeAttribute(status.getStringAttribute("DCHLTH"))
+
+  def lowerFilterHealth: F[Option[String]] = safeAttribute(status.getStringAttribute("FILT2CAR"))
+
+  def simulationMode: F[Option[String]] = safeAttribute(status.getStringAttribute("DCSIM"))
+
+  def timingBoardCodeName: F[Option[String]] = safeAttribute(status.getStringAttribute("DSPTIMBN"))
+
+  def readInterval: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("READDLAY"))
+
+  def detectorTemperature: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("DETTEMP"))
+
+  def upperFilterHealth: F[Option[String]] = safeAttribute(status.getStringAttribute("FILT1CAR"))
+
+  def dewarPressure: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("DEWPRES"))
+
+  def obsElapsedTime: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("ELAPSED"))
+
+  def lowerFilterEngPos: F[Option[Int]] = safeAttributeSInt(status.getIntegerAttribute("FILT2POS"))
+
+  def resetDelay: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("RSTDLAY"))
+
+  def detectorHousingTemperature: F[Option[Double]] =
+    safeAttributeSDouble(status.getDoubleAttribute("DETHTEMP"))
+
+  def utilityWheelEngPos: F[Option[Int]] = safeAttributeSInt(status.getIntegerAttribute("UTLWPOS"))
+
+  def utilityWheelHealth: F[Option[String]] = safeAttribute(status.getStringAttribute("UTLWCAR"))
+
+  def windowCoverHealth: F[Option[String]] = safeAttribute(status.getStringAttribute("CVERCAR"))
+
+  def upperFilterEngPos: F[Option[Int]] = safeAttributeSInt(status.getIntegerAttribute("FILT1POS"))
+
+  def expositionMode: F[Option[String]] = safeAttribute(status.getStringAttribute("EXPMODE"))
+
+  def dcName: F[Option[String]] = safeAttribute(status.getStringAttribute("DCNAME"))
+
+  def pciBoardCodeName: F[Option[String]] = safeAttribute(status.getStringAttribute("DSPPCIN"))
+
+  def readTime: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("READTIME"))
+
+  def requestedExposureTime: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("exposureTime"))
+
+  def numberOfResets: F[Option[Int]] = safeAttributeSInt(status.getIntegerAttribute("numberOfResets"))
+
+  def readMode: F[Option[String]] = safeAttribute(status.getStringAttribute("readMode"))
+
+  def numberOfFowlerSamples: F[Option[Int]] = safeAttributeSInt(status.getIntegerAttribute("numberOfFowSamples"))
+
+  def coadds: F[Option[Int]] = safeAttributeSInt(status.getIntegerAttribute("coadds"))
+
+  def exposedTime: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("exposedTime"))
+
+  def timeMode: F[Option[String]] = safeAttribute(status.getStringAttribute("timeMode"))
+
+  def countdown: F[Option[Double]] =  safeAttributeSDouble(status.getDoubleAttribute("countdown"))
+
+  private val dhsConnectedAttr: CaAttribute[DhsConnected] =
+    status.addEnum[DhsConnected]("dhsConnected", s"${GsaoiTop}sad:dc:dhsConnO", classOf[DhsConnected])
+  def dhsConnected: F[Option[DhsConnected]] = safeAttribute(dhsConnectedAttr)
+
+
+}
+
+object GsaoiEpics extends EpicsSystem[GsaoiEpics[IO]] {
+
+  override val className: String = getClass.getName
+  override val Log: Logger = getLogger
+  override val CA_CONFIG_FILE: String = "/Gsaoi.xml"
+
+  override def build(service: CaService, tops: Map[String, String]) =
+    new GsaoiEpics[IO](service, tops)
+
+}

--- a/modules/seqexec/web/server/src/main/resources/app.conf
+++ b/modules/seqexec/web/server/src/main/resources/app.conf
@@ -62,7 +62,7 @@ seqexec-engine {
     # if instForceError is true fail at the given iteration
     failAt = 2
     odbQueuePollingInterval = 3 seconds
-    tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gw=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"
+    tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gw=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:, gsaoi=gsaoi:"
     epics_ca_addr_list = "127.0.0.1"
     ioTimeout = 5 seconds
     # We normally always use GS for smartGCalDir


### PR DESCRIPTION
I had to create a specialized version of `CaObserveSenderImpl` for GSAOI, called `CaSimpleObserveSenderImpl`. It is actually simpler, because it does not use two CAR records, but only one.
When writing the tests for `CaSimpleObserveSenderImpl` I found a bug in `CaObserveSenderImpl`, and another in the tests that hid the bug in `CaObserveSenderImpl`. They will be fixed in SEQNG-978