### PR TITLE
SEQNG-979 Better handling of step selection when a sequence is running

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Event.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Event.scala
@@ -20,7 +20,8 @@ final case class EventSystem(se: SystemEvent) extends Event[Nothing]
 
 object Event {
 
-  def start[D<:Engine.Types](id: Observation.Id, user: UserDetails, clientId: ClientId, userCheck: D#StateType => Boolean): Event[D] = EventUser[D](Start[D](id, user.some, clientId, userCheck))
+  def start[D<:Engine.Types](id: Observation.Id, user: UserDetails, clientId: ClientId, userCheck: D#StateType => Boolean): Event[D] =
+    EventUser[D](Start[D](id, user.some, clientId, userCheck))
   def pause[D<:Engine.Types](id: Observation.Id, user: UserDetails): Event[D] = EventUser[D](Pause(id, user.some))
   def cancelPause[D<:Engine.Types](id: Observation.Id, user: UserDetails): Event[D] = EventUser[D](CancelPause(id, user.some))
   def breakpoint[D<:Engine.Types](id: Observation.Id, user: UserDetails, step: StepId, v: Boolean): Event[D] = EventUser[D](Breakpoint(id, user.some, step, v))

--- a/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/ModelLenses.scala
@@ -76,7 +76,7 @@ trait ModelLenses {
   // Focus on the sequence view
   val sequenceQueueViewL: Lens[SeqexecModelUpdate, SequencesQueue[SequenceView]] =
     Lens[SeqexecModelUpdate, SequencesQueue[SequenceView]](_.view)(q => {
-      case e @ SequenceStart(_)                => e.copy(view = q)
+      case e @ SequenceStart(_, _, _)          => e.copy(view = q)
       case e @ StepExecuted(_, _)              => e.copy(view = q)
       case e @ FileIdStepExecuted(_, _)        => e.copy(view = q)
       case e @ SequenceCompleted(_)            => e.copy(view = q)

--- a/modules/seqexec/model/src/main/scala/seqexec/model/RunningStep.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/RunningStep.scala
@@ -1,12 +1,13 @@
 // Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package seqexec.web.client.model
+package seqexec.model
 
-import cats._
+import cats.Show
+import cats.Eq
 import cats.implicits._
 
-final case class RunningStep(last: Int, total: Int)
+final case class RunningStep(last: StepId, total: StepId)
 
 object RunningStep {
   implicit val show: Show[RunningStep] =

--- a/modules/seqexec/model/src/main/scala/seqexec/model/RunningStep.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/RunningStep.scala
@@ -7,9 +7,22 @@ import cats.Show
 import cats.Eq
 import cats.implicits._
 
-final case class RunningStep(last: StepId, total: StepId)
+sealed trait RunningStep {
+  val last: StepId
+  val total: StepId
+}
 
 object RunningStep {
+  val Zero: RunningStep = RunningStepImpl(0, 0)
+
+  private final case class RunningStepImpl(last: StepId, total: StepId) extends RunningStep
+
+  def fromInt(last: StepId, total: StepId): Option[RunningStep] =
+    if (last >= 0 && total >= last) RunningStepImpl(last, total).some else none
+
+  def unapply(r: RunningStep): Option[(StepId, StepId)] =
+    Some((r.last, r.total))
+
   implicit val show: Show[RunningStep] =
     Show.show(u => s"${u.last + 1}/${u.total}")
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/SequenceView.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/SequenceView.scala
@@ -18,14 +18,14 @@ final case class SequenceView (
   willStopIn: Option[Int]
 ) {
 
-  def progress: RunningStep =
-    RunningStep(steps.count(_.isFinished), steps.length)
+  def progress: Option[RunningStep] =
+    RunningStep.fromInt(steps.count(_.isFinished), steps.length)
 
   // Returns where on the sequence the execution is at
   def runningStep: Option[RunningStep] = status match {
-    case SequenceState.Running(_, _) => Some(progress)
-    case SequenceState.Failed(_)     => Some(progress)
-    case _                           => None
+    case SequenceState.Running(_, _) => progress
+    case SequenceState.Failed(_)     => progress
+    case _                           => none
   }
 }
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/SequenceView.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/SequenceView.scala
@@ -16,7 +16,18 @@ final case class SequenceView (
   status:     SequenceState,
   steps:      List[Step],
   willStopIn: Option[Int]
-)
+) {
+
+  def progress: RunningStep =
+    RunningStep(steps.count(_.isFinished), steps.length)
+
+  // Returns where on the sequence the execution is at
+  def runningStep: Option[RunningStep] = status match {
+    case SequenceState.Running(_, _) => Some(progress)
+    case SequenceState.Failed(_)     => Some(progress)
+    case _                           => None
+  }
+}
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SequenceView {

--- a/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
@@ -98,12 +98,12 @@ object events {
       Some(u.view)
   }
 
-  final case class SequenceStart(view: SequencesQueue[SequenceView])
+  final case class SequenceStart(obsId: Observation.Id, stepId: StepId, view: SequencesQueue[SequenceView])
       extends SeqexecModelUpdate
 
   object SequenceStart {
     implicit lazy val equal: Eq[SequenceStart] =
-      Eq.by(_.view)
+      Eq.by(x => (x.obsId, x.stepId, x.view))
   }
 
   final case class StepExecuted(obsId: Observation.Id,

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -8,13 +8,14 @@ import cats.kernel.laws.discipline._
 import seqexec.model.enum._
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.events.SingleActionEvent
+import seqexec.model.arb.ArbRunningStep
 import squants.time.Time
 import squants.time.TimeUnit
 
 /**
   * Tests Model typeclasses
   */
-final class ModelSpec extends CatsSuite {
+final class ModelSpec extends CatsSuite with ArbRunningStep {
 
   checkAll("Eq[UserDetails]", EqTests[UserDetails].eqv)
   checkAll("Eq[SystemName]", EqTests[SystemName].eqv)
@@ -59,4 +60,5 @@ final class ModelSpec extends CatsSuite {
   checkAll("Eq[Time]", EqTests[Time].eqv)
   checkAll("Eq[SingleActionOp]", EqTests[SingleActionOp].eqv)
   checkAll("Eq[SingleActionEvent]", EqTests[SingleActionEvent].eqv)
+  checkAll("Eq[RunningStep]", EqTests[RunningStep].eqv)
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -23,9 +23,15 @@ trait SequenceEventsArbitraries extends ArbTime {
       id <- arbitrary[ClientId]
     } yield ConnectionOpenEvent(u, id)
   }
+
   implicit val sseArb = Arbitrary[SequenceStart] {
-    arbitrary[SequencesQueue[SequenceView]].map(SequenceStart.apply)
+    for {
+      id <- arbitrary[Observation.Id]
+      si <- arbitrary[StepId]
+      sv <- arbitrary[SequencesQueue[SequenceView]]
+    } yield SequenceStart(id, si, sv)
   }
+
   implicit val seeArb = Arbitrary[StepExecuted] {
     for {
       i <- arbitrary[Observation.Id]
@@ -293,6 +299,7 @@ trait SequenceEventsArbitraries extends ArbTime {
 
   implicit val oprCogen: Cogen[ObservationProgressEvent] =
     Cogen[ObservationProgress].contramap(_.progress)
+
 }
 
 object SequenceEventsArbitraries extends SequenceEventsArbitraries

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbRunningStep.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbRunningStep.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.arb
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Arbitrary._
+import seqexec.model.RunningStep
+import seqexec.model.StepId
+
+trait ArbRunningStep {
+
+  implicit val arbRunningStep: Arbitrary[RunningStep] =
+    Arbitrary {
+      for {
+        l <- arbitrary[StepId]
+        i <- arbitrary[StepId]
+      } yield RunningStep(l, i)
+    }
+
+  implicit val runningStepCogen: Cogen[RunningStep] =
+    Cogen[(StepId, StepId)].contramap(x => (x.last, x.total))
+
+}
+
+object ArbRunningStep extends ArbRunningStep

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbRunningStep.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbRunningStep.scala
@@ -5,7 +5,7 @@ package seqexec.model.arb
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
 import seqexec.model.RunningStep
 import seqexec.model.StepId
 
@@ -14,9 +14,9 @@ trait ArbRunningStep {
   implicit val arbRunningStep: Arbitrary[RunningStep] =
     Arbitrary {
       for {
-        l <- arbitrary[StepId]
-        i <- arbitrary[StepId]
-      } yield RunningStep(l, i)
+        l <- Gen.posNum[Int]
+        i <- Gen.choose(l, Int.MaxValue)
+      } yield RunningStep.fromInt(l, i).getOrElse(RunningStep.Zero)
     }
 
   implicit val runningStepCogen: Cogen[RunningStep] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -92,9 +92,9 @@ package server {
   final case class UpdateQueueRemove(qid: QueueId, seqs: List[Observation.Id], pos: List[Int]) extends SeqEvent
   final case class UpdateQueueMoved(qid: QueueId, cid: ClientId, oid: Observation.Id, pos: Int) extends SeqEvent
   final case class UpdateQueueClear(qid: QueueId) extends SeqEvent
-  final case class StartSysConfig(sid: Observation.Id, stepIs: StepId, res: Resource) extends SeqEvent
+  final case class StartSysConfig(sid: Observation.Id, stepId: StepId, res: Resource) extends SeqEvent
   final case class Busy(sid: Observation.Id, cid: ClientId) extends SeqEvent
-  case object SequenceStart extends SeqEvent
+  final case class SequenceStart(sid: Observation.Id, stepId: StepId) extends SeqEvent
   case object NullSeqEvent extends SeqEvent
 
   sealed trait ControlStrategy

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -29,11 +29,11 @@ import seqexec.model.UnknownTargetName
 import seqexec.model.Observer
 import seqexec.model.SequenceState
 import seqexec.model.CalibrationQueueId
+import seqexec.model.RunningStep
 import seqexec.web.client.circuit._
 import seqexec.web.client.actions._
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.model.ObsClass
-import seqexec.web.client.model.RunningStep
 import seqexec.web.client.model.SessionQueueFilter
 import seqexec.web.client.model.ModelOps._
 import seqexec.web.client.semanticui.elements.icon.Icon.IconAttention

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -97,7 +97,7 @@ object StepConfigToolbar {
                                       onClick = p.router.setUrlAndDispatchCB(
                                         prevStepPage)), "Prev"))),
               Label(
-                Label.Props(RunningStep(p.step, p.total).show,
+                Label.Props(RunningStep.fromInt(p.step, p.total).getOrElse(RunningStep.Zero).show,
                             size        = Size.Large,
                             extraStyles = List(SeqexecStyles.labelAsButton))),
               // Next step button

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -12,8 +12,8 @@ import japgolly.scalajs.react.React
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import seqexec.model.enum.Instrument
+import seqexec.model.RunningStep
 import seqexec.web.client.model.Pages._
-import seqexec.web.client.model.RunningStep
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.circuit.SequenceInfoFocus
 import seqexec.web.client.components.SeqexecStyles

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SequenceTab.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SequenceTab.scala
@@ -14,10 +14,10 @@ import japgolly.scalajs.react._
 import seqexec.model.Observer
 import seqexec.model.SequenceState
 import seqexec.model.enum.Instrument
+import seqexec.model.RunningStep
 import seqexec.web.client.actions.LoadSequence
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.model.AvailableTab
-import seqexec.web.client.model.RunningStep
 import seqexec.web.client.model.TabSelected
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.semanticui._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/InitialSyncHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/InitialSyncHandler.scala
@@ -14,7 +14,6 @@ import seqexec.model.events.SeqexecModelUpdate
 import seqexec.web.client.actions._
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages._
-import seqexec.web.client.model.ModelOps._
 import scala.concurrent.Future
 import cats.implicits._
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ObservationsProgressStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ObservationsProgressStateHandler.scala
@@ -14,7 +14,6 @@ import seqexec.web.client.model._
 import seqexec.web.client.actions._
 import seqexec.web.client.model.lenses.sequenceStepT
 import seqexec.web.client.model.lenses.sequenceViewT
-import seqexec.web.client.model.ModelOps._
 
 /**
   * Handles updates to obs progress

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
@@ -177,6 +177,12 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       updated(value.copy(sequences = filterSequences(sv)), clearAction)
   }
 
+  val sequenceStartMessage: PartialFunction[Any, ActionResult[M]] = {
+    case ServerMessage(SequenceStart(id, s, sv)) =>
+      val updateSelectedStep = Effect(Future(UpdateSelectedStep(id, s)))
+      updated(value.copy(sequences = filterSequences(sv)), updateSelectedStep)
+  }
+
   val stopCompletedMessage: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(SequenceStopped(id, sv)) =>
       // A step completed with a stop
@@ -261,6 +267,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       sequenceLoadedMessage,
       sequenceUnloadedMessage,
       stopCompletedMessage,
+      sequenceStartMessage,
       sequenceRefreshedMessage,
       sequencePauseCancelMessage,
       modelUpdateMessage,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -57,16 +57,6 @@ object ModelOps {
 
   implicit class SequenceViewOps(val s: SequenceView) extends AnyVal {
 
-    def progress: RunningStep =
-      RunningStep(s.steps.count(_.isFinished), s.steps.length)
-
-    // Returns where on the sequence the execution is at
-    def runningStep: Option[RunningStep] = s.status match {
-      case SequenceState.Running(_, _) => Some(progress)
-      case SequenceState.Failed(_)     => Some(progress)
-      case _                           => None
-    }
-
     def allStepsDone: Boolean = s.steps.forall(_.status === StepState.Completed)
 
     def flipSkipMarkAtStep(step: Step): SequenceView =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -16,6 +16,7 @@ import seqexec.model.Observer
 import seqexec.model.StepId
 import seqexec.model.SequenceState
 import seqexec.model.SequenceView
+import seqexec.model.RunningStep
 import seqexec.model.enum._
 import seqexec.web.client.model.ModelOps._
 import seqexec.web.client.components.sequence.steps.StepsTable

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -27,7 +27,10 @@ import seqexec.model.Step
 import seqexec.model.StepId
 import seqexec.model.UserDetails
 import seqexec.model.ObservationProgress
+import seqexec.model.RunningStep
+import seqexec.model.ObservationProgress
 import seqexec.model.events.ServerLogMessage
+import seqexec.model.arb.ArbRunningStep._
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.SequenceEventsArbitraries.slmArb
 import seqexec.model.SequenceEventsArbitraries.slmCogen
@@ -409,17 +412,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
 
   implicit val cssCogen: Cogen[ClientStatus] =
     Cogen[(Option[UserDetails], WebSocketConnection)].contramap(x => (x.u, x.w))
-
-  implicit val arbRunningStep: Arbitrary[RunningStep] =
-    Arbitrary {
-      for {
-        l <- arbitrary[Int]
-        i <- arbitrary[Int]
-      } yield RunningStep(l, i)
-    }
-
-  implicit val runningStepCogen: Cogen[RunningStep] =
-    Cogen[(Int, Int)].contramap(x => (x.last, x.total))
 
   implicit val arbSection: Arbitrary[SectionVisibilityState] =
     Arbitrary(Gen.oneOf(SectionOpen, SectionClosed))

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -25,7 +25,6 @@ final class ModelSpec extends CatsSuite with ArbitrariesWebClient {
   checkAll("Eq[Pot[A]]", EqTests[Pot[Int]].eqv)
   checkAll("Eq[WebSocketConnection]", EqTests[WebSocketConnection].eqv)
   checkAll("Eq[ClientStatus]", EqTests[ClientStatus].eqv)
-  checkAll("Eq[RunningStep]", EqTests[RunningStep].eqv)
   checkAll("Eq[AvailableTab]", EqTests[AvailableTab].eqv)
   checkAll("Eq[TabSelected]", EqTests[TabSelected].eqv)
   checkAll("Eq[SeqexecTabActive]", EqTests[SeqexecTabActive].eqv)


### PR DESCRIPTION
At the moment you can select step x and if you execute run on a previous step you end up with an odd situation where the run subsystem buttons are available though the sequence is running as:

![image](https://user-images.githubusercontent.com/3615303/56758260-2fed9280-6764-11e9-9ba2-b824fecb0b95.png)

This PR fixes that removing the step selection in this case. Additionally we forbid step selection while a sequence is running