### PR TITLE
SENG-887A: Make Epics reads referentially transparent

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -403,9 +403,7 @@ object EpicsUtil {
   def executeIfNeeded[F[_]: Monad, A](i:     List[F[Option[F[Unit]]]],
                                               after: F[A]): F[Unit] =
     i.sequence.flatMap { l =>
-      val act: List[F[Unit]] = l.collect {
-        case Some(x) => x
-      }
+      val act: List[F[Unit]] = l.mapFilter(identity)
       (act.sequence *> after).whenA(act.nonEmpty)
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -77,9 +77,9 @@ object Flamingos2Header {
   }
 
   object InstKeywordReaderImpl extends InstKeywordsReader[IO] {
-    override def getHealth: SeqActionF[IO, String] = Flamingos2Epics.instance.health.toSeqActionDefault
+    override def getHealth: SeqActionF[IO, String] = SeqActionF.embed(Flamingos2Epics.instance.health.safeValOrDefault)
 
-    override def getState: SeqActionF[IO, String] = Flamingos2Epics.instance.state.toSeqActionDefault
+    override def getState: SeqActionF[IO, String] = SeqActionF.embed(Flamingos2Epics.instance.state.safeValOrDefault)
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -196,10 +196,12 @@ package keywords {
       new DefaultHeaderValue[Int] {
         val default: Int = IntDefault
       }
+
     implicit val DoubleDefaultValue: DefaultHeaderValue[Double] =
       new DefaultHeaderValue[Double] {
         val default: Double = DoubleDefault
       }
+
     implicit val StrDefaultValue: DefaultHeaderValue[String] =
       new DefaultHeaderValue[String] {
         val default: String = StrDefault

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.nifs
 
-import cats.Monad
 import cats.Eq
 import cats.data.OptionT
 import cats.effect.IO
@@ -100,17 +99,6 @@ object NifsControllerEpics extends NifsEncoders {
 
   private val ConfigTimeout: Time  = Seconds(400)
   private val DefaultTimeout: Time = Seconds(60)
-
-  // This method takes a list of actions returning possible actions
-  // If at least one is defined it will execute them and then execut after
-  private def executeIfNeeded[F[_]: Monad, A](i:     List[F[Option[F[Unit]]]],
-                                              after: F[A]): F[Unit] =
-    i.sequence.flatMap { l =>
-      val act: List[F[Unit]] = l.collect {
-        case Some(x) => x
-      }
-      (act.sequence *> after).whenA(act.nonEmpty)
-    }
 
   import NifsController._
   import NifsLookupTables._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
@@ -80,54 +80,58 @@ object NiriKeywordReaderDummy extends NiriKeywordReader[IO] {
 
 object NiriKeywordReaderImpl extends NiriKeywordReader[IO] {
   val sys = NiriEpics.instance
-  override def arrayId: SeqAction[String] = sys.arrayId.toSeqActionDefault
-  override def arrayType: SeqAction[String] = sys.arrayType.toSeqActionDefault
-  override def camera: SeqAction[String] = sys.camera.toSeqActionDefault
-  override def coadds: SeqAction[Int] = sys.coadds.toSeqActionDefault
-  override def exposureTime: SeqAction[Double] = (sys.integrationTime, sys.minIntegration).mapN(_ + _)
-    .toSeqActionDefault
-  override def filter1: SeqAction[String] = sys.filter1.toSeqActionDefault
-  override def filter2: SeqAction[String] = sys.filter2.toSeqActionDefault
-  override def filter3: SeqAction[String] = sys.filter3.toSeqActionDefault
-  override def focusName: SeqAction[String] = sys.focus.toSeqActionDefault
-  override def focusPosition: SeqAction[Double] = sys.focusPosition.toSeqActionDefault
-  override def focalPlaneMask: SeqAction[String] = sys.mask.toSeqActionDefault
-  override def beamSplitter: SeqAction[String] = sys.beamSplitter.toSeqActionDefault
-  override def windowCover: SeqAction[String] = sys.windowCover.toSeqActionDefault
-  override def framesPerCycle: SeqAction[Int] = sys.framesPerCycle.toSeqActionDefault
-  override def headerTiming: SeqAction[String] = sys.hdrTiming.toSeqActionDefault.map{
+  override def arrayId: SeqAction[String] = SeqActionF.embed(sys.arrayId.safeValOrDefault)
+  override def arrayType: SeqAction[String] = SeqActionF.embed(sys.arrayType.safeValOrDefault)
+  override def camera: SeqAction[String] = SeqActionF.embed(sys.camera.safeValOrDefault)
+  override def coadds: SeqAction[Int] = SeqActionF.embed(sys.coadds.safeValOrDefault)
+  override def exposureTime: SeqAction[Double] = SeqActionF.embed {
+    (for {
+      it <- sys.integrationTime
+      mi <- sys.minIntegration
+    } yield (it, mi).mapN(_ + _)).safeValOrDefault
+  }
+  override def filter1: SeqAction[String] = SeqActionF.embed(sys.filter1.safeValOrDefault)
+  override def filter2: SeqAction[String] = SeqActionF.embed(sys.filter2.safeValOrDefault)
+  override def filter3: SeqAction[String] = SeqActionF.embed(sys.filter3.safeValOrDefault)
+  override def focusName: SeqAction[String] = SeqActionF.embed(sys.focus.safeValOrDefault)
+  override def focusPosition: SeqAction[Double] = SeqActionF.embed(sys.focusPosition.safeValOrDefault)
+  override def focalPlaneMask: SeqAction[String] = SeqActionF.embed(sys.mask.safeValOrDefault)
+  override def beamSplitter: SeqAction[String] = SeqActionF.embed(sys.beamSplitter.safeValOrDefault)
+  override def windowCover: SeqAction[String] = SeqActionF.embed(sys.windowCover.safeValOrDefault)
+  override def framesPerCycle: SeqAction[Int] = SeqActionF.embed(sys.framesPerCycle.safeValOrDefault)
+  override def headerTiming: SeqAction[String] = SeqActionF.embed(sys.hdrTiming.safeValOrDefault.map{
     case 1 => "BEFORE"
     case 2 => "AFTER"
     case 3 => "BOTH"
     case _ => "INDEF"
-  }
-  override def lnrs: SeqAction[Int] = sys.lnrs.toSeqActionDefault
-  override def mode: SeqAction[String] = sys.mode.toSeqActionDefault.map{
+  })
+  override def lnrs: SeqAction[Int] = SeqActionF.embed(sys.lnrs.safeValOrDefault)
+  override def mode: SeqAction[String] = SeqActionF.embed(sys.mode.safeValOrDefault.map{
     case 0 => "STARE"
     case 1 => "SEP"
     case 2 => "CHOP"
     case 3 => "CHOP2"
     case 4 => "TEST"
     case _ => "INDEF"
-  }
-  override def numberDigitalAverage: SeqAction[Int] = sys.digitalAverageCount.toSeqActionDefault
-  override def pupilViewer: SeqAction[String] = sys.pupilViewer.toSeqActionDefault
-  override def detectorTemperature: SeqAction[Double] = sys.detectorTemp.toSeqActionDefault
-  override def mountTemperature: SeqAction[Double] = sys.mountTemp.toSeqActionDefault
-  override def µcodeName: SeqAction[String] = sys.µcodeName.toSeqActionDefault
-  override def µcodeType: SeqAction[String] = sys.µcodeType.toSeqActionDefault.map{
+  })
+  override def numberDigitalAverage: SeqAction[Int] = SeqActionF.embed(sys.digitalAverageCount.safeValOrDefault)
+  override def pupilViewer: SeqAction[String] = SeqActionF.embed(sys.pupilViewer.safeValOrDefault)
+  override def detectorTemperature: SeqAction[Double] = SeqActionF.embed(sys.detectorTemp.safeValOrDefault)
+  override def mountTemperature: SeqAction[Double] = SeqActionF.embed(sys.mountTemp.safeValOrDefault)
+  override def µcodeName: SeqAction[String] = SeqActionF.embed(sys.µcodeName.safeValOrDefault)
+  override def µcodeType: SeqAction[String] = SeqActionF.embed(sys.µcodeType.safeValOrDefault.map{
     case 1 => "RRD"
     case 2 => "RDD"
     case 3 => "RD"
     case 4 => "SRB"
     case _ => "INDEF"
-  }
-  override def cl1VoltageDD: SeqAction[Double] = sys.vddCl1.toSeqActionDefault
-  override def cl2VoltageDD: SeqAction[Double] = sys.vddCl2.toSeqActionDefault
-  override def ucVoltage: SeqAction[Double] = sys.vddUc.toSeqActionDefault
-  override def detectorVoltage: SeqAction[Double] = sys.detectorVDetBias.toSeqActionDefault
-  override def cl1VoltageGG: SeqAction[Double] = sys.vggCl1.toSeqActionDefault
-  override def cl2VoltageGG: SeqAction[Double] = sys.vggCl2.toSeqActionDefault
-  override def setVoltage: SeqAction[Double] = sys.detectorVSetBias.toSeqActionDefault
-  override def observationEpoch: SeqAction[Double] = sys.obsEpoch.toSeqActionDefault
+  })
+  override def cl1VoltageDD: SeqAction[Double] = SeqActionF.embed(sys.vddCl1.safeValOrDefault)
+  override def cl2VoltageDD: SeqAction[Double] = SeqActionF.embed(sys.vddCl2.safeValOrDefault)
+  override def ucVoltage: SeqAction[Double] = SeqActionF.embed(sys.vddUc.safeValOrDefault)
+  override def detectorVoltage: SeqAction[Double] = SeqActionF.embed(sys.detectorVDetBias.safeValOrDefault)
+  override def cl1VoltageGG: SeqAction[Double] = SeqActionF.embed(sys.vggCl1.safeValOrDefault)
+  override def cl2VoltageGG: SeqAction[Double] = SeqActionF.embed(sys.vggCl2.safeValOrDefault)
+  override def setVoltage: SeqAction[Double] = SeqActionF.embed(sys.detectorVSetBias.safeValOrDefault)
+  override def observationEpoch: SeqAction[Double] = SeqActionF.embed(sys.obsEpoch.safeValOrDefault)
 }


### PR DESCRIPTION
We should do all epics reads in a referentially transparent way. Some instruments are already doing that but we should port the others. This is a largish task so I'm doing a part here, porting F2 and NIRI

Note there are plenty of opportunities for further refactoring but I'm trying to make smallish PRs