### PR TITLE
Upgrade http4s and other libraries

### DIFF
--- a/modules/shared/web/server/src/test/scala/web/server/common/StaticRoutesSpec.scala
+++ b/modules/shared/web/server/src/test/scala/web/server/common/StaticRoutesSpec.scala
@@ -49,7 +49,7 @@ class StaticRoutesSpec extends FlatSpec with Matchers with EitherValues {
     "return a file if present on resources" in {
       val service = new StaticRoutes(false, builtAtMillis, ExecutionContext.global).service
       service.apply(Request(uri = uri("/css/test.css"))).value.map(_.map(_.status)).unsafeRunSync should contain(Status.Ok)
-      service.apply(Request(uri = uri("/css/test.css"))).value.map(_.map(_.headers)).unsafeRunSync.getOrElse(Headers.empty) should contain (`Content-Type`(text.css))
+      service.apply(Request(uri = uri("/css/test.css"))).value.map(_.map(_.headers)).unsafeRunSync.getOrElse(Headers.empty).toList should contain (`Content-Type`(text.css))
     }
     it should "not leak the application configuration file" in {
       val service = new StaticRoutes(true, builtAtMillis, ExecutionContext.global).service
@@ -57,11 +57,11 @@ class StaticRoutesSpec extends FlatSpec with Matchers with EitherValues {
     }
     it should "cache them for a year on production mode" in {
       val service = new StaticRoutes(false, builtAtMillis, ExecutionContext.global).service
-      service.apply(Request(uri = uri("/css/test.css"))).value.map(_.map(_.headers)).unsafeRunSync.getOrElse(Headers.empty) should contain (`Cache-Control`(NonEmptyList.of(`max-age`(31536000.seconds))))
+      service.apply(Request(uri = uri("/css/test.css"))).value.map(_.map(_.headers)).unsafeRunSync.getOrElse(Headers.empty).toList should contain (`Cache-Control`(NonEmptyList.of(`max-age`(31536000.seconds))))
     }
     it should "not cache them on dev mode" in {
       val service = new StaticRoutes(true, builtAtMillis, ExecutionContext.global).service
-      service.apply(Request(uri = uri("/css/test.css"))).value.map(_.map(_.headers)).unsafeRunSync.getOrElse(Headers.empty) should not contain `Cache-Control`(NonEmptyList.of(`max-age`(31536000.seconds)))
+      service.apply(Request(uri = uri("/css/test.css"))).value.map(_.map(_.headers)).unsafeRunSync.getOrElse(Headers.empty).toList should not contain `Cache-Control`(NonEmptyList.of(`max-age`(31536000.seconds)))
     }
     it should "support fingerprinting" in {
       val service = new StaticRoutes(true, builtAtMillis, ExecutionContext.global).service

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -91,9 +91,9 @@ object Settings {
     val scalaParsersVersion     = "1.1.1"
     val scalaXmlVerson          = "1.1.1"
 
-    val http4sVersion           = "0.20.0-M7"
+    val http4sVersion           = "0.20.0"
     val squants                 = "1.4.0"
-    val argonaut                = "6.2.2"
+    val argonaut                = "6.2.3"
     val commonsHttp             = "2.0.2"
     val unboundId               = "3.2.1"
     val jwt                     = "2.1.0"
@@ -106,9 +106,9 @@ object Settings {
     val monocleVersion          = "1.5.1-cats"
     val circeVersion            = "0.11.1"
     val doobieVersion           = "0.6.0"
-    val flywayVersion           = "5.2.1"
+    val flywayVersion           = "5.2.4"
     val tucoVersion             = "0.4.1"
-    val declineVersion          = "0.6.0"
+    val declineVersion          = "0.6.2"
 
     // test libraries
     val scalaTest               = "3.0.5"
@@ -275,7 +275,7 @@ object Settings {
   object PluginVersions {
     // Compiler plugins
     val paradiseVersion    = "2.1.1"
-    val kpVersion          = "0.9.9"
+    val kpVersion          = "0.9.10"
   }
 
   object Plugins {


### PR DESCRIPTION
Http4s 0.20.0 has been released. Note that we are still using the async client