### PR TITLE
SEQNG-821 Synchronize resource execution across clients

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -74,6 +74,10 @@ object actions {
                                step:     StepId,
                                resource: Resource)
       extends Action
+  final case class RunResourceRemote(id:       Observation.Id,
+                                     step:     StepId,
+                                     resource: Resource)
+      extends Action
   final case class RunResourceComplete(id:       Observation.Id,
                                        step:     StepId,
                                        resource: Resource)
@@ -169,6 +173,8 @@ object actions {
                                         s:  TableState[StepsTable.TableColumn])
       extends Action
   final case class UpdateSelectedStep(id: Observation.Id, step: StepId)
+      extends Action
+  final case class UpdateSelectedStepForce(id: Observation.Id, step: StepId)
       extends Action
   final case class UpdateCalTableState(id: QueueId,
                                        s:  TableState[CalQueueTable.TableColumn])

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/RemoteRequestsHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/RemoteRequestsHandler.scala
@@ -8,7 +8,6 @@ import diode.ActionHandler
 import diode.ActionResult
 import diode.Effect
 import diode.ModelRW
-import gem.Observation
 import seqexec.model.ClientId
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
@@ -131,9 +130,8 @@ class RemoteRequestsHandler[M](modelRW: ModelRW[M, Option[ClientId]])
         requestEffect(
           id,
           SeqexecWebClient.runResource(step, resource, _),
-          (id: Observation.Id) => RunResource(id, step, resource),
-          (id: Observation.Id) =>
-            RunResourceFailed(id,
+          RunResource(_, step, resource),
+          RunResourceFailed(_,
                               step,
                               resource,
                               s"Http call to configure ${resource.show} failed")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
@@ -236,6 +236,10 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       effectOnly(Effect(Future(RunResourceComplete(sid, stepId, r))))
 
     case ServerMessage(
+        SingleActionEvent(SingleActionOp.Started(sid, stepId, r))) =>
+      effectOnly(Effect(Future(RunResourceRemote(sid, stepId, r))))
+
+    case ServerMessage(
         SingleActionEvent(SingleActionOp.Error(sid, stepId, r, msg))) =>
       // Unbundle the underlying exception message
       val actualMsg = msg match {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -229,7 +229,7 @@ object InstrumentSequenceTab {
         (x.instrument,
          x.sequence,
          x.stepConfig,
-         x.selectedStep,
+         x.selected,
          x.tableState,
          x.tabOperations))
 


### PR DESCRIPTION
There are some discrepancies across multiple clients when a resource is executed. this PR fixes two things:

* If a resource in step x is executed the state of execution is reflected in all clients
* If a second client has selected another step y and step x is executed at the first client, the step being executed is selected in all clients

![screencast 2019-04-25 17-36-50](https://user-images.githubusercontent.com/3615303/56770059-03943f00-6781-11e9-961e-f7ac480bda63.gif)
