### PR TITLE
SEQNG-978: ObserveStateSpec rework and fix for ignoring fixes to write DIR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -598,7 +598,8 @@ lazy val acm = project
       XmlUnit,
       JUnitInterface,
       ScalaMock
-    ),
+    ) ++ Logback,
+    libraryDependencies in Test ++= Logback,
     testOptions in Test := Seq(),
     sourceGenerators in Compile += Def.task {
       import scala.sys.process._

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplyRecord.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplyRecord.java
@@ -30,19 +30,21 @@ final class CaApplyRecord {
 
     private final String epicsName;
 
-    private EpicsReader epicsReader;
-    private EpicsWriter epicsWriter;
+    private final EpicsReader epicsReader;
+    private final EpicsWriter epicsWriter;
     private ReadWriteClientEpicsChannel<CadDirective> dir;
     private ReadOnlyClientEpicsChannel<Integer> val;
     private ReadOnlyClientEpicsChannel<String> mess;
 
     private ChannelListener<Integer> valListener;
 
-    CaApplyRecord(String epicsName, EpicsService epicsService) {
+    CaApplyRecord(String epicsName, EpicsReader epicsReader, EpicsWriter epicsWriter) {
         this.epicsName = epicsName;
+        assert(epicsReader != null);
+        assert(epicsWriter != null);
 
-        epicsReader = new EpicsReaderImpl(epicsService);
-        epicsWriter = new EpicsWriterImpl(epicsService);
+        this.epicsReader = epicsReader;
+        this.epicsWriter = epicsWriter;
 
         updateChannels();
     }
@@ -75,9 +77,6 @@ final class CaApplyRecord {
     }
 
     synchronized void unbind() {
-        assert(epicsReader!=null);
-        assert(epicsWriter!=null);
-
         if(dir!=null) {
             try {
                 epicsWriter.destroyChannel(dir);
@@ -104,9 +103,6 @@ final class CaApplyRecord {
             }
             mess = null;
         }
-
-        epicsWriter = null;
-        epicsReader = null;
     }
 
     synchronized void registerValListener(ChannelListener<Integer> listener) throws CAException {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -13,7 +13,8 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.gemini.epics.EpicsService;
+import edu.gemini.epics.EpicsReader;
+import edu.gemini.epics.EpicsWriter;
 import edu.gemini.epics.api.ChannelListener;
 import gov.aps.jca.CAException;
 import gov.aps.jca.TimeoutException;
@@ -29,7 +30,7 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
     private final CaApplyRecord apply;
     private final CaCarRecord<C> car;
 
-    private final Boolean trace = false;
+    private final Boolean trace = true;
 
     private long timeout;
     private TimeUnit timeoutUnit;
@@ -70,13 +71,14 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
         final String carRecord,
         final String description,
         final Class<C> carClass,
-        final EpicsService epicsService) throws CAException {
+        final EpicsReader epicsReader,
+        final EpicsWriter epicsWriter) throws CAException {
         super();
         this.name = name;
         this.description = description;
         this.currentState = IdleState;
 
-        apply = new CaApplyRecord(applyRecord, epicsService);
+        apply = new CaApplyRecord(applyRecord, epicsReader, epicsWriter);
         apply.registerValListener(valListener = new ChannelListener<Integer>() {
             @Override
             public void valueChanged(String arg0, List<Integer> newVals) {
@@ -86,7 +88,7 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
             }
         });
 
-        car = new CaCarRecord<C>(carRecord, carClass, epicsService);
+        car = new CaCarRecord<C>(carRecord, carClass, epicsReader);
         car.registerClidListener(carClidListener = new ChannelListener<Integer>() {
             @Override
             public void valueChanged(String arg0, List<Integer> newVals) {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -126,7 +126,7 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
             }
         });
 
-        executor = new ScheduledThreadPoolExecutor(2, threadFactory);
+        executor = SafeExecutor.safeExecutor(2, LOG);
     }
 
     @Override

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.ThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +30,7 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
     private final CaApplyRecord apply;
     private final CaCarRecord<C> car;
 
-    private final Boolean trace = true;
+    private final Boolean trace = Boolean.getBoolean("epics.apply.trace");
 
     private long timeout;
     private TimeUnit timeoutUnit;
@@ -64,25 +63,6 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
         public State onTimeout() {
             return this;
         }
-    };
-
-    private ThreadFactory threadFactory = new ThreadFactory(){
-
-        @Override
-        public Thread newThread(Runnable r) {
-            final Thread thread = new Thread(r);
-
-            thread.setUncaughtExceptionHandler( new Thread.UncaughtExceptionHandler() {
-
-                @Override
-                public void uncaughtException(Thread t, Throwable e) {
-                    LOG.error("Uncaught exception on CaSimpleObserverSender", e);
-                }
-            });
-
-            return thread;
-        }
-
     };
 
     public CaApplySenderImpl(

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +66,25 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
         }
     };
 
+    private ThreadFactory threadFactory = new ThreadFactory(){
+
+        @Override
+        public Thread newThread(Runnable r) {
+            final Thread thread = new Thread(r);
+
+            thread.setUncaughtExceptionHandler( new Thread.UncaughtExceptionHandler() {
+
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    LOG.error("Uncaught exception on CaSimpleObserverSender", e);
+                }
+            });
+
+            return thread;
+        }
+
+    };
+
     public CaApplySenderImpl(
         final String name,
         final String applyRecord,
@@ -106,7 +126,7 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
             }
         });
 
-        executor = new ScheduledThreadPoolExecutor(2);
+        executor = new ScheduledThreadPoolExecutor(2, threadFactory);
     }
 
     @Override

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCarRecord.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCarRecord.java
@@ -6,7 +6,6 @@
 package edu.gemini.epics.acm;
 
 import edu.gemini.epics.EpicsReader;
-import edu.gemini.epics.EpicsService;
 import edu.gemini.epics.ReadOnlyClientEpicsChannel;
 import edu.gemini.epics.api.ChannelListener;
 import edu.gemini.epics.impl.EpicsReaderImpl;
@@ -25,8 +24,8 @@ final class CaCarRecord<C extends Enum<C> & CarStateGeneric> {
     private static final String CAR_OMSS_SUFFIX = ".OMSS";
 
     private final String epicsName;
-    private EpicsReader epicsReader;
-    private Class<C> carClass;
+    private final EpicsReader epicsReader;
+    private final Class<C> carClass;
     private ReadOnlyClientEpicsChannel<Integer> clid;
     private ReadOnlyClientEpicsChannel<C> val;
     private ReadOnlyClientEpicsChannel<String> omss;
@@ -34,10 +33,10 @@ final class CaCarRecord<C extends Enum<C> & CarStateGeneric> {
     private ChannelListener<Integer> clidListener;
     private ChannelListener<C> valListener;
 
-    CaCarRecord(String epicsName, Class<C> carClass, EpicsService epicsService) {
+    CaCarRecord(String epicsName, Class<C> carClass, EpicsReader epicsReader) {
         this.epicsName = epicsName;
         this.carClass = carClass;
-        epicsReader = new EpicsReaderImpl(epicsService);
+        this.epicsReader = epicsReader;
 
         updateChannels();
     }
@@ -93,8 +92,6 @@ final class CaCarRecord<C extends Enum<C> & CarStateGeneric> {
             LOG.warn(e.getMessage());
         }
         omss = null;
-
-        epicsReader = null;
     }
 
     String getEpicsName() {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -56,25 +56,6 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
     private ChannelListener<Short> stopMarkListener;
     private CaObserveSenderImpl.ApplyState currentState;
 
-    private ThreadFactory threadFactory = new ThreadFactory(){
-
-        @Override
-        public Thread newThread(Runnable r) {
-            final Thread thread = new Thread(r);
-
-            thread.setUncaughtExceptionHandler( new Thread.UncaughtExceptionHandler() {
-
-                @Override
-                public void uncaughtException(Thread t, Throwable e) {
-                    LOG.error("Uncaught exception on CaSimpleObserverSender", e);
-                }
-            });
-
-            return thread;
-        }
-
-    };
-
     public CaObserveSenderImpl(
         final String name,
         final String applyRecord,
@@ -161,7 +142,7 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
         }
         this.abortMark = abortMark;
 
-        executor = new ScheduledThreadPoolExecutor(2, threadFactory);
+        executor = SafeExecutor.safeExecutor(2, LOG);
     }
 
     @Override

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -14,6 +14,10 @@ import java.util.concurrent.locks.ReentrantLock;
 import com.google.common.collect.ImmutableSet;
 
 import edu.gemini.epics.EpicsService;
+import edu.gemini.epics.EpicsReader;
+import edu.gemini.epics.impl.EpicsReaderImpl;
+import edu.gemini.epics.EpicsWriter;
+import edu.gemini.epics.impl.EpicsWriterImpl;
 import gov.aps.jca.CAException;
 
 /**
@@ -179,20 +183,21 @@ public final class CaService {
      *            optional description for the apply sender.
      * @return the apply sender.
      * @throws CAException
-     *            Error in the Channel Access library.
      */
     public CaApplySender createApplySender(String name, String applyRecord,
             String carRecord, Boolean gem5, String description) throws CAException {
         CaApplySender a = applySenders.get(name);
         if (a == null) {
             ApplySenderWithResource b;
+            EpicsReader epicsReader = new EpicsReaderImpl(epicsService);
+            EpicsWriter epicsWriter = new EpicsWriterImpl(epicsService);
             if(gem5) {
                 b = new CaApplySenderImpl<>(name, applyRecord, carRecord,
-                        description, CarStateGEM5.class, epicsService);
+                        description, CarStateGEM5.class, epicsReader, epicsWriter);
             }
             else {
                 b = new CaApplySenderImpl<>(name, applyRecord, carRecord,
-                        description, CarState.class, epicsService);
+                        description, CarState.class, epicsReader, epicsWriter);
             }
             applySenders.put(name, b);
             return b;
@@ -216,32 +221,25 @@ public final class CaService {
      *            the name of the EPICS apply record.
      * @param carRecord
      *            the name of the EPICS CAR record associated with the apply.
-     * @param observeCarRecord
-     *            the name of the EPICS CAR record for the observe state.
-     * @param gem5
-     *            CAR record uses GEM5 definition.
-     * @param stopCmdRecord
-     *            the name of the EPICS CAD for the stop command.
-     * @param abortCmdRecord
-     *            the name of the EPICS CAD for the abort command.
      * @param description
      *            optional description for the apply sender.
      * @return the apply sender.
      * @throws CAException
-     *            Error in the Channel Access library.
      */
     public CaApplySender createObserveSender(String name, String applyRecord,
             String carRecord, String observeCarRecord, Boolean gem5, String stopCmdRecord, String abortCmdRecord, String description) throws CAException {
         CaApplySender a = observeSenders.get(name);
         if (a == null) {
             ApplySenderWithResource b;
+            EpicsReader epicsReader = new EpicsReaderImpl(epicsService);
+            EpicsWriter epicsWriter = new EpicsWriterImpl(epicsService);
             if(gem5) {
                 b = new CaObserveSenderImpl<CarStateGEM5>(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
-                        description, CarStateGEM5.class, epicsService);
+                        description, CarStateGEM5.class, epicsReader, epicsWriter);
             }
             else  {
                 b = new CaObserveSenderImpl<CarState>(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
-                        description, CarState.class, epicsService);
+                        description, CarState.class, epicsReader, epicsWriter);
             }
             observeSenders.put(name, b);
             return b;
@@ -282,13 +280,15 @@ public final class CaService {
         CaApplySender a = observeSenders.get(name);
         if (a == null) {
             ApplySenderWithResource b;
+            EpicsReader epicsReader = new EpicsReaderImpl(epicsService);
+            EpicsWriter epicsWriter = new EpicsWriterImpl(epicsService);
             if(gem5) {
                 b = new CaSimpleObserveSenderImpl<CarStateGEM5>(name, applyRecord, carRecord, stopCmdRecord, abortCmdRecord,
-                        description, CarStateGEM5.class, epicsService);
+                        description, CarStateGEM5.class, epicsReader, epicsWriter);
             }
             else  {
                 b = new CaSimpleObserveSenderImpl<CarState>(name, applyRecord, carRecord, stopCmdRecord, abortCmdRecord,
-                        description, CarState.class, epicsService);
+                        description, CarState.class, epicsReader, epicsWriter);
             }
             observeSenders.put(name, b);
             return b;
@@ -424,7 +424,7 @@ public final class CaService {
      * @param recordName the name of the EPICS record
      * @param description the description of the record.
      * @return the TaskControlSender
-     * @throws CAException Error in the Channel Access library.
+     * @throws CAException
      */
     public CaTaskControl createTaskControlSender(String name, String recordName, String description)
             throws CAException {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -183,6 +183,7 @@ public final class CaService {
      *            optional description for the apply sender.
      * @return the apply sender.
      * @throws CAException
+     *            Error in the Channel Access library.
      */
     public CaApplySender createApplySender(String name, String applyRecord,
             String carRecord, Boolean gem5, String description) throws CAException {
@@ -221,10 +222,19 @@ public final class CaService {
      *            the name of the EPICS apply record.
      * @param carRecord
      *            the name of the EPICS CAR record associated with the apply.
+     * @param observeCarRecord
+     *            the name of the EPICS CAR record for the observe state.
+     * @param gem5
+     *            CAR record uses GEM5 definition.
+     * @param stopCmdRecord
+     *            the name of the EPICS CAD for the stop command.
+     * @param abortCmdRecord
+     *            the name of the EPICS CAD for the abort command.
      * @param description
      *            optional description for the apply sender.
      * @return the apply sender.
      * @throws CAException
+     *            Error in the Channel Access library.
      */
     public CaApplySender createObserveSender(String name, String applyRecord,
             String carRecord, String observeCarRecord, Boolean gem5, String stopCmdRecord, String abortCmdRecord, String description) throws CAException {
@@ -425,6 +435,7 @@ public final class CaService {
      * @param description the description of the record.
      * @return the TaskControlSender
      * @throws CAException
+     *            Error in the Channel Access library.
      */
     public CaTaskControl createTaskControlSender(String name, String recordName, String description)
             throws CAException {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaSimpleObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaSimpleObserveSenderImpl.java
@@ -6,7 +6,7 @@
 package edu.gemini.epics.acm;
 
 import edu.gemini.epics.EpicsReader;
-import edu.gemini.epics.EpicsService;
+import edu.gemini.epics.EpicsWriter;
 import edu.gemini.epics.ReadOnlyClientEpicsChannel;
 import edu.gemini.epics.api.ChannelListener;
 import edu.gemini.epics.impl.EpicsReaderImpl;
@@ -61,15 +61,14 @@ public class CaSimpleObserveSenderImpl<C extends Enum<C> & CarStateGeneric> impl
             final String abortCmd,
             final String description,
             final Class<C> carClass,
-            final EpicsService epicsService) throws CAException {
+            final EpicsReader epicsReader,
+            final EpicsWriter epicsWriter) throws CAException {
         super();
         this.name = name;
         this.description = description;
         this.currentState = idleState;
 
-        EpicsReader epicsReader = new EpicsReaderImpl(epicsService);
-
-        apply = new CaApplyRecord(applyRecord, epicsService);
+        apply = new CaApplyRecord(applyRecord, epicsReader, epicsWriter);
         // apply.VAL int > 0
         apply.registerValListener(valListener = (String arg0, List<Integer> newVals) -> {
             if (newVals != null && !newVals.isEmpty()) {
@@ -77,7 +76,7 @@ public class CaSimpleObserveSenderImpl<C extends Enum<C> & CarStateGeneric> impl
             }
         });
 
-        car = new CaCarRecord<C>(carRecord, carClass, epicsService);
+        car = new CaCarRecord<C>(carRecord, carClass, epicsReader);
         // applyC.CLID int > 0
         car.registerClidListener(carClidListener = (String arg0, List<Integer> newVals) -> {
             if (newVals != null && !newVals.isEmpty()) {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaSimpleObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaSimpleObserveSenderImpl.java
@@ -629,8 +629,21 @@ public class CaSimpleObserveSenderImpl<C extends Enum<C> & CarStateGeneric> impl
 
         @Override
         public ApplyState onCarValChange(CarStateGeneric val)  {
-            failCommand(cm, new CaObserveAborted());
-            return idleState;
+            if(val.isIdle()) {
+                failCommand(cm, new CaObserveAborted());
+                return idleState;
+            }
+            else if(val.isError()) {
+                failCommandWithCarError(cm);
+                return idleState;
+            }
+            else if(val.isPaused()) {
+                pauseCommand(cm);
+                return idleState;
+            }
+            else {
+                return this;
+            }
         }
 
         @Override

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CadDirective.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CadDirective.java
@@ -5,6 +5,6 @@
 
 package edu.gemini.epics.acm;
 
-enum CadDirective {
+public enum CadDirective {
     MARK, CLEAR, PRESET, START, STOP
 }

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/SafeExecutor.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/SafeExecutor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package edu.gemini.epics.acm;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import org.slf4j.Logger;
+
+public interface SafeExecutor {
+    public static ScheduledExecutorService safeExecutor(Integer threadCount, Logger logger) {
+        ThreadFactory threadFactory = new ThreadFactory() {
+
+            @Override
+            public Thread newThread(Runnable r) {
+                final Thread thread = new Thread(r);
+
+                thread.setUncaughtExceptionHandler( new Thread.UncaughtExceptionHandler() {
+
+                    @Override
+                    public void uncaughtException(Thread t, Throwable e) {
+                        logger.error("Uncaught exception on CaSimpleObserverSender at thread: " + t.getId(), e);
+                    }
+                });
+
+                return thread;
+            }
+
+        };
+
+        return new ScheduledThreadPoolExecutor(2, threadFactory);
+    }
+
+}

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
@@ -3,24 +3,15 @@
 
 package edu.gemini.epics.acm
 
-import java.util.concurrent.TimeUnit
-
-// import com.cosylab.epics.caj.CAJContext
-// import edu.gemini.epics.EpicsService
-// import com.cosylab.epics.caj.CAJContext
-// import com.cosylab.epics.caj.CAJChannel
-// import edu.gemini.epics.EpicsService
 import edu.gemini.epics.EpicsReader
 import edu.gemini.epics.EpicsWriter
 import edu.gemini.epics.api.ChannelListener
 import edu.gemini.epics.ReadWriteClientEpicsChannel
-// import edu.gemini.epics.impl.ReadWriteEpicsEnumChannel
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-
-import org.scalamock.scalatest.MockFactory
-// import org.scalamock.function.MockFunction1
 import java.lang.{Integer => JInteger}
 import java.lang.{Short => JShort}
+import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 
 /**
@@ -110,7 +101,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // CAR VAL change
     observe.onCarValChange(CarState.IDLE)
     assert(observe.applyState().isIdle)
-    l.waitDone()
+    l.waitDone(1, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // Check that listener was called
@@ -322,7 +313,6 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // CAR VAL change
     observe.onCarValChange(CarState.IDLE)
     assert(observe.applyState().isIdle)
-    // l.waitDone()
     assert(!l.isDone)
     // Check that listener was called
     assert(observeErrorCount.get() === 0)
@@ -375,7 +365,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.IDLE)
     assert(observe.applyState().isIdle)
-    // k.waitDone()
+    k.waitDone(1, TimeUnit.SECONDS)
     assert(k.isDone)
 
     // ENDOBSERVE
@@ -480,7 +470,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     observe.onObserveCarValChange(CarState.IDLE)
     // And we are done and IDLE
     assert(observe.applyState().isIdle)
-    l.waitDone()
+    l.waitDone(1, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // Check that listener was called
@@ -567,7 +557,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     observe.onObserveCarValChange(CarState.ERROR)
     // We should capture the error and go IDLE
     assert(observe.applyState().isIdle)
-    l.waitDone()
+    l.waitDone(1, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // Check that listener was called
@@ -644,7 +634,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     observe.onObserveCarValChange(CarState.ERROR)
     // We should capture the error and go IDLE
     assert(observe.applyState().isIdle)
-    l.waitDone()
+    l.waitDone(1, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // Check that listener was called
@@ -726,200 +716,204 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     assert(observeSuccessCount.get() === 1)
   }
 
-  // // TODO Enable the following tests after SEQNG-978 is done
-  // test("GSAOI stopped observation") {
-  //   val context: CAJContext = mock[CAJContext]
-  //   (context.addContextExceptionListener _).expects(*).returns(()).repeat(4)
-  //   (context.addContextMessageListener _).expects(*).returns(()).repeat(4)
-  //   (context.pendIO _).expects(*).returns(()).repeat(1 to 6)
-  //   // We just return null as we don't need the channels and don't want to mock them
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.DIR").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.VAL").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.MESS").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:observeC.CLID").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:observeC.VAL").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:observeC.OMSS").returns(null)
-  //   val epicsService = new EpicsService(context)
-  //   val observe = new CaSimpleObserveSenderImpl(
-  //     "gsaoi::observeCmd",
-  //     "gsaoi:dc:obsapply",
-  //     "gsaoi:dc:observeC",
-  //     "gsaoi:dc:stop",
-  //     "gsaoi:dc:abort",
-  //     "GSAOI Observe",
-  //     classOf[CarState],
-  //     epicsService)
-  //   // Start idle
-  //   assert(observe.applyState().isIdle)
-  //
-  //   // Post an observe
-  //   val l = observe.post()
-  //
-  //   // VAL change
-  //   observe.onApplyValChange(4167)
-  //   assert(!observe.applyState().isIdle)
-  //   // CAR CLID change
-  //   observe.onCarClidChange(4167)
-  //   assert(!observe.applyState().isIdle)
-  //   // CAR VAL change
-  //   observe.onCarValChange(CarState.BUSY)
-  //   assert(!observe.applyState().isIdle)
-  //   // Another VAL change
-  //   observe.onApplyValChange(4167)
-  //   assert(!observe.applyState().isIdle)
-  //   // CAR CLID change
-  //   observe.onCarClidChange(4167)
-  //   assert(!observe.applyState().isIdle)
-  //   observe.onStopMarkChange(1.toShort)
-  //   assert(!observe.applyState().isIdle)
-  //   observe.onStopMarkChange(2.toShort)
-  //   assert(!observe.applyState().isIdle)
-  //   observe.onStopMarkChange(0.toShort)
-  //   assert(!observe.applyState().isIdle)
-  //   // Apply goes IDLE
-  //   observe.onCarValChange(CarState.IDLE)
-  //   // And we are done and IDLE
-  //   assert(observe.applyState().isIdle)
-  //   l.waitDone(1, TimeUnit.SECONDS)
-  //   assert(l.error.isInstanceOf[CaObserveStopped])
-  // }
-  //
-  // test("GSAOI aborted observation") {
-  //   val context: CAJContext = mock[CAJContext]
-  //   (context.addContextExceptionListener _).expects(*).returns(()).repeat(4)
-  //   (context.addContextMessageListener _).expects(*).returns(()).repeat(4)
-  //   (context.pendIO _).expects(*).returns(()).repeat(1 to 6)
-  //   // We just return null as we don't need the channels and don't want to mock them
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.DIR").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.VAL").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:obsapply.MESS").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:observeC.CLID").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:observeC.VAL").returns(null)
-  //   (context.createChannel(_: String)).expects("gsaoi:dc:observeC.OMSS").returns(null)
-  //   val epicsService = new EpicsService(context)
-  //   val observe = new CaSimpleObserveSenderImpl(
-  //     "gsaoi::observeCmd",
-  //     "gsaoi:dc:obsapply",
-  //     "gsaoi:dc:observeC",
-  //     "gsaoi:dc:stop",
-  //     "gsaoi:dc:abort",
-  //     "GSAOI Observe",
-  //     classOf[CarState],
-  //     epicsService)
-  //   // Start idle
-  //   assert(observe.applyState().isIdle)
-  //
-  //   // Post an observe
-  //   val l = observe.post()
-  //
-  //   // VAL change
-  //   observe.onApplyValChange(4167)
-  //   assert(!observe.applyState().isIdle)
-  //   // CAR CLID change
-  //   observe.onCarClidChange(4167)
-  //   assert(!observe.applyState().isIdle)
-  //   // CAR VAL change
-  //   observe.onCarValChange(CarState.BUSY)
-  //   assert(!observe.applyState().isIdle)
-  //   // Another VAL change
-  //   observe.onApplyValChange(4167)
-  //   assert(!observe.applyState().isIdle)
-  //   // CAR CLID change
-  //   observe.onCarClidChange(4167)
-  //   assert(!observe.applyState().isIdle)
-  //   observe.onAbortMarkChange(1.toShort)
-  //   assert(!observe.applyState().isIdle)
-  //   observe.onAbortMarkChange(2.toShort)
-  //   assert(!observe.applyState().isIdle)
-  //   observe.onAbortMarkChange(0.toShort)
-  //   assert(!observe.applyState().isIdle)
-  //   // Apply goes IDLE
-  //   observe.onCarValChange(CarState.IDLE)
-  //   // And we are done and IDLE
-  //   assert(observe.applyState().isIdle)
-  //   l.waitDone(1, TimeUnit.SECONDS)
-  //   assert(l.error.isInstanceOf[CaObserveAborted])
-  // }
+  test("GSAOI stopped observation") {
+    val epicsReader = mock[EpicsReader]
+    val epicsWriter = mock[EpicsWriter]
+
+    (epicsWriter.getEnumChannel _).expects("gsaoi:dc:obsapply.DIR", *).returns(dirChannel)
+    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:obsapply.VAL").returns(intChannelS)
+    (epicsReader.getStringChannel _).expects("gsaoi:dc:obsapply.MESS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:observeC.CLID").returns(intChannelS)
+    (epicsReader.getEnumChannel _).expects("gsaoi:dc:observeC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gsaoi:dc:observeC.OMSS").returns(strChannel)
+    (epicsReader.getShortChannel _).expects("gsaoi:dc:stop.MARK").returns(shortChannel)
+    (epicsReader.getShortChannel _).expects("gsaoi:dc:abort.MARK").returns(shortChannel)
+    val observe = new CaSimpleObserveSenderImpl(
+      "gsaoi::observeCmd",
+      "gsaoi:dc:obsapply",
+      "gsaoi:dc:observeC",
+      "gsaoi:dc:stop",
+      "gsaoi:dc:abort",
+      "GSAOI Observe",
+      classOf[CarState],
+      epicsReader,
+      epicsWriter)
+    // Start idle
+    assert(observe.applyState().isIdle)
+
+    val observeErrorCount = new AtomicInteger()
+    val observePauseCount = new AtomicInteger()
+    val observeSuccessCount = new AtomicInteger()
+    // Post an observe
+    val l = observe.post()
+    l.setCallback(new CaCommandListener() {
+      def onFailure(ex: Exception): Unit = {
+        observeErrorCount.incrementAndGet()
+        ()
+      }
+      def onPause(): Unit = {
+        observePauseCount.incrementAndGet()
+        ()
+      }
+      def onSuccess(): Unit = {
+        observeSuccessCount.incrementAndGet()
+        ()
+      }
+    })
+
+    // VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+    // Another VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    observe.onStopMarkChange(1.toShort)
+    assert(!observe.applyState().isIdle)
+    observe.onStopMarkChange(2.toShort)
+    assert(!observe.applyState().isIdle)
+    observe.onStopMarkChange(0.toShort)
+    assert(!observe.applyState().isIdle)
+    // Apply goes IDLE
+    observe.onCarValChange(CarState.IDLE)
+    // And we are done and IDLE
+    assert(observe.applyState().isIdle)
+    l.waitDone(1, TimeUnit.SECONDS)
+    assert(l.error.isInstanceOf[CaObserveStopped])
+    // Check that listener was called
+    assert(observeErrorCount.get() === 1)
+    assert(observePauseCount.get() === 0)
+    assert(observeSuccessCount.get() === 0)
+  }
+
+  test("GSAOI aborted observation") {
+    val epicsReader = mock[EpicsReader]
+    val epicsWriter = mock[EpicsWriter]
+
+    (epicsWriter.getEnumChannel _).expects("gsaoi:dc:obsapply.DIR", *).returns(dirChannel)
+    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:obsapply.VAL").returns(intChannelS)
+    (epicsReader.getStringChannel _).expects("gsaoi:dc:obsapply.MESS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:observeC.CLID").returns(intChannelS)
+    (epicsReader.getEnumChannel _).expects("gsaoi:dc:observeC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gsaoi:dc:observeC.OMSS").returns(strChannel)
+    (epicsReader.getShortChannel _).expects("gsaoi:dc:stop.MARK").returns(shortChannel)
+    (epicsReader.getShortChannel _).expects("gsaoi:dc:abort.MARK").returns(shortChannel)
+    val observe = new CaSimpleObserveSenderImpl(
+      "gsaoi::observeCmd",
+      "gsaoi:dc:obsapply",
+      "gsaoi:dc:observeC",
+      "gsaoi:dc:stop",
+      "gsaoi:dc:abort",
+      "GSAOI Observe",
+      classOf[CarState],
+      epicsReader,
+      epicsWriter)
+    // Start idle
+    assert(observe.applyState().isIdle)
+
+    val observeErrorCount = new AtomicInteger()
+    val observePauseCount = new AtomicInteger()
+    val observeSuccessCount = new AtomicInteger()
+    // Post an observe
+    val l = observe.post()
+    l.setCallback(new CaCommandListener() {
+      def onFailure(ex: Exception): Unit = {
+        observeErrorCount.incrementAndGet()
+        ()
+      }
+      def onPause(): Unit = {
+        observePauseCount.incrementAndGet()
+        ()
+      }
+      def onSuccess(): Unit = {
+        observeSuccessCount.incrementAndGet()
+        ()
+      }
+    })
+
+    // VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+    // Another VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    observe.onAbortMarkChange(1.toShort)
+    assert(!observe.applyState().isIdle)
+    observe.onAbortMarkChange(2.toShort)
+    assert(!observe.applyState().isIdle)
+    observe.onAbortMarkChange(0.toShort)
+    assert(!observe.applyState().isIdle)
+    // Apply goes IDLE
+    observe.onCarValChange(CarState.IDLE)
+    // And we are done and IDLE
+    l.waitDone(1, TimeUnit.SECONDS)
+    assert(observe.applyState().isIdle)
+    assert(l.error.isInstanceOf[CaObserveAborted])
+
+    // Check that listener was called
+    assert(observeErrorCount.get() === 1)
+    assert(observePauseCount.get() === 0)
+    assert(observeSuccessCount.get() === 0)
+  }
+
+
+  // Functions to setup mocks with different expectations
 
   def dirChannel = {
-    val m  = mock[CadDirectiveChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
+    val m  = mock[CadDirectiveChannelMock]
     (m.setValue(_: CadDirective)).expects(*)
-    // (m.registerListener(_: edu.gemini.epics.api.ChannelListener[CadDirective])).expects(*)
-    // (m.registerListener _).expects(*)
     m
   }
+
   def dirChannelPause = {
     val m  = mock[CadDirectiveChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
     (m.setValue(_: CadDirective)).expects(*).twice()
-    // (m.registerListener(_: edu.gemini.epics.api.ChannelListener[CadDirective])).expects(*)
-    // (m.registerListener _).expects(*)
     m
   }
-  def dirChannelNoSet = {
-    val m  = mock[CadDirectiveChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
-    // (m.setValue(_: CadDirective)).expects(*)
-    // (m.registerListener(_: edu.gemini.epics.api.ChannelListener[CadDirective])).expects(*)
-    // (m.registerListener _).expects(*)
-    m
-  }
+
+  def dirChannelNoSet = mock[CadDirectiveChannelMock]
+
   def carChannel = {
-    val m  = mock[CarStateChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
-    // (m.setValue(_: CarState)).expects(*)
+    val m  = mock[CarStateChannelMock]
     (m.registerListener(_: edu.gemini.epics.api.ChannelListener[CarState])).expects(*)
-    // (m.registerListener _).expects(*)
     m
   }
+
   def intChannelS = {
-    val m  = mock[IntChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
-    // (m.setValue(_: JInteger)).expects(*)
+    val m  = mock[IntChannelMock]
     (m.registerListener(_: ChannelListener[JInteger])).expects(*)
-    // (m.registerListener _).expects(*)
     m
   }
-  def intChannel = {
-    val m  = mock[IntChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
-    // (m.setValue(_: JInteger)).expects(*)
-    // (m.registerListener(_: ChannelListener[JInteger])).expects(*)
-    // (m.registerListener _).expects(*)
-    m
-  }
-  def strChannel = {
-    val m  = mock[StringChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
-    // (m.setValue(_: JInteger)).expects(*)
-    // (m.registerListener(_: ChannelListener[String])).expects(*)
-    // (m.registerListener _).expects(*)
-    m
-  }
+  def intChannel =  mock[IntChannelMock]
+
+  def strChannel = mock[StringChannelMock]
+
   def strChannelErr = {
-    val m  = mock[StringChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
+    val m  = mock[StringChannelMock]
     (m.getFirst _).expects().once().returns("Error msg")
-    // (m.registerListener(_: ChannelListener[String])).expects(*)
-    // (m.registerListener _).expects(*)
     m
   }
+
   def shortChannel = {
-    val m  = mock[ShortChannelMock]//(dirCAJChannel, null, 0.1)
-    // val t: MockFunction1[edu.gemini.epics.api.ChannelListener[A], Unit] = m.registerListener: edu.gemini.epics.api.ChannelListener[A] => Unit
-    // (t).expects(*)
-    // (m.setValue(_: JInteger)).expects(*)
+    val m  = mock[ShortChannelMock]
     (m.registerListener(_: ChannelListener[JShort])).expects(*)
-    // (m.registerListener _).expects(*)
     m
   }
 }
@@ -938,10 +932,10 @@ class CadDirectiveChannelMock extends ReadWriteClientEpicsChannel[CadDirective] 
   override def getName(): String = null
   override def getType(): gov.aps.jca.dbr.DBRType = null
   override def isValid(): Boolean = true
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[CadDirective]): Unit = {}
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelListener[CadDirective]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[CadDirective]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelListener[CadDirective]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelAlarmListener[CadDirective]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelListener[CadDirective]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelAlarmListener[CadDirective]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelListener[CadDirective]): Unit = {}
   override def destroy(): Unit = {}
 }
 
@@ -954,10 +948,10 @@ class CarStateChannelMock extends ReadWriteClientEpicsChannel[CarState] {
   override def getName(): String = null
   override def getType(): gov.aps.jca.dbr.DBRType = null
   override def isValid(): Boolean = true
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[CarState]): Unit = {}
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelListener[CarState]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[CarState]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelListener[CarState]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelAlarmListener[CarState]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelListener[CarState]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelAlarmListener[CarState]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelListener[CarState]): Unit = {}
   override def destroy(): Unit = {}
 }
 
@@ -970,10 +964,10 @@ class IntChannelMock extends ReadWriteClientEpicsChannel[JInteger] {
   override def getName(): String = null
   override def getType(): gov.aps.jca.dbr.DBRType = null
   override def isValid(): Boolean = true
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[JInteger]): Unit = {}
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelListener[JInteger]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[JInteger]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelListener[JInteger]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelAlarmListener[JInteger]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelListener[JInteger]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelAlarmListener[JInteger]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelListener[JInteger]): Unit = {}
   override def destroy(): Unit = {}
 }
 
@@ -986,10 +980,10 @@ class ShortChannelMock extends ReadWriteClientEpicsChannel[JShort] {
   override def getName(): String = null
   override def getType(): gov.aps.jca.dbr.DBRType = null
   override def isValid(): Boolean = true
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[JShort]): Unit = {}
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelListener[JShort]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[JShort]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelListener[JShort]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelAlarmListener[JShort]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelListener[JShort]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelAlarmListener[JShort]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelListener[JShort]): Unit = {}
   override def destroy(): Unit = {}
 }
 
@@ -1002,9 +996,9 @@ class StringChannelMock extends ReadWriteClientEpicsChannel[String] {
   override def getName(): String = null
   override def getType(): gov.aps.jca.dbr.DBRType = null
   override def isValid(): Boolean = true
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[String]): Unit = {}
-  override def registerListener(x$1: edu.gemini.epics.api.ChannelListener[String]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelAlarmListener[String]): Unit = {}
-  override def unRegisterListener(x$1: edu.gemini.epics.api.ChannelListener[String]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelAlarmListener[String]): Unit = {}
+  override def registerListener(x: edu.gemini.epics.api.ChannelListener[String]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelAlarmListener[String]): Unit = {}
+  override def unRegisterListener(x: edu.gemini.epics.api.ChannelListener[String]): Unit = {}
   override def destroy(): Unit = {}
 }

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
@@ -23,7 +23,10 @@ import org.scalatest._
   * care about the state of the channels. Instead we want to only observe
   * the state transitions
   */
-@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.PublicInference", "org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.AsInstanceOf"))
+@SuppressWarnings(
+  Array("org.wartremover.warts.NonUnitStatements",
+        "org.wartremover.warts.PublicInference",
+        "org.wartremover.warts.IsInstanceOf"))
 final class ObserveStateSpec extends FunSuite with MockFactory {
 
   test("NIFS normal observation") {
@@ -923,6 +926,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
 // This is exactly the case for `ReadWriteClientEpicsChannel[T]` and the [register|unRegister]Listener methods
 // The workaround is to create classes such as below with concrete type and mock those
 // https://github.com/paulbutcher/ScalaMock/issues/193
+@SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
 class CadDirectiveChannelMock extends ReadWriteClientEpicsChannel[CadDirective] {
   override def setValue(a: java.util.List[CadDirective]): Unit = {}
   override def setValue(a : CadDirective): Unit = {}
@@ -939,6 +943,7 @@ class CadDirectiveChannelMock extends ReadWriteClientEpicsChannel[CadDirective] 
   override def destroy(): Unit = {}
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
 class CarStateChannelMock extends ReadWriteClientEpicsChannel[CarState] {
   override def setValue(a: java.util.List[CarState]): Unit = {}
   override def setValue(a : CarState): Unit = {}
@@ -955,6 +960,7 @@ class CarStateChannelMock extends ReadWriteClientEpicsChannel[CarState] {
   override def destroy(): Unit = {}
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
 class IntChannelMock extends ReadWriteClientEpicsChannel[JInteger] {
   override def setValue(a: java.util.List[JInteger]): Unit = {}
   override def setValue(a : JInteger): Unit = {}
@@ -971,6 +977,7 @@ class IntChannelMock extends ReadWriteClientEpicsChannel[JInteger] {
   override def destroy(): Unit = {}
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
 class ShortChannelMock extends ReadWriteClientEpicsChannel[JShort] {
   override def setValue(a: java.util.List[JShort]): Unit = {}
   override def setValue(a : JShort): Unit = {}
@@ -987,6 +994,7 @@ class ShortChannelMock extends ReadWriteClientEpicsChannel[JShort] {
   override def destroy(): Unit = {}
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
 class StringChannelMock extends ReadWriteClientEpicsChannel[String] {
   override def setValue(a: java.util.List[String]): Unit = {}
   override def setValue(a : String): Unit = {}

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
@@ -27,23 +27,11 @@ import org.scalatest._
   Array("org.wartremover.warts.NonUnitStatements",
         "org.wartremover.warts.PublicInference",
         "org.wartremover.warts.IsInstanceOf"))
-final class ObserveStateSpec extends FunSuite with MockFactory {
+final class ObserveStateSpec extends FunSuite with GsaoiMocks with NifsMocks with GmosMocks with NiriMocks {
 
   test("NIFS normal observation") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
+    val (epicsReader, epicsWriter) = nifsMocks
 
-    (epicsWriter.getEnumChannel _).expects("nifs:dc:nifsApply.DIR", *).returns(dirChannel)
-    (epicsReader.getIntegerChannel _).expects("nifs:dc:nifsApply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("nifs:dc:nifsApply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("nifs:dc:applyC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("nifs:dc:applyC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("nifs:dc:applyC.OMSS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("nifs:dc:observeC.CLID").returns(intChannel)
-    (epicsReader.getEnumChannel _).expects("nifs:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("nifs:dc:observeC.OMSS").returns(strChannel)
-    (epicsReader.getShortChannel _).expects("nifs:dc:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("nifs:dc:abort.MARK").returns(shortChannel)
     val observe = new CaObserveSenderImpl(
       "nifs::observeCmd",
       "nifs:dc:nifsApply",
@@ -104,7 +92,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // CAR VAL change
     observe.onCarValChange(CarState.IDLE)
     assert(observe.applyState().isIdle)
-    l.waitDone(1, TimeUnit.SECONDS)
+    l.waitDone(2, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // Check that listener was called
@@ -114,20 +102,8 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
   }
 
   test("GMOS normal observation") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
+    val (epicsReader, epicsWriter) = gmosMocks
 
-    (epicsWriter.getEnumChannel _).expects("gm:apply.DIR", *).returns(dirChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:apply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("gm:apply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:applyC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("gm:applyC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gm:applyC.OMSS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:dc:observeC.CLID").returns(intChannel)
-    (epicsReader.getEnumChannel _).expects("gm:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gm:dc:observeC.OMSS").returns(strChannel)
-    (epicsReader.getShortChannel _).expects("gm:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("gm:abort.MARK").returns(shortChannel)
     val observe = new CaObserveSenderImpl(
       "gmos::observeCmd",
       "gm:apply",
@@ -191,7 +167,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     observe.onObserveCarValChange(CarState.IDLE)
     // And we are done and IDLE
     assert(observe.applyState().isIdle)
-    l.waitDone(1, TimeUnit.SECONDS)
+    l.waitDone(2, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // ENDOBSERVE
@@ -221,20 +197,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
   }
 
   test("GMOS paused observation") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
-
-    (epicsWriter.getEnumChannel _).expects("gm:apply.DIR", *).returns(dirChannelPause)
-    (epicsReader.getIntegerChannel _).expects("gm:apply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("gm:apply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:applyC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("gm:applyC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gm:applyC.OMSS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:dc:observeC.CLID").returns(intChannel)
-    (epicsReader.getEnumChannel _).expects("gm:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gm:dc:observeC.OMSS").returns(strChannel)
-    (epicsReader.getShortChannel _).expects("gm:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("gm:abort.MARK").returns(shortChannel)
+    val (epicsReader, epicsWriter) = gmosPausedMocks
 
     val observe = new CaObserveSenderImpl(
       "gmos::observeCmd",
@@ -368,7 +331,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // Observe CAR VAL change
     observe.onObserveCarValChange(CarState.IDLE)
     assert(observe.applyState().isIdle)
-    k.waitDone(1, TimeUnit.SECONDS)
+    k.waitDone(2, TimeUnit.SECONDS)
     assert(k.isDone)
 
     // ENDOBSERVE
@@ -397,106 +360,9 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     assert(observeSuccessCount.get() === 1)
   }
 
-  test("NIRI normal observation") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
-
-    (epicsWriter.getEnumChannel _).expects("niri:dc:apply.DIR", *).returns(dirChannel)
-    (epicsReader.getIntegerChannel _).expects("niri:dc:apply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("niri:dc:apply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("niri:dc:applyC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("niri:dc:applyC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("niri:dc:applyC.OMSS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("niri:dc:observeC.CLID").returns(intChannel)
-    (epicsReader.getEnumChannel _).expects("niri:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("niri:dc:observeC.OMSS").returns(strChannel)
-    (epicsReader.getShortChannel _).expects("niri:dc:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("niri:dc:abort.MARK").returns(shortChannel)
-
-    val observe = new CaObserveSenderImpl(
-      "niri::observeCmd",
-      "niri:dc:apply",
-      "niri:dc:applyC",
-      "niri:dc:observeC",
-      "niri:dc:stop",
-      "niri:dc:abort",
-      "NIRI Observe",
-      classOf[CarState],
-      epicsReader,
-      epicsWriter)
-
-    // Start idle
-    assert(observe.applyState().isIdle)
-    val observeErrorCount = new AtomicInteger()
-    val observePauseCount = new AtomicInteger()
-    val observeSuccessCount = new AtomicInteger()
-    // Post an observe
-    val l = observe.post()
-    l.setCallback(new CaCommandListener() {
-      def onFailure(ex: Exception): Unit = {
-        observeErrorCount.incrementAndGet()
-        ()
-      }
-      def onPause(): Unit = {
-        observePauseCount.incrementAndGet()
-        ()
-      }
-      def onSuccess(): Unit = {
-        observeSuccessCount.incrementAndGet()
-        ()
-      }
-    })
-
-    // OBSERVE
-    // OBSERVE goes BUSY
-    observe.onObserveCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle)
-    // CAR CLID change
-    observe.onCarClidChange(365)
-    assert(!observe.applyState().isIdle)
-    // CAR VAL change
-    observe.onCarValChange(CarState.BUSY)
-    assert(!observe.applyState().isIdle)
-
-    // Apply VAL change
-    observe.onApplyValChange(365)
-    assert(!observe.applyState().isIdle)
-    // CAR CLID change
-    observe.onCarClidChange(365)
-    assert(!observe.applyState().isIdle)
-    // CAR VAL change
-    observe.onCarValChange(CarState.IDLE)
-    assert(!observe.applyState().isIdle)
-
-    // OBSERVE goes IDLE
-    // Observe CAR VAL change
-    observe.onObserveCarValChange(CarState.IDLE)
-    // And we are done and IDLE
-    assert(observe.applyState().isIdle)
-    l.waitDone(1, TimeUnit.SECONDS)
-    assert(l.isDone)
-
-    // Check that listener was called
-    assert(observeErrorCount.get() === 0)
-    assert(observePauseCount.get() === 0)
-    assert(observeSuccessCount.get() === 1)
-  }
-
   test("GMOS observation with an error case 1") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
+    val (epicsReader, epicsWriter) = gmosErrMocks
 
-    (epicsWriter.getEnumChannel _).expects("gm:apply.DIR", *).returns(dirChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:apply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("gm:apply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:applyC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("gm:applyC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gm:applyC.OMSS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:dc:observeC.CLID").returns(intChannel)
-    (epicsReader.getEnumChannel _).expects("gm:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gm:dc:observeC.OMSS").returns(strChannelErr)
-    (epicsReader.getShortChannel _).expects("gm:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("gm:abort.MARK").returns(shortChannel)
     val observe = new CaObserveSenderImpl(
       "gmos::observeCmd",
       "gm:apply",
@@ -560,7 +426,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     observe.onObserveCarValChange(CarState.ERROR)
     // We should capture the error and go IDLE
     assert(observe.applyState().isIdle)
-    l.waitDone(1, TimeUnit.SECONDS)
+    l.waitDone(2, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // Check that listener was called
@@ -570,20 +436,8 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
   }
 
   test("GMOS observation with an error case 2") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
+    val (epicsReader, epicsWriter) = gmosErrMocks
 
-    (epicsWriter.getEnumChannel _).expects("gm:apply.DIR", *).returns(dirChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:apply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("gm:apply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:applyC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("gm:applyC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gm:applyC.OMSS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gm:dc:observeC.CLID").returns(intChannel)
-    (epicsReader.getEnumChannel _).expects("gm:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gm:dc:observeC.OMSS").returns(strChannelErr)
-    (epicsReader.getShortChannel _).expects("gm:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("gm:abort.MARK").returns(shortChannel)
     val observe = new CaObserveSenderImpl(
       "gmos::observeCmd",
       "gm:apply",
@@ -637,7 +491,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     observe.onObserveCarValChange(CarState.ERROR)
     // We should capture the error and go IDLE
     assert(observe.applyState().isIdle)
-    l.waitDone(1, TimeUnit.SECONDS)
+    l.waitDone(2, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // Check that listener was called
@@ -646,18 +500,80 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     assert(observeSuccessCount.get() === 0)
   }
 
-  test("GSAOI normal observation") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
+  test("NIRI normal observation") {
+    val (epicsReader, epicsWriter) = niriMocks
 
-    (epicsWriter.getEnumChannel _).expects("gsaoi:dc:obsapply.DIR", *).returns(dirChannel)
-    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:obsapply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("gsaoi:dc:obsapply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:observeC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("gsaoi:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gsaoi:dc:observeC.OMSS").returns(strChannel)
-    (epicsReader.getShortChannel _).expects("gsaoi:dc:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("gsaoi:dc:abort.MARK").returns(shortChannel)
+    val observe = new CaObserveSenderImpl(
+      "niri::observeCmd",
+      "niri:dc:apply",
+      "niri:dc:applyC",
+      "niri:dc:observeC",
+      "niri:dc:stop",
+      "niri:dc:abort",
+      "NIRI Observe",
+      classOf[CarState],
+      epicsReader,
+      epicsWriter)
+
+    // Start idle
+    assert(observe.applyState().isIdle)
+    val observeErrorCount = new AtomicInteger()
+    val observePauseCount = new AtomicInteger()
+    val observeSuccessCount = new AtomicInteger()
+    // Post an observe
+    val l = observe.post()
+    l.setCallback(new CaCommandListener() {
+      def onFailure(ex: Exception): Unit = {
+        observeErrorCount.incrementAndGet()
+        ()
+      }
+      def onPause(): Unit = {
+        observePauseCount.incrementAndGet()
+        ()
+      }
+      def onSuccess(): Unit = {
+        observeSuccessCount.incrementAndGet()
+        ()
+      }
+    })
+
+    // OBSERVE
+    // OBSERVE goes BUSY
+    observe.onObserveCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(365)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+
+    // Apply VAL change
+    observe.onApplyValChange(365)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(365)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.IDLE)
+    assert(!observe.applyState().isIdle)
+
+    // OBSERVE goes IDLE
+    // Observe CAR VAL change
+    observe.onObserveCarValChange(CarState.IDLE)
+    // And we are done and IDLE
+    assert(observe.applyState().isIdle)
+    l.waitDone(2, TimeUnit.SECONDS)
+    assert(l.isDone)
+
+    // Check that listener was called
+    assert(observeErrorCount.get() === 0)
+    assert(observePauseCount.get() === 0)
+    assert(observeSuccessCount.get() === 1)
+  }
+
+  test("GSAOI normal observation") {
+    val (epicsReader, epicsWriter) = gsaoiMocks
     val observe = new CaSimpleObserveSenderImpl(
       "gsaoi::observeCmd",
       "gsaoi:dc:obsapply",
@@ -710,7 +626,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     observe.onCarValChange(CarState.IDLE)
     // And we are done and IDLE
     assert(observe.applyState().isIdle)
-    l.waitDone(1, TimeUnit.SECONDS)
+    l.waitDone(2, TimeUnit.SECONDS)
     assert(l.isDone)
 
     // Check that listener was called
@@ -720,17 +636,8 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
   }
 
   test("GSAOI stopped observation") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
+    val (epicsReader, epicsWriter) = gsaoiMocks
 
-    (epicsWriter.getEnumChannel _).expects("gsaoi:dc:obsapply.DIR", *).returns(dirChannel)
-    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:obsapply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("gsaoi:dc:obsapply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:observeC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("gsaoi:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gsaoi:dc:observeC.OMSS").returns(strChannel)
-    (epicsReader.getShortChannel _).expects("gsaoi:dc:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("gsaoi:dc:abort.MARK").returns(shortChannel)
     val observe = new CaSimpleObserveSenderImpl(
       "gsaoi::observeCmd",
       "gsaoi:dc:obsapply",
@@ -789,7 +696,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     observe.onCarValChange(CarState.IDLE)
     // And we are done and IDLE
     assert(observe.applyState().isIdle)
-    l.waitDone(1, TimeUnit.SECONDS)
+    l.waitDone(2, TimeUnit.SECONDS)
     assert(l.error.isInstanceOf[CaObserveStopped])
     // Check that listener was called
     assert(observeErrorCount.get() === 1)
@@ -798,17 +705,8 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
   }
 
   test("GSAOI aborted observation") {
-    val epicsReader = mock[EpicsReader]
-    val epicsWriter = mock[EpicsWriter]
+    val (epicsReader, epicsWriter) = gsaoiMocks
 
-    (epicsWriter.getEnumChannel _).expects("gsaoi:dc:obsapply.DIR", *).returns(dirChannel)
-    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:obsapply.VAL").returns(intChannelS)
-    (epicsReader.getStringChannel _).expects("gsaoi:dc:obsapply.MESS").returns(strChannel)
-    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:observeC.CLID").returns(intChannelS)
-    (epicsReader.getEnumChannel _).expects("gsaoi:dc:observeC.VAL", *).returns(carChannel)
-    (epicsReader.getStringChannel _).expects("gsaoi:dc:observeC.OMSS").returns(strChannel)
-    (epicsReader.getShortChannel _).expects("gsaoi:dc:stop.MARK").returns(shortChannel)
-    (epicsReader.getShortChannel _).expects("gsaoi:dc:abort.MARK").returns(shortChannel)
     val observe = new CaSimpleObserveSenderImpl(
       "gsaoi::observeCmd",
       "gsaoi:dc:obsapply",
@@ -866,7 +764,7 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     // Apply goes IDLE
     observe.onCarValChange(CarState.IDLE)
     // And we are done and IDLE
-    l.waitDone(1, TimeUnit.SECONDS)
+    l.waitDone(2, TimeUnit.SECONDS)
     assert(observe.applyState().isIdle)
     assert(l.error.isInstanceOf[CaObserveAborted])
 
@@ -876,49 +774,6 @@ final class ObserveStateSpec extends FunSuite with MockFactory {
     assert(observeSuccessCount.get() === 0)
   }
 
-
-  // Functions to setup mocks with different expectations
-
-  def dirChannel = {
-    val m  = mock[CadDirectiveChannelMock]
-    (m.setValue(_: CadDirective)).expects(*)
-    m
-  }
-
-  def dirChannelPause = {
-    val m  = mock[CadDirectiveChannelMock]//(dirCAJChannel, null, 0.1)
-    (m.setValue(_: CadDirective)).expects(*).twice()
-    m
-  }
-
-  def dirChannelNoSet = mock[CadDirectiveChannelMock]
-
-  def carChannel = {
-    val m  = mock[CarStateChannelMock]
-    (m.registerListener(_: edu.gemini.epics.api.ChannelListener[CarState])).expects(*)
-    m
-  }
-
-  def intChannelS = {
-    val m  = mock[IntChannelMock]
-    (m.registerListener(_: ChannelListener[JInteger])).expects(*)
-    m
-  }
-  def intChannel =  mock[IntChannelMock]
-
-  def strChannel = mock[StringChannelMock]
-
-  def strChannelErr = {
-    val m  = mock[StringChannelMock]
-    (m.getFirst _).expects().once().returns("Error msg")
-    m
-  }
-
-  def shortChannel = {
-    val m  = mock[ShortChannelMock]
-    (m.registerListener(_: ChannelListener[JShort])).expects(*)
-    m
-  }
 }
 
 // ScalaMock has a restriction that doesn't allow it to mock overloaded methods
@@ -1009,4 +864,180 @@ class StringChannelMock extends ReadWriteClientEpicsChannel[String] {
   override def unRegisterListener(x: edu.gemini.epics.api.ChannelAlarmListener[String]): Unit = {}
   override def unRegisterListener(x: edu.gemini.epics.api.ChannelListener[String]): Unit = {}
   override def destroy(): Unit = {}
+}
+
+@SuppressWarnings(
+  Array("org.wartremover.warts.NonUnitStatements",
+        "org.wartremover.warts.PublicInference"))
+trait ChannelsFactory extends MockFactory {
+  // Functions to setup mocks with different expectations
+  def dirChannel = {
+    val m  = mock[CadDirectiveChannelMock]
+    (m.setValue(_: CadDirective)).expects(*)
+    m
+  }
+
+  def dirChannelPause = {
+    val m  = mock[CadDirectiveChannelMock]//(dirCAJChannel, null, 0.1)
+    (m.setValue(_: CadDirective)).expects(*).twice()
+    m
+  }
+
+  def dirChannelNoSet = mock[CadDirectiveChannelMock]
+
+  def carChannel = {
+    val m  = mock[CarStateChannelMock]
+    (m.registerListener(_: edu.gemini.epics.api.ChannelListener[CarState])).expects(*)
+    m
+  }
+
+  def intChannelS = {
+    val m  = mock[IntChannelMock]
+    (m.registerListener(_: ChannelListener[JInteger])).expects(*)
+    m
+  }
+  def intChannel =  mock[IntChannelMock]
+
+  def strChannel = mock[StringChannelMock]
+
+  def strChannelErr = {
+    val m  = mock[StringChannelMock]
+    (m.getFirst _).expects().once().returns("Error msg")
+    m
+  }
+
+  def shortChannel = {
+    val m  = mock[ShortChannelMock]
+    (m.registerListener(_: ChannelListener[JShort])).expects(*)
+    m
+  }
+}
+
+@SuppressWarnings(
+  Array("org.wartremover.warts.NonUnitStatements",
+        "org.wartremover.warts.PublicInference"))
+trait GsaoiMocks extends ChannelsFactory {
+  def gsaoiMocks: (EpicsReader, EpicsWriter) = {
+    val epicsReader = mock[EpicsReader]
+    val epicsWriter = mock[EpicsWriter]
+
+    (epicsWriter.getEnumChannel _).expects("gsaoi:dc:obsapply.DIR", *).returns(dirChannel)
+    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:obsapply.VAL").returns(intChannelS)
+    (epicsReader.getStringChannel _).expects("gsaoi:dc:obsapply.MESS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gsaoi:dc:observeC.CLID").returns(intChannelS)
+    (epicsReader.getEnumChannel _).expects("gsaoi:dc:observeC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gsaoi:dc:observeC.OMSS").returns(strChannel)
+    (epicsReader.getShortChannel _).expects("gsaoi:dc:stop.MARK").returns(shortChannel)
+    (epicsReader.getShortChannel _).expects("gsaoi:dc:abort.MARK").returns(shortChannel)
+    (epicsReader, epicsWriter)
+  }
+
+}
+
+@SuppressWarnings(
+  Array("org.wartremover.warts.NonUnitStatements",
+        "org.wartremover.warts.PublicInference"))
+trait NifsMocks extends ChannelsFactory {
+  def nifsMocks: (EpicsReader, EpicsWriter) = {
+    val epicsReader = mock[EpicsReader]
+    val epicsWriter = mock[EpicsWriter]
+
+    (epicsWriter.getEnumChannel _).expects("nifs:dc:nifsApply.DIR", *).returns(dirChannel)
+    (epicsReader.getIntegerChannel _).expects("nifs:dc:nifsApply.VAL").returns(intChannelS)
+    (epicsReader.getStringChannel _).expects("nifs:dc:nifsApply.MESS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("nifs:dc:applyC.CLID").returns(intChannelS)
+    (epicsReader.getEnumChannel _).expects("nifs:dc:applyC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("nifs:dc:applyC.OMSS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("nifs:dc:observeC.CLID").returns(intChannel)
+    (epicsReader.getEnumChannel _).expects("nifs:dc:observeC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("nifs:dc:observeC.OMSS").returns(strChannel)
+    (epicsReader.getShortChannel _).expects("nifs:dc:stop.MARK").returns(shortChannel)
+    (epicsReader.getShortChannel _).expects("nifs:dc:abort.MARK").returns(shortChannel)
+    (epicsReader, epicsWriter)
+  }
+
+}
+
+@SuppressWarnings(
+  Array("org.wartremover.warts.NonUnitStatements",
+        "org.wartremover.warts.PublicInference"))
+trait GmosMocks extends ChannelsFactory {
+  def gmosMocks: (EpicsReader, EpicsWriter) = {
+    val epicsReader = mock[EpicsReader]
+    val epicsWriter = mock[EpicsWriter]
+
+    (epicsWriter.getEnumChannel _).expects("gm:apply.DIR", *).returns(dirChannel)
+    (epicsReader.getIntegerChannel _).expects("gm:apply.VAL").returns(intChannelS)
+    (epicsReader.getStringChannel _).expects("gm:apply.MESS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gm:applyC.CLID").returns(intChannelS)
+    (epicsReader.getEnumChannel _).expects("gm:applyC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gm:applyC.OMSS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gm:dc:observeC.CLID").returns(intChannel)
+    (epicsReader.getEnumChannel _).expects("gm:dc:observeC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gm:dc:observeC.OMSS").returns(strChannel)
+    (epicsReader.getShortChannel _).expects("gm:stop.MARK").returns(shortChannel)
+    (epicsReader.getShortChannel _).expects("gm:abort.MARK").returns(shortChannel)
+    (epicsReader, epicsWriter)
+  }
+
+  def gmosPausedMocks: (EpicsReader, EpicsWriter) = {
+    val epicsReader = mock[EpicsReader]
+    val epicsWriter = mock[EpicsWriter]
+
+    (epicsWriter.getEnumChannel _).expects("gm:apply.DIR", *).returns(dirChannelPause)
+    (epicsReader.getIntegerChannel _).expects("gm:apply.VAL").returns(intChannelS)
+    (epicsReader.getStringChannel _).expects("gm:apply.MESS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gm:applyC.CLID").returns(intChannelS)
+    (epicsReader.getEnumChannel _).expects("gm:applyC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gm:applyC.OMSS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gm:dc:observeC.CLID").returns(intChannel)
+    (epicsReader.getEnumChannel _).expects("gm:dc:observeC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gm:dc:observeC.OMSS").returns(strChannel)
+    (epicsReader.getShortChannel _).expects("gm:stop.MARK").returns(shortChannel)
+    (epicsReader.getShortChannel _).expects("gm:abort.MARK").returns(shortChannel)
+    (epicsReader, epicsWriter)
+  }
+
+  def gmosErrMocks: (EpicsReader, EpicsWriter) = {
+    val epicsReader = mock[EpicsReader]
+    val epicsWriter = mock[EpicsWriter]
+
+    (epicsWriter.getEnumChannel _).expects("gm:apply.DIR", *).returns(dirChannel)
+    (epicsReader.getIntegerChannel _).expects("gm:apply.VAL").returns(intChannelS)
+    (epicsReader.getStringChannel _).expects("gm:apply.MESS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gm:applyC.CLID").returns(intChannelS)
+    (epicsReader.getEnumChannel _).expects("gm:applyC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gm:applyC.OMSS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("gm:dc:observeC.CLID").returns(intChannel)
+    (epicsReader.getEnumChannel _).expects("gm:dc:observeC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("gm:dc:observeC.OMSS").returns(strChannelErr)
+    (epicsReader.getShortChannel _).expects("gm:stop.MARK").returns(shortChannel)
+    (epicsReader.getShortChannel _).expects("gm:abort.MARK").returns(shortChannel)
+    (epicsReader, epicsWriter)
+  }
+
+}
+
+@SuppressWarnings(
+  Array("org.wartremover.warts.NonUnitStatements",
+        "org.wartremover.warts.PublicInference"))
+trait NiriMocks extends ChannelsFactory {
+  def niriMocks: (EpicsReader, EpicsWriter) = {
+    val epicsReader = mock[EpicsReader]
+    val epicsWriter = mock[EpicsWriter]
+
+    (epicsWriter.getEnumChannel _).expects("niri:dc:apply.DIR", *).returns(dirChannel)
+    (epicsReader.getIntegerChannel _).expects("niri:dc:apply.VAL").returns(intChannelS)
+    (epicsReader.getStringChannel _).expects("niri:dc:apply.MESS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("niri:dc:applyC.CLID").returns(intChannelS)
+    (epicsReader.getEnumChannel _).expects("niri:dc:applyC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("niri:dc:applyC.OMSS").returns(strChannel)
+    (epicsReader.getIntegerChannel _).expects("niri:dc:observeC.CLID").returns(intChannel)
+    (epicsReader.getEnumChannel _).expects("niri:dc:observeC.VAL", *).returns(carChannel)
+    (epicsReader.getStringChannel _).expects("niri:dc:observeC.OMSS").returns(strChannel)
+    (epicsReader.getShortChannel _).expects("niri:dc:stop.MARK").returns(shortChannel)
+    (epicsReader.getShortChannel _).expects("niri:dc:abort.MARK").returns(shortChannel)
+    (epicsReader, epicsWriter)
+  }
+
 }


### PR DESCRIPTION
This PR includes several changes to the epics code to handle observations:

* Epics channels can be mocked using `EpicsReader` and `EpicsWriter` rather than `EpicsService`. This way we can test the listeners and avoid certain failures
* Failures to write to DIR are properly handled
* GSAOI ignored tests are now enabled
* GSAOI abort properly ends on failure
* the executors used on the the classes handling state changes will caught exceptions. This should help to debug exceptional situations not yet considered