### PR TITLE
SEQNG-877C: Convert GWS to do epics reads inside an effect

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsHealth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsHealth.scala
@@ -3,16 +3,15 @@
 
 package seqexec.server
 
-import scalaz.syntax.equal._
-import scalaz.std.AllInstances._
+import cats.Eq
+import cats.implicits._
 
-/**
-  * Created by jluhrs on 7/18/17.
-  */
-sealed trait EpicsHealth
+sealed trait EpicsHealth extends Product with Serializable
 
 object EpicsHealth {
-  object Good extends EpicsHealth
-  object Bad extends EpicsHealth
+  case object Good extends EpicsHealth
+  case object Bad extends EpicsHealth
   implicit def fromInt(v: Int): EpicsHealth = if (v === 0) Good else Bad
+
+  implicit val healthEq: Eq[EpicsHealth] = Eq.fromUniversalEquals
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -37,7 +37,7 @@ import seqexec.server.ghost.{Ghost, GhostHeader}
 import seqexec.server.gsaoi._
 import seqexec.server.gcal._
 import seqexec.server.gmos.{GmosHeader, GmosNorth, GmosSouth}
-import seqexec.server.gws.{DummyGwsKeywordsReader, GwsHeader, GwsKeywordsReaderImpl}
+import seqexec.server.gws.{DummyGwsKeywordsReader, GwsHeader, GwsKeywordsReaderEpics}
 import seqexec.server.tcs._
 import seqexec.server.tcs.TcsController.LightPath
 import seqexec.server.gnirs._
@@ -538,8 +538,8 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
       tcsSubsystems
     )
 
-  private def gwsHeaders(i: InstrumentSystem[IO]): Header[IO] = GwsHeader.header(i,
-    if (settings.gwsKeywords) GwsKeywordsReaderImpl else DummyGwsKeywordsReader)
+  private def gwsHeaders[F[_]: Sync: LiftIO](i: InstrumentSystem[F]): Header[F] = GwsHeader.header(i,
+    if (settings.gwsKeywords) GwsKeywordsReaderEpics[F] else DummyGwsKeywordsReader[F])
 
   private def gcalHeader[F[_]: Sync: LiftIO](i: InstrumentSystem[F]): Header[F] = GcalHeader.header(i,
     if (settings.gcalKeywords) GcalKeywordsReaderEpics[F] else DummyGcalKeywordsReader[F] )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
@@ -44,6 +44,9 @@ object SeqexecFailure {
   /** XMLRPC error while communicating with the GDS */
   final case class GdsXmlError(msg: String, url: Uri) extends SeqexecFailure
 
+  /** Null epics read */
+  final case class NullEpicsError(name: String) extends SeqexecFailure
+
   /** Failed simulation */
   case object FailedSimulation extends SeqexecFailure
 
@@ -63,6 +66,7 @@ object SeqexecFailure {
       s"Failure connecting with GDS at $url: ${ex.getMessage}"
     case GdsXmlError(msg, url)        => s"XML RPC error with GDS at $url: $msg"
     case FailedSimulation             => s"Failed to simulate"
+    case NullEpicsError(channel)      => s"Failed to read epics channel: $channel"
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsEpics.scala
@@ -3,14 +3,24 @@
 
 package seqexec.server.gws
 
+import cats.effect.IO
+import cats.effect.Sync
+import cats.implicits._
 import edu.gemini.epics.acm.CaService
-import seqexec.server.{EpicsHealth, EpicsSystem}
-import org.log4s.{Logger, getLogger}
+import seqexec.server.EpicsHealth
+import seqexec.server.EpicsSystem
+import seqexec.server.EpicsUtil._
+import org.log4s.Logger
+import org.log4s.getLogger
 import squants.MetricSystem.Milli
-import squants.motion.{Bars, MetersPerSecond, Pressure}
-import squants.space.{Angle, Degrees}
+import squants.motion.Bars
+import squants.motion.MetersPerSecond
+import squants.motion.Pressure
+import squants.space.Angle
+import squants.space.Degrees
 import squants.thermal.Celsius
-import squants.{Temperature, Velocity}
+import squants.Temperature
+import squants.Velocity
 
 /**
   * GwsEpics wraps the non-functional parts of the EPICS ACM library to interact with the Weather Server.
@@ -18,23 +28,36 @@ import squants.{Temperature, Velocity}
   *
   * Created by jluhrs on 3/10/17.
   */
-final class GwsEpics private (epicsService: CaService) {
+final class GwsEpics[F[_]: Sync] private (epicsService: CaService) {
   private val state = epicsService.getStatusAcceptor("gws::state")
 
-  def humidity: Option[Double] = Option(state.getDoubleAttribute("humidity").value).map(_.doubleValue)
-  def windVelocity: Option[Velocity] = Option(state.getDoubleAttribute("windspee").value).map(v => MetersPerSecond(v.doubleValue))
-  def airPressure: Option[Pressure] = Option(state.getDoubleAttribute("pressure").value).map(v => Bars(v.doubleValue*Milli))
-  def ambientT: Option[Temperature] = Option(state.getDoubleAttribute("tambient").value).map(v => Celsius(v.doubleValue))
-  def health: Option[EpicsHealth] = Option(state.getIntegerAttribute("health").value).map(h => EpicsHealth.fromInt(h.intValue))
-  def dewPoint: Option[Temperature] = Option(state.getDoubleAttribute("dewpoint").value).map(v => Celsius(v.doubleValue))
-  def windDirection: Option[Angle] = Option(state.getDoubleAttribute("winddire").value).map(v => Degrees(v.doubleValue))
+  // Eventually move it to a shared package
+  private def readD(name: String): F[Double] =
+    safeAttributeSDoubleF[F](name, state.getDoubleAttribute(name))
+  private def readI(name: String): F[Int] =
+    safeAttributeSIntF[F](name, state.getIntegerAttribute(name))
+
+  def humidity: F[Double] = readD("humidity").map(_.doubleValue)
+  def windVelocity: F[Velocity] =
+    readD("windspee").map(v => MetersPerSecond(v.doubleValue))
+  def airPressure: F[Pressure] =
+    readD("pressure").map(v => Bars(v.doubleValue * Milli))
+  def ambientT: F[Temperature] =
+    readD("tambient").map(v => Celsius(v.doubleValue))
+  def health: F[EpicsHealth] =
+    readI("health").map(h => EpicsHealth.fromInt(h.intValue))
+  def dewPoint: F[Temperature] =
+    readD("dewpoint").map(v => Celsius(v.doubleValue))
+  def windDirection: F[Angle] =
+    readD("winddire").map(v => Degrees(v.doubleValue))
 
 }
 
-object GwsEpics extends EpicsSystem[GwsEpics] {
-  override val className: String = getClass.getName
-  override val Log: Logger = getLogger
+object GwsEpics extends EpicsSystem[GwsEpics[IO]] {
+  override val className: String      = getClass.getName
+  override val Log: Logger            = getLogger
   override val CA_CONFIG_FILE: String = "/Gws.xml"
 
-  override def build(service: CaService, tops: Map[String, String]) = new GwsEpics(service)
+  override def build(service: CaService, tops: Map[String, String]) =
+    new GwsEpics(service)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsHeader.scala
@@ -3,9 +3,8 @@
 
 package seqexec.server.gws
 
-import cats.Applicative
+import cats._
 import cats.implicits._
-import cats.effect.Sync
 import gem.Observation
 import gem.enum.KeywordName
 import seqexec.model.dhs.ImageFileId
@@ -13,51 +12,21 @@ import seqexec.server.keywords._
 import seqexec.server.{EpicsHealth, InstrumentSystem}
 
 object GwsHeader {
-  def header[F[_]: Sync: cats.Monad](inst: InstrumentSystem[F], gwsReader: GwsKeywordReader[F]): Header[F] = new Header[F] {
-    override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] = {
-      gwsReader.getHealth.liftF.flatMap {
-        case Some(EpicsHealth.Good) => sendKeywords[F](id, inst, List(
-          buildDouble(gwsReader.getHumidity.orDefault, KeywordName.HUMIDITY),
-          {
-            val x = gwsReader.getTemperature.map(_.map(_.toCelsiusScale))
-            buildDouble(x.orDefault, KeywordName.TAMBIENT)
-          },
-          {
-            val x = gwsReader.getTemperature.map(_.map(_.toFahrenheitScale))
-            buildDouble(x.orDefault, KeywordName.TAMBIEN2)
-          },
-          {
-            val x = gwsReader.getAirPressure.map(_.map(_.toMillimetersOfMercury))
-            buildDouble(x.orDefault, KeywordName.PRESSURE)
-          },
-          {
-            val x = gwsReader.getAirPressure.map(_.map(_.toPascals))
-            buildDouble(x.orDefault, KeywordName.PRESSUR2)
-          },
-          {
-            val x = gwsReader.getDewPoint.map(_.map(_.toCelsiusScale))
-            buildDouble(x.orDefault, KeywordName.DEWPOINT)
-          },
-          {
-            val x = gwsReader.getDewPoint.map(_.map(_.toFahrenheitScale))
-            buildDouble(x.orDefault, KeywordName.DEWPOIN2)
-          },
-          {
-            val x = gwsReader.getWindVelocity.map(_.map(_.toMetersPerSecond))
-            buildDouble(x.orDefault, KeywordName.WINDSPEE)
-          },
-          {
-            val x = gwsReader.getWindVelocity.map(_.map(_.toInternationalMilesPerHour))
-            buildDouble(x.orDefault, KeywordName.WINDSPE2)
-          },
-          {
-            val x = gwsReader.getWindDirection.map(_.map(_.toDegrees))
-            buildDouble(x.orDefault, KeywordName.WINDDIRE)
-          }
-        ))
-        case _       => Applicative[F].unit
-      }
-    }
+  def header[F[_]: MonadError[?[_], Throwable]](inst: InstrumentSystem[F], gwsReader: GwsKeywordReader[F]): Header[F] = new Header[F] {
+    override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
+      gwsReader.health.map(_ === EpicsHealth.Good).ifM(
+        sendKeywords[F](id, inst, List(
+          buildDoubleS(gwsReader.humidity, KeywordName.HUMIDITY),
+          buildDoubleS(gwsReader.temperature.map(_.toCelsiusScale), KeywordName.TAMBIENT),
+          buildDoubleS(gwsReader.temperature.map(_.toFahrenheitScale), KeywordName.TAMBIEN2),
+          buildDoubleS(gwsReader.airPressure.map(_.toMillimetersOfMercury), KeywordName.PRESSURE),
+          buildDoubleS(gwsReader.airPressure.map(_.toPascals), KeywordName.PRESSUR2),
+          buildDoubleS(gwsReader.dewPoint.map(_.toCelsiusScale), KeywordName.DEWPOINT),
+          buildDoubleS(gwsReader.dewPoint.map(_.toFahrenheitScale), KeywordName.DEWPOIN2),
+          buildDoubleS(gwsReader.windVelocity.map(_.toMetersPerSecond), KeywordName.WINDSPEE),
+          buildDoubleS(gwsReader.windVelocity.map(_.toInternationalMilesPerHour), KeywordName.WINDSPE2),
+          buildDoubleS(gwsReader.windDirection.map(_.toDegrees), KeywordName.WINDDIRE)
+        )), Applicative[F].unit)
 
     override def sendAfter(id: ImageFileId): F[Unit] = Applicative[F].unit
   }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
@@ -38,4 +38,10 @@ trait SeqexecServerArbitraries {
   implicit val executionQueueCogen: Cogen[ExecutionQueue] =
     Cogen[(String, BatchCommandState, List[Observation.Id])]
       .contramap(x => (x.name, x.cmdState, x.queue))
+
+  implicit val epicsHealthArb: Arbitrary[EpicsHealth] =
+    Arbitrary(Gen.oneOf(EpicsHealth.Good, EpicsHealth.Bad))
+
+  implicit val epicsHealthCogen: Cogen[EpicsHealth] =
+    Cogen[String].contramap(_.productPrefix)
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerSpec.scala
@@ -11,4 +11,5 @@ import cats.tests.CatsSuite
   */
 final class SeqexecServerSpec extends CatsSuite with SeqexecServerArbitraries {
   checkAll("Eq[ObserveCommand.Result]", EqTests[ObserveCommand.Result].eqv)
+  checkAll("Eq[EpicsHealth]", EqTests[EpicsHealth].eqv)
 }


### PR DESCRIPTION
Another PR to make GWS do reads as referential reads inside an `F[_]`

There is a bigger change in this PR, we normally return things like `F[Option[A]]` acknowledging that Epics reads can return null. We could simplify this code a bit doing reads as `F[A]` taking care of checking of nulls and raising an error

If this style seems appropriate we could refactor the other classes as well