### PR TITLE
SEQNG-860: Set stepstable col widths based on content

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ServerLogLevel.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ServerLogLevel.scala
@@ -3,7 +3,8 @@
 
 package seqexec.model.enum
 
-import cats.{ Eq, Show }
+import cats._
+import cats.implicits._
 
 sealed abstract class ServerLogLevel(val label: String)
   extends Product with Serializable
@@ -22,5 +23,8 @@ object ServerLogLevel {
 
   implicit val show: Show[ServerLogLevel] =
     Show.show(_.label)
+
+  implicit val order: Order[ServerLogLevel] =
+    Order.by(_.label)
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -23,8 +23,9 @@ import seqexec.server._
 import seqexec.server.keywords.GdsClient
 import seqexec.server.keywords.GdsInstrument
 import seqexec.server.keywords.KeywordsClient
-import scala.concurrent.duration._
 import squants.Time
+
+import scala.concurrent.duration._
 import squants.time.Milliseconds
 import squants.time.Seconds
 import squants.time.Time

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -207,6 +207,8 @@ body {
 
 .SeqexecStyles-logSecondarySegment {
   .normalizedSegment;
+  padding-left: 0.4em !important;
+  padding-right: 0.4em !important;
 }
 
 .SeqexecStyles-logControlRow {
@@ -796,7 +798,7 @@ body {
 }
 
 .SeqexecStyles-completedIcon {
-  .queueText
+  .queueText;
 }
 
 .SeqexecStyles-breakPointOnIcon {
@@ -1149,8 +1151,12 @@ body {
     .mobileSegment;
   }
   .ReactVirtualized__Table__rowColumn {
-    padding-right: 2px;
-    padding-left: 2px;
+    padding-right: 0.5em;
+    padding-left: 0.5em;
+  }
+  .ReactVirtualized__Table__headerTruncatedText {
+    padding-right: 0.5em;
+    padding-left: 0.5em;
   }
   .SeqexecStyles-queueAreaRow {
     padding-top: 0 !important;

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/CalQueueFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/CalQueueFocus.scala
@@ -51,7 +51,7 @@ object CalQueueFocus {
     id: QueueId
   ): Lens[SeqexecAppRootModel, Option[TableState[CalQueueTable.TableColumn]]] =
     SeqexecAppRootModel.uiModel        ^|->
-      AppTableStates.tableStateL       ^|->
+      SeqexecUIModel.appTableStates    ^|->
       AppTableStates.queueTableAtL(id)
 
   private def seqOpsL(id: QueueId) =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
@@ -68,7 +68,7 @@ object SeqexecCircuit
       SeqexecAppRootModel.uiModel ^|-> InitialSyncFocus.initialSyncFocusL)
 
   val tableStateRW: ModelRW[SeqexecAppRootModel, AppTableStates] =
-    this.zoomRWL(SeqexecAppRootModel.uiModel ^|-> AppTableStates.tableStateL)
+    this.zoomRWL(SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.appTableStates)
 
   // Reader to indicate the allowed interactions
   val statusReader: ModelR[SeqexecAppRootModel, ClientStatus] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StatusAndLoadedSequencesFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StatusAndLoadedSequencesFocus.scala
@@ -90,7 +90,7 @@ object StatusAndLoadedSequencesFocus {
   val statusAndLoadedSequencesG
     : Getter[SeqexecAppRootModel, StatusAndLoadedSequencesFocus] =
     ClientStatus.clientStatusFocusL.asGetter.zip(
-      sessionQueueG.zip(sodG.zip(SeqexecAppRootModel.queueTableStateL.asGetter
+      sessionQueueG.zip(sodG.zip(SeqexecAppRootModel.sessionQueueTableStateL.asGetter
         .zip(sessionQueueFilterG.zip(SeqexecAppRootModel.dayCalG))))) >>> {
       case (s, (queue, (sod, (queueTable, (filter, dayCal))))) =>
         StatusAndLoadedSequencesFocus(

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableAndStatusFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableAndStatusFocus.scala
@@ -15,7 +15,7 @@ import web.client.table._
 final case class StepsTableAndStatusFocus(
   status:           ClientStatus,
   stepsTable:       Option[StepsTableFocus],
-  tableState: TableState[StepsTable.TableColumn],
+  tableState:       TableState[StepsTable.TableColumn],
   configTableState: TableState[StepConfigTable.TableColumn])
 
 object StepsTableAndStatusFocus {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableAndStatusFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableAndStatusFocus.scala
@@ -9,16 +9,18 @@ import gem.Observation
 import monocle.Getter
 import seqexec.web.client.model._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
+import seqexec.web.client.components.sequence.steps.StepsTable
 import web.client.table._
 
 final case class StepsTableAndStatusFocus(
   status:           ClientStatus,
   stepsTable:       Option[StepsTableFocus],
+  tableState: TableState[StepsTable.TableColumn],
   configTableState: TableState[StepConfigTable.TableColumn])
 
 object StepsTableAndStatusFocus {
   implicit val eq: Eq[StepsTableAndStatusFocus] =
-    Eq.by(x => (x.status, x.stepsTable, x.configTableState))
+    Eq.by(x => (x.status, x.stepsTable, x.tableState, x.configTableState))
 
   def stepsTableAndStatusFocusG(
     id: Observation.Id): Getter[SeqexecAppRootModel, StepsTableAndStatusFocus] =
@@ -26,8 +28,8 @@ object StepsTableAndStatusFocus {
       .zip(
         StepsTableFocus
           .stepsTableG(id)
-          .zip(SeqexecAppRootModel.configTableStateL.asGetter)) >>> {
-      case (s, (f, t)) => StepsTableAndStatusFocus(s, f, t)
+          .zip(SeqexecAppRootModel.stepsTableStateL(id).asGetter.zip(SeqexecAppRootModel.configTableStateL.asGetter))) >>> {
+      case (s, (f, (a, t))) => StepsTableAndStatusFocus(s, f, a.getOrElse(StepsTable.State.InitialTableState), t)
     }
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
@@ -49,10 +49,10 @@ object StepsTableFocus {
     id: Observation.Id
   ): Getter[SeqexecAppRootModel, Option[StepsTableFocus]] =
     SeqexecAppRootModel.sequencesOnDisplayL.composeGetter(
-      SequencesOnDisplay.tabG(id)) >>> {
-      _.map {
-        case SeqexecTabActive(tab, _) =>
+      SequencesOnDisplay.tabG(id)).zip(SeqexecAppRootModel.stepsTableStateL(id).asGetter) >>> {
+        case (Some(SeqexecTabActive(tab, _)), ts) =>
           val sequence = tab.sequence
+          // println(s"Step table focus ${tab.tableState.isModified}")
           StepsTableFocus(
             sequence.id,
             sequence.metadata.instrument,
@@ -64,10 +64,9 @@ object StepsTableFocus {
               .orElse(sequence.nextStepToRun), // start with the nextstep selected
             sequence.runningStep,
             tab.isPreview,
-            tab.tableState,
+            ts.getOrElse(StepsTable.State.InitialTableState),
             tab.tabOperations
-          )
-
-      }
+          ).some
+        case _ => none
     }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/StepsTableFocus.scala
@@ -52,7 +52,6 @@ object StepsTableFocus {
       SequencesOnDisplay.tabG(id)).zip(SeqexecAppRootModel.stepsTableStateL(id).asGetter) >>> {
         case (Some(SeqexecTabActive(tab, _)), ts) =>
           val sequence = tab.sequence
-          // println(s"Step table focus ${tab.tableState.isModified}")
           StepsTableFocus(
             sequence.id,
             sequence.metadata.instrument,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -234,7 +234,7 @@ object LogArea {
             dataKey = name,
             label   = label,
             headerRenderer = resizableHeaderRenderer(b.state.tableState
-              .resizeRow(c, size, x => b.runState(updateTableState(x)))),
+              .resizeRowB(c, size, x => b.runState(updateTableState(x)))),
             className = LogColumnStyle
           ))
     }
@@ -289,8 +289,7 @@ object LogArea {
         headerClassName  = SeqexecStyles.tableHeader.htmlClass,
         headerHeight     = SeqexecStyles.headerHeight
       ),
-      s.tableState.columnBuilder(size,
-                                 TableState.AllColsVisible,
+      s.tableState.columnBuilderB(size,
                                  colBuilder(b, size)): _*
     ).vdomElement
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -180,6 +180,8 @@ object LogArea {
     name    = "level",
     label   = "Level",
     visible = true,
+    grow = 1,
+    removeable = 2,
     width   = VariableColumnWidth.unsafeFromDouble(0.1, LevelMinWidth)
   )
 
@@ -188,6 +190,7 @@ object LogArea {
     name    = "msg",
     label   = "Message",
     visible = true,
+    grow = 10,
     width   = VariableColumnWidth.unsafeFromDouble(0.7, MessageMinWidth)
   )
 
@@ -213,32 +216,24 @@ object LogArea {
     r match {
       case ColumnRenderArgs(meta, _, _, _) if meta.column === ClipboardColumn =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width           = ClipboardWidth,
             dataKey         = meta.name,
             headerRenderer  = clipboardHeaderRenderer,
             cellRenderer    = clipboardCellRenderer(b.props.site),
             className       = SeqexecStyles.clipboardIconDiv.htmlClass,
-            headerClassName = SeqexecStyles.clipboardIconHeader.htmlClass,
-            flexGrow = 0,
-            flexShrink = 0,
-            minWidth = ClipboardWidth,
-            maxWidth = ClipboardWidth
+            headerClassName = SeqexecStyles.clipboardIconHeader.htmlClass
           ))
       case ColumnRenderArgs(meta, _, width, _) if meta.column === MsgColumn =>
         Column(
-          Column.props(width     = width,
+          Column.propsNoFlex(width     = width,
                              dataKey   = meta.name,
                              label     = meta.label,
-                             className = LogColumnStyle,
-            flexGrow = 5,
-            flexShrink = 2,
-            minWidth = ClipboardWidth,
-            maxWidth = ClipboardWidth
+                             className = LogColumnStyle
                            ))
       case ColumnRenderArgs(meta, _, width, _) =>
         Column(
-          Column.props(
+          Column.propsNoFlex(
             width   = width,
             dataKey = meta.name,
             label   = meta.label,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -213,23 +213,32 @@ object LogArea {
     r match {
       case ColumnRenderArgs(meta, _, _, _) if meta.column === ClipboardColumn =>
         Column(
-          Column.propsNoFlex(
+          Column.props(
             width           = ClipboardWidth,
             dataKey         = meta.name,
             headerRenderer  = clipboardHeaderRenderer,
             cellRenderer    = clipboardCellRenderer(b.props.site),
             className       = SeqexecStyles.clipboardIconDiv.htmlClass,
-            headerClassName = SeqexecStyles.clipboardIconHeader.htmlClass
+            headerClassName = SeqexecStyles.clipboardIconHeader.htmlClass,
+            flexGrow = 0,
+            flexShrink = 0,
+            minWidth = ClipboardWidth,
+            maxWidth = ClipboardWidth
           ))
       case ColumnRenderArgs(meta, _, width, _) if meta.column === MsgColumn =>
         Column(
-          Column.propsNoFlex(width     = width,
+          Column.props(width     = width,
                              dataKey   = meta.name,
                              label     = meta.label,
-                             className = LogColumnStyle))
+                             className = LogColumnStyle,
+            flexGrow = 5,
+            flexShrink = 2,
+            minWidth = ClipboardWidth,
+            maxWidth = ClipboardWidth
+                           ))
       case ColumnRenderArgs(meta, _, width, _) =>
         Column(
-          Column.propsNoFlex(
+          Column.props(
             width   = width,
             dataKey = meta.name,
             label   = meta.label,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -211,30 +211,30 @@ object LogArea {
 
   def colBuilder(b: Backend, size: Size)(r: ColumnRenderArgs[TableColumn]): Table.ColumnArg =
     r match {
-      case ColumnRenderArgs(ColumnMeta(ClipboardColumn, name, _, _, _), _, _, _) =>
+      case ColumnRenderArgs(meta, _, _, _) if meta.column === ClipboardColumn =>
         Column(
           Column.propsNoFlex(
             width           = ClipboardWidth,
-            dataKey         = name,
+            dataKey         = meta.name,
             headerRenderer  = clipboardHeaderRenderer,
             cellRenderer    = clipboardCellRenderer(b.props.site),
             className       = SeqexecStyles.clipboardIconDiv.htmlClass,
             headerClassName = SeqexecStyles.clipboardIconHeader.htmlClass
           ))
-      case ColumnRenderArgs(ColumnMeta(MsgColumn, name, label, _, _), _, width, _) =>
+      case ColumnRenderArgs(meta, _, width, _) if meta.column === MsgColumn =>
         Column(
           Column.propsNoFlex(width     = width,
-                             dataKey   = name,
-                             label     = label,
+                             dataKey   = meta.name,
+                             label     = meta.label,
                              className = LogColumnStyle))
-      case ColumnRenderArgs(ColumnMeta(c, name, label, _, _), _, width, _) =>
+      case ColumnRenderArgs(meta, _, width, _) =>
         Column(
           Column.propsNoFlex(
             width   = width,
-            dataKey = name,
-            label   = label,
+            dataKey = meta.name,
+            label   = meta.label,
             headerRenderer = resizableHeaderRenderer(b.state.tableState
-              .resizeRowB(c, size, x => b.runState(updateTableState(x)))),
+              .resizeRowB(meta.column, size, x => b.runState(updateTableState(x)))),
             className = LogColumnStyle
           ))
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -253,9 +253,9 @@ object LogArea {
             label          = meta.label,
             headerRenderer = resizableHeaderRenderer(
               b.state.tableState
-                .resizeRowB(meta.column,
-                            size,
-                            x => b.setStateL(State.tableState)(x))),
+                .resizeColumn(meta.column,
+                              size,
+                              b.setStateL(State.tableState)(_))),
             className = LogColumnStyle
           ))
     }
@@ -309,7 +309,7 @@ object LogArea {
         headerClassName  = SeqexecStyles.tableHeader.htmlClass,
         headerHeight     = SeqexecStyles.headerHeight
       ),
-      b.state.tableState.columnBuilder2(size, _ => none, colBuilder(b, size)): _*
+      b.state.tableState.columnBuilder(size, colBuilder(b, size)): _*
     ).vdomElement
 
   private def onResize(b: Backend): Size => Callback = s =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -12,14 +12,19 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.extra.Reusability
-import japgolly.scalajs.react.CatsReact._
+import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.vdom.html_<^._
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import monocle.Lens
+import monocle.macros.Lenses
+import monocle.function.At.at
+import monocle.function.At.atSortedMap
 import react.virtualized._
 import react.clipboard._
 import scala.scalajs.js
+import scala.collection.immutable.SortedMap
 import seqexec.model.enum.ServerLogLevel
 import seqexec.model.events._
 import seqexec.web.client.semanticui.elements.checkbox.Checkbox
@@ -70,7 +75,8 @@ object LogArea {
   case object ClipboardColumn extends TableColumn
 
   object TableColumn {
-    implicit val eq: Eq[TableColumn] = Eq.fromUniversalEquals
+    implicit val eq: Eq[TableColumn]               = Eq.fromUniversalEquals
+    implicit val tcReuse: Reusability[TableColumn] = Reusability.byRef
   }
 
   // Date time formatter
@@ -130,89 +136,98 @@ object LogArea {
 
   }
 
-  final case class State(selectedLevels: Map[ServerLogLevel, Boolean],
+  @Lenses
+  final case class State(selectedLevels: SortedMap[ServerLogLevel, Boolean],
                          tableState:     TableState[TableColumn]) {
-
-    def updateLevel(level: ServerLogLevel, value: Boolean): State =
-      copy(selectedLevels + (level -> value))
 
     def allowedLevel(level: ServerLogLevel): Boolean =
       selectedLevels.getOrElse(level, false)
+
   }
 
   implicit val propsReuse: Reusability[Props] =
     Reusability.derive[Props]
-  implicit val tcReuse: Reusability[TableColumn] = Reusability.byRef
   implicit val stateReuse: Reusability[State] =
-    Reusability.derive[State]
+    Reusability.by(x => (x.selectedLevels.toList, x.tableState))
 
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object State {
 
-    val DefaultTableState: TableState[TableColumn] = TableState[TableColumn](
-      userModified   = NotModified,
-      scrollPosition = 0,
-      columns = NonEmptyList.of(TimestampColumnMeta,
-                                LevelColumnMeta,
-                                MsgColumnMeta,
-                                ClipboardColumnMeta))
+    def levelLens(l: ServerLogLevel): Lens[State, Option[Boolean]] =
+      State.selectedLevels ^|-> at(l)
+
+    private val DefaultTableState: TableState[TableColumn] =
+      TableState[TableColumn](userModified   = NotModified,
+                              scrollPosition = 0,
+                              columns = NonEmptyList.of(TimestampColumnMeta,
+                                                        LevelColumnMeta,
+                                                        MsgColumnMeta,
+                                                        ClipboardColumnMeta))
 
     val Default: State =
-      State(ServerLogLevel.all.map(_ -> true).toMap, DefaultTableState)
+      State(SortedMap(ServerLogLevel.all.map(_ -> true): _*), DefaultTableState)
   }
-
-  private val ST = ReactS.Fix[State]
 
   private val ClipboardWidth    = 37.0
   private val TimestampMinWidth = 90.1667 + SeqexecStyles.TableBorderWidth
   private val LevelMinWidth     = 59.3333 + SeqexecStyles.TableBorderWidth
   private val MessageMinWidth   = 89.35 + SeqexecStyles.TableBorderWidth
 
-  val TimestampColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
-    column  = TimestampColumn,
-    name    = "local",
-    label   = "Timestamp",
-    visible = true,
-    width   = VariableColumnWidth.unsafeFromDouble(0.2, TimestampMinWidth)
-  )
+  private val TimestampColumnMeta: ColumnMeta[TableColumn] =
+    ColumnMeta[TableColumn](
+      column  = TimestampColumn,
+      name    = "local",
+      label   = "Timestamp",
+      visible = true,
+      width   = VariableColumnWidth.unsafeFromDouble(0.2, TimestampMinWidth)
+    )
 
-  val LevelColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
-    column  = LevelColumn,
-    name    = "level",
-    label   = "Level",
-    visible = true,
-    grow = 1,
-    removeable = 2,
-    width   = VariableColumnWidth.unsafeFromDouble(0.1, LevelMinWidth)
-  )
+  private val LevelColumnMeta: ColumnMeta[TableColumn] =
+    ColumnMeta[TableColumn](
+      column     = LevelColumn,
+      name       = "level",
+      label      = "Level",
+      visible    = true,
+      grow       = 1,
+      removeable = 2,
+      width      = VariableColumnWidth.unsafeFromDouble(0.1, LevelMinWidth)
+    )
 
-  val MsgColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
-    column  = MsgColumn,
-    name    = "msg",
-    label   = "Message",
-    visible = true,
-    grow = 10,
-    width   = VariableColumnWidth.unsafeFromDouble(0.7, MessageMinWidth)
-  )
+  private val MsgColumnMeta: ColumnMeta[TableColumn] =
+    ColumnMeta[TableColumn](
+      column  = MsgColumn,
+      name    = "msg",
+      label   = "Message",
+      visible = true,
+      grow    = 10,
+      width   = VariableColumnWidth.unsafeFromDouble(0.7, MessageMinWidth)
+    )
 
-  val ClipboardColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
-    column  = ClipboardColumn,
-    name    = "clip",
-    label   = "",
-    visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(ClipboardWidth)
-  )
+  private val ClipboardColumnMeta: ColumnMeta[TableColumn] =
+    ColumnMeta[TableColumn](
+      column  = ClipboardColumn,
+      name    = "clip",
+      label   = "",
+      visible = true,
+      width   = FixedColumnWidth.unsafeFromDouble(ClipboardWidth)
+    )
+
+  private val columnWidths: TableColumn => Option[Double] = {
+    case TimestampColumn => 200.0.some
+    case LevelColumn     => 100.0.some
+    case MsgColumn       => 400.0.some
+    case _               => none
+  }
 
   private val LogColumnStyle: String = SeqexecStyles.queueText.htmlClass
 
-  private def updateTableState(st: TableState[TableColumn]) =
-    ST.mod(_.copy(tableState = st)).liftCB
-
   // Custom renderers for the last column
-  val clipboardHeaderRenderer: HeaderRenderer[js.Object] =
+  private val clipboardHeaderRenderer: HeaderRenderer[js.Object] =
     (_, _, _, _, _, _) =>
       IconCopy.copyIcon(extraStyles = List(SeqexecStyles.logIconHeader))
 
-  def colBuilder(b: Backend, size: Size)(r: ColumnRenderArgs[TableColumn]): Table.ColumnArg =
+  private def colBuilder(b: Backend, size: Size)(
+    r:                      ColumnRenderArgs[TableColumn]): Table.ColumnArg =
     r match {
       case ColumnRenderArgs(meta, _, _, _) if meta.column === ClipboardColumn =>
         Column(
@@ -229,21 +244,25 @@ object LogArea {
           Column.propsNoFlex(width     = width,
                              dataKey   = meta.name,
                              label     = meta.label,
-                             className = LogColumnStyle
-                           ))
+                             className = LogColumnStyle))
       case ColumnRenderArgs(meta, _, width, _) =>
         Column(
           Column.propsNoFlex(
-            width   = width,
-            dataKey = meta.name,
-            label   = meta.label,
-            headerRenderer = resizableHeaderRenderer(b.state.tableState
-              .resizeRowB(meta.column, size, x => b.runState(updateTableState(x)))),
+            width          = width,
+            dataKey        = meta.name,
+            label          = meta.label,
+            headerRenderer = resizableHeaderRenderer(
+              b.state.tableState
+                .resizeRowB(meta.column,
+                            size,
+                            x => b.setStateL(State.tableState)(x))),
             className = LogColumnStyle
           ))
     }
 
-  def clipboardCellRenderer(site: Site): CellRenderer[js.Object, js.Object, LogRow] =
+  private def clipboardCellRenderer(
+    site: Site
+  ): CellRenderer[js.Object, js.Object, LogRow] =
     (_, _, _, row: LogRow, _) => {
       // Simple csv export
       val localTime = LocalDateTime.ofInstant(row.timestamp, site.timezone)
@@ -252,7 +271,7 @@ object LogArea {
     }
 
   // Style for each row
-  def rowClassName(b: Backend)(i: Int): String =
+  private def rowClassName(b: Backend)(i: Int): String =
     ((i, b.props.rowGetter(b.state)(i)) match {
       case (-1, _)                                    =>
         SeqexecStyles.headerRowStyle
@@ -269,10 +288,7 @@ object LogArea {
   /**
     * Build the table log
     */
-  def table(b: Backend)(size: Size): VdomNode = {
-    val p = b.props
-    val s = b.state
-
+  private def table(b: Backend)(size: Size): VdomNode =
     Table(
       Table.props(
         disableHeader = false,
@@ -285,26 +301,32 @@ object LogArea {
         ),
         overscanRowCount = SeqexecStyles.overscanRowCount,
         height           = 200,
-        rowCount         = p.rowCount(s),
+        rowCount         = b.props.rowCount(b.state),
         rowHeight        = SeqexecStyles.rowHeight,
         rowClassName     = rowClassName(b) _,
         width            = size.width,
-        rowGetter        = p.rowGetter(s) _,
+        rowGetter        = b.props.rowGetter(b.state) _,
         headerClassName  = SeqexecStyles.tableHeader.htmlClass,
         headerHeight     = SeqexecStyles.headerHeight
       ),
-      s.tableState.columnBuilderB(size,
-                                 colBuilder(b, size)): _*
+      b.state.tableState.columnBuilder2(size, _ => none, colBuilder(b, size)): _*
     ).vdomElement
-  }
 
-  private def updateState(level: ServerLogLevel)(value: Boolean) =
-    ST.mod(_.updateLevel(level, value)).liftCB
+  private def onResize(b: Backend): Size => Callback = s =>
+    b.modStateL(State.tableState)(_.recalculateWidths(s, _ => true, columnWidths))
+
+  private def onLevelChange(
+    b: Backend,
+    l: ServerLogLevel
+  ): Boolean => Callback =
+    s => b.setStateL(State.levelLens(l))(s.some)
 
   private val component = ScalaComponent
     .builder[Props]("LogArea")
     .initialState(State.Default)
-    .renderPS { ($, p, s) =>
+    .render { b =>
+      val p = b.props
+      val s = b.state
       val toggleIcon = (p.log.display === SectionOpen)
         .fold(IconAngleDoubleDown, IconAngleDoubleUp)
       val toggleText =
@@ -342,9 +364,7 @@ object LogArea {
                         <.div(
                           ^.cls := "inline field",
                           Checkbox(
-                            Checkbox.Props(l.show,
-                                           s,
-                                           v => $.runState(updateState(l)(v))))
+                            Checkbox.Props(l.show, s, onLevelChange(b, l)))
                         )
                     }
                   )
@@ -354,7 +374,10 @@ object LogArea {
             <.div(
               ^.cls := "ui row",
               SeqexecStyles.logTableRow,
-              AutoSizer(AutoSizer.props(table($), disableHeight = true))
+              AutoSizer(
+                AutoSizer.props(table(b),
+                                disableHeight = true,
+                                onResize      = onResize(b)))
             ).when(p.log.display === SectionOpen)
           )
         )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -92,7 +92,7 @@ object SeqexecMain {
             ^.cls := "ui row",
             // Add margin to avoid covering the footer
             SeqexecStyles.logArea,
-            logConnect(l => LogArea(p.site, l))
+            logConnect(l => LogArea(p.site, l()))
           )
         ),
         lbConnect(p => LoginBox(p())),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -86,7 +86,7 @@ object SeqexecMain {
           <.div(
             ^.cls := "ui row",
             SeqexecStyles.shorterRow,
-            TabsArea(TabsArea.Props(p.ctl, p.site)).when(false)
+            TabsArea(TabsArea.Props(p.ctl, p.site)).when(true)
           ),
           <.div(
             ^.cls := "ui row",

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -51,7 +51,7 @@ object SeqexecMain {
   implicit val propsReuse: Reusability[Props] = Reusability.by(_.site)
 
   private val lbConnect  = SeqexecCircuit.connect(_.uiModel.loginBox)
-  // private val logConnect = SeqexecCircuit.connect(_.uiModel.globalLog)
+  private val logConnect = SeqexecCircuit.connect(_.uiModel.globalLog)
   private val userNotificationConnect = SeqexecCircuit.connect(_.uiModel.notification)
   private val headerSideBarConnect = SeqexecCircuit.connect(SeqexecCircuit.headerSideBarReader)
   private val wsConnect = SeqexecCircuit.connect(_.ws)
@@ -92,7 +92,7 @@ object SeqexecMain {
             ^.cls := "ui row",
             // Add margin to avoid covering the footer
             SeqexecStyles.logArea,
-            // logConnect(l => LogArea(p.site, l()))
+            logConnect(l => LogArea(p.site, l()))
           )
         ),
         lbConnect(p => LoginBox(p())),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -51,7 +51,7 @@ object SeqexecMain {
   implicit val propsReuse: Reusability[Props] = Reusability.by(_.site)
 
   private val lbConnect  = SeqexecCircuit.connect(_.uiModel.loginBox)
-  private val logConnect = SeqexecCircuit.connect(_.uiModel.globalLog)
+  // private val logConnect = SeqexecCircuit.connect(_.uiModel.globalLog)
   private val userNotificationConnect = SeqexecCircuit.connect(_.uiModel.notification)
   private val headerSideBarConnect = SeqexecCircuit.connect(SeqexecCircuit.headerSideBarReader)
   private val wsConnect = SeqexecCircuit.connect(_.ws)
@@ -75,7 +75,7 @@ object SeqexecMain {
             <.div(
               ^.cls := "sixteen wide mobile ten wide tablet ten wide computer column",
               SeqexecStyles.queueArea,
-              SessionQueueTableSection(p.ctl).when(false)
+              SessionQueueTableSection(p.ctl).when(true)
             ),
             <.div(
               ^.cls := "six wide column tablet computer only",
@@ -92,7 +92,7 @@ object SeqexecMain {
             ^.cls := "ui row",
             // Add margin to avoid covering the footer
             SeqexecStyles.logArea,
-            logConnect(l => LogArea(p.site, l()))
+            // logConnect(l => LogArea(p.site, l()))
           )
         ),
         lbConnect(p => LoginBox(p())),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -75,7 +75,7 @@ object SeqexecMain {
             <.div(
               ^.cls := "sixteen wide mobile ten wide tablet ten wide computer column",
               SeqexecStyles.queueArea,
-              SessionQueueTableSection(p.ctl)
+              SessionQueueTableSection(p.ctl).when(false)
             ),
             <.div(
               ^.cls := "six wide column tablet computer only",
@@ -86,7 +86,7 @@ object SeqexecMain {
           <.div(
             ^.cls := "ui row",
             SeqexecStyles.shorterRow,
-            TabsArea(TabsArea.Props(p.ctl, p.site))
+            TabsArea(TabsArea.Props(p.ctl, p.site)).when(false)
           ),
           <.div(
             ^.cls := "ui row",

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -208,11 +208,11 @@ object SessionQueueTable {
       State.loggedIn
         .set(false)
         .andThen(State.columns.modify(_.map {
-          case c @ ColumnMeta(ObsNameColumn, _, _, _, _) =>
+          case c @ ColumnMeta(ObsNameColumn, _, _, _, _, _, _) =>
             c.copy(visible = false)
-          case c @ ColumnMeta(AddQueueColumn, _, _, _, _) =>
+          case c @ ColumnMeta(AddQueueColumn, _, _, _, _, _, _) =>
             c.copy(visible = false)
-          case c @ ColumnMeta(TargetNameColumn, _, _, _, _) =>
+          case c @ ColumnMeta(TargetNameColumn, _, _, _, _, _, _) =>
             c.copy(visible = false)
           case c =>
             c
@@ -664,29 +664,29 @@ object SessionQueueTable {
     }
 
     tb match {
-      case ColumnRenderArgs(ColumnMeta(c, name, label, _, _), _, width, true) =>
+      case ColumnRenderArgs(meta, _, width, true) =>
         Column(
           Column.propsNoFlex(
             width        = width,
-            dataKey      = name,
-            label        = label,
-            cellRenderer = renderer(c, b),
+            dataKey      = meta.name,
+            label        = meta.label,
+            cellRenderer = renderer(meta.column, b),
             headerRenderer = resizableHeaderRenderer(
-              b.state.tableState.resizeRow(c,
+              b.state.tableState.resizeRow(meta.column,
                                            size,
                                            b.state.visibleColsFor(_, _),
                                            updateScrollPosition)),
-            className = columnStyle(c).foldMap(_.htmlClass)
+            className = columnStyle(meta.column).foldMap(_.htmlClass)
           ))
 
-      case ColumnRenderArgs(ColumnMeta(c, name, label, _, _), _, width, false) =>
+      case ColumnRenderArgs(meta, _, width, false) =>
         Column(
           Column.propsNoFlex(width          = width,
-                             dataKey        = name,
-                             label          = label,
-                             headerRenderer = fixedHeaderRenderer(c),
-                             cellRenderer   = renderer(c, b),
-                             className      = columnStyle(c).foldMap(_.htmlClass)))
+                             dataKey        = meta.name,
+                             label          = meta.label,
+                             headerRenderer = fixedHeaderRenderer(meta.column),
+                             cellRenderer   = renderer(meta.column, b),
+                             className      = columnStyle(meta.column).foldMap(_.htmlClass)))
     }
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -54,8 +54,6 @@ import web.client.table._
 object SessionQueueTable {
   type Backend = RenderScope[Props, State, Unit]
 
-  private val PhoneCut              = 400.0
-  private val LargePhoneCut         = 570.0
   private val IconColumnWidth       = 25.0
   private val AddQueueColumnWidth   = 30.0
   private val ClassColumnWidth      = 26.0
@@ -89,56 +87,59 @@ object SessionQueueTable {
     name    = "status",
     label   = "",
     visible = true,
-    FixedColumnWidth.unsafeFromDouble(IconColumnWidth))
+    width = FixedColumnWidth.unsafeFromDouble(IconColumnWidth))
 
   val ClassColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ClassColumn,
     name    = "class",
     label   = "",
     visible = true,
-    FixedColumnWidth.unsafeFromDouble(ClassColumnWidth))
+    width = FixedColumnWidth.unsafeFromDouble(ClassColumnWidth))
 
   val AddQueueColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     AddQueueColumn,
     name    = "",
     label   = "",
     visible = true,
-    FixedColumnWidth.unsafeFromDouble(AddQueueColumnWidth))
+    width = FixedColumnWidth.unsafeFromDouble(AddQueueColumnWidth))
 
   val ObsIdColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObsIdColumn,
     name    = "obsid",
     label   = "Obs. ID",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.2, ObsIdMinWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.2, ObsIdMinWidth))
 
   val StateColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     StateColumn,
     name    = "state",
     label   = "State",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, StateMinWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, StateMinWidth))
 
   val InstrumentColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     InstrumentColumn,
     name    = "instrument",
     label   = "Instrument",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.2, InstrumentMinWidth))
+    removeable = 1,
+    width = VariableColumnWidth.unsafeFromDouble(0.2, InstrumentMinWidth))
 
   val TargetNameColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     TargetNameColumn,
     name    = "target",
     label   = "Target",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.25, TargetMinWidth))
+    removeable = 2,
+    width = VariableColumnWidth.unsafeFromDouble(0.25, TargetMinWidth))
 
   val ObsNameColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObsNameColumn,
     name    = "obsName",
     label   = "Obs. Name",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.25, ObsNameMinWidth))
+    removeable = 3,
+    width = VariableColumnWidth.unsafeFromDouble(0.25, ObsNameMinWidth))
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] = NonEmptyList.of(
     IconColumnMeta,
@@ -240,33 +241,11 @@ object SessionQueueTable {
       }
 
     // Hide some columns depending on width
-    def visibleColsFor(s: Size, t: TableColumn): Boolean =
-      s.width match {
-        case w if w < PhoneCut =>
-          t match {
-            case ObsNameColumn | TargetNameColumn =>
-              false
-            case AddQueueColumn =>
-              loggedIn
-            case _ =>
-              true
-          }
-        case w if w < LargePhoneCut =>
-          t match {
-            case TargetNameColumn =>
-              false
-            case ObsNameColumn | AddQueueColumn =>
-              loggedIn
-            case _ =>
-              true
-          }
-        case _ =>
-          t match {
-            case TargetNameColumn | ObsNameColumn | AddQueueColumn =>
-              loggedIn
-            case _ =>
-              true
-          }
+    def visibleColsFor(t: TableColumn): Boolean =
+      t match {
+        case ObsNameColumn | AddQueueColumn | TargetNameColumn =>
+          loggedIn
+        case _ => true
       }
   }
 
@@ -674,7 +653,7 @@ object SessionQueueTable {
             headerRenderer = resizableHeaderRenderer(
               b.state.tableState.resizeRow(meta.column,
                                            size,
-                                           b.state.visibleColsFor(_, _),
+                                           b.state.visibleColsFor,
                                            updateScrollPosition)),
             className = columnStyle(meta.column).foldMap(_.htmlClass)
           ))
@@ -749,7 +728,7 @@ object SessionQueueTable {
         rowRenderer      = draggableRowRenderer(b)
       ),
       b.state.tableState.columnBuilder(size,
-                                       b.state.visibleColsFor(_, _),
+                                       b.state.visibleColsFor,
                                        colWidths(b.props.sequencesList),
                                        colBuilder(b, size)): _*
     ).vdomElement

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -21,7 +21,6 @@ import react.virtualized._
 import scala.math.max
 import scala.scalajs.js
 import react.common._
-import react.common.syntax._
 import seqexec.model.enum.Instrument
 import seqexec.model.UserDetails
 import seqexec.model.UnknownTargetName

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -17,7 +17,7 @@ import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.raw.JsNumber
 import monocle.Lens
-import monocle.macros.GenLens
+import monocle.macros.Lenses
 import react.virtualized._
 import scala.scalajs.js
 import react.common._
@@ -241,6 +241,7 @@ object SessionQueueTable extends Columns {
 
   }
 
+  @Lenses
   final case class State(tableState: TableState[TableColumn],
                          rowLoading: Option[Int],
                          lastSize:   Option[Size]) {
@@ -254,20 +255,9 @@ object SessionQueueTable extends Columns {
 
   }
 
-  val InitialTableState: TableState[TableColumn] =
-    TableState(NotModified, 0, all)
-
-  val InitialState: State =
-    State(InitialTableState, None, None)
-
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object State {
     // Lenses
-    val tableState: Lens[State, TableState[TableColumn]] =
-      GenLens[State](_.tableState)
-
-    val lastSize: Lens[State, Option[Size]] =
-      GenLens[State](_.lastSize)
-
     val columns: Lens[State, NonEmptyList[ColumnMeta[TableColumn]]] =
       tableState ^|-> TableState.columns[TableColumn]
 
@@ -276,6 +266,13 @@ object SessionQueueTable extends Columns {
 
     val scrollPosition: Lens[State, JsNumber] =
       tableState ^|-> TableState.scrollPosition[TableColumn]
+
+    val InitialTableState: TableState[TableColumn] =
+      TableState(NotModified, 0, all)
+
+    val InitialState: State =
+      State(InitialTableState, None, None)
+
   }
 
   // Reusability
@@ -713,10 +710,10 @@ object SessionQueueTable extends Columns {
     }
 
   private def initialState(p: Props): State =
-    State.tableState.set(p.sequences.tableState)(InitialState)
+    State.tableState.set(p.sequences.tableState)(State.InitialState)
 
   private def onResize(b: Backend): Size => Callback = s =>
-    Callback.log(s"onResize ${b.state.tableState.userModified}") *> b.setStateL(State.lastSize)(s.some) *>
+    b.setStateL(State.lastSize)(s.some) *>
       b.modStateL(State.tableState)(_.recalculateWidths(s, b.props.visibleColumns, b.props.columnWidths))
 
   private val component = ScalaComponent

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/TableContainer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/TableContainer.scala
@@ -5,6 +5,7 @@ package seqexec.web.client.components
 
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.Reusability
 import react.virtualized._
@@ -16,7 +17,7 @@ import web.client.style._
 object TableContainer {
 
   // Todo use Reusable[A ~=> B]
-  final case class Props(hasControls: Boolean, table: Size => VdomElement)
+  final case class Props(hasControls: Boolean, table: Size => VdomElement, onResize: Size => Callback)
 
   implicit val reuse: Reusability[Props] = Reusability.never
 
@@ -27,7 +28,7 @@ object TableContainer {
       <.div(
         SeqexecStyles.tableContainer.when(p.hasControls),
         SeqexecStyles.tableContainerNoControls.unless(p.hasControls),
-        AutoSizer(AutoSizer.props(p.table))
+        AutoSizer(AutoSizer.props(p.table, onResize = p.onResize))
     ))
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -286,7 +286,7 @@ object CalQueueTable {
               label        = meta.label,
               cellRenderer = renderer(meta.column),
               headerRenderer = resizableHeaderRenderer(
-                state.tableState.resizeRowB(meta.column, size, updateState)),
+                state.tableState.resizeColumn(meta.column, size, updateState)),
               className = SeqexecStyles.queueTextColumn.htmlClass
             ))
         case ColumnRenderArgs(meta, _, width, false) =>
@@ -400,7 +400,7 @@ object CalQueueTable {
           val sortableList = SortableContainer.wrapC(
             Table.component,
             s.tableState
-              .columnBuilderC(size, colBuilder(p, s, size))
+              .columnBuilder(size, colBuilder(p, s, size))
               .map(_.vdomElement))
 
           // If distance is 0 we can miss some events

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -278,31 +278,25 @@ object CalQueueTable {
       }
 
       tb match {
-        case ColumnRenderArgs(ColumnMeta(c, name, label, _, _),
-                              _,
-                              width,
-                              true) =>
+        case ColumnRenderArgs(meta, _, width, true) =>
           Column(
             Column.propsNoFlex(
               width        = width,
-              dataKey      = name,
-              label        = label,
-              cellRenderer = renderer(c),
+              dataKey      = meta.name,
+              label        = meta.label,
+              cellRenderer = renderer(meta.column),
               headerRenderer = resizableHeaderRenderer(
-                state.tableState.resizeRowB(c, size, updateState)),
+                state.tableState.resizeRowB(meta.column, size, updateState)),
               className = SeqexecStyles.queueTextColumn.htmlClass
             ))
-        case ColumnRenderArgs(ColumnMeta(c, name, label, _, _),
-                              _,
-                              width,
-                              false) =>
+        case ColumnRenderArgs(meta, _, width, false) =>
           Column(
             Column.propsNoFlex(width        = width,
-                               dataKey      = name,
-                               label        = label,
-                               cellRenderer = renderer(c),
+                               dataKey      = meta.name,
+                               label        = meta.label,
+                               cellRenderer = renderer(meta.column),
                                className =
-                                 if (c === InstrumentColumn)
+                                 if (meta.column === InstrumentColumn)
                                    SeqexecStyles.queueTextColumn.htmlClass
                                  else "")
           )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -192,7 +192,7 @@ object CalQueueTable {
   implicit val icReuse: Reusability[IndexChange] =
     Reusability.derive[IndexChange]
   implicit val stateReuse: Reusability[State] =
-    Reusability.by(x => x.moved)//(x.tableState, x.moved))
+    Reusability.by(x => (x.tableState, x.moved))
 
   // ScalaJS defined trait
   // scalastyle:off
@@ -291,14 +291,16 @@ object CalQueueTable {
             ))
         case ColumnRenderArgs(meta, _, width, false) =>
           Column(
-            Column.propsNoFlex(width        = width,
-                               dataKey      = meta.name,
-                               label        = meta.label,
-                               cellRenderer = renderer(meta.column),
-                               className =
-                                 if (meta.column === InstrumentColumn)
-                                   SeqexecStyles.queueTextColumn.htmlClass
-                                 else "")
+            Column.propsNoFlex(
+              width        = width,
+              dataKey      = meta.name,
+              label        = meta.label,
+              cellRenderer = renderer(meta.column),
+              className =
+                if (meta.column === InstrumentColumn)
+                  SeqexecStyles.queueTextColumn.htmlClass
+                else ""
+            )
           )
       }
     }
@@ -396,23 +398,28 @@ object CalQueueTable {
       }
 
     def render(p: Props, s: State): VdomElement =
-      TableContainer(TableContainer.Props(p.canOperate, size => {
-          val sortableList = SortableContainer.wrapC(
-            Table.component,
-            s.tableState
-              .columnBuilder(size, colBuilder(p, s, size))
-              .map(_.vdomElement))
+      TableContainer(
+        TableContainer.Props(
+          p.canOperate,
+          size => {
+            val sortableList = SortableContainer.wrapC(
+              Table.component,
+              s.tableState
+                .columnBuilder(size, colBuilder(p, s, size))
+                .map(_.vdomElement))
 
-          // If distance is 0 we can miss some events
-          val cp = SortableContainer.Props(
-            onSortEnd         = requestMove,
-            shouldCancelStart = _ => CallbackTo(!p.data.canOperate),
-            helperClass =
-              (SeqexecStyles.noselect |+| SeqexecStyles.draggedRowHelper).htmlClass,
-            distance = 3
-          )
-          sortableList(cp)(table(p, s)(size))
-      }, onResize = _ => Callback.empty))
+            // If distance is 0 we can miss some events
+            val cp = SortableContainer.Props(
+              onSortEnd         = requestMove,
+              shouldCancelStart = _ => CallbackTo(!p.data.canOperate),
+              helperClass =
+                (SeqexecStyles.noselect |+| SeqexecStyles.draggedRowHelper).htmlClass,
+              distance = 3
+            )
+            sortableList(cp)(table(p, s)(size))
+          },
+          onResize = _ => Callback.empty
+        ))
 
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -289,7 +289,7 @@ object CalQueueTable {
               label        = label,
               cellRenderer = renderer(c),
               headerRenderer = resizableHeaderRenderer(
-                state.tableState.resizeRow(c, size, updateState)),
+                state.tableState.resizeRowB(c, size, updateState)),
               className = SeqexecStyles.queueTextColumn.htmlClass
             ))
         case ColumnRenderArgs(ColumnMeta(c, name, label, _, _),
@@ -406,7 +406,7 @@ object CalQueueTable {
           val sortableList = SortableContainer.wrapC(
             Table.component,
             s.tableState
-              .columnBuilder(size, TableState.AllColsVisible, colBuilder(p, s, size))
+              .columnBuilderB(size, colBuilder(p, s, size))
               .map(_.vdomElement))
 
           // If distance is 0 we can miss some events

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -400,7 +400,7 @@ object CalQueueTable {
           val sortableList = SortableContainer.wrapC(
             Table.component,
             s.tableState
-              .columnBuilderB(size, colBuilder(p, s, size))
+              .columnBuilderC(size, colBuilder(p, s, size))
               .map(_.vdomElement))
 
           // If distance is 0 we can miss some events
@@ -412,7 +412,7 @@ object CalQueueTable {
             distance = 3
           )
           sortableList(cp)(table(p, s)(size))
-      }))
+      }, onResize = _ => Callback.empty))
 
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -72,14 +72,14 @@ object CalQueueTable {
     name    = "obsid",
     label   = "Obs. ID",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.5, ObsIdMinWidth))
+    VariableColumnWidth.unsafeFromDouble(0.5, ObsIdMinWidth))
 
   val InstrumentColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     InstrumentColumn,
     name    = "instrument",
     label   = "Instrument",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.5, InstrumentMinWidth))
+    VariableColumnWidth.unsafeFromDouble(0.5, InstrumentMinWidth))
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] =
     NonEmptyList.of(RemoveSeqMeta, ObsIdColumnMeta, InstrumentColumnMeta)
@@ -406,7 +406,7 @@ object CalQueueTable {
           val sortableList = SortableContainer.wrapC(
             Table.component,
             s.tableState
-              .columnBuilder(size, colBuilder(p, s, size))
+              .columnBuilder(size, TableState.AllColsVisible, colBuilder(p, s, size))
               .map(_.vdomElement))
 
           // If distance is 0 we can miss some events

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -192,7 +192,7 @@ object CalQueueTable {
   implicit val icReuse: Reusability[IndexChange] =
     Reusability.derive[IndexChange]
   implicit val stateReuse: Reusability[State] =
-    Reusability.by(x => (x.tableState, x.moved))
+    Reusability.by(x => x.moved)//(x.tableState, x.moved))
 
   // ScalaJS defined trait
   // scalastyle:off

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -121,7 +121,7 @@ object StepConfigTable {
             width          = width,
             dataKey        = meta.name,
             label          = meta.label,
-            headerRenderer = resizableHeaderRenderer(b.state.resizeRowB(meta.column, size, updateState)),
+            headerRenderer = resizableHeaderRenderer(b.state.resizeColumn(meta.column, size, updateState)),
             className      = SeqexecStyles.paddedStepRow.htmlClass
           ))
       case ColumnRenderArgs(meta, _, width, false) =>
@@ -183,7 +183,7 @@ object StepConfigTable {
     .render ( b =>
       TableContainer(TableContainer.Props(true, size =>
         Table(settingsTableProps(b, size),
-              b.state.columnBuilderC(size, colBuilder(b, size)): _*),
+              b.state.columnBuilder(size, colBuilder(b, size)): _*),
               onResize = _ => Callback.empty))
     )
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -185,7 +185,8 @@ object StepConfigTable {
     .render ( b =>
       TableContainer(TableContainer.Props(true, size =>
         Table(settingsTableProps(b, size),
-              b.state.columnBuilderB(size, colBuilder(b, size)): _*)))
+              b.state.columnBuilderC(size, colBuilder(b, size)): _*),
+              onResize = _ => Callback.empty))
     )
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -115,21 +115,21 @@ object StepConfigTable {
       b.setState(s) >> SeqexecCircuit.dispatchCB(UpdateStepsConfigTableState(s))
 
     tb match {
-      case ColumnRenderArgs(ColumnMeta(c, name, label, _, _), _, width, true) =>
+      case ColumnRenderArgs(meta, _, width, true) =>
         Column(
           Column.propsNoFlex(
             width          = width,
-            dataKey        = name,
-            label          = label,
-            headerRenderer = resizableHeaderRenderer(b.state.resizeRowB(c, size, updateState)),
+            dataKey        = meta.name,
+            label          = meta.label,
+            headerRenderer = resizableHeaderRenderer(b.state.resizeRowB(meta.column, size, updateState)),
             className      = SeqexecStyles.paddedStepRow.htmlClass
           ))
-      case ColumnRenderArgs(ColumnMeta(_, name, label, _, _), _, width, false) =>
+      case ColumnRenderArgs(meta, _, width, false) =>
         Column(
           Column.propsNoFlex(
             width     = width,
-            dataKey   = name,
-            label     = label,
+            dataKey   = meta.name,
+            label     = meta.label,
             className = SeqexecStyles.paddedStepRow.htmlClass))
     }
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -121,7 +121,7 @@ object StepConfigTable {
             width          = width,
             dataKey        = name,
             label          = label,
-            headerRenderer = resizableHeaderRenderer(b.state.resizeRow(c, size, updateState)),
+            headerRenderer = resizableHeaderRenderer(b.state.resizeRowB(c, size, updateState)),
             className      = SeqexecStyles.paddedStepRow.htmlClass
           ))
       case ColumnRenderArgs(ColumnMeta(_, name, label, _, _), _, width, false) =>
@@ -185,7 +185,7 @@ object StepConfigTable {
     .render ( b =>
       TableContainer(TableContainer.Props(true, size =>
         Table(settingsTableProps(b, size),
-              b.state.columnBuilder(size, TableState.AllColsVisible, colBuilder(b, size)): _*)))
+              b.state.columnBuilderB(size, colBuilder(b, size)): _*)))
     )
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -21,6 +21,7 @@ import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.components.TableContainer
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.actions.UpdateStepsConfigTableState
+import seqexec.web.client.reusability._
 import web.client.table._
 import seqexec.web.client.reusability._
 
@@ -88,7 +89,7 @@ object StepConfigTable {
     name    = "name",
     label   = "Name",
     visible = true,
-    width = PercentageColumnWidth.unsafeFromDouble(
+    width = VariableColumnWidth.unsafeFromDouble(
       percentage = 0.5,
       minWidth   = 57.3833 + SeqexecStyles.TableBorderWidth)
   )
@@ -99,7 +100,7 @@ object StepConfigTable {
     label   = "Value",
     visible = true,
     width =
-      PercentageColumnWidth.unsafeFromDouble(percentage = 0.5, minWidth = 60.0))
+      VariableColumnWidth.unsafeFromDouble(percentage = 0.5, minWidth = 60.0))
 
   val InitialTableState: TableState[TableColumn] = TableState[TableColumn](
     userModified   = NotModified,
@@ -110,7 +111,6 @@ object StepConfigTable {
     b:    Backend,
     size: Size
   ): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb => {
-    val state = b.state
     def updateState(s: TableState[TableColumn]): Callback =
       b.setState(s) >> SeqexecCircuit.dispatchCB(UpdateStepsConfigTableState(s))
 
@@ -121,7 +121,7 @@ object StepConfigTable {
             width          = width,
             dataKey        = name,
             label          = label,
-            headerRenderer = resizableHeaderRenderer(state.resizeRow(c, size, updateState)),
+            headerRenderer = resizableHeaderRenderer(b.state.resizeRow(c, size, updateState)),
             className      = SeqexecStyles.paddedStepRow.htmlClass
           ))
       case ColumnRenderArgs(ColumnMeta(_, name, label, _, _), _, width, false) =>
@@ -185,7 +185,7 @@ object StepConfigTable {
     .render ( b =>
       TableContainer(TableContainer.Props(true, size =>
         Table(settingsTableProps(b, size),
-              b.state.columnBuilder(size, colBuilder(b, size)): _*)))
+              b.state.columnBuilder(size, TableState.AllColsVisible, colBuilder(b, size)): _*)))
     )
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -155,8 +155,7 @@ object StepConfigTable {
         SeqexecStyles.stepRow
     }).htmlClass
 
-  def settingsTableProps(b: Backend, size: Size): Table.Props = {
-    val p = b.props
+  def settingsTableProps(b: Backend, size: Size): Table.Props =
     Table.props(
       disableHeader = false,
       noRowsRenderer = () =>
@@ -167,17 +166,16 @@ object StepConfigTable {
       ),
       overscanRowCount = SeqexecStyles.overscanRowCount,
       height           = size.height.toInt,
-      rowCount         = p.rowCount,
+      rowCount         = b.props.rowCount,
       rowHeight        = SeqexecStyles.rowHeight,
-      rowClassName     = rowClassName(p) _,
+      rowClassName     = rowClassName(b.props) _,
       width            = size.width.toInt,
-      rowGetter        = p.rowGetter _,
+      rowGetter        = b.props.rowGetter _,
       scrollTop        = b.state.scrollPosition,
       headerClassName  = SeqexecStyles.tableHeader.htmlClass,
       onScroll         = (_, _, pos) => updateScrollPosition(b, pos),
       headerHeight     = SeqexecStyles.headerHeight
     )
-  }
 
   private val component = ScalaComponent
     .builder[Props]("StepConfig")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -21,6 +21,7 @@ import seqexec.model.SequenceState
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.TabOperations
 import seqexec.web.client.model.StopOperation
+import seqexec.web.client.model.StepItems._
 import seqexec.web.client.model.ModelOps._
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.semanticui.elements.icon.Icon

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -14,7 +14,6 @@ import seqexec.model.enum.Instrument
 import seqexec.model.enum.StepType
 import seqexec.model.Step
 import seqexec.model.StepState
-import seqexec.model.enumerations
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.model.Pages
 import seqexec.web.client.model.lenses._
@@ -268,17 +267,9 @@ object CameraCell {
     .builder[Props]("CameraCell")
     .stateless
     .render_P { p =>
-      def cameraName(s: Step): Option[String] = p.i match {
-        case Instrument.Niri =>
-          instrumentCameraO
-            .getOption(s)
-            .flatMap(enumerations.camera.Niri.get)
-        case _ => None
-      }
-
       <.div(
         SeqexecStyles.componentLabel,
-        cameraName(p.s).map(_.sentenceCase).getOrElse("Unknown"): String
+        p.s.cameraName(p.i).map(_.sentenceCase).getOrElse("Unknown"): String
       )
     }
     .configure(Reusability.shouldComponentUpdate)
@@ -299,12 +290,9 @@ object DeckerCell {
     .builder[Props]("DeckerCell")
     .stateless
     .render_P { p =>
-      def deckerName(s: Step): Option[String] =
-        instrumentDeckerO.getOption(s)
-
       <.div(
         SeqexecStyles.componentLabel,
-        deckerName(p.s).map(_.sentenceCase).getOrElse("Unknown"): String
+        p.s.deckerName.map(_.sentenceCase).getOrElse("Unknown"): String
       )
     }
     .configure(Reusability.shouldComponentUpdate)
@@ -351,12 +339,9 @@ object ImagingMirrorCell {
     .builder[Props]("ImagingMirrorCell")
     .stateless
     .render_P { p =>
-      def imagingMirrorName(s: Step): Option[String] =
-        instrumentImagingMirrorO.getOption(s)
-
       <.div(
         SeqexecStyles.componentLabel,
-        imagingMirrorName(p.s).map(_.sentenceCase).getOrElse("Unknown"): String
+        p.s.imagingMirrorName.map(_.sentenceCase).getOrElse("Unknown"): String
       )
     }
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -19,7 +19,8 @@ import seqexec.model.enumerations
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.model.Pages
 import seqexec.web.client.model.lenses._
-import seqexec.web.client.model.ModelOps._
+import seqexec.web.client.model.StepItems._
+import seqexec.web.client.model.Formatting._
 import seqexec.web.client.semanticui.elements.label.Label
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.Size

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -10,10 +10,7 @@ import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import gem.Observation
-import gem.enum.GpiDisperser
-import gem.enum.GpiFilter
 import gem.enum.GpiObservingMode
-import seqexec.model.enum.FPUMode
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.StepType
 import seqexec.model.Step
@@ -41,30 +38,11 @@ object FPUCell {
     .builder[Props]("FPUCell")
     .stateless
     .render_P { p =>
-      val nameMapper: String => Option[String] = p.i match {
-        case Instrument.GmosS => enumerations.fpu.GmosSFPU.get
-        case Instrument.GmosN => enumerations.fpu.GmosNFPU.get
-        case Instrument.F2    => enumerations.fpu.Flamingos2.get
-        case _                => _ => none
-      }
-
-      val fpuValue = for {
-        mode <- instrumentFPUModeO
-          .getOption(p.s)
-          .orElse(FPUMode.BuiltIn.some) // If the instrument has no fpu mode default to built in
-        fpuL = if (mode === FPUMode.BuiltIn) instrumentFPUO
-        else instrumentFPUCustomMaskO
-        fpu <- fpuL.getOption(p.s)
-      } yield nameMapper(fpu).getOrElse(fpu)
-
       <.div(
         SeqexecStyles.componentLabel,
-        fpuValue
-          .orElse(
-            instrumentSlitWidthO
-              .getOption(p.s)
-              .map(_.sentenceCase)
-              .orElse(instrumentMaskO.getOption(p.s).map(_.sentenceCase)))
+        p.s
+          .fpu(p.i)
+          .orElse(p.s.fpuOrMask(p.i).map(_.sentenceCase))
           .getOrElse("Unknown"): String
       )
     }
@@ -82,59 +60,13 @@ object FilterCell {
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private val gpiObsMode = GpiObservingMode.all.map(x => x.shortName -> x).toMap
-
-  private val gpiFiltersMap: Map[String, GpiFilter] =
-    GpiFilter.all.map(x => (x.shortName, x)).toMap
-
-  def gpiFilter: Step => Option[String] = s => {
-    // Read the filter, if not found deduce it from the obs mode
-    val f: Option[GpiFilter] =
-      instrumentFilterO.getOption(s).flatMap(gpiFiltersMap.get).orElse {
-        for {
-          m <- instrumentObservingModeO.getOption(s)
-          o <- gpiObsMode.get(m)
-          f <- o.filter
-        } yield f
-      }
-    f.map(_.longName)
-  }
-
   private val component = ScalaComponent
     .builder[Props]("FilterCell")
     .stateless
     .render_P { p =>
-      def filterName(s: Step): Option[String] = p.i match {
-        case Instrument.GmosS =>
-          instrumentFilterO
-            .getOption(s)
-            .flatMap(enumerations.filter.GmosSFilter.get)
-        case Instrument.GmosN =>
-          instrumentFilterO
-            .getOption(s)
-            .flatMap(enumerations.filter.GmosNFilter.get)
-        case Instrument.F2 =>
-          instrumentFilterO
-            .getOption(s)
-        case Instrument.Niri =>
-          instrumentFilterO
-            .getOption(s)
-            .flatMap(enumerations.filter.Niri.get)
-        case Instrument.Gnirs =>
-          instrumentFilterO
-            .getOption(s)
-            .map(_.sentenceCase)
-        case Instrument.Nifs =>
-          instrumentFilterO
-            .getOption(s)
-            .map(_.sentenceCase)
-        case Instrument.Gpi => gpiFilter(s)
-        case _              => None
-      }
-
       <.div(
         SeqexecStyles.componentLabel,
-        filterName(p.s).getOrElse("Unknown"): String
+        p.s.filter(p.i).getOrElse("Unknown"): String
       )
     }
     .configure(Reusability.shouldComponentUpdate)
@@ -151,34 +83,13 @@ object DisperserCell {
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  val gpiDispersers: Map[String, String] =
-    GpiDisperser.all.map(x => x.shortName -> x.longName).toMap
-
   private val component = ScalaComponent
     .builder[Props]("DisperserCell")
     .stateless
     .render_P { p =>
-      val nameMapper: Map[String, String] = p.i match {
-        case Instrument.GmosS => enumerations.disperser.GmosSDisperser
-        case Instrument.GmosN => enumerations.disperser.GmosNDisperser
-        case Instrument.Gpi   => gpiDispersers
-        case _                => Map.empty
-      }
-
-      val disperser = for {
-        disperser <- instrumentDisperserO.getOption(p.s)
-      } yield nameMapper.getOrElse(disperser, disperser)
-      val centralWavelength = instrumentDisperserLambdaO.getOption(p.s)
-
-      // Formatter
-      val displayedText = (disperser, centralWavelength) match {
-        case (Some(d), Some(w)) => f"$d @ $w%.0f nm"
-        case (Some(d), None)    => d
-        case _                  => "Unknown"
-      }
       <.div(
         SeqexecStyles.componentLabel,
-        displayedText
+        p.s.disperser(p.i)
       )
     }
     .configure(Reusability.shouldComponentUpdate)
@@ -199,13 +110,8 @@ object ExposureTimeCell {
     .builder[Props]("ExposureTimeCell")
     .stateless
     .render_P { p =>
-      def formatExposureTime(e: Double): String = p.i match {
-        case Instrument.GmosN | Instrument.GmosS => f"$e%.0f"
-        case _                                   => f"$e%.2f"
-      }
-
-      val exposureTime = observeExposureTimeO.getOption(p.s)
-      val coadds       = observeCoaddsO.getOption(p.s)
+      val exposureTime = p.s.exposureTimeS(p.i)
+      val coadds       = p.s.coAdds
 
       // TODO Find a better way to output math-style text
       val seconds = List(
@@ -224,10 +130,10 @@ object ExposureTimeCell {
             <.span(^.display := "inline-block",
                    ^.verticalAlign := "none",
                    "\u2A2F"),
-            <.span(^.display := "inline-block", s"${formatExposureTime(e)}")
+            <.span(^.display := "inline-block", s"$e")
           ) ::: seconds).toTagMod
         case (_, Some(e)) =>
-          ((s"${formatExposureTime(e)}": VdomNode) :: seconds).toTagMod
+          ((s"$e": VdomNode) :: seconds).toTagMod
         case _ => EmptyVdom
       }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -10,7 +10,6 @@ import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import gem.Observation
-import gem.enum.GpiObservingMode
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.StepType
 import seqexec.model.Step
@@ -241,9 +240,6 @@ object ObservingModeCell {
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private val obsNames =
-    GpiObservingMode.all.map(x => x.shortName -> x.longName).toMap
-
   private val component = ScalaComponent
     .builder[Props]("ObsModeCell")
     .stateless
@@ -251,9 +247,7 @@ object ObservingModeCell {
       p =>
         <.div(
           SeqexecStyles.componentLabel,
-          instrumentObservingModeO
-            .getOption(p.s)
-            .flatMap(obsNames.get)
+          p.s.observingMode
             .getOrElse("Unknown"): String
       ))
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -18,7 +18,6 @@ import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.model.Pages
 import seqexec.web.client.model.lenses._
 import seqexec.web.client.model.StepItems._
-import seqexec.web.client.model.Formatting._
 import seqexec.web.client.semanticui.elements.label.Label
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.Size
@@ -26,69 +25,20 @@ import seqexec.web.client.reusability._
 import web.client.style._
 
 /**
-  * Component to display the FPU
+  * Component to display an item of a sequence
   */
-object FPUCell {
-  final case class Props(s: Step, i: Instrument)
+object StepItemCell {
+  final case class Props(value: Option[String])
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   private val component = ScalaComponent
-    .builder[Props]("FPUCell")
+    .builder[Props]("StepItemCell")
     .stateless
     .render_P { p =>
       <.div(
         SeqexecStyles.componentLabel,
-        p.s
-          .fpu(p.i)
-          .orElse(p.s.fpuOrMask(p.i).map(_.sentenceCase))
-          .getOrElse("Unknown"): String
-      )
-    }
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
-  * Component to display the Filter
-  */
-object FilterCell {
-  final case class Props(s: Step, i: Instrument)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  private val component = ScalaComponent
-    .builder[Props]("FilterCell")
-    .stateless
-    .render_P { p =>
-      <.div(
-        SeqexecStyles.componentLabel,
-        p.s.filter(p.i).getOrElse("Unknown"): String
-      )
-    }
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
-  * Component to display the disperser and wavelength
-  */
-object DisperserCell {
-  final case class Props(s: Step, i: Instrument)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  private val component = ScalaComponent
-    .builder[Props]("DisperserCell")
-    .stateless
-    .render_P { p =>
-      <.div(
-        SeqexecStyles.componentLabel,
-        p.s.disperser(p.i)
+        p.value.getOrElse("Unknown"): String
       )
     }
     .configure(Reusability.shouldComponentUpdate)
@@ -229,123 +179,4 @@ object ObjectTypeCell {
     .build
 
   def apply(i: Props): Unmounted[Props, Unit, Unit] = component(i)
-}
-
-/**
-  * Component to display the Observing Mode (GPI Only)
-  */
-object ObservingModeCell {
-  final case class Props(s: Step)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  private val component = ScalaComponent
-    .builder[Props]("ObsModeCell")
-    .stateless
-    .render_P(
-      p =>
-        <.div(
-          SeqexecStyles.componentLabel,
-          p.s.observingMode
-            .getOrElse("Unknown"): String
-      ))
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
-  * Component to display the camera
-  */
-object CameraCell {
-  final case class Props(s: Step, i: Instrument)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  private val component = ScalaComponent
-    .builder[Props]("CameraCell")
-    .stateless
-    .render_P { p =>
-      <.div(
-        SeqexecStyles.componentLabel,
-        p.s.cameraName(p.i).map(_.sentenceCase).getOrElse("Unknown"): String
-      )
-    }
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
-  * Component to display the decker
-  */
-object DeckerCell {
-  final case class Props(s: Step)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  private val component = ScalaComponent
-    .builder[Props]("DeckerCell")
-    .stateless
-    .render_P { p =>
-      <.div(
-        SeqexecStyles.componentLabel,
-        p.s.deckerName.map(_.sentenceCase).getOrElse("Unknown"): String
-      )
-    }
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
-  * Component to display the read mode
-  */
-object ReadModeCell {
-  final case class Props(s: Step)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  private val component = ScalaComponent
-    .builder[Props]("ReadModeCell")
-    .stateless
-    .render_P { p =>
-      def readModeName(s: Step): Option[String] =
-        instrumentReadModeO.getOption(s)
-
-      <.div(
-        SeqexecStyles.componentLabel,
-        readModeName(p.s).map(_.sentenceCase).getOrElse("Unknown"): String
-      )
-    }
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
-  * Component to imaging mirror the decker
-  */
-object ImagingMirrorCell {
-  final case class Props(s: Step)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  private val component = ScalaComponent
-    .builder[Props]("ImagingMirrorCell")
-    .stateless
-    .render_P { p =>
-      <.div(
-        SeqexecStyles.componentLabel,
-        p.s.imagingMirrorName.map(_.sentenceCase).getOrElse("Unknown"): String
-      )
-    }
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -127,113 +127,114 @@ trait Columns {
     name    = "control",
     label   = "",
     visible = true,
-    width = FixedColumnWidth.unsafeFromDouble(ControlWidth))
+    width   = FixedColumnWidth.unsafeFromDouble(ControlWidth))
 
   val StepMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     StepColumn,
     name    = "idx",
     label   = "Step",
     visible = true,
-    width = FixedColumnWidth.unsafeFromDouble(StepWidth))
+    width   = FixedColumnWidth.unsafeFromDouble(StepWidth))
 
   val ExecutionMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExecutionColumn,
     name    = "state",
     label   = "Execution Progress",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ExecutionMinWidth),
-    grow = 20)
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, ExecutionMinWidth),
+    grow    = 20)
 
   val OffsetMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     OffsetColumn,
     name    = "offsets",
     label   = "Offsets",
     visible = true,
-    width = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase))
+    width   = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase))
 
   val ObservingModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObservingModeColumn,
     name    = "obsMode",
     label   = "Observing Mode",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth))
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth))
 
   val ExposureMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExposureColumn,
     name    = "exposure",
     label   = "Exposure",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth))
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth))
 
   val DisperserMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DisperserColumn,
     name    = "disperser",
     label   = "Disperser",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth))
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth))
 
   val FilterMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FilterColumn,
-    name    = "filter",
-    label   = "Filter",
-    visible = true,
+    name       = "filter",
+    label      = "Filter",
+    visible    = true,
     removeable = 2,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth))
 
   val FPUMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FPUColumn,
-    name    = "fpu",
-    label   = "FPU",
+    name       = "fpu",
+    label      = "FPU",
     removeable = 3,
-    visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth))
+    visible    = true,
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth))
 
   val CameraMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     CameraColumn,
-    name    = "camera",
-    label   = "Camera",
-    visible = true,
+    name       = "camera",
+    label      = "Camera",
+    visible    = true,
     removeable = 4,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth))
 
   val DeckerMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DeckerColumn,
-    name    = "camera",
-    label   = "Decker",
+    name       = "camera",
+    label      = "Decker",
     removeable = 5,
-    visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth))
+    visible    = true,
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth))
 
   val ReadModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ReadModeColumn,
-    name    = "camera",
-    label   = "ReadMode",
-    visible = true,
+    name       = "camera",
+    label      = "ReadMode",
+    visible    = true,
     removeable = 6,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth))
 
   val ImagingMirrorMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ImagingMirrorColumn,
-    name    = "camera",
-    label   = "ImagingMirror",
-    visible = true,
+    name       = "camera",
+    label      = "ImagingMirror",
+    visible    = true,
     removeable = 7,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorMinWidth)
+  )
 
   val ObjectTypeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObjectTypeColumn,
-    name    = "type",
-    label   = "Type",
-    visible = true,
+    name       = "type",
+    label      = "Type",
+    visible    = true,
     removeable = 1,
-    width = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth))
+    width      = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth))
 
   val SettingsMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     SettingsColumn,
     name    = "set",
     label   = "",
     visible = true,
-    width = FixedColumnWidth.unsafeFromDouble(SettingsWidth))
+    width   = FixedColumnWidth.unsafeFromDouble(SettingsWidth))
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] =
     NonEmptyList.of(
@@ -365,7 +366,8 @@ object StepsTable extends Columns {
       (max(p, q) + labelWidth + OffsetIconWidth + OffsetPadding * 4).some
     }
 
-    val exposure: Step => Option[String] = s => instrument.flatMap(s.exposureAndCoaddsS)
+    val exposure: Step => Option[String] = s =>
+      instrument.flatMap(s.exposureAndCoaddsS)
 
     val disperser: Step => Option[String] = s => instrument.flatMap(s.disperser)
 
@@ -394,23 +396,28 @@ object StepsTable extends Columns {
       shownForInstrument.map(_.column).contains _
 
     val extractors = List[(TableColumn, Step => Option[String])](
-        (ExposureColumn, exposure),
-        (FPUColumn, fpuOrMask),
-        (FilterColumn, filter),
-        (DisperserColumn, disperser),
-        (CameraColumn, camera),
-        (DeckerColumn, _.deckerName),
-        (ImagingMirrorColumn, _.imagingMirrorName),
-        (ObservingModeColumn, _.observingMode),
-        (ReadModeColumn, _.readMode)).toMap
+      (ExposureColumn, exposure),
+      (FPUColumn, fpuOrMask),
+      (FilterColumn, filter),
+      (DisperserColumn, disperser),
+      (CameraColumn, camera),
+      (DeckerColumn, _.deckerName),
+      (ImagingMirrorColumn, _.imagingMirrorName),
+      (ObservingModeColumn, _.observingMode),
+      (ReadModeColumn, _.readMode)
+    ).toMap
 
     private val valueCalculatedCols: TableColumn => Option[Double] = {
       case ExecutionColumn => 200.0.some
-      case OffsetColumn => offsetWidth
-      case _ => none
+      case OffsetColumn    => offsetWidth
+      case _               => none
     }
     private val measuredColumnWidths: TableColumn => Option[Double] =
-      colWidthsO(stepsList, allTC, extractors, columnsMinWidth, Map.empty[TableColumn, Double])
+      colWidthsO(stepsList,
+                 allTC,
+                 extractors,
+                 columnsMinWidth,
+                 Map.empty[TableColumn, Double])
 
     val columnWidths: TableColumn => Option[Double] =
       c => measuredColumnWidths(c).orElse(valueCalculatedCols(c))
@@ -543,7 +550,7 @@ object StepsTable extends Columns {
     (_, _, _, row: StepRow, _) =>
       ObjectTypeCell(ObjectTypeCell.Props(row.step, size))
 
-  private def stepRowStyle(step: Step): GStyle = step match {
+  private val stepRowStyle: Step => GStyle = {
     case s if s.hasError                       => SeqexecStyles.rowError
     case s if s.status === StepState.Running   => SeqexecStyles.rowWarning
     case s if s.status === StepState.Paused    => SeqexecStyles.rowWarning
@@ -612,26 +619,24 @@ object StepsTable extends Columns {
         baseHeight(b.props)
     }
 
-  def columnClassName(c: TableColumn): Option[GStyle] =
-    c match {
-      case ControlColumn                => SeqexecStyles.controlCellRow.some
-      case StepColumn | ExecutionColumn => SeqexecStyles.paddedStepRow.some
-      case ObservingModeColumn | ExposureColumn | DisperserColumn |
-          FilterColumn | FPUColumn | CameraColumn | ObjectTypeColumn |
-          DeckerColumn | ReadModeColumn | ImagingMirrorColumn =>
-        SeqexecStyles.centeredCell.some
-      case SettingsColumn => SeqexecStyles.settingsCellRow.some
-      case _              => none
-    }
+  val columnClassName: TableColumn => Option[GStyle] = {
+    case ControlColumn                => SeqexecStyles.controlCellRow.some
+    case StepColumn | ExecutionColumn => SeqexecStyles.paddedStepRow.some
+    case ObservingModeColumn | ExposureColumn | DisperserColumn | FilterColumn |
+        FPUColumn | CameraColumn | ObjectTypeColumn | DeckerColumn |
+        ReadModeColumn | ImagingMirrorColumn =>
+      SeqexecStyles.centeredCell.some
+    case SettingsColumn => SeqexecStyles.settingsCellRow.some
+    case _              => none
+  }
 
-  def headerClassName(c: TableColumn): Option[GStyle] =
-    c match {
-      case ControlColumn =>
-        (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
-      case SettingsColumn =>
-        (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
-      case _ => none
-    }
+  val headerClassName: TableColumn => Option[GStyle] = {
+    case ControlColumn =>
+      (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
+    case SettingsColumn =>
+      (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
+    case _ => none
+  }
 
   val controlHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
     <.span(
@@ -645,18 +650,17 @@ object StepsTable extends Columns {
       IconBrowser
   )
 
-  private def fixedHeaderRenderer(c: TableColumn): HeaderRenderer[js.Object] =
-    c match {
-      case ControlColumn  => controlHeaderRenderer
-      case SettingsColumn => settingsHeaderRenderer
-      case _              => defaultHeaderRendererS
-    }
+  private val fixedHeaderRenderer: TableColumn => HeaderRenderer[js.Object] = {
+    case ControlColumn  => controlHeaderRenderer
+    case SettingsColumn => settingsHeaderRenderer
+    case _              => defaultHeaderRendererS
+  }
 
   private def columnCellRenderer(
     b: Backend,
     c: TableColumn): CellRenderer[js.Object, js.Object, StepRow] = {
     val optR = c match {
-      case ControlColumn =>
+      case ControlColumn       =>
         b.props.steps.map(
           stepControlRenderer(_,
                               b,
@@ -667,20 +671,17 @@ object StepsTable extends Columns {
       case ExecutionColumn     => b.props.steps.map(stepProgressRenderer(_, b))
       case OffsetColumn        => stepStatusRenderer(b.props.offsetsDisplay).some
       case ObservingModeColumn => stepItemRenderer(_.observingMode).some
-      case ExposureColumn =>
-        b.props.instrument.map(stepExposureRenderer)
-      case DisperserColumn =>
-        b.props.instrument.map(i => stepItemRenderer(_.disperser(i)))
-      case FilterColumn => b.props.instrument.map(i => stepItemRenderer(_.filter(i)))
-      case FPUColumn        => b.props.instrument.map(i => stepFPURenderer(i))
-      case CameraColumn     => b.props.instrument.map(i => stepItemRenderer(_.cameraName(i)))
-      case ObjectTypeColumn => stepObjectTypeRenderer(SSize.Small).some
-      case SettingsColumn =>
-        b.props.steps.map(p => settingsControlRenderer(b.props, p))
-      case ReadModeColumn => stepItemRendererS(_.readMode).some
-      case DeckerColumn => stepItemRendererS(_.deckerName).some
+      case ExposureColumn      => b.props.instrument.map(stepExposureRenderer)
+      case DisperserColumn     => b.props.instrument.map(i => stepItemRenderer(_.disperser(i)))
+      case FilterColumn        => b.props.instrument.map(i => stepItemRenderer(_.filter(i)))
+      case FPUColumn           => b.props.instrument.map(i => stepFPURenderer(i))
+      case CameraColumn        => b.props.instrument.map(i => stepItemRenderer(_.cameraName(i)))
+      case ObjectTypeColumn    => stepObjectTypeRenderer(SSize.Small).some
+      case SettingsColumn      => b.props.steps.map(p => settingsControlRenderer(b.props, p))
+      case ReadModeColumn      => stepItemRendererS(_.readMode).some
+      case DeckerColumn        => stepItemRendererS(_.deckerName).some
       case ImagingMirrorColumn => stepItemRendererS(_.imagingMirrorName).some
-      case _ => none
+      case _                   => none
     }
     optR.getOrElse(defaultCellRendererS)
   }
@@ -704,10 +705,10 @@ object StepsTable extends Columns {
             headerRenderer = resizableHeaderRenderer(
               b.state.tableState
                 .resizeColumn(meta.column,
-                           size,
-                           updateState,
-                           b.props.visibleColumns,
-                           b.props.columnWidths)),
+                              size,
+                              updateState,
+                              b.props.visibleColumns,
+                              b.props.columnWidths)),
             headerClassName = headerClassName(meta.column).foldMap(_.htmlClass),
             cellRenderer    = columnCellRenderer(b, meta.column),
             className       = columnClassName(meta.column).foldMap(_.htmlClass)
@@ -730,12 +731,12 @@ object StepsTable extends Columns {
   // This is fairly convoluted as the table always calls this at start when
   // the table is rendered with position 0
   // Aditionally if we programatically scroll to a position we get another call
-  // Only after that we assume scroll is user bade
+  // Only after that we assume scroll is user initatied
   def updateScrollPosition(b: Backend, pos: JsNumber): Callback = {
-    val modMod = b.setStateL(State.userModified)(IsModified)
-    val posMod = b.setStateL(State.scrollPosition)(pos)
+    val modMod            = b.setStateL(State.userModified)(IsModified)
+    val posMod            = b.setStateL(State.scrollPosition)(pos)
     val hasScrolledBefore = b.state.scrollCount > 1
-    val scrollCountMods = b.modStateL(State.scrollCount)(_ + 1)
+    val scrollCountMods   = b.modStateL(State.scrollCount)(_ + 1)
     // Separately calculate the state to send upstream
     val newTs = if (hasScrolledBefore) {
       (State.userModified.set(IsModified) >>> State.scrollPosition.set(pos))(b.state)
@@ -748,8 +749,7 @@ object StepsTable extends Columns {
       // And silently update the model
       b.props.obsId
         .map(id =>
-          SeqexecCircuit.dispatchCB(
-            UpdateStepTableState(id, newTs.tableState)))
+          SeqexecCircuit.dispatchCB(UpdateStepTableState(id, newTs.tableState)))
         .getOrEmpty
   }
 
@@ -775,8 +775,9 @@ object StepsTable extends Columns {
         SeqexecCircuit
           .dispatchCB(ClearAllResouceOptions(id)) *>
         b.modState(State.selected.set(Some(i))) *>
-        recomputeRowHeightsCB(min(b.state.selected.getOrElse(i), i))
-      ).when(b.props.stepSelectionAllowed(i)).void
+        recomputeRowHeightsCB(min(b.state.selected.getOrElse(i), i)))
+        .when(b.props.stepSelectionAllowed(i))
+        .void
     }.getOrEmpty
 
   def stepsTableProps(b: Backend)(size: Size): Table.Props =
@@ -798,7 +799,8 @@ object StepsTable extends Columns {
       scrollToIndex    = startScrollToIndex(b),
       scrollTop        = startScrollTop(b.state),
       onRowClick       = singleClick(b),
-      onScroll = (a, _, pos) => updateScrollPosition(b, pos).when(a.toDouble > 0) *> Callback.empty,
+      onScroll = (a, _, pos) =>
+        updateScrollPosition(b, pos).when(a.toDouble > 0) *> Callback.empty,
       scrollToAlignment = ScrollToAlignment.Center,
       headerClassName   = SeqexecStyles.tableHeader.htmlClass,
       headerHeight      = SeqexecStyles.headerHeight,
@@ -870,7 +872,8 @@ object StepsTable extends Columns {
                          i:     StepId): Callback =
     (SeqexecCircuit.dispatchCB(UpdateSelectedStep(obsId, i)) *>
       b.modState(State.selected.set(i.some)))
-      .when(p.canControlSubsystems(i)).void
+      .when(p.canControlSubsystems(i))
+      .void
 
   // We need to update the state if the props change
   def receiveNewProps(b: ReceiveProps): Callback = {
@@ -937,16 +940,18 @@ object StepsTable extends Columns {
         size => {
           val ts =
             b.state.tableState
-              .columnBuilder(size,
-                             colBuilder(b, size),
-                             b.props.columnWidths)
+              .columnBuilder(size, colBuilder(b, size), b.props.columnWidths)
               .map(_.vdomElement)
 
           ref
             .component(stepsTableProps(b)(size))(ts: _*)
             .vdomElement
         },
-        onResize = s => b.modStateL(State.tableState)(_.recalculateWidths(s, b.props.visibleColumns, b.props.columnWidths))
+        onResize = s =>
+          b.modStateL(State.tableState)(
+            _.recalculateWidths(s,
+                                b.props.visibleColumns,
+                                b.props.columnWidths))
       ))
 
   def initialState(p: Props): State =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -115,7 +115,7 @@ trait Columns {
     ReadModeColumn -> ReadModeWidth,
     ImagingMirrorColumn -> ImagingMirrorWidth,
     ObjectTypeColumn -> ObjectTypeWidth,
-    SettingsColumn -> SettingsWidth,
+    SettingsColumn -> SettingsWidth
   )
 
   object TableColumn {
@@ -129,21 +129,21 @@ trait Columns {
     name    = "control",
     label   = "",
     visible = true,
-    FixedColumnWidth.unsafeFromDouble(ControlWidth))
+    width = FixedColumnWidth.unsafeFromDouble(ControlWidth))
 
   val StepMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     StepColumn,
     name    = "idx",
     label   = "Step",
     visible = true,
-    FixedColumnWidth.unsafeFromDouble(StepWidth))
+    width = FixedColumnWidth.unsafeFromDouble(StepWidth))
 
   val ExecutionMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExecutionColumn,
     name    = "state",
     label   = "Execution Progress",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, StateWidth),
+    width = VariableColumnWidth.unsafeFromDouble(0.1, StateWidth),
     grow = 20)
 
   val OffsetMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
@@ -151,84 +151,87 @@ trait Columns {
     name    = "offsets",
     label   = "Offsets",
     visible = true,
-    FixedColumnWidth.unsafeFromDouble(OffsetWidthBase))
+    width = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase))
 
   val ObservingModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObservingModeColumn,
     name    = "obsMode",
     label   = "Observing Mode",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeWidth))
 
   val ExposureMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExposureColumn,
     name    = "exposure",
     label   = "Exposure",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth))
 
   val DisperserMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DisperserColumn,
     name    = "disperser",
     label   = "Disperser",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth))
 
   val FilterMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FilterColumn,
     name    = "filter",
     label   = "Filter",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, FilterWidth))
+    removeable = 2,
+    width = VariableColumnWidth.unsafeFromDouble(0.1, FilterWidth))
 
   val FPUMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FPUColumn,
     name    = "camera",
     label   = "FPU",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, FPUWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, FPUWidth))
 
   val CameraMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     CameraColumn,
     name    = "camera",
     label   = "Camera",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, CameraWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, CameraWidth))
 
   val DeckerMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DeckerColumn,
     name    = "camera",
     label   = "Decker",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, DeckerWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, DeckerWidth))
 
   val ReadModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ReadModeColumn,
     name    = "camera",
     label   = "ReadMode",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, ReadModeWidth))
+    removeable = 3,
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeWidth))
 
   val ImagingMirrorMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ImagingMirrorColumn,
     name    = "camera",
     label   = "ImagingMirror",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorWidth))
 
   val ObjectTypeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObjectTypeColumn,
     name    = "type",
     label   = "Type",
     visible = true,
-    FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth))
+    removeable = 1,
+    width = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth))
 
   val SettingsMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     SettingsColumn,
     name    = "set",
     label   = "",
     visible = true,
-    FixedColumnWidth.unsafeFromDouble(SettingsWidth))
+    width = FixedColumnWidth.unsafeFromDouble(SettingsWidth))
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] =
     NonEmptyList.of(
@@ -416,7 +419,6 @@ object StepsTable extends Columns {
       visibleColumnsForInstrument.contains(col)
 
     val startState: State = {
-      // println(s"INIT st ${tableState.isModified}")
       State.InitialState.copy(tableState = tableState)
     }
 
@@ -430,7 +432,6 @@ object StepsTable extends Columns {
       State.columns.set(NonEmptyList.fromListUnsafe(p.shownForInstrument))(this)
 
     def columnWidths(size: Size, p: Props): TableColumn => Option[Double] =
-      // println(s"Mod ${tableState.isModified}")
       if (tableState.isModified) { _ =>
         none
       } else if (size.width > 0) { col =>
@@ -635,16 +636,10 @@ object StepsTable extends Columns {
       case (_, StepRow(s @ StandardStep(_, _, _, true, _, _, _, _)), true, _) =>
         // row with control elements and breakpoint
         SeqexecStyles.stepRowWithBreakpointAndControl |+| stepRowStyle(s)
-      case (_,
-            StepRow(s @ StandardStep(_, _, _, true, _, _, _, _)),
-            false,
-            _) =>
+      case (_, StepRow(s @ StandardStep(_, _, _, true, _, _, _, _)), false, _) =>
         // row with breakpoint
         SeqexecStyles.stepRowWithBreakpoint |+| stepRowStyle(s)
-      case (j,
-            StepRow(s @ StandardStep(_, _, _, false, _, _, _, _)),
-            _,
-            Some(k)) if j === k =>
+      case (j, StepRow(s @ StandardStep(_, _, _, false, _, _, _, _)), _, Some(k)) if j === k =>
         // row with breakpoint and hover
         SeqexecStyles.stepRowWithBreakpointHover |+| stepRowStyle(s)
       case (_, StepRow(s), _, _) =>
@@ -672,8 +667,7 @@ object StepsTable extends Columns {
         // Row running with a breakpoint set
         SeqexecStyles.runningRowHeight + BreakpointLineHeight
       case StepRow(StandardStep(i, _, _, _, _, _, _, _))
-          if b.state.selected.exists(_ === i) && b.props.canControlSubsystems(
-            i) =>
+          if b.state.selected.exists(_ === i) && b.props.canControlSubsystems(i) =>
         // Selected
         SeqexecStyles.runningRowHeight
       case StepRow(s: Step) if s.status === StepState.Running =>
@@ -686,9 +680,6 @@ object StepsTable extends Columns {
         // default row
         baseHeight(b.props)
     }
-
-  // private val PhoneCut      = 412
-  // private val LargePhoneCut = 767
 
   def columnClassName(c: TableColumn): Option[GStyle] =
     c match {
@@ -780,8 +771,6 @@ object StepsTable extends Columns {
 
     tb match {
       case ColumnRenderArgs(meta, _, width, true) =>
-        // println(c)
-        // println(width)
         Column(
           Column.propsNoFlex(
             width   = width,
@@ -1008,7 +997,6 @@ object StepsTable extends Columns {
       TableContainer.Props(
         b.props.hasControls,
         size => {
-          // println("Rerender ")
           val ts =
             b.state.tableState
               .columnBuilder(size,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -49,7 +49,6 @@ import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.components.TableContainer
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.{ Size => SSize }
-//import seqexec.web.client.reusability._
 import react.virtualized._
 import web.client.style._
 import web.client.table._
@@ -57,16 +56,17 @@ import web.client.table._
 trait Columns {
   val ControlWidth: Double          = 40
   val StepWidth: Double             = 60
-  val StateWidth: Double            = 200
+  val ExecutionWidth: Double        = 260
+  val ExecutionMinWidth: Double     = 200
   val OffsetWidthBase: Double       = 75
   val OffsetIconWidth: Double       = 23.02
   val OffsetPadding: Double         = 12
   val ExposureWidth: Double         = 75
-  val ExposureMinWidth: Double      = 78.95 + SeqexecStyles.TableBorderWidth
+  val ExposureMinWidth: Double      = 83.667 + SeqexecStyles.TableBorderWidth
   val DisperserWidth: Double        = 100
   val DisperserMinWidth: Double     = 100 + SeqexecStyles.TableBorderWidth
   val ObservingModeWidth: Double    = 180
-  val ObservingModeMinWidth: Double = 100
+  val ObservingModeMinWidth: Double = 130.8 + SeqexecStyles.TableBorderWidth
   val FilterWidth: Double           = 180
   val FilterMinWidth: Double        = 100
   val FPUWidth: Double              = 100
@@ -102,7 +102,7 @@ trait Columns {
   val columnsDefaultWidth: Map[TableColumn, Double] = Map(
     ControlColumn -> ControlWidth,
     StepColumn -> StepWidth,
-    ExecutionColumn -> StateWidth,
+    ExecutionColumn -> ExposureMinWidth,
     OffsetColumn -> OffsetWidthBase,
     ObservingModeColumn -> ObservingModeWidth,
     ExposureColumn -> ExposureWidth,
@@ -142,7 +142,7 @@ trait Columns {
     name    = "state",
     label   = "Execution Progress",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, StateWidth),
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ExecutionMinWidth),
     grow = 20)
 
   val OffsetMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
@@ -157,7 +157,7 @@ trait Columns {
     name    = "obsMode",
     label   = "Observing Mode",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth))
 
   val ExposureMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExposureColumn,
@@ -179,28 +179,28 @@ trait Columns {
     label   = "Filter",
     visible = true,
     removeable = 2,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, FilterWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth))
 
   val FPUMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FPUColumn,
     name    = "camera",
     label   = "FPU",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, FPUWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth))
 
   val CameraMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     CameraColumn,
     name    = "camera",
     label   = "Camera",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, CameraWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth))
 
   val DeckerMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DeckerColumn,
     name    = "camera",
     label   = "Decker",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, DeckerWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth))
 
   val ReadModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ReadModeColumn,
@@ -208,14 +208,14 @@ trait Columns {
     label   = "ReadMode",
     visible = true,
     removeable = 3,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth))
 
   val ImagingMirrorMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ImagingMirrorColumn,
     name    = "camera",
     label   = "ImagingMirror",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorWidth))
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorMinWidth))
 
   val ObjectTypeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObjectTypeColumn,
@@ -708,11 +708,11 @@ object StepsTable extends Columns {
             label   = meta.label,
             headerRenderer = resizableHeaderRenderer(
               b.state.tableState
-                .resizeRow(meta.column,
+                .resizeColumn(meta.column,
                            size,
+                           updateState,
                            b.props.visibleColumns,
-                           b.props.columnWidths,
-                           updateState)),
+                           b.props.columnWidths)),
             headerClassName = headerClassName(meta.column).foldMap(_.htmlClass),
             cellRenderer    = columnCellRenderer(b, meta.column),
             className       = columnClassName(meta.column).foldMap(_.htmlClass)
@@ -928,9 +928,9 @@ object StepsTable extends Columns {
         size => {
           val ts =
             b.state.tableState
-              .columnBuilder2(size,
-                             b.props.columnWidths,
-                             colBuilder(b, size))
+              .columnBuilder(size,
+                             colBuilder(b, size),
+                             b.props.columnWidths)
               .map(_.vdomElement)
 
           ref

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -36,6 +36,7 @@ import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.TabOperations
 import seqexec.web.client.model.Pages.SeqexecPages
 import seqexec.web.client.model.ModelOps._
+import seqexec.web.client.model.StepItems._
 import seqexec.web.client.model.Formatting._
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.circuit.StepsTableAndStatusFocus
@@ -44,7 +45,6 @@ import seqexec.web.client.actions.{ClearAllResouceOptions, UpdateSelectedStep, U
 import seqexec.web.client.actions.FlipBreakpointStep
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.components.TableContainer
-import seqexec.web.client.components.sequence.steps.OffsetFns._
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.{Size => SSize}
 import seqexec.web.client.reusability._
@@ -58,6 +58,8 @@ trait Columns {
   val StepWidth: Double          = 50
   val StateWidth: Double         = 200
   val OffsetWidthBase: Double    = 75
+  val OffsetIconWidth: Double    = 23.02
+  val OffsetPadding: Double      = 12
   val ExposureWidth: Double      = 75
   val ExposureMinWidth: Double   = 78.95 + SeqexecStyles.TableBorderWidth
   val DisperserWidth: Double     = 100
@@ -132,10 +134,10 @@ trait Columns {
 
   val OffsetMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     OffsetColumn,
-    name    = "state",
+    name    = "offsets",
     label   = "Offsets",
     visible = true,
-    VariableColumnWidth.unsafeFromDouble(0.1, OffsetWidthBase))
+    FixedColumnWidth.unsafeFromDouble(OffsetWidthBase))
 
   val ObservingModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObservingModeColumn,
@@ -325,10 +327,19 @@ object StepsTable extends Columns {
 
     val disperserMaxWidth: Option[Double] = longestValueWidth(_.disperser)
 
+    val offsetWidth: Option[Double] = {
+      val (p, q)     = stepsList.sequenceOffsetWidths
+      val labelWidth = max(pLabelWidth, qLabelWidth)
+      (max(p, q) + labelWidth + OffsetIconWidth + OffsetPadding * 4).some
+    }
+
     val shownForInstrument: List[ColumnMeta[TableColumn]] =
       all.filter {
-        case DisperserMeta     => showDisperser
-        case OffsetMeta        => showOffsets
+        case DisperserMeta => showDisperser
+        case OffsetMeta =>
+          println(s"Shomw off $showOffsets")
+
+          showOffsets
         case ObservingModeMeta => showObservingMode
         case ExposureMeta      => showExposure
         case FilterMeta        => showFilter
@@ -398,7 +409,9 @@ object StepsTable extends Columns {
           case FilterColumn => p.filterMaxWidth.map(max(_, FilterMinWidth))
           case DisperserColumn =>
             p.disperserMaxWidth.map(max(_, DisperserMinWidth))
-          case _ => 200.0.some
+          case OffsetColumn =>
+            p.offsetWidth
+          case _ => none
         }
       } else { _ =>
         none

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -413,10 +413,8 @@ object StepsTable extends Columns {
         case _                 => true
       }
 
-    private val visibleColumnsForInstrument = shownForInstrument.map(_.column)
-
-    val visibleColumns: (Size, TableColumn) => Boolean = (_, col) =>
-      visibleColumnsForInstrument.contains(col)
+    val visibleColumns: TableColumn => Boolean =
+      shownForInstrument.map(_.column).contains _
 
     val startState: State = {
       State.InitialState.copy(tableState = tableState)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -52,11 +52,13 @@ import web.client.table._
 
 trait Columns {
   val ControlWidth: Double       = 40
-  val StepWidth: Double           = 50
+  val StepWidth: Double          = 50
   val StateWidth: Double         = 200
   val OffsetWidthBase: Double    = 75
   val ExposureWidth: Double      = 75
+  val ExposureMinWidth: Double   = 78.95 + SeqexecStyles.TableBorderWidth
   val DisperserWidth: Double     = 100
+  val DisperserMinWidth: Double  = 100 + SeqexecStyles.TableBorderWidth
   val ObservingModeWidth: Double = 180
   val FilterWidth: Double        = 180
   val FPUWidth: Double           = 100
@@ -121,63 +123,63 @@ trait Columns {
     name    = "state",
     label   = "Execution Progress",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, StateWidth))
+    VariableColumnWidth.unsafeFromDouble(0.1, StateWidth))
 
   val OffsetMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     OffsetColumn,
     name    = "state",
     label   = "Execution Progress",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, OffsetWidthBase))
+    VariableColumnWidth.unsafeFromDouble(0.1, OffsetWidthBase))
 
   val ObservingModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObservingModeColumn,
     name    = "obsMode",
     label   = "Observing Mode",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, ObservingModeWidth))
+    VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeWidth))
 
   val ExposureMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExposureColumn,
     name    = "exposure",
     label   = "Exposure",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, ExposureWidth))
+    VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth))
 
   val DisperserMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DisperserColumn,
     name    = "disperser",
     label   = "Disperser",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, DisperserWidth))
+    VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth))
 
   val FilterMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FilterColumn,
     name    = "filter",
     label   = "Filter",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, FilterWidth))
+    VariableColumnWidth.unsafeFromDouble(0.1, FilterWidth))
 
   val FPUMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FPUColumn,
     name    = "camera",
     label   = "FPU",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, FPUWidth))
+    VariableColumnWidth.unsafeFromDouble(0.1, FPUWidth))
 
   val CameraMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     CameraColumn,
     name    = "camera",
     label   = "Camera",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, CameraWidth))
+    VariableColumnWidth.unsafeFromDouble(0.1, CameraWidth))
 
   val ObjectTypeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObjectTypeColumn,
     name    = "type",
     label   = "Type",
     visible = true,
-    PercentageColumnWidth.unsafeFromDouble(0.1, ObjectTypeWidth))
+    FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth))
 
   val SettingsMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     SettingsColumn,
@@ -187,16 +189,19 @@ trait Columns {
     FixedColumnWidth.unsafeFromDouble(SettingsWidth))
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] =
-    NonEmptyList.of(ControlColumnMeta, StepMeta, ExecutionMeta,
-    OffsetMeta,
-    ObservingModeMeta,
-    ExposureMeta,
-    DisperserMeta,
-    FilterMeta,
-    FPUMeta,
-    CameraMeta,
-    ObjectTypeMeta,
-    SettingsMeta
+    NonEmptyList.of(
+      ControlColumnMeta,
+      StepMeta,
+      ExecutionMeta,
+      OffsetMeta,
+      ObservingModeMeta,
+      ExposureMeta,
+      DisperserMeta,
+      FilterMeta,
+      FPUMeta,
+      CameraMeta,
+      ObjectTypeMeta,
+      SettingsMeta
     )
 
 }
@@ -285,20 +290,20 @@ object StepsTable extends Columns {
 
     val startState: State =
       tableState
-        .map(s =>
-          (State.tableState.set(s) >>> State.selected.set(selectedStep))(State.InitialState))
+        .map(
+          s =>
+            (State.tableState.set(s) >>> State.selected.set(selectedStep))(
+              State.InitialState))
         .getOrElse(State.InitialState)
         .visibleCols(this)
   }
 
-  final case class State(
-    tableState:      TableState[TableColumn],
-    breakpointHover: Option[Int],
-    selected:        Option[StepId]) {
+  final case class State(tableState:      TableState[TableColumn],
+                         breakpointHover: Option[Int],
+                         selected:        Option[StepId]) {
 
     // Hide some columns depending on width
-    def hideOnWidth(s: Size): State =
-       {
+    def hideOnWidth(s: Size): State = {
       // s.width match {
       //   case w if w < PhoneCut =>
       //     State.columns.modify(_.map {
@@ -318,40 +323,40 @@ object StepsTable extends Columns {
       //     })(this)
       //   case _ =>
       //     this
-      println(s)
+      // println(s)
       this
-      }
-
-    def shownForInstrument(p: Props): List[ColumnMeta[TableColumn]] = {
-      all.filter {
-        case DisperserMeta => p.showDisperser
-        case OffsetMeta => p.showOffsets
-        case ObservingModeMeta => p.showObservingMode
-        case ExposureMeta => p.showExposure
-        case FilterMeta => p.showFilter
-        case FPUMeta => p.showFPU
-        case CameraMeta => p.showCamera
-        case _ => true
-      }
     }
+
+    def shownForInstrument(p: Props): List[ColumnMeta[TableColumn]] =
+      all.filter {
+        case DisperserMeta     => p.showDisperser
+        case OffsetMeta        => p.showOffsets
+        case ObservingModeMeta => p.showObservingMode
+        case ExposureMeta      => p.showExposure
+        case FilterMeta        => p.showFilter
+        case FPUMeta           => p.showFPU
+        case CameraMeta        => p.showCamera
+        case _                 => true
+      }
 
     def visibleCols(p: Props): State =
-      State.columns.set(NonEmptyList.fromListUnsafe(shownForInstrument(p)))(this)
+      State.columns.set(NonEmptyList.fromListUnsafe(shownForInstrument(p)))(
+        this)
 
-    def visibleColumnsSizes(p: Props, s: Size): List[(TableColumn, Double, Boolean)] = {
-      val visibleCols = shownForInstrument(p)
-      val fixedVisibleCols = 2
-      for {
-        (c, i) <- visibleCols.toList.zipWithIndex // TODO hide on width
-        if c.visible
-      } yield
-        (c.column,
-         tableState.widthOf(c.column, s),
-         i === tableState.columns.filter(_.visible).length - fixedVisibleCols)
-    }
+    // def visibleColumnsSizes(p: Props, s: Size): List[(TableColumn, Double, Boolean)] = {
+    //   val visibleCols = shownForInstrument(p)
+    //   val fixedVisibleCols = 2
+    //   for {
+    //     (c, i) <- visibleCols.toList.zipWithIndex // TODO hide on width
+    //     if c.visible
+    //   } yield
+    //     (c.column,
+    //      tableState.widthOf(c.column, s),
+    //      i === tableState.columns.filter(_.visible).length - fixedVisibleCols)
+    // }
     // calculate the relative widths of each column based on content only
     // this should be renormalized against the actual tabel width
-      def withWidths(steps: List[Step]): State = {
+    def withWidths(steps: List[Step]): State = {
       // if (tableState.userModified === IsModified) {
       //   this
       // } else {
@@ -391,18 +396,18 @@ object StepsTable extends Columns {
       //     .sum + ClassColumnWidth + (if (loggedIn) AddQueueColumnWidth else 0)
       //   // Normalize based on visibility
       //   State.columns.modify(_.map {
-      //     case c @ ColumnMeta(t, _, _, true, PercentageColumnWidth(_, m)) =>
-      //       PercentageColumnWidth
+      //     case c @ ColumnMeta(t, _, _, true, VariableColumnWidth(_, m)) =>
+      //       VariableColumnWidth
       //         .fromDouble(optimalSizes.getOrElse(t, m).toDouble / width, m)
       //         .fold(c)(w => c.copy(width = w))
       //     case c =>
       //       c
       //   })(this)
       // }
-        println(steps.length)
-        this
-      }
+      // println(steps.length)
+      this
     }
+  }
 
   object State {
 
@@ -435,18 +440,6 @@ object StepsTable extends Columns {
   implicit val tcReuse: Reusability[TableColumn] = Reusability.byRef
   implicit val stateReuse: Reusability[State] =
     Reusability.by(x => (x.tableState, x.breakpointHover, x.selected))
-
-  val controlHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
-    <.span(
-      ^.title := "Control",
-      IconSettings
-  )
-
-  val settingsHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
-    <.span(
-      ^.title := "Settings",
-      IconBrowser
-  )
 
   private def firstRunnableIndex(l: List[Step]): Int =
     l.zipWithIndex.find(!_._1.isFinished).map(_._2).getOrElse(l.length)
@@ -635,171 +628,109 @@ object StepsTable extends Columns {
 
   def columnClassName(c: TableColumn): Option[GStyle] =
     c match {
-      case ControlColumn => SeqexecStyles.controlCellRow.some
+      case ControlColumn                => SeqexecStyles.controlCellRow.some
       case StepColumn | ExecutionColumn => SeqexecStyles.paddedStepRow.some
-      case ObservingModeColumn | ExposureColumn | DisperserColumn | FilterColumn | FPUColumn | CameraColumn | ObjectTypeColumn => SeqexecStyles.centeredCell.some
+      case ObservingModeColumn | ExposureColumn | DisperserColumn |
+          FilterColumn | FPUColumn | CameraColumn | ObjectTypeColumn =>
+        SeqexecStyles.centeredCell.some
       case SettingsColumn => SeqexecStyles.settingsCellRow.some
-      case _ => none
+      case _              => none
     }
 
   def headerClassName(c: TableColumn): Option[GStyle] =
     c match {
-      case ControlColumn => (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
-      case SettingsColumn => (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
+      case ControlColumn =>
+        (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
+      case SettingsColumn =>
+        (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
       case _ => none
     }
 
-  def columnCellRenderer(b: Backend, c: TableColumn): CellRenderer[js.Object, js.Object, StepRow] = {
+  val controlHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
+    <.span(
+      ^.title := "Control",
+      IconSettings
+  )
+
+  val settingsHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
+    <.span(
+      ^.title := "Settings",
+      IconBrowser
+  )
+
+  private def fixedHeaderRenderer(c: TableColumn): HeaderRenderer[js.Object] =
+    c match {
+      case ControlColumn  => controlHeaderRenderer
+      case SettingsColumn => settingsHeaderRenderer
+      case _              => defaultHeaderRendererS
+    }
+
+  private def columnCellRenderer(
+    b: Backend,
+    c: TableColumn): CellRenderer[js.Object, js.Object, StepRow] = {
     val optR = c match {
-      case ControlColumn => b.props.steps.map(stepControlRenderer(_, b,
-                                                        rowBreakpointHoverOnCB(b),
-                                               rowBreakpointHoverOffCB(b),
-                                               recomputeRowHeightsCB))
-      case StepColumn => stepIdRenderer.some
-      case ExecutionColumn => b.props.steps.map(stepProgressRenderer(_, b))
-      case OffsetColumn => stepStatusRenderer(b.props.offsetsDisplay).some
+      case ControlColumn =>
+        b.props.steps.map(
+          stepControlRenderer(_,
+                              b,
+                              rowBreakpointHoverOnCB(b),
+                              rowBreakpointHoverOffCB(b),
+                              recomputeRowHeightsCB))
+      case StepColumn          => stepIdRenderer.some
+      case ExecutionColumn     => b.props.steps.map(stepProgressRenderer(_, b))
+      case OffsetColumn        => stepStatusRenderer(b.props.offsetsDisplay).some
       case ObservingModeColumn => stepObsModeRenderer.some
-      case ExposureColumn => b.props.steps.map(p => stepExposureRenderer(p.instrument))
-      case DisperserColumn => b.props.steps.map(p => stepDisperserRenderer(p.instrument))
-      case FilterColumn => b.props.steps.map(p => stepFilterRenderer(p.instrument))
-      case FPUColumn => b.props.steps.map(p => stepFPURenderer(p.instrument))
-      case CameraColumn => b.props.steps.map(p => cameraRenderer(p.instrument))
+      case ExposureColumn =>
+        b.props.steps.map(p => stepExposureRenderer(p.instrument))
+      case DisperserColumn =>
+        b.props.steps.map(p => stepDisperserRenderer(p.instrument))
+      case FilterColumn =>
+        b.props.steps.map(p => stepFilterRenderer(p.instrument))
+      case FPUColumn        => b.props.steps.map(p => stepFPURenderer(p.instrument))
+      case CameraColumn     => b.props.steps.map(p => cameraRenderer(p.instrument))
       case ObjectTypeColumn => stepObjectTypeRenderer(SSize.Small).some
-      case SettingsColumn => b.props.steps.map(p => settingsControlRenderer(b.props, p))
+      case SettingsColumn =>
+        b.props.steps.map(p => settingsControlRenderer(b.props, p))
       case _ => none
     }
     optR.getOrElse(defaultCellRendererS)
   }
 
   // Columns for the table
-  private def colBuilder(b: Backend, size: Size): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb  => {
-  //   ???
-  // }
-  // private def columns(b: Backend, size: Size): List[Table.ColumnArg] = {
-  //   val p = b.props
-    // val (offsetVisible,
-    //      exposureVisible,
-    //      disperserVisible,
-    //      fpuVisible,
-    //      cameraVisible,
-    //      filterVisible,
-    //      objectSize) =
-    //   size.width match {
-    //     case w if w < PhoneCut =>
-    //       (false, false, false, false, false, false, SSize.Tiny)
-    //     case w if w < LargePhoneCut =>
-    //       (false, true, false, false, false, false, SSize.Small)
-    //     case _ =>
-    //       (b.props.showOffsets, true, true, true, true, true, SSize.Small)
-    //   }
-
-    // val (offsetCol, offsetWidth) = offsetColumn(p, offsetVisible)
-    // val disperserCol             = disperserColumn(p, disperserVisible)
-    // val observingModeCol         = observingModeColumn(p, 0)
-    // val exposureCol              = exposureColumn(p, exposureVisible)
-    // val fpuCol                   = fpuColumn(p, fpuVisible)
-    // val cameraCol                = cameraColumn(p, cameraVisible)
-    // val iconCol                  = controlColumn(b)
-    // val filterCol                = filterColumn(p, filterVisible)
-    // val typeCol                  = typeColumn(p, objectSize)
-    // val settingsCol              = settingsColumn(p)
-    //
-    // // Let's precisely calculate the width of the control column
-    // val colsWidth =
-    //   ControlWidth +
-    //     StepWidth +
-    //     // offsetCol.fold(0.0)(_ => offsetWidth) +
-    //     exposureCol.fold(0.0)(_ => ExposureWidth) +
-    //     disperserCol.fold(0.0)(_ => DisperserWidth) +
-    //     filterCol.fold(0.0)(_ => FilterWidth) +
-    //     fpuCol.fold(0.0)(_ => FPUWidth) +
-    //     cameraCol.fold(0.0)(_ => CameraWidth) +
-    //     observingModeCol.fold(0.0)(_ => ObservingModeWidth) +
-    //     ObjectTypeWidth +
-    //     SettingsWidth
-    // val controlWidth = size.width - colsWidth
-    // val stateCol     = executionColumn(b, controlWidth)
-
-  // val all: NonEmptyList[ColumnMeta[TableColumn]] =
-  //   NonEmptyList.of(ControlColumnMeta, StepMeta, ExecutionMeta,
-  //   OffsetMeta,
-  //   ObservingModeMeta,
-  //   ExposureMeta,
-  //   DisperserMeta,
-  //   FilterMeta,
-  //   FPUMeta,
-  //   CameraMeta,
-  //   ObjectTypeMeta,
-  //   SettingsMeta
-  //   )
-    // b.state.visibleColumnsSizes(p, size).collect {
+  private def colBuilder(
+    b:    Backend,
+    size: Size): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb => {
     def updateState(s: TableState[TableColumn]): Callback =
-      b.modState(State.tableState.set(s))// >> SeqexecCircuit.dispatchCB(UpdateStepsConfigTableState(s))
+      b.modState(State.tableState.set(s)) // >> SeqexecCircuit.dispatchCB(UpdateStepsConfigTableState(s))
 
     tb match {
       case ColumnRenderArgs(ColumnMeta(c, name, label, _, _), _, width, true) =>
         Column(
           Column.propsNoFlex(
-            width          = width,
-            dataKey        = name,
-            label          = label,
-            headerRenderer = resizableHeaderRenderer(b.state.tableState.resizeRow(c, size, updateState)),
+            width   = width,
+            dataKey = name,
+            label   = label,
+            headerRenderer = resizableHeaderRenderer(
+              b.state.tableState.resizeRowB(c, size, updateState)),
             headerClassName = headerClassName(c).foldMap(_.htmlClass),
-            cellRenderer = columnCellRenderer(b, c),
-            className      = columnClassName(c).foldMap(_.htmlClass)
+            cellRenderer    = columnCellRenderer(b, c),
+            className       = columnClassName(c).foldMap(_.htmlClass)
           ))
-      case ColumnRenderArgs(ColumnMeta(c, name, label, _, _), _, width, false) =>
+      case ColumnRenderArgs(ColumnMeta(c, name, label, _, _),
+                            _,
+                            width,
+                            false) =>
         Column(
           Column.propsNoFlex(
-            width     = width,
-            dataKey   = name,
-            label     = label,
+            width           = width,
+            dataKey         = name,
+            label           = label,
+            headerRenderer  = fixedHeaderRenderer(c),
             headerClassName = headerClassName(c).foldMap(_.htmlClass),
-            cellRenderer = columnCellRenderer(b, c),
-            className      = columnClassName(c).foldMap(_.htmlClass)
+            cellRenderer    = columnCellRenderer(b, c),
+            className       = columnClassName(c).foldMap(_.htmlClass)
           ))
-        }
-    // b.state.visibleColumnsSizes(p, size).collect {
-    //   case (ControlColumn, _, _) =>
-    //     controlColumn(b)
-    //   case (StepColumn, _, _) =>
-    //     stepColumn
-    //   case (ExecutionColumn, width, _) =>
-    //     executionColumn(b, width)
-    //   case (OffsetColumn, width, _) =>
-    //     offsetColumn(p, width)._1
-    //   case (ObservingModeColumn, width, _) =>
-    //     observingModeColumn(p, width)
-    //   case (ExposureColumn, width, _) =>
-    //     exposureColumn(p, width)
-    //   case (DisperserColumn, width, _) =>
-    //     disperserColumn(p, width)
-    //   case (FilterColumn, width, _) =>
-    //     filterColumn(p, width)
-    //   case (FPUColumn, width, _) =>
-    //     fpuColumn(p, width)
-    //   case (CameraColumn, width, _) =>
-    //     cameraColumn(p, width)
-    //   case (ObjectTypeColumn, width, _) =>
-    //     objectTypeColumn(p, width, SSize.Small)
-    //   case (SettingsColumn, _, _) =>
-    //     settingsColumn(p)
-    // }.collect { case Some(x) => x }
-
-    // List(
-    //   iconCol,
-    //   stepColumn,
-    //   stateCol,
-    //   // offsetCol,
-    //   observingModeCol,
-    //   exposureCol,
-    //   disperserCol,
-    //   filterCol,
-    //   fpuCol,
-    //   cameraCol,
-    //   typeCol,
-    //   settingsCol
-
+    }
   }
   // scalastyle:on
 
@@ -989,13 +920,16 @@ object StepsTable extends Columns {
   // Wire it up from VDOM
   def render(b: Backend): VdomElement =
     TableContainer(
-      TableContainer.Props(b.props.hasControls,
-                           size =>
-                             ref
-                               .component(stepsTableProps(b)(size))(
-                                 b.state.tableState.columnBuilder(size, colBuilder(b, size)).map(_.vdomElement): _*)
-                                 // columns(b, size).map(_.vdomElement): _*)
-                               .vdomElement))
+      TableContainer.Props(
+        b.props.hasControls,
+        size =>
+          ref
+            .component(stepsTableProps(b)(size))(
+              b.state.tableState
+                .columnBuilderB(size, colBuilder(b, size))
+                .map(_.vdomElement): _*)
+            .vdomElement
+      ))
 
   private val component = ScalaComponent
     .builder[Props]("StepsTable")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -916,7 +916,7 @@ object StepsTable extends Columns {
     // The selected step may have changed externally
     val selectedStepChange: Callback =
       (cur.selectedStep, next.selectedStep).mapN { (c, n) =>
-        b.modState(State.selected.set(n.some)).when(c =!= n) *> Callback.empty
+        b.modState(State.selected.set(n.some)).when(c =!= n).void
       }.getOrEmpty
 
     // If the step is running recalculate height
@@ -955,7 +955,7 @@ object StepsTable extends Columns {
       ))
 
   def initialState(p: Props): State =
-    State.tableState.set(p.tableState)(State.InitialState)
+    (State.tableState.set(p.tableState) >>> State.selected.set(p.selectedStep))(State.InitialState)
 
   private val component = ScalaComponent
     .builder[Props]("StepsTable")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
@@ -76,7 +76,7 @@ object StepIconCell {
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  def stepIcon(p: Props): VdomNode =
+  private def stepIcon(p: Props): VdomNode =
     p.status match {
       case StepState.Completed => IconCheckmark
       case StepState.Running   => IconCircleNotched.copyIcon(loading = true)
@@ -104,12 +104,12 @@ object StepIconCell {
   private val component = ScalaComponent
     .builder[Props]("StepIconCell")
     .stateless
-    .render_P { p =>
+    .render_P( p =>
       <.div(
         stepStyle(p),
-        // stepIcon(p)
+        stepIcon(p)
       )
-    }
+    )
     .configure(Reusability.shouldComponentUpdate)
     .build
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
@@ -104,12 +104,12 @@ object StepIconCell {
   private val component = ScalaComponent
     .builder[Props]("StepIconCell")
     .stateless
-    .render_P( p =>
-      <.div(
-        stepStyle(p),
-        stepIcon(p)
-      )
-    )
+    .render_P(
+      p =>
+        <.div(
+          stepStyle(p),
+          stepIcon(p)
+      ))
     .configure(Reusability.shouldComponentUpdate)
     .build
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
@@ -76,7 +76,7 @@ object StepIconCell {
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private def stepIcon(p: Props): VdomNode =
+  def stepIcon(p: Props): VdomNode =
     p.status match {
       case StepState.Completed => IconCheckmark
       case StepState.Running   => IconCircleNotched.copyIcon(loading = true)
@@ -107,7 +107,7 @@ object StepIconCell {
     .render_P { p =>
       <.div(
         stepStyle(p),
-        stepIcon(p)
+        // stepIcon(p)
       )
     }
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/TableStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/TableStateHandler.scala
@@ -7,10 +7,10 @@ import diode.ActionHandler
 import diode.ActionResult
 import diode.ModelRW
 import seqexec.web.client.actions._
-import seqexec.web.client.circuit._
+import seqexec.web.client.model.AppTableStates
 
 /**
-  * Handle to preserve the steps table state
+  * Handle to preserve the table states
   */
 class TableStateHandler[M](modelRW: ModelRW[M, AppTableStates])
     extends ActionHandler(modelRW)
@@ -20,10 +20,10 @@ class TableStateHandler[M](modelRW: ModelRW[M, AppTableStates])
       updatedSilentL(AppTableStates.stepConfigTable.set(state)) // We should only do silent updates as these change too quickly
 
     case UpdateSessionQueueTableState(state) =>
-      updatedSilentL(AppTableStates.queueTable.set(state)) // We should only do silent updates as these change too quickly
+      updatedSilentL(AppTableStates.sessionQueueTable.set(state)) // We should only do silent updates as these change too quickly
 
     case UpdateStepTableState(id, state) =>
-      updatedSilentL(AppTableStates.stepTableAtL(id).set(Some(state))) // We should only do silent updates as these change too quickly
+      updatedSilentL(AppTableStates.stepsTableAtL(id).set(Some(state))) // We should only do silent updates as these change too quickly
 
     case UpdateCalTableState(id, state) =>
       updatedSilentL(AppTableStates.queueTableAtL(id).set(Some(state))) // We should only do silent updates as these change too quickly

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AppTableStates.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AppTableStates.scala
@@ -21,10 +21,10 @@ import web.client.table._
  */
 @Lenses
 final case class AppTableStates(
-  sessionQueueTable:      TableState[SessionQueueTable.TableColumn],
-  stepConfigTable: TableState[StepConfigTable.TableColumn],
-  stepsTables:     Map[Observation.Id, TableState[StepsTable.TableColumn]],
-  queueTables:     Map[QueueId, TableState[CalQueueTable.TableColumn]])
+  sessionQueueTable: TableState[SessionQueueTable.TableColumn],
+  stepConfigTable:   TableState[StepConfigTable.TableColumn],
+  stepsTables:       Map[Observation.Id, TableState[StepsTable.TableColumn]],
+  queueTables:       Map[QueueId, TableState[CalQueueTable.TableColumn]])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object AppTableStates {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AppTableStates.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AppTableStates.scala
@@ -30,7 +30,7 @@ final case class AppTableStates(
 object AppTableStates {
 
   val Initial: AppTableStates = AppTableStates(
-    SessionQueueTable.InitialState.tableState,
+    SessionQueueTable.State.InitialState.tableState,
     StepConfigTable.InitialTableState,
     Map.empty,
     Map.empty

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AppTableStates.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AppTableStates.scala
@@ -39,24 +39,6 @@ object AppTableStates {
   implicit val eq: Eq[AppTableStates] =
     Eq.by(x => (x.sessionQueueTable, x.stepConfigTable, x.stepsTables, x.queueTables))
 
-  // val tableStateL: Lens[SeqexecUIModel, AppTableStates] =
-  //   Lens[SeqexecUIModel, AppTableStates](
-  //     m =>
-  //       AppTableStates(m.queueTableState,
-  //                      m.configTableState,
-  //                      m.sequencesOnDisplay.stepsTables,
-  //                      m.queues.queueTables))(
-  //     v =>
-  //       m =>
-  //         m.copy(
-  //           queueTableState  = v.sessionQueueTable,
-  //           configTableState = v.stepConfigTable,
-  //           sequencesOnDisplay = m.sequencesOnDisplay
-  //             .updateTableStates(v.stepsTables),
-  //           queues = m.queues
-  //             .updateTableStates(v.queueTables)
-  //     ))
-  //
   def stepsTableAtL(
     id: Observation.Id
   ): Lens[AppTableStates, Option[TableState[StepsTable.TableColumn]]] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AppTableStates.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AppTableStates.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package seqexec.web.client.circuit
+package seqexec.web.client.model
 
 import cats.Eq
 import cats.implicits._
@@ -10,44 +10,54 @@ import monocle.Lens
 import monocle.macros.Lenses
 import monocle.function.At._
 import seqexec.model._
-import seqexec.web.client.model._
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.components.SessionQueueTable
 import seqexec.web.client.components.queue.CalQueueTable
 import web.client.table._
 
+/**
+ * Store the state of each of the app tables
+ */
 @Lenses
 final case class AppTableStates(
-  queueTable:      TableState[SessionQueueTable.TableColumn],
+  sessionQueueTable:      TableState[SessionQueueTable.TableColumn],
   stepConfigTable: TableState[StepConfigTable.TableColumn],
   stepsTables:     Map[Observation.Id, TableState[StepsTable.TableColumn]],
   queueTables:     Map[QueueId, TableState[CalQueueTable.TableColumn]])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object AppTableStates {
+
+  val Initial: AppTableStates = AppTableStates(
+    SessionQueueTable.InitialState.tableState,
+    StepConfigTable.InitialTableState,
+    Map.empty,
+    Map.empty
+  )
+
   implicit val eq: Eq[AppTableStates] =
-    Eq.by(x => (x.queueTable, x.stepConfigTable, x.stepsTables))
+    Eq.by(x => (x.sessionQueueTable, x.stepConfigTable, x.stepsTables, x.queueTables))
 
-  val tableStateL: Lens[SeqexecUIModel, AppTableStates] =
-    Lens[SeqexecUIModel, AppTableStates](
-      m =>
-        AppTableStates(m.queueTableState,
-                       m.configTableState,
-                       m.sequencesOnDisplay.stepsTables,
-                       m.queues.queueTables))(
-      v =>
-        m =>
-          m.copy(
-            queueTableState  = v.queueTable,
-            configTableState = v.stepConfigTable,
-            sequencesOnDisplay = m.sequencesOnDisplay
-              .updateTableStates(v.stepsTables),
-            queues = m.queues
-              .updateTableStates(v.queueTables)
-      ))
-
-  def stepTableAtL(
+  // val tableStateL: Lens[SeqexecUIModel, AppTableStates] =
+  //   Lens[SeqexecUIModel, AppTableStates](
+  //     m =>
+  //       AppTableStates(m.queueTableState,
+  //                      m.configTableState,
+  //                      m.sequencesOnDisplay.stepsTables,
+  //                      m.queues.queueTables))(
+  //     v =>
+  //       m =>
+  //         m.copy(
+  //           queueTableState  = v.sessionQueueTable,
+  //           configTableState = v.stepConfigTable,
+  //           sequencesOnDisplay = m.sequencesOnDisplay
+  //             .updateTableStates(v.stepsTables),
+  //           queues = m.queues
+  //             .updateTableStates(v.queueTables)
+  //     ))
+  //
+  def stepsTableAtL(
     id: Observation.Id
   ): Lens[AppTableStates, Option[TableState[StepsTable.TableColumn]]] =
     AppTableStates.stepsTables ^|-> at(id)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Formatting.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Formatting.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.model
+
+import seqexec.model.enum.Instrument
+
+object Formatting {
+
+  def formatExposureTime(i: Instrument)(e: Double): String = i match {
+    case Instrument.GmosN | Instrument.GmosS => f"$e%.0f"
+    case _                                   => f"$e%.2f"
+  }
+
+  def formatExposure(i: Instrument)(v: Double): String =
+    formatExposureTime(i)(v)
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Formatting.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/Formatting.scala
@@ -13,21 +13,9 @@ import seqexec.web.client.model.StepItems._
 import web.client.utils._
 
 /**
-  * Utility methods to display offsets and calculate their widths
+  * Utility methods to format step items
   */
-trait OffsetFns {
-  def offsetAxis(axis: OffsetAxis): String =
-    f"${axis.show}:"
-
-  def offsetValueFormat(off: Offset): String =
-    f" ${off.value}%03.2f″"
-
-  val pLabelWidth: Double = tableTextWidth(offsetAxis(OffsetAxis.AxisP))
-  val qLabelWidth: Double = tableTextWidth(offsetAxis(OffsetAxis.AxisQ))
-
-}
-
-object Formatting extends OffsetFns {
+object Formatting {
   // Used to decide if the offsets are displayed
   sealed trait OffsetsDisplay
 
@@ -40,6 +28,15 @@ object Formatting extends OffsetFns {
         case DisplayOffsets(v) => Some(v)
       }
   }
+
+  def offsetAxis(axis: OffsetAxis): String =
+    f"${axis.show}:"
+
+  def offsetValueFormat(off: Offset): String =
+    f" ${off.value}%03.2f″"
+
+  val pLabelWidth: Double = tableTextWidth(offsetAxis(OffsetAxis.AxisP))
+  val qLabelWidth: Double = tableTextWidth(offsetAxis(OffsetAxis.AxisQ))
 
   implicit class OffsetWidthsFnsOps(val steps: List[Step]) extends AnyVal {
     // Calculate the widest offset step

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -7,21 +7,14 @@ import cats.Show
 import cats.implicits._
 import cats.data.NonEmptyList
 import gem.enum.Site
-import gem.enum.GpiDisperser
-import gem.enum.GpiObservingMode
-import gem.enum.GpiFilter
 import seqexec.model.enum.ActionStatus
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.Resource
-import seqexec.model.enum.FPUMode
 import seqexec.model.StepState
 import seqexec.model.SequenceState
 import seqexec.model.Step
 import seqexec.model.StandardStep
 import seqexec.model.SequenceView
-import seqexec.model.enumerations
-import seqexec.web.client.model.lenses._
-import seqexec.web.client.model.Formatting._
 
 /**
   * Contains useful operations for the seqexec model
@@ -109,127 +102,12 @@ object ModelOps {
       })
   }
 
-  private val gpiObsMode = GpiObservingMode.all.map(x => x.shortName -> x).toMap
-
-  private val gpiFiltersMap: Map[String, GpiFilter] =
-    GpiFilter.all.map(x => (x.shortName, x)).toMap
-
-  val gpiDispersers: Map[String, String] =
-    GpiDisperser.all.map(x => x.shortName -> x.longName).toMap
-
-  implicit class StepOps(val s: Step) extends AnyVal {
-    def fpuNameMapper(i: Instrument): String => Option[String] = i match {
-      case Instrument.GmosS => enumerations.fpu.GmosSFPU.get
-      case Instrument.GmosN => enumerations.fpu.GmosNFPU.get
-      case Instrument.F2    => enumerations.fpu.Flamingos2.get
-      case _ =>
-        _ =>
-          none
-    }
-
-    def exposureTime: Option[Double] = observeExposureTimeO.getOption(s)
-    def exposureTimeS(i: Instrument): Option[String] =
-      exposureTime.map(formatExposureTime(i))
-    def coAdds: Option[Int] = observeCoaddsO.getOption(s)
-    def fpu(i: Instrument): Option[String] =
-      for {
-        mode <- instrumentFPUModeO
-          .getOption(s)
-          .orElse(FPUMode.BuiltIn.some) // If the instrument has no fpu mode default to built in
-        fpuL = if (mode === FPUMode.BuiltIn) instrumentFPUO
-        else instrumentFPUCustomMaskO
-        fpu <- fpuL.getOption(s)
-      } yield fpuNameMapper(i)(fpu).getOrElse(fpu)
-
-    def fpuOrMask(i: Instrument): Option[String] =
-      fpu(i)
-        .orElse(instrumentSlitWidthO.getOption(s))
-        .orElse(instrumentMaskO.getOption(s))
-
-    private def gpiFilter: Step => Option[String] = s => {
-      // Read the filter, if not found deduce it from the obs mode
-      val f: Option[GpiFilter] =
-        instrumentFilterO.getOption(s).flatMap(gpiFiltersMap.get).orElse {
-          for {
-            m <- instrumentObservingModeO.getOption(s)
-            o <- gpiObsMode.get(m)
-            f <- o.filter
-          } yield f
-        }
-      f.map(_.longName)
-    }
-
-    def filter(i: Instrument): Option[String] = i match {
-      case Instrument.GmosS =>
-        instrumentFilterO
-          .getOption(s)
-          .flatMap(enumerations.filter.GmosSFilter.get)
-      case Instrument.GmosN =>
-        instrumentFilterO
-          .getOption(s)
-          .flatMap(enumerations.filter.GmosNFilter.get)
-      case Instrument.F2 =>
-        instrumentFilterO
-          .getOption(s)
-          .flatMap(enumerations.filter.F2Filter.get)
-      case Instrument.Niri =>
-        instrumentFilterO
-          .getOption(s)
-          .flatMap(enumerations.filter.Niri.get)
-      case Instrument.Gnirs =>
-        instrumentFilterO
-          .getOption(s)
-          .map(_.sentenceCase)
-      case Instrument.Nifs =>
-        instrumentFilterO
-          .getOption(s)
-          .map(_.sentenceCase)
-      case Instrument.Gpi => gpiFilter(s)
-      case _              => None
-    }
-
-    private def disperserNameMapper(i: Instrument): Map[String, String] =
-      i match {
-        case Instrument.GmosS => enumerations.disperser.GmosSDisperser
-        case Instrument.GmosN => enumerations.disperser.GmosNDisperser
-        case Instrument.Gpi   => gpiDispersers
-        case _                => Map.empty
-      }
-
-    def disperser(i: Instrument): Option[String] = {
-      val disperser = for {
-        disperser <- instrumentDisperserO.getOption(s)
-      } yield disperserNameMapper(i).getOrElse(disperser, disperser)
-      val centralWavelength = instrumentDisperserLambdaO.getOption(s)
-
-      // Format
-      (disperser, centralWavelength) match {
-        case (Some(d), Some(w)) => f"$d @ $w%.0f nm".some
-        case (Some(d), None)    => d.some
-        case _                  => none
-      }
-
-    def canRunFrom: Boolean = s.status match {
-      case StepState.Pending | StepState.Failed(_) => true
-      case _                                       => false
-    
-    }
-  }
-
   implicit class SiteOps(val s: Site) extends AnyVal {
 
     def instruments: NonEmptyList[Instrument] = s match {
       case Site.GN => Instrument.gnInstruments
       case Site.GS => Instrument.gsInstruments
     }
-  }
-
-  implicit class ExtraStringOps(val s: String) extends AnyVal {
-    def sentenceCase: String =
-      (s.toList match {
-        case Nil       => Nil
-        case x :: rest => x.toUpper :: rest.map(_.toLower)
-      }).mkString
   }
 
   sealed trait InstrumentProperties

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -6,6 +6,7 @@ package seqexec.web.client.model
 import cats._
 import cats.implicits._
 import gem.enum.Site
+import gem.Observation
 import monocle.Lens
 import monocle.Getter
 import monocle.Traversal
@@ -23,6 +24,7 @@ import seqexec.model.SequenceView
 import seqexec.model.SequencesQueue
 import seqexec.model.CalibrationQueueId
 import seqexec.web.client.components.sequence.steps.StepConfigTable
+import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.components.SessionQueueTable
 import web.client.table._
 
@@ -67,16 +69,20 @@ object SeqexecAppRootModel {
   val sessionQueueL: Lens[SeqexecAppRootModel, List[SequenceView]] =
     SeqexecAppRootModel.sequences ^|-> SequencesQueue.sessionQueue
 
-  val queueTableStateL
+  val sessionQueueTableStateL
     : Lens[SeqexecAppRootModel, TableState[SessionQueueTable.TableColumn]] =
-    SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.queueTableState
+    SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.appTableStates ^|-> AppTableStates.sessionQueueTable
+
+  def stepsTableStateL(id: Observation.Id)
+    : Lens[SeqexecAppRootModel, Option[TableState[StepsTable.TableColumn]]] =
+    SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.appTableStates ^|-> AppTableStates.stepsTableAtL(id)
 
   val soundSettingL: Lens[SeqexecAppRootModel, SoundSelection] =
     SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.sound
 
   val configTableStateL
     : Lens[SeqexecAppRootModel, TableState[StepConfigTable.TableColumn]] =
-    SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.configTableState
+    SeqexecAppRootModel.uiModel ^|-> SeqexecUIModel.appTableStates ^|-> AppTableStates.stepConfigTable
 
   def executionQueuesT(
     id: QueueId

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -56,7 +56,7 @@ object SeqexecUIModel {
     GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
     SequencesOnDisplay.Empty,
     StepConfigTable.InitialTableState,
-    SessionQueueTable.InitialTableState.tableState,
+    SessionQueueTable.InitialState.tableState,
     Observer(""),
     UserNotificationState.Empty,
     CalibrationQueues.Default,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -49,7 +49,7 @@ object SeqexecUIModel {
     Pages.Root,
     None,
     SectionClosed,
-    GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionOpen),
+    GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
     SequencesOnDisplay.Empty,
     AppTableStates.Initial,
     Observer(""),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -9,9 +9,6 @@ import monocle.macros.Lenses
 import seqexec.model.Observer
 import seqexec.model.UserDetails
 import seqexec.web.common.FixedLengthBuffer
-import seqexec.web.client.components.sequence.steps.StepConfigTable
-import seqexec.web.client.components.SessionQueueTable
-import web.client.table._
 
 sealed trait SoundSelection extends Product with Serializable
 
@@ -37,8 +34,7 @@ final case class SeqexecUIModel(
   loginBox:           SectionVisibilityState,
   globalLog:          GlobalLog,
   sequencesOnDisplay: SequencesOnDisplay,
-  configTableState:   TableState[StepConfigTable.TableColumn],
-  queueTableState:    TableState[SessionQueueTable.TableColumn],
+  appTableStates:     AppTableStates,
   defaultObserver:    Observer,
   notification:       UserNotificationState,
   queues:             CalibrationQueues,
@@ -55,8 +51,7 @@ object SeqexecUIModel {
     SectionClosed,
     GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
     SequencesOnDisplay.Empty,
-    StepConfigTable.InitialTableState,
-    SessionQueueTable.InitialState.tableState,
+    AppTableStates.Initial,
     Observer(""),
     UserNotificationState.Empty,
     CalibrationQueues.Default,
@@ -74,8 +69,7 @@ object SeqexecUIModel {
          x.loginBox,
          x.globalLog,
          x.sequencesOnDisplay,
-         x.configTableState,
-         x.queueTableState,
+         x.appTableStates,
          x.defaultObserver,
          x.notification,
          x.queues,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -49,7 +49,7 @@ object SeqexecUIModel {
     Pages.Root,
     None,
     SectionClosed,
-    GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionClosed),
+    GlobalLog(FixedLengthBuffer.unsafeFromInt(500), SectionOpen),
     SequencesOnDisplay.Empty,
     AppTableStates.Initial,
     Observer(""),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -22,9 +22,7 @@ import seqexec.model.enum._
 import seqexec.web.common.Zipper
 import seqexec.web.client.circuit.SequenceObserverFocus
 import seqexec.web.client.circuit.DayCalObserverFocus
-import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.model.ModelOps._
-import web.client.table._
 
 // Model for the tabbed area of sequences
 @Lenses
@@ -63,7 +61,7 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     */
   def loadedIds: List[Observation.Id] =
     tabs.toNel.collect {
-      case InstrumentSequenceTab(_, Right(curr), _, _, _, _) => curr.id
+      case InstrumentSequenceTab(_, Right(curr), _, _, _) => curr.id
     }
 
   /**
@@ -71,7 +69,7 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     */
   def updateCalTabObserver(o: Observer): SequencesOnDisplay = {
     val q = tabs.map {
-      case c @ CalibrationQueueTab(_, _, _) =>
+      case c @ CalibrationQueueTab(_, _) =>
         CalibrationQueueTab.observer.set(o.some)(c)
       case i =>
         i
@@ -96,12 +94,12 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     val updated =
       updateLoaded(loadedInSessionQueue ::: completedIds, allIds).tabs
         .map {
-          case p @ PreviewSequenceTab(curr, r, _, t, o) =>
+          case p @ PreviewSequenceTab(curr, r, _, o) =>
             s.sessionQueue
               .find(_.id === curr.id)
-              .map(s => PreviewSequenceTab(s, r, false, t, o))
+              .map(s => PreviewSequenceTab(s, r, false, o))
               .getOrElse(p)
-          case c @ CalibrationQueueTab(_, _, _) =>
+          case c @ CalibrationQueueTab(_, _) =>
             s.queues
               .get(CalibrationQueueId)
               .map { q =>
@@ -132,9 +130,10 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
       case Some(x) =>
         val tab = currentInsTabs
           .find(_.obsId === x.id)
-        val curTableState = tab
-          .map(_.tableState)
-          .getOrElse(StepsTable.State.InitialTableState)
+          // FIXME
+        // val curTableState = tab
+        //   .map(_.tableState)
+        //   .getOrElse(StepsTable.State.InitialTableState)
         val left         = tag[InstrumentSequenceTab.CompletedSV][SequenceView](x)
         val right        = tag[InstrumentSequenceTab.LoadedSV][SequenceView](x)
         val seq          = tab.filter(_.isComplete).as(left).toLeft(right)
@@ -145,7 +144,6 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
                               seq,
                               stepConfig,
                               selectedStep,
-                              curTableState,
                               tabOperations).some
     }
 
@@ -184,11 +182,12 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     val isLoaded = loadedIds.contains(s.id)
     // Replace the sequence for the instrument or the completed sequence and reset displaying a step
     val seq = if (s.metadata.instrument === i && !isLoaded) {
-      val newPreview = SequencesOnDisplay.previewTabById(obsId).isEmpty(this)
-      val tsUpd = (ts: TableState[StepsTable.TableColumn]) =>
-        if (newPreview) StepsTable.State.InitialTableState else ts
+      // val newPreview = SequencesOnDisplay.previewTabById(obsId).isEmpty(this)
+      // FIXME
+      // val tsUpd = (ts: TableState[StepsTable.TableColumn]) =>
+      //   if (newPreview) StepsTable.State.InitialTableState else ts
       val update =
-        PreviewSequenceTab.tableState.modify(tsUpd) >>>
+        // PreviewSequenceTab.tableState.modify(tsUpd) >>>
           PreviewSequenceTab.currentSequence.set(s) >>>
           PreviewSequenceTab.stepConfig.set(None)
       val q = withPreviewTab(s).tabs
@@ -197,7 +196,7 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
       q
     } else if (isLoaded) {
       tabs.findFocusP {
-        case InstrumentSequenceTab(_, Right(curr), _, _, _, _) =>
+        case InstrumentSequenceTab(_, Right(curr), _, _, _) =>
           obsId === curr.id
       }
     } else {
@@ -229,7 +228,6 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
                           PreviewSequenceTab(s,
                                              None,
                                              false,
-                                             StepsTable.State.InitialTableState,
                                              TabOperations.Default))
         case t =>
           NonEmptyList.of(t)
@@ -281,9 +279,9 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
   // Is the id focused?
   def idDisplayed(id: Observation.Id): Boolean =
     tabs.withFocus.exists {
-      case (InstrumentSequenceTab(_, Right(curr), _, _, _, _), true) =>
+      case (InstrumentSequenceTab(_, Right(curr), _, _, _), true) =>
         curr.id === id
-      case (PreviewSequenceTab(curr, _, _, _, _), true) =>
+      case (PreviewSequenceTab(curr, _, _, _), true) =>
         curr.id === id
       case _ =>
         false
@@ -332,7 +330,7 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     SequencesOnDisplay.focusSequence
       .getOption(this)
       .collect {
-        case InstrumentSequenceTab(_, Right(s), _, _, _, _) =>
+        case InstrumentSequenceTab(_, Right(s), _, _, _) =>
           SequenceObserverFocus(s.metadata.instrument,
                                 s.id,
                                 s.allStepsDone,
@@ -340,7 +338,7 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
       }
       .orElse {
         SequencesOnDisplay.focusQueue.getOption(this).collect {
-          case CalibrationQueueTab(_, _, o) =>
+          case CalibrationQueueTab(_, o) =>
             DayCalObserverFocus(CalibrationQueueId, o).asLeft
         }
       }
@@ -354,7 +352,7 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
     // As this is a client side only state it won't be cleaned automatically
     val cleaned = copy(
       tabs = Zipper.fromNel(NonEmptyList.fromListUnsafe(tabs.toList.filter {
-        case InstrumentSequenceTab(inst, Left(_), _, _, _, _) => inst =!= i
+        case InstrumentSequenceTab(inst, Left(_), _, _, _) => inst =!= i
         case _                                                => true
       })))
 
@@ -376,33 +374,33 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
   def markAsLoading(id: Observation.Id): SequencesOnDisplay =
     SequencesOnDisplay.loadingL(id).set(true)(this)
 
-  def stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]] =
-    SequencesOnDisplay.sequenceTabs
-      .getAll(this)
-      .collect {
-        case i: InstrumentSequenceTab =>
-          (i.sequence.id, i.tableState)
-        case PreviewSequenceTab(curr, _, _, tableState, _) =>
-          (curr.id, tableState)
-      }
-      .toMap
-
-  def updateTableStates(
-    stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]]
-  ): SequencesOnDisplay =
-    copy(tabs = tabs.map {
-      case i: InstrumentSequenceTab =>
-        stepsTables
-          .get(i.obsId)
-          .map(s => i.copy(tableState = s))
-          .getOrElse(i)
-      case i @ PreviewSequenceTab(curr, _, _, _, _) =>
-        stepsTables
-          .get(curr.id)
-          .map(s => i.copy(tableState = s))
-          .getOrElse(i)
-      case i => i
-    })
+  // def stepsTableStates: Map[Observation.Id, TableState[StepsTable.TableColumn]] =
+  //   SequencesOnDisplay.sequenceTabs
+  //     .getAll(this)
+  //     .collect {
+  //       case i: InstrumentSequenceTab =>
+  //         (i.sequence.id, i.tableState)
+  //       case PreviewSequenceTab(curr, _, _, tableState, _) =>
+  //         (curr.id, tableState)
+  //     }
+  //     .toMap
+  //
+  // def updateTableState(
+  //   stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]]
+  // ): SequencesOnDisplay =
+  //   copy(tabs = tabs.map {
+  //     case i: InstrumentSequenceTab =>
+  //       stepsTables
+  //         .get(i.obsId)
+  //         .map(s => i.copy(tableState = s))
+  //         .getOrElse(i)
+  //     case i @ PreviewSequenceTab(curr, _, _, _, _) =>
+  //       stepsTables
+  //         .get(curr.id)
+  //         .map(s => i.copy(tableState = s))
+  //         .getOrElse(i)
+  //     case i => i
+  //   })
 
   def markOperations(
     id:      Observation.Id,
@@ -444,7 +442,7 @@ object SequencesOnDisplay {
 
   private def previewMatch(id: Observation.Id)(tab: SeqexecTab): Boolean =
     tab match {
-      case PreviewSequenceTab(curr, _, _, _, _) => curr.id === id
+      case PreviewSequenceTab(curr, _, _, _) => curr.id === id
       case _                                    => false
     }
 
@@ -453,25 +451,36 @@ object SequencesOnDisplay {
   ): Traversal[SequencesOnDisplay, PreviewSequenceTab] =
     SequencesOnDisplay.tabs ^|->> Zipper.unsafeFilterZ(previewMatch(id)) ^<-? SeqexecTab.previewTab
 
+  private def instrumentSequenceMatch(id: Observation.Id)(tab: SeqexecTab): Boolean =
+    tab match {
+      case InstrumentSequenceTab(_, Right(curr), _, _, _) => curr.id === id
+      case _                                                 => false
+    }
+
   private def sequenceMatch(id: Observation.Id)(tab: SeqexecTab): Boolean =
     tab match {
-      case InstrumentSequenceTab(_, Right(curr), _, _, _, _) => curr.id === id
+      case t: InstrumentSequenceTab => t.obsId === id
+      case t: PreviewSequenceTab => t.obsId === id
       case _                                                 => false
     }
 
   def instrumentTabById(
     id: Observation.Id
   ): Traversal[SequencesOnDisplay, InstrumentSequenceTab] =
-    SequencesOnDisplay.tabs ^|->> Zipper.unsafeFilterZ(sequenceMatch(id)) ^<-? SeqexecTab.instrumentTab
+    SequencesOnDisplay.tabs ^|->> Zipper.unsafeFilterZ(instrumentSequenceMatch(id)) ^<-? SeqexecTab.instrumentTab
+
+  def sequenceTabById(
+    id: Observation.Id
+  ): Traversal[SequencesOnDisplay, SequenceTab] =
+    SequencesOnDisplay.tabs ^|->> Zipper.unsafeFilterZ(sequenceMatch(id)) ^<-? SeqexecTab.sequenceTab
 
   val previewTab: Traversal[SequencesOnDisplay, PreviewSequenceTab] =
     SequencesOnDisplay.tabs ^|->> Zipper.unsafeFilterZ(_.isPreview) ^<-? SeqexecTab.previewTab
 
   private def instrumentMatch(i: Instrument)(tab: SeqexecTab): Boolean =
     tab match {
-      case t: InstrumentSequenceTab =>
-        t.inst === i
-      case _ => false
+      case t: InstrumentSequenceTab => t.inst === i
+      case _                        => false
     }
 
   def instrumentTabFor(
@@ -551,4 +560,14 @@ object SequencesOnDisplay {
           SeqexecTabActive(i, selected)
       }.headOption
     }
+
+  // def stepsTableStateAtL(
+  //   id: Observation.Id
+  // ): Traversal[SequencesOnDisplay, TableState[StepsTable.TableColumn]] =
+  //   sequenceTabById(id) ^|-> SequenceTab.tableState
+  //
+  // def queueTableAtL(
+  //   id: QueueId
+  // ): Lens[AppTableStates, Option[TableState[CalQueueTable.TableColumn]]] =
+  //   AppTableStates.queueTables ^|-> at(id)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SequencesOnDisplay.scala
@@ -374,34 +374,6 @@ final case class SequencesOnDisplay(tabs: Zipper[SeqexecTab]) {
   def markAsLoading(id: Observation.Id): SequencesOnDisplay =
     SequencesOnDisplay.loadingL(id).set(true)(this)
 
-  // def stepsTableStates: Map[Observation.Id, TableState[StepsTable.TableColumn]] =
-  //   SequencesOnDisplay.sequenceTabs
-  //     .getAll(this)
-  //     .collect {
-  //       case i: InstrumentSequenceTab =>
-  //         (i.sequence.id, i.tableState)
-  //       case PreviewSequenceTab(curr, _, _, tableState, _) =>
-  //         (curr.id, tableState)
-  //     }
-  //     .toMap
-  //
-  // def updateTableState(
-  //   stepsTables: Map[Observation.Id, TableState[StepsTable.TableColumn]]
-  // ): SequencesOnDisplay =
-  //   copy(tabs = tabs.map {
-  //     case i: InstrumentSequenceTab =>
-  //       stepsTables
-  //         .get(i.obsId)
-  //         .map(s => i.copy(tableState = s))
-  //         .getOrElse(i)
-  //     case i @ PreviewSequenceTab(curr, _, _, _, _) =>
-  //       stepsTables
-  //         .get(curr.id)
-  //         .map(s => i.copy(tableState = s))
-  //         .getOrElse(i)
-  //     case i => i
-  //   })
-
   def markOperations(
     id:      Observation.Id,
     updater: TabOperations => TabOperations
@@ -561,13 +533,4 @@ object SequencesOnDisplay {
       }.headOption
     }
 
-  // def stepsTableStateAtL(
-  //   id: Observation.Id
-  // ): Traversal[SequencesOnDisplay, TableState[StepsTable.TableColumn]] =
-  //   sequenceTabById(id) ^|-> SequenceTab.tableState
-  //
-  // def queueTableAtL(
-  //   id: QueueId
-  // ): Lens[AppTableStates, Option[TableState[CalQueueTable.TableColumn]]] =
-  //   AppTableStates.queueTables ^|-> at(id)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -114,6 +114,10 @@ object StepItems {
         instrumentFilterO
           .getOption(s)
           .map(_.sentenceCase)
+      case Instrument.Gsaoi =>
+        instrumentFilterO
+          .getOption(s)
+          .map(_.sentenceCase)
       case Instrument.Gpi => gpiFilter(s)
       case _              => None
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -1,0 +1,163 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.model
+
+import cats.implicits._
+import gem.enum.GpiDisperser
+import gem.enum.GpiObservingMode
+import gem.enum.GpiFilter
+import seqexec.model.enum.Instrument
+import seqexec.model.enum.FPUMode
+import seqexec.model.enum.Guiding
+import seqexec.model.Step
+import seqexec.model.enumerations
+import seqexec.model.OffsetAxis
+import seqexec.model.TelescopeOffset
+import seqexec.web.client.model.lenses._
+import seqexec.web.client.model.Formatting._
+
+/**
+  * Contains methods to access details of a step normally stored on the step sequence
+  */
+object StepItems {
+
+  private val gpiObsMode = GpiObservingMode.all.map(x => x.shortName -> x).toMap
+
+  private val gpiFiltersMap: Map[String, GpiFilter] =
+    GpiFilter.all.map(x => (x.shortName, x)).toMap
+
+  val gpiDispersers: Map[String, String] =
+    GpiDisperser.all.map(x => x.shortName -> x.longName).toMap
+
+  implicit class StepOps(val s: Step) extends AnyVal {
+    def fpuNameMapper(i: Instrument): String => Option[String] = i match {
+      case Instrument.GmosS => enumerations.fpu.GmosSFPU.get
+      case Instrument.GmosN => enumerations.fpu.GmosNFPU.get
+      case Instrument.F2    => enumerations.fpu.Flamingos2.get
+      case _ =>
+        _ =>
+          none
+    }
+
+    def exposureTime: Option[Double] = observeExposureTimeO.getOption(s)
+    def exposureTimeS(i: Instrument): Option[String] =
+      exposureTime.map(formatExposureTime(i))
+    def coAdds: Option[Int] = observeCoaddsO.getOption(s)
+    def fpu(i: Instrument): Option[String] =
+      for {
+        mode <- instrumentFPUModeO
+          .getOption(s)
+          .orElse(FPUMode.BuiltIn.some) // If the instrument has no fpu mode default to built in
+        fpuL = if (mode === FPUMode.BuiltIn) instrumentFPUO
+        else instrumentFPUCustomMaskO
+        fpu <- fpuL.getOption(s)
+      } yield fpuNameMapper(i)(fpu).getOrElse(fpu)
+
+    def fpuOrMask(i: Instrument): Option[String] =
+      fpu(i)
+        .orElse(instrumentSlitWidthO.getOption(s))
+        .orElse(instrumentMaskO.getOption(s))
+
+    private def gpiFilter: Step => Option[String] = s => {
+      // Read the filter, if not found deduce it from the obs mode
+      val f: Option[GpiFilter] =
+        instrumentFilterO.getOption(s).flatMap(gpiFiltersMap.get).orElse {
+          for {
+            m <- instrumentObservingModeO.getOption(s)
+            o <- gpiObsMode.get(m)
+            f <- o.filter
+          } yield f
+        }
+      f.map(_.longName)
+    }
+
+    def filter(i: Instrument): Option[String] = i match {
+      case Instrument.GmosS =>
+        instrumentFilterO
+          .getOption(s)
+          .flatMap(enumerations.filter.GmosSFilter.get)
+      case Instrument.GmosN =>
+        instrumentFilterO
+          .getOption(s)
+          .flatMap(enumerations.filter.GmosNFilter.get)
+      case Instrument.F2 =>
+        instrumentFilterO
+          .getOption(s)
+          .flatMap(enumerations.filter.F2Filter.get)
+      case Instrument.Niri =>
+        instrumentFilterO
+          .getOption(s)
+          .flatMap(enumerations.filter.Niri.get)
+      case Instrument.Gnirs =>
+        instrumentFilterO
+          .getOption(s)
+          .map(_.sentenceCase)
+      case Instrument.Nifs =>
+        instrumentFilterO
+          .getOption(s)
+          .map(_.sentenceCase)
+      case Instrument.Gpi => gpiFilter(s)
+      case _              => None
+    }
+
+    private def disperserNameMapper(i: Instrument): Map[String, String] =
+      i match {
+        case Instrument.GmosS => enumerations.disperser.GmosSDisperser
+        case Instrument.GmosN => enumerations.disperser.GmosNDisperser
+        case Instrument.Gpi   => gpiDispersers
+        case _                => Map.empty
+      }
+
+    def disperser(i: Instrument): Option[String] = {
+      val disperser = for {
+        disperser <- instrumentDisperserO.getOption(s)
+      } yield disperserNameMapper(i).getOrElse(disperser, disperser)
+      val centralWavelength = instrumentDisperserLambdaO.getOption(s)
+
+      // Format
+      (disperser, centralWavelength) match {
+        case (Some(d), Some(w)) => f"$d @ $w%.0f nm".some
+        case (Some(d), None)    => d.some
+        case _                  => none
+      }
+    }
+
+    def offsetP =
+      telescopeOffsetPO.getOption(s).getOrElse(TelescopeOffset.P.Zero)
+    def offsetQ =
+      telescopeOffsetQO.getOption(s).getOrElse(TelescopeOffset.Q.Zero)
+    def guiding = telescopeGuidingWithT.exist(_ === Guiding.Guide)(s)
+
+    def offsetText(axis: OffsetAxis): String =
+      offsetValueFormat(axis match {
+        case OffsetAxis.AxisP =>
+          telescopeOffsetPO.getOption(s).getOrElse(TelescopeOffset.P.Zero)
+        case OffsetAxis.AxisQ =>
+          telescopeOffsetQO.getOption(s).getOrElse(TelescopeOffset.Q.Zero)
+      })
+
+    def offsetPText: String = offsetText(OffsetAxis.AxisP)
+    def offsetQText: String = offsetText(OffsetAxis.AxisQ)
+
+  }
+
+  implicit class OffsetFnsOps(val steps: List[Step]) extends AnyVal {
+    // Calculate if there are non-zero offsets
+    def areNonZeroOffsets: Boolean =
+      steps
+        .map(
+          s =>
+            telescopeOffsetPO
+              .exist(_ =!= TelescopeOffset.P.Zero)(s) || telescopeOffsetQO
+              .exist(_ =!= TelescopeOffset.Q.Zero)(s))
+        .fold(false)(_ || _)
+
+    // Offsets to be displayed with a width
+    def offsetsDisplay: OffsetsDisplay = {
+      val (p, q) = steps.sequenceOffsetWidths
+      OffsetsDisplay.DisplayOffsets(scala.math.max(p, q))
+    }
+  }
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -46,6 +46,14 @@ object StepItems {
     def exposureTime: Option[Double] = observeExposureTimeO.getOption(s)
     def exposureTimeS(i: Instrument): Option[String] =
       exposureTime.map(formatExposureTime(i))
+    def exposureAndCoaddsS(i: Instrument): Option[String] =
+      (coAdds, exposureTime) match {
+        case (c, Some(e)) if c.exists(_ > 1) =>
+          s"${c.foldMap(_.show)}x${formatExposureTime(i)(e)} [s]".some
+        case (_, Some(e)) =>
+          s"${formatExposureTime(i)(e)} [s]".some
+        case _ => none
+      }
     def coAdds: Option[Int] = observeCoaddsO.getOption(s)
     def fpu(i: Instrument): Option[String] =
       for {
@@ -148,6 +156,19 @@ object StepItems {
         .getOption(s)
         .flatMap(obsNames.get)
 
+    def cameraName(i: Instrument): Option[String] = i match {
+      case Instrument.Niri =>
+        instrumentCameraO
+          .getOption(s)
+          .flatMap(enumerations.camera.Niri.get)
+      case _ => None
+    }
+
+    def deckerName: Option[String] =
+      instrumentDeckerO.getOption(s)
+
+    def imagingMirrorName: Option[String] =
+      instrumentImagingMirrorO.getOption(s)
   }
 
   implicit class OffsetFnsOps(val steps: List[Step]) extends AnyVal {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -30,6 +30,9 @@ object StepItems {
   val gpiDispersers: Map[String, String] =
     GpiDisperser.all.map(x => x.shortName -> x.longName).toMap
 
+  private val obsNames =
+    GpiObservingMode.all.map(x => x.shortName -> x.longName).toMap
+
   implicit class StepOps(val s: Step) extends AnyVal {
     def fpuNameMapper(i: Instrument): String => Option[String] = i match {
       case Instrument.GmosS => enumerations.fpu.GmosSFPU.get
@@ -139,6 +142,11 @@ object StepItems {
 
     def offsetPText: String = offsetText(OffsetAxis.AxisP)
     def offsetQText: String = offsetText(OffsetAxis.AxisQ)
+
+    def observingMode: Option[String] =
+      instrumentObservingModeO
+        .getOption(s)
+        .flatMap(obsNames.get)
 
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -148,7 +148,7 @@ object StepItems {
       telescopeOffsetPO.getOption(s).getOrElse(TelescopeOffset.P.Zero)
     def offsetQ: TelescopeOffset.Q =
       telescopeOffsetQO.getOption(s).getOrElse(TelescopeOffset.Q.Zero)
-    def guiding: Boolean = telescopeGuidingWithT.exist(_ === Guiding.Guide)(s)
+    def guiding: Boolean         = telescopeGuidingWithT.exist(_ === Guiding.Guide)(s)
     def readMode: Option[String] = instrumentReadModeO.getOption(s)
 
     def offsetText(axis: OffsetAxis): String =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -140,12 +140,12 @@ object StepItems {
       }
     }
 
-    def offsetP =
+    def offsetP: TelescopeOffset.P =
       telescopeOffsetPO.getOption(s).getOrElse(TelescopeOffset.P.Zero)
-    def offsetQ =
+    def offsetQ: TelescopeOffset.Q =
       telescopeOffsetQO.getOption(s).getOrElse(TelescopeOffset.Q.Zero)
-    def guiding = telescopeGuidingWithT.exist(_ === Guiding.Guide)(s)
-    def readMode = instrumentReadModeO.getOption(s)
+    def guiding: Boolean = telescopeGuidingWithT.exist(_ === Guiding.Guide)(s)
+    def readMode: Option[String] = instrumentReadModeO.getOption(s)
 
     def offsetText(axis: OffsetAxis): String =
       offsetValueFormat(axis match {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -11,6 +11,7 @@ import seqexec.model.enum.Instrument
 import seqexec.model.enum.FPUMode
 import seqexec.model.enum.Guiding
 import seqexec.model.Step
+import seqexec.model.StepState
 import seqexec.model.enumerations
 import seqexec.model.OffsetAxis
 import seqexec.model.TelescopeOffset
@@ -34,6 +35,11 @@ object StepItems {
     GpiObservingMode.all.map(x => x.shortName -> x.longName).toMap
 
   implicit class StepOps(val s: Step) extends AnyVal {
+    def canRunFrom: Boolean = s.status match {
+      case StepState.Pending | StepState.Failed(_) => true
+      case _                                       => false
+    }
+
     def fpuNameMapper(i: Instrument): String => Option[String] = i match {
       case Instrument.GmosS => enumerations.fpu.GmosSFPU.get
       case Instrument.GmosN => enumerations.fpu.GmosNFPU.get
@@ -139,6 +145,7 @@ object StepItems {
     def offsetQ =
       telescopeOffsetQO.getOption(s).getOrElse(TelescopeOffset.Q.Zero)
     def guiding = telescopeGuidingWithT.exist(_ === Guiding.Guide)(s)
+    def readMode = instrumentReadModeO.getOption(s)
 
     def offsetText(axis: OffsetAxis): String =
       offsetValueFormat(axis match {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -219,7 +219,6 @@ object InstrumentSequenceTab {
          x.sequence,
          x.stepConfig,
          x.selected,
-         x.tableState,
          x.tabOperations))
 
   implicit val completedSequence

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -19,8 +19,6 @@ import seqexec.model.SequenceView
 import seqexec.model.RunningStep
 import seqexec.model.enum._
 import seqexec.web.client.model.ModelOps._
-import seqexec.web.client.components.sequence.steps.StepsTable
-import web.client.table._
 import shapeless.tag.@@
 
 final case class AvailableTab(id:            Observation.Id,
@@ -75,9 +73,6 @@ object SeqexecTabActive {
 }
 
 sealed trait SeqexecTab {
-  type TC
-  val tableState: TableState[TC]
-
   def isPreview: Boolean
 }
 
@@ -100,33 +95,29 @@ object SeqexecTab {
       case p: PreviewSequenceTab    => p
       case i: InstrumentSequenceTab => i
     }(identity)
+
 }
 
 @Lenses
 final case class CalibrationQueueTab(
-  tableState: TableState[StepsTable.TableColumn],
   state:      BatchExecState,
   observer:   Option[Observer])
     extends SeqexecTab {
-  type TC = StepsTable.TableColumn
   val isPreview: Boolean = false
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object CalibrationQueueTab {
   val Empty: CalibrationQueueTab =
-    CalibrationQueueTab(StepsTable.State.InitialTableState,
-                        BatchExecState.Idle,
+    CalibrationQueueTab(BatchExecState.Idle,
                         None)
 
   implicit val eq: Eq[CalibrationQueueTab] =
-    Eq.by(x => (x.tableState, x.state, x.observer))
+    Eq.by(x => (x.state, x.observer))
 }
 
 sealed trait SequenceTab extends SeqexecTab {
-  type TC = StepsTable.TableColumn
   val tabOperations: TabOperations
-
   def instrument: Instrument = this match {
     case i: InstrumentSequenceTab => i.inst
     case i: PreviewSequenceTab    => i.currentSequence.metadata.instrument
@@ -151,7 +142,7 @@ sealed trait SequenceTab extends SeqexecTab {
   }
 
   def isComplete: Boolean = this match {
-    case InstrumentSequenceTab(_, Left(_: InstrumentSequenceTab.CompletedSequenceView), _, _, _, _) => true
+    case InstrumentSequenceTab(_, Left(_: InstrumentSequenceTab.CompletedSequenceView), _, _, _) => true
     case _                                              => false
   }
 
@@ -181,7 +172,6 @@ object SequenceTab {
       case _                                                    => false
     }
 
-  // Some lenses
   val stepConfigL: Lens[SequenceTab, Option[StepId]] =
     Lens[SequenceTab, Option[StepId]] {
       case t: InstrumentSequenceTab => t.stepConfig
@@ -202,7 +192,6 @@ final case class InstrumentSequenceTab(
                       InstrumentSequenceTab.LoadedSequenceView],
   stepConfig:    Option[StepId],
   selected:      Option[StepId],
-  tableState:    TableState[StepsTable.TableColumn],
   tabOperations: TabOperations)
     extends SequenceTab {
   val seq: SequenceView = curSequence match {
@@ -247,7 +236,6 @@ final case class PreviewSequenceTab(
   currentSequence: SequenceView,
   stepConfig:      Option[Int],
   isLoading:       Boolean,
-  tableState:      TableState[StepsTable.TableColumn],
   tabOperations:   TabOperations)
     extends SequenceTab
 
@@ -259,6 +247,5 @@ object PreviewSequenceTab {
         (x.currentSequence,
          x.stepConfig,
          x.isLoading,
-         x.tableState,
          x.tabOperations))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -58,8 +58,6 @@ package object reusability {
     Reusability.byEq
   implicit val sCFocusReuse: Reusability[SequenceControlFocus] =
     Reusability.byEq
-  implicit val stfReuse: Reusability[StepsTableAndStatusFocus] =
-    Reusability.derive[StepsTableAndStatusFocus]
   implicit val tabSelReuse: Reusability[TabSelected] = Reusability.byRef
   implicit val sysnReuse: Reusability[SystemName]    = Reusability.byRef
   implicit val sectReuse: Reusability[SectionVisibilityState] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -14,6 +14,7 @@ import seqexec.model.enum.Instrument
 import seqexec.model.enum.BatchExecState
 import seqexec.model.enum.Resource
 import seqexec.model.enum.SystemName
+import seqexec.model.enum.ServerLogLevel
 import seqexec.model.Observer
 import seqexec.model.QueueId
 import seqexec.model.Step
@@ -36,6 +37,7 @@ import seqexec.web.client.model.ResourceRunOperation
 import seqexec.web.client.model.StartFromOperation
 import seqexec.web.client.model.TabSelected
 import seqexec.web.client.model.SoundSelection
+import seqexec.web.client.model.GlobalLog
 import seqexec.web.client.circuit._
 
 package object reusability {
@@ -84,8 +86,11 @@ package object reusability {
   implicit val qidReuse: Reusability[QueueId]              = Reusability.byEq
   implicit val bexReuse: Reusability[BatchExecState]       = Reusability.byRef
   implicit val soundReuse: Reusability[SoundSelection]     = Reusability.byRef
-
+  implicit val globalLogReuse: Reusability[GlobalLog]      = Reusability.byEq
+  implicit val sllReuse: Reusability[ServerLogLevel]       = Reusability.byEq
   implicit val resMap: Reusability[Map[Resource, ResourceRunOperation]] =
+    Reusability.map
+  implicit val sllbMap: Reusability[Map[ServerLogLevel, Boolean]] =
     Reusability.map
   implicit val resSMap: Reusability[SortedMap[Resource, ResourceRunOperation]] =
     Reusability.by(_.toMap)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -59,7 +59,7 @@ package object reusability {
   implicit val sCFocusReuse: Reusability[SequenceControlFocus] =
     Reusability.byEq
   implicit val stfReuse: Reusability[StepsTableAndStatusFocus] =
-    Reusability.byEq
+    Reusability.derive[StepsTableAndStatusFocus]
   implicit val tabSelReuse: Reusability[TabSelected] = Reusability.byRef
   implicit val sysnReuse: Reusability[SystemName]    = Reusability.byRef
   implicit val sectReuse: Reusability[SectionVisibilityState] =

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -213,14 +213,13 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val arbCalibrationQueueTab: Arbitrary[CalibrationQueueTab] =
     Arbitrary {
       for {
-        ts <- arbitrary[TableState[StepsTable.TableColumn]]
         st <- arbitrary[BatchExecState]
         o  <- arbitrary[Option[Observer]]
       } yield CalibrationQueueTab(st, o)
     }
 
   implicit val cqtCogen: Cogen[CalibrationQueueTab] =
-    Cogen[(TableState[StepsTable.TableColumn], BatchExecState, Option[Observer])]
+    Cogen[(BatchExecState, Option[Observer])]
       .contramap { x =>
         (x.state, x.observer)
       }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -42,7 +42,7 @@ import seqexec.web.client.model._
 import seqexec.web.client.model.RunOperation
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages._
-import seqexec.web.client.components.sequence.steps.OffsetFns.OffsetsDisplay
+import seqexec.web.client.model.Formatting.OffsetsDisplay
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.components.queue.CalQueueTable
@@ -216,13 +216,13 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         ts <- arbitrary[TableState[StepsTable.TableColumn]]
         st <- arbitrary[BatchExecState]
         o  <- arbitrary[Option[Observer]]
-      } yield CalibrationQueueTab(ts, st, o)
+      } yield CalibrationQueueTab(st, o)
     }
 
   implicit val cqtCogen: Cogen[CalibrationQueueTab] =
     Cogen[(TableState[StepsTable.TableColumn], BatchExecState, Option[Observer])]
       .contramap { x =>
-        (x.tableState, x.state, x.observer)
+        (x.state, x.observer)
       }
 
   implicit val arbQueueSeqOperations: Arbitrary[QueueSeqOperations] =
@@ -243,7 +243,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         i   <- arbitrary[Instrument]
         idx <- arbitrary[Option[Int]]
         sv  <- arbitrary[Either[SequenceView, SequenceView]]
-        ts  <- arbitrary[TableState[StepsTable.TableColumn]]
         to  <- arbitrary[TabOperations]
         se  <- arbitrary[Option[StepId]]
       } yield
@@ -253,7 +252,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
                    tag[InstrumentSequenceTab.LoadedSV][SequenceView]),
           idx,
           se,
-          ts,
           to)
     }
 
@@ -262,13 +260,11 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
            SequenceView,
            Option[StepId],
            Option[StepId],
-           TableState[StepsTable.TableColumn],
            TabOperations)].contramap { x =>
       (x.inst,
        x.sequence,
        x.stepConfig,
        x.selectedStep,
-       x.tableState,
        x.tabOperations)
     }
 
@@ -278,17 +274,15 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         idx <- arbitrary[Option[Int]]
         sv  <- arbitrary[SequenceView]
         lo  <- arbitrary[Boolean]
-        ts  <- arbitrary[TableState[StepsTable.TableColumn]]
         to  <- arbitrary[TabOperations]
-      } yield PreviewSequenceTab(sv, idx, lo, ts, to)
+      } yield PreviewSequenceTab(sv, idx, lo, to)
     }
 
   implicit val pstCogen: Cogen[PreviewSequenceTab] =
     Cogen[(SequenceView,
            Option[Int],
-           TableState[StepsTable.TableColumn],
            TabOperations)].contramap { x =>
-      (x.currentSequence, x.stepConfig, x.tableState, x.tabOperations)
+      (x.currentSequence, x.stepConfig, x.tabOperations)
     }
 
   implicit val arbSeqexecTab: Arbitrary[SeqexecTab] = Arbitrary {
@@ -725,7 +719,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
     Cogen[String].contramap(_.productPrefix)
 
   implicit val arbStepsTableTableColumn: Arbitrary[StepsTable.TableColumn] =
-    Arbitrary(Gen.const(StepsTable.IconColumn))
+    Arbitrary(Gen.oneOf(StepsTable.all.map(_.column).toList))
 
   implicit val stepsTableColumnCogen: Cogen[StepsTable.TableColumn] =
     Cogen[String].contramap(_.productPrefix)
@@ -805,8 +799,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
         loginBox           <- arbitrary[SectionVisibilityState]
         globalLog          <- arbitrary[GlobalLog]
         sequencesOnDisplay <- arbitrary[SequencesOnDisplay]
-        configTableState   <- arbitrary[TableState[StepConfigTable.TableColumn]]
-        queueTableState    <- arbitrary[TableState[SessionQueueTable.TableColumn]]
+        appTableStates     <- arbitrary[AppTableStates]
         defaultObserver    <- arbitrary[Observer]
         notification       <- arbitrary[UserNotificationState]
         queues             <- arbitrary[CalibrationQueues]
@@ -821,8 +814,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
           loginBox,
           globalLog,
           sequencesOnDisplay,
-          configTableState,
-          queueTableState,
+          appTableStates,
           defaultObserver,
           notification,
           queues,
@@ -839,8 +831,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
        SectionVisibilityState,
        GlobalLog,
        SequencesOnDisplay,
-       TableState[StepConfigTable.TableColumn],
-       TableState[SessionQueueTable.TableColumn],
+       AppTableStates,
        Observer,
        UserNotificationState,
        CalibrationQueues,
@@ -855,8 +846,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
            x.loginBox,
            x.globalLog,
            x.sequencesOnDisplay,
-           x.configTableState,
-           x.queueTableState,
+           x.appTableStates,
            x.defaultObserver,
            x.notification,
            x.queues,
@@ -953,9 +943,10 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries {
   implicit val appTableStatesCogen: Cogen[AppTableStates] =
     Cogen[(TableState[SessionQueueTable.TableColumn],
            TableState[StepConfigTable.TableColumn],
-           List[(Observation.Id, TableState[StepsTable.TableColumn])])]
+           List[(Observation.Id, TableState[StepsTable.TableColumn])],
+           List[(QueueId, TableState[CalQueueTable.TableColumn])])]
       .contramap { x =>
-        (x.queueTable, x.stepConfigTable, x.stepsTables.toList)
+        (x.sessionQueueTable, x.stepConfigTable, x.stepsTables.toList, x.queueTables.toList)
       }
 
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -8,11 +8,11 @@ import cats.tests.CatsSuite
 import diode.data._
 import monocle.law.discipline.LensTests
 import org.scalajs.dom.WebSocket
-import seqexec.web.client.components.sequence.steps.OffsetFns.OffsetsDisplay
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.SessionQueueTable
 import seqexec.web.client.circuit.StepsTableTypeSelection
 import seqexec.web.client.model._
+import seqexec.web.client.model.Formatting.OffsetsDisplay
 import web.client.table.TableState
 
 /**

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/SequencesOnDisplaySpec.scala
@@ -77,7 +77,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     val sod3 = sod.unsetPreviewOn(obsId)
     sod3.tabs.length should be(1)
     sod3.tabs.focus should matchPattern {
-      case CalibrationQueueTab(_, _, _) =>
+      case CalibrationQueueTab(_, _) =>
     }
   }
   test("Update loaded") {
@@ -90,7 +90,7 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
       SequencesQueue(loaded, Conditions.Default, None, SortedMap.empty, queue))
     sod.tabs.length should be(2)
     sod.tabs.toList.lift(1) should matchPattern {
-      case Some(InstrumentSequenceTab(_, Right(s), _, _, _, _))
+      case Some(InstrumentSequenceTab(_, Right(s), _, _, _))
           if s.id === obsId =>
     }
   }
@@ -109,11 +109,11 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
 
     sod2.tabs.length should be(3)
     sod2.tabs.toList.lift(2) should matchPattern {
-      case Some(InstrumentSequenceTab(_, Right(s), _, _, _, _))
+      case Some(InstrumentSequenceTab(_, Right(s), _, _, _))
           if s.id === obsId =>
     }
     sod2.tabs.focus should matchPattern {
-      case PreviewSequenceTab(s, _, _, _, _) if s.id === obs2 =>
+      case PreviewSequenceTab(s, _, _, _) if s.id === obs2 =>
     }
   }
 }

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -191,7 +191,8 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
   )(conf: WebServerConfiguration): Resource[IO, Server[IO]] = {
     val router = Router[IO](
       "/api/seqexec/guide" -> new GuideConfigDbRoutes(gcdb).service,
-      "/" -> new RedirectToHttpsRoutes(443, conf.externalBaseUrl).service
+      "/smartgcal"         -> new SmartGcalRoutes(conf.smartGCalHost, conf.smartGCalLocation).service,
+      "/"                  -> new RedirectToHttpsRoutes(443, conf.externalBaseUrl).service
     )
 
     BlazeServerBuilder[IO]

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnMeta.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnMeta.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package web.client.table
+
+import cats.Eq
+import cats.implicits._
+import japgolly.scalajs.react.extra.Reusability
+import monocle.macros.Lenses
+
+/**
+  * Metadata for a column
+  */
+@Lenses
+@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+final case class ColumnMeta[A](column:     A,
+                               name:       String,
+                               label:      String,
+                               visible:    Boolean,
+                               width:      ColumnWidth,
+                               grow:       Int = 1,
+                               removeable: Int = 1)
+
+@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+object ColumnMeta {
+  implicit def eqCm[A: Eq]: Eq[ColumnMeta[A]] =
+    Eq.by(x =>
+      (x.column, x.name, x.label, x.visible, x.width, x.grow, x.removeable))
+
+  implicit def reuse[A: Reusability]: Reusability[ColumnMeta[A]] =
+    Reusability.derive[ColumnMeta[A]]
+}

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnMeta.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnMeta.scala
@@ -19,7 +19,12 @@ final case class ColumnMeta[A](column:     A,
                                visible:    Boolean,
                                width:      ColumnWidth,
                                grow:       Int = 1,
-                               removeable: Int = 0)
+                               removeable: Int = 0) {
+  def isVariable: Boolean = width match {
+    case _: FixedColumnWidth => false
+    case _ => true
+  }
+}
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object ColumnMeta {

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnMeta.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnMeta.scala
@@ -19,7 +19,7 @@ final case class ColumnMeta[A](column:     A,
                                visible:    Boolean,
                                width:      ColumnWidth,
                                grow:       Int = 1,
-                               removeable: Int = 1)
+                               removeable: Int = 0)
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object ColumnMeta {

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnRendererArgs.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnRendererArgs.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package web.client.table
+
+import japgolly.scalajs.react.raw.JsNumber
+
+final case class ColumnRenderArgs[A](meta:      ColumnMeta[A],
+                                     index:     Int,
+                                     width:     JsNumber,
+                                     resizable: Boolean)

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnWidth.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnWidth.scala
@@ -18,13 +18,7 @@ sealed abstract class FixedColumnWidth(val width: Double) extends ColumnWidth {
 sealed abstract class VariableColumnWidth(val percentage: Double,
                                           val minWidth:   Double)
     extends ColumnWidth {
-  if (!(percentage > 0 && percentage <= 1)) {
-    println(s"Bogus percentage $percentage")
-  }
   assert(percentage > 0 && percentage <= 1)
-  if (!(minWidth>=0)) {
-    println(s"Bogus minwidth $minWidth")
-  }
   assert(minWidth >= 0)
   override def toString: String =
     s"Variable(${percentage}%, ${minWidth}px)"

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnWidth.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnWidth.scala
@@ -18,7 +18,13 @@ sealed abstract class FixedColumnWidth(val width: Double) extends ColumnWidth {
 sealed abstract class VariableColumnWidth(val percentage: Double,
                                           val minWidth:   Double)
     extends ColumnWidth {
+  if (!(percentage > 0 && percentage <= 1)) {
+    println(s"Bogus percentage $percentage")
+  }
   assert(percentage > 0 && percentage <= 1)
+  if (!(minWidth>=0)) {
+    println(s"Bogus minwidth $minWidth")
+  }
   assert(minWidth >= 0)
   override def toString: String =
     s"Variable(${percentage}%, ${minWidth}px)"

--- a/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
@@ -56,7 +56,6 @@ final case class TableState[A: Eq](userModified:   UserModified,
     val width   = s.width - fixedWidth
     val refCol  = cl.lift(indexOf)
     val nextCol = cl.lift(indexOf + 1)
-    cl.foreach(println)
 
     if (delta === 0.0) {
       this

--- a/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.data.NonEmptyList
 import cats.implicits._
 import monocle.Lens
+import monocle.function.Each._
 import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.Callback
 import react.common.syntax._
@@ -26,38 +27,29 @@ final case class TableState[A: Eq](userModified:   UserModified,
 
   // Reset visibility given the filters
   private def withVisibleCols(visibleFilter: A => Boolean): TableState[A] =
-    TableState
-      .columns[A]
-      .modify { x =>
-        val visibleCols: List[ColumnMeta[A]] = x.toList
-          .map {
-            case c @ ColumnMeta(i, _, _, _, _, _, _) if !visibleFilter( i) =>
-              ColumnMeta.visible.set(false)(c)
-            case c => c
-          }
-          .collect {
-            case c @ ColumnMeta(_, _, _, true, _, _, _) => c
-          }
-        if (visibleCols.nonEmpty) {
-          NonEmptyList.fromListUnsafe(visibleCols)
-        } else {
-          sys.error("At least 1 column must be visible")
-        }
+    (TableState
+      .columns[A] ^|->> each).modify { c =>
+        ColumnMeta.visible.set(visibleFilter(c.column))(c)
       }(this)
 
   // width set aside for fixed width columns
-  private val fixedWidth = columns.collect {
-    case ColumnMeta(_, _, _, true, FixedColumnWidth(x), _, _) => x
+  private def fixedWidth(calculatedWidth: A => Option[Double]): Double = columns.collect {
+    case ColumnMeta(c, _, _, true, FixedColumnWidth(x), _, _) =>
+      calculatedWidth(c).getOrElse(x)
   }.sum
 
   // Changes the relative widths when a column is being dragged
   // delta is the change in percentage, negative to the left, positive to the right
-  private def applyOffset(column: A, delta: Double, s: Size): TableState[A] = {
+  def applyOffset(calculatedWidth: A => Option[Double], column: A, delta: Double, s: Size): TableState[A] = {
     val cl      = columns.toList.filter(_.visible)
     val indexOf = cl.indexWhere(_.column === column)
-    val width   = s.width - fixedWidth
+    val fw      = fixedWidth(calculatedWidth)
+    val width   = s.width - fw
     val refCol  = cl.lift(indexOf)
     val nextCol = cl.lift(indexOf + 1)
+    println("Apply off ")
+              println(column)
+              println(indexOf)
 
     if (delta === 0.0) {
       this
@@ -66,6 +58,7 @@ final case class TableState[A: Eq](userModified:   UserModified,
       val result = cl.zipWithIndex.map {
         case (c @ ColumnMeta(_, _, _, true, VariableColumnWidth(curPct, min), _, _),
               idx) if idx === indexOf =>
+              println(curPct)
           val newPct    = curPct + delta
           val newWidth  = max(min, width * newPct)
           val actualPct = newWidth / width
@@ -106,23 +99,27 @@ final case class TableState[A: Eq](userModified:   UserModified,
 
   private def minVarWidth(calculatedWidth: A => Option[Double], cols: List[ColumnMeta[A]]): Double =
     cols.collect {
-      case ColumnMeta(c, _, _, _, VariableColumnWidth(_, mw), _, _) =>
-        calculatedWidth(c).map(min(mw, _)).getOrElse(mw)
+      case ColumnMeta(c, _, _, true, VariableColumnWidth(_, mw), _, _) =>
+        calculatedWidth(c).map(max(mw, _)).getOrElse(mw)
     }.sum
 
   @tailrec
   private def discardUntilUnder(calculatedWidth: A => Option[Double], cols: List[ColumnMeta[A]], allowedWidth: Double): List[ColumnMeta[A]] = {
     val minWidth = minVarWidth(calculatedWidth, cols)
-    if (cols.isEmpty || minWidth < allowedWidth) {
+    val nonRemoveableCount = cols.count(c => c.removeable === 0 && c.visible)
+    if (cols.length <= nonRemoveableCount || minWidth < allowedWidth) {
       cols
     } else {
-      // Take the one with higher chance to be removed
-      val removeOne = cols.filter(_.removeable > 0).sortBy(_.removeable).lastOption
-      val updatedCols = cols.filterNot(c => removeOne.exists(_.column === c.column))
-      if (updatedCols.length === cols.length) {
-        cols
-      } else {
-        discardUntilUnder(calculatedWidth, updatedCols, allowedWidth)
+      // Take the one with higher chance to be removed and hide it
+      val hideOne = cols.filter(_.removeable > 0).filter(_.visible).sortBy(_.removeable).lastOption
+      hideOne match {
+        case None => cols
+        case Some(x) =>
+          val updatedCols = cols.map {
+            case c if x.column === c.column => ColumnMeta.visible.set(false)(c)
+            case c => c
+          }
+          discardUntilUnder(calculatedWidth, updatedCols, allowedWidth)
       }
     }
   }
@@ -134,25 +131,29 @@ final case class TableState[A: Eq](userModified:   UserModified,
   private def distributePercentages(
     s:               Size,
     calculatedWidth: A => Option[Double]): TableState[A] =
-    if (isModified) {
+    if (isModified || s.width === 0) {
       // If we have been modified don't redistribute
       this
     } else {
       // list of visible columns
-      val visibleCols = columns.toList.filter(_.visible)
+      val visibleCols = columns.toList
       // Width according to the suggested sizes
       val requestedWidth = visibleCols.collect {
-        case ColumnMeta(c, _, _, _, FixedColumnWidth(w), _, _) =>
+        case ColumnMeta(c, _, _, true, FixedColumnWidth(w), _, _) =>
           calculatedWidth(c).getOrElse(w)
-        case ColumnMeta(c, _, _, _, VariableColumnWidth(_, mw), _, _) =>
+        case ColumnMeta(c, _, _, true, VariableColumnWidth(_, mw), _, _) =>
           calculatedWidth(c).map(max(mw, _)).getOrElse(mw)
       }.sum
+      println("requestedWidth")
+      println(requestedWidth)
       val minWidth = minVarWidth(calculatedWidth, visibleCols)
-      val totalVariableWidth = s.width - fixedWidth
+      val totalVariableWidth = s.width - fixedWidth(calculatedWidth)
+      // val cs = visibleCols.toList.map(_.column).mkString(",")
+      // println(cs)
       val cols  =
         if (totalVariableWidth > requestedWidth) {
-          // There is extra space on the, lets distribute it among the cols
-          val unallocatedWidth = totalVariableWidth - requestedWidth
+          // There is extra space on the table, lets distribute it among the cols
+          val unallocatedWidth = totalVariableWidth - minWidth
           val weights = visibleCols.collect {
             case ColumnMeta(c, _, _, _, _, g, _) =>
               (c, g)
@@ -162,34 +163,40 @@ final case class TableState[A: Eq](userModified:   UserModified,
           // a segment is pixels per weight
           val segment = (unallocatedWidth / weightsSum)
           visibleCols.map {
-            case m @ ColumnMeta(c, _, _, _, FixedColumnWidth(w), _, _) =>
+            case m @ ColumnMeta(c, _, _, true, FixedColumnWidth(w), _, _) =>
               ColumnMeta.width[A].set(FixedColumnWidth.unsafeFromDouble(calculatedWidth(c).getOrElse(w)))(m)
-            case m @ ColumnMeta(c, _, _, _, VariableColumnWidth(_, mw), g, _) =>
+            case m @ ColumnMeta(c, _, _, true, VariableColumnWidth(w, mw), g, _) =>
               val vc = VariableColumnWidth(
                 calculatedWidth(c)
-                  .map(w => (w + g * segment) / totalVariableWidth)
-                  .getOrElse(mw / totalVariableWidth), mw)
+                  .map(w => (max(w, mw) + g * segment) / totalVariableWidth)
+                  .getOrElse(w), mw)
               ColumnMeta.width[A].set(vc)(m)
             case x => x
           }
         } else {
           // There is less space on the table, we need to shrink
+          // println("Drop")
           // Lets drop columns if needed
-          val actuallyVisibleCols = if (totalVariableWidth < minWidth && s.width > 0) {
+          val reducedVisibleCols = if (totalVariableWidth < minWidth && s.width > 0) {
             discardUntilUnder(calculatedWidth, visibleCols, totalVariableWidth)
           } else {
             visibleCols
           }
+          // println(reducedVisibleCols.length)
+          // println(reducedVisibleCols.map(x => s"${x.column} -> ${x.width}").mkString(","))
           // Update the columns with the correct percentage.
-          actuallyVisibleCols.map {
-            case m @ ColumnMeta(c, _, _, _, FixedColumnWidth(w), _, _) =>
+          reducedVisibleCols.map {
+            case m @ ColumnMeta(c, _, _, true, FixedColumnWidth(w), _, _) =>
               ColumnMeta.width[A].set(
                 FixedColumnWidth.unsafeFromDouble(
                   calculatedWidth(c).getOrElse(w)))(m)
-            case m @ ColumnMeta(c, _, _, true, VariableColumnWidth(_, mw), _, _) =>
+            case m @ ColumnMeta(c, _, _, true, VariableColumnWidth(w, mw), _, _) =>
+              // println(c)
+              // println(calculatedWidth(c).map(w => min(1.0, max(w, mw) / totalVariableWidth)))
               val vc = VariableColumnWidth(calculatedWidth(c)
-                                             .map(_ / requestedWidth)
-                                             .getOrElse(mw / requestedWidth), mw)
+                  .map(w => min(1.0, max(w, mw) / totalVariableWidth))
+                                             .getOrElse(w), mw)
+                                             println("done")
               ColumnMeta.width[A].set(vc)(m)
             case x => x
           }
@@ -212,7 +219,8 @@ final case class TableState[A: Eq](userModified:   UserModified,
 
     val ts = vc.normalizeColumnWidths(s)
     // recalculate as the widths way have varied
-    val fixedWidth = ts.fixedWidth
+    val fixedWidth = ts.fixedWidth(calculatedWidth)
+    println(s"Builder")
     ts.columns.toList.zipWithIndex
       .map {
         case (m @ ColumnMeta(_, _, _, true, FixedColumnWidth(w), _, _), i) =>
@@ -227,11 +235,69 @@ final case class TableState[A: Eq](userModified:   UserModified,
         case _ =>
           None
       }
-      .collect { case Some(c) => c }
+      .mapFilter(identity)
   }
 
   // Table can call this to build the columns
-  def columnBuilderB(
+  def columnBuilder2(
+    s:               Size,
+    calculatedWidth: A => Option[Double],
+    cb:              ColumnRenderArgs[A] => Table.ColumnArg
+  ): List[Table.ColumnArg] = {
+    val fw = fixedWidth(calculatedWidth)
+    val vcl = columns.count(_.visible)
+    columns.toList.zipWithIndex
+      .map {
+        case (m @ ColumnMeta(_, _, _, true, FixedColumnWidth(w), _, _), i) =>
+          cb(ColumnRenderArgs(m, i, w, false)).some
+
+        case (m @ ColumnMeta(_, _, _, true, VariableColumnWidth(p, mw), _, _),
+              i) =>
+          val beforeLast = i < (vcl - 1)
+          val w          = max((s.width - fw) * p, mw)
+          cb(ColumnRenderArgs(m, i, w, beforeLast)).some
+
+        case _ =>
+          None
+      }
+      .mapFilter(identity)
+  }
+
+  def printCols: String =
+    columns.toList.map {
+      case ColumnMeta(c, _, _, _, FixedColumnWidth(w), _, _) =>
+        s"$c -> Fix: $w"
+      case ColumnMeta(c, _, _, _, VariableColumnWidth(w, mw), _, _) =>
+        s"$c -> Var: $w $mw"
+    }.mkString(",")
+
+  def printVisibleCols: String =
+    columns.toList.filter(_.visible).map {
+      case ColumnMeta(c, _, _, _, FixedColumnWidth(w), _, _) =>
+        s"$c -> Fix: $w"
+      case ColumnMeta(c, _, _, _, VariableColumnWidth(w, mw), _, _) =>
+        s"$c -> Var: $w $mw"
+    }.mkString(",")
+
+  // Reset all the columns to be visible
+  private def resetVisibleColumns: TableState[A] =
+    (TableState.columns[A] ^|->> each ^|-> ColumnMeta.visible).set(true)(this)
+
+  // Table can call this to build the columns
+  def recalculateWidths(
+    s:               Size,
+    visibleCols:     A => Boolean,
+    calculatedWidth: A => Option[Double]
+  ): TableState[A] = {
+    println("recal")
+    resetVisibleColumns
+      .withVisibleCols(visibleCols)
+      .distributePercentages(s, calculatedWidth)
+      .normalizeColumnWidths(s)
+    }
+
+  // Table can call this to build the columns
+  def columnBuilderC(
     s:  Size,
     cb: ColumnRenderArgs[A] => Table.ColumnArg
   ): List[Table.ColumnArg] =
@@ -246,15 +312,14 @@ final case class TableState[A: Eq](userModified:   UserModified,
         case ColumnMeta(_, _, _, true, VariableColumnWidth(p, _), _, _) =>
           p
       }.sum
-      val k = (TableState
-        .columns[A]
-        .modify(_.map {
+      (TableState
+        .columns[A] ^|->> each)
+        .modify{
           case c @ ColumnMeta(_, _, _, true, VariableColumnWidth(p, min), _, _) =>
             c.copy(width = VariableColumnWidth(p / percentagesSum, min))
           case c =>
             c
-        }))(this)
-      k
+        }(this)
     } else {
       this
     }
@@ -263,13 +328,17 @@ final case class TableState[A: Eq](userModified:   UserModified,
     column:      A,
     s:           Size,
     visibleCols: A => Boolean,
+    calculatedWidth: A => Option[Double],
     cb:          TableState[A] => Callback
   ): (String, JsNumber) => Callback =
     (_, dx) => {
-      val delta = dx.toDouble / (s.width - fixedWidth)
+      val delta = dx.toDouble / (s.width - fixedWidth(calculatedWidth))
+      // println(pr.mkString(","))
       val st = withVisibleCols(visibleCols)
         .normalizeColumnWidths(s)
-        .applyOffset(column, delta, s)
+        .applyOffset(calculatedWidth, column, delta, s)
+      println("after")
+      // println(pr3.mkString(","))
       cb(st)
     }
 
@@ -278,7 +347,7 @@ final case class TableState[A: Eq](userModified:   UserModified,
     s:      Size,
     cb:     TableState[A] => Callback
   ): (String, JsNumber) => Callback =
-    resizeRow(column, s, TableState.AllColsVisible, cb)
+    resizeRow(column, s, TableState.AllColsVisible, _ => none, cb)
 }
 
 object TableState {
@@ -288,6 +357,9 @@ object TableState {
 
   implicit def eqTs[A: Eq]: Eq[TableState[A]] =
     Eq.by(x => (x.userModified, x.scrollPosition.toDouble, x.columns))
+
+  implicit val eqSize: Eq[Size] =
+    Eq.by(x => (x.width, x.height))
 
   def userModified[A: Eq]: Lens[TableState[A], UserModified] =
     Lens[TableState[A], UserModified](_.userModified)(n =>

--- a/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
@@ -75,7 +75,7 @@ final case class TableState[A: Eq](userModified:   UserModified,
           }
 
           if (nextCanChange && newWidth <= s.width) {
-            println(s"Next change $curPct $actualPct")
+            // println(s"Next change $curPct $actualPct")
             ColumnMeta.width.set(VariableColumnWidth(actualPct, min))(c)
           } else {
             c
@@ -93,7 +93,7 @@ final case class TableState[A: Eq](userModified:   UserModified,
           }
 
           if (prevCanChange && newWidth <= width) {
-            println("Prev change")
+            // println("Prev change")
             ColumnMeta.width.set(VariableColumnWidth(actualPct, min))(c)
           } else {
             c
@@ -129,6 +129,9 @@ final case class TableState[A: Eq](userModified:   UserModified,
           "org.wartremover.warts.Throw"))
   def distributePercentages(
     calculatedWidth: A => Option[Double]): TableState[A] = {
+      if (isModified) {
+        this
+      } else {
     val visibleCols = columns.toList.filter(_.visible)
     val sumWidth = visibleCols.map {
       case ColumnMeta(c, _, _, true, FixedColumnWidth(w)) =>
@@ -136,12 +139,12 @@ final case class TableState[A: Eq](userModified:   UserModified,
       case ColumnMeta(c, _, _, true, VariableColumnWidth(_, mw)) =>
         calculatedWidth(c).getOrElse(mw)
     }.sum
-    println(sumWidth)
+    // println(sumWidth)
     val cols = visibleCols.map {
       case m @ ColumnMeta(c, _, _, true, FixedColumnWidth(w)) =>
         val u = ColumnMeta.width.set(
           FixedColumnWidth.unsafeFromDouble(calculatedWidth(c).getOrElse(w)))(m)
-        println(s"Dist $c ${calculatedWidth(c)} $u")
+        // println(s"Dist $c ${calculatedWidth(c)} $u")
 
         u
       case m @ ColumnMeta(c, _, _, true, VariableColumnWidth(_, mw)) =>
@@ -151,6 +154,7 @@ final case class TableState[A: Eq](userModified:   UserModified,
         ColumnMeta.width.set(vc)(m)
     }
     copy(columns = NonEmptyList.fromListUnsafe(cols))
+  }
   }
 
   // Table can call this to build the columns
@@ -170,13 +174,13 @@ final case class TableState[A: Eq](userModified:   UserModified,
     ts.columns.toList.zipWithIndex
       .map {
         case (m @ ColumnMeta(_, _, _, true, FixedColumnWidth(w)), i) =>
-          println(s"Fixed ${m.column} $w")
+          // println(s"Fixed ${m.column} $w")
           cb(ColumnRenderArgs(m, i, w, false)).some
 
         case (m @ ColumnMeta(_, _, _, true, VariableColumnWidth(p, mw)), i) =>
           val beforeLast = i < (vcl - 1)
           val w          = max((s.width - fixedWidth) * p, mw)
-          println(s"Variable ${m.column} $p width: $w, $mw")
+          // println(s"Variable ${m.column} $p width: $w, $mw")
           cb(ColumnRenderArgs(m, i, w, beforeLast)).some
 
         case _ =>

--- a/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/TableState.scala
@@ -20,6 +20,8 @@ final case class TableState[A: Eq](userModified:   UserModified,
                                    scrollPosition: JsNumber,
                                    columns:        NonEmptyList[ColumnMeta[A]]) {
 
+  val isModified: Boolean = userModified === IsModified
+
   // Reset visibility given the filters
   private def withVisibleCols(visibleFilter: (Size, A) => Boolean,
                               s:             Size): TableState[A] =
@@ -73,6 +75,7 @@ final case class TableState[A: Eq](userModified:   UserModified,
           }
 
           if (nextCanChange && newWidth <= s.width) {
+            println(s"Next change $curPct $actualPct")
             ColumnMeta.width.set(VariableColumnWidth(actualPct, min))(c)
           } else {
             c
@@ -90,6 +93,7 @@ final case class TableState[A: Eq](userModified:   UserModified,
           }
 
           if (prevCanChange && newWidth <= width) {
+            println("Prev change")
             ColumnMeta.width.set(VariableColumnWidth(actualPct, min))(c)
           } else {
             c
@@ -160,7 +164,6 @@ final case class TableState[A: Eq](userModified:   UserModified,
       withVisibleCols(visibleCols, s).distributePercentages(calculatedWidth)
     val vcl = vc.columns.count(_.visible)
 
-    // vc.normalizeColumnWidths(s).columns.toList.foreach(println)
     val ts = vc.normalizeColumnWidths(s)
     // recalculate as the widths way have varied
     val fixedWidth = ts.fixedWidth

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -12,6 +12,8 @@ import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.React
 import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.extra._
+import monocle.macros.Lenses
 import org.scalajs.dom.MouseEvent
 import scala.scalajs.js
 import js.JSConverters._
@@ -33,12 +35,14 @@ package table {
   /**
     * Metadata for a column
     */
+  @Lenses
   final case class ColumnMeta[A](column:  A,
                                  name:    String,
                                  label:   String,
                                  visible: Boolean,
                                  width:   ColumnWidth)
 
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   object ColumnMeta {
     implicit def eqCm[A: Eq]: Eq[ColumnMeta[A]] =
       Eq.by(x => (x.column, x.name, x.label, x.visible, x.width))
@@ -52,6 +56,12 @@ package table {
 package object table {
   val DragHandleWidth: Int = 12
 
+  private implicit val doubleReuse: Reusability[Double] =
+    Reusability.double(0.01)
+
+  implicit val sizeReuse: Reusability[Size] =
+    Reusability.by(x => (x.width, x.height))
+
   implicit def nelR[A: Reusability]: Reusability[NonEmptyList[A]] =
     Reusability.by(_.toList)
 
@@ -60,7 +70,7 @@ package object table {
 
   // Renderer for a resizable column
   def resizableHeaderRenderer(
-    rs: (String, JsNumber) => Callback): HeaderRenderer[js.Object] =
+    rs: => (String, JsNumber) => Callback): HeaderRenderer[js.Object] =
     (_, dataKey: String, _, label: VdomNode, _, _) =>
       React.Fragment.withKey(dataKey)(
         <.div(

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -36,7 +36,7 @@ package object table {
     Reusability.by(_.toList)
 
   implicit def tsR[A: Reusability]: Reusability[TableState[A]] =
-    Reusability.derive[TableState[A]]
+    Reusability.by(x => (x.userModified, x.scrollPosition, x.columns))
 
   // Renderer for a resizable column
   def resizableHeaderRenderer(

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -3,7 +3,6 @@
 
 package web.client
 
-import cats.Eq
 import cats.Monoid
 import cats.data.NonEmptyList
 import cats.implicits._
@@ -13,7 +12,6 @@ import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.React
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.extra._
-import monocle.macros.Lenses
 import org.scalajs.dom.MouseEvent
 import scala.scalajs.js
 import js.JSConverters._
@@ -24,34 +22,6 @@ import react.common.syntax._
 import react.sortable._
 import react.draggable._
 import web.client.utils._
-
-package table {
-
-  final case class ColumnRenderArgs[A](meta:      ColumnMeta[A],
-                                       index:     Int,
-                                       width:     JsNumber,
-                                       resizable: Boolean)
-
-  /**
-    * Metadata for a column
-    */
-  @Lenses
-  final case class ColumnMeta[A](column:  A,
-                                 name:    String,
-                                 label:   String,
-                                 visible: Boolean,
-                                 width:   ColumnWidth)
-
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  object ColumnMeta {
-    implicit def eqCm[A: Eq]: Eq[ColumnMeta[A]] =
-      Eq.by(x => (x.column, x.name, x.label, x.visible, x.width))
-
-    implicit def reuse[A: Reusability]: Reusability[ColumnMeta[A]] =
-      Reusability.derive[ColumnMeta[A]]
-  }
-
-}
 
 package object table {
   val DragHandleWidth: Int = 12

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableArbitraries.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableArbitraries.scala
@@ -28,26 +28,26 @@ trait TableArbitraries {
   implicit val fixedColumnWidthCogen: Cogen[FixedColumnWidth] =
     Cogen[Double].contramap(_.width)
 
-  val genPercentageColumnWidth: Gen[PercentageColumnWidth] =
+  val genVariableColumnWidth: Gen[VariableColumnWidth] =
     for {
-      p <- Gen.choose[Double](0, 1)
+      w <- Gen.choose[Double](0, 100)
       m <- Gen.choose[Double](0, 100)
-    } yield PercentageColumnWidth(p, m)
+    } yield VariableColumnWidth.unsafeFromDouble(w, m)
 
-  implicit val percentageColumnWidthArb: Arbitrary[PercentageColumnWidth] =
-    Arbitrary(genPercentageColumnWidth)
+  implicit val VariableColumnWidthArb: Arbitrary[VariableColumnWidth] =
+    Arbitrary(genVariableColumnWidth)
 
-  implicit val percentColumnWidthCogen: Cogen[PercentageColumnWidth] =
-    Cogen[Double].contramap(_.percentage)
+  implicit val percentColumnWidthCogen: Cogen[VariableColumnWidth] =
+    Cogen[(Double, Double)].contramap(x => (x.percentage, x.minWidth))
 
   implicit val arbColumnWidth: Arbitrary[ColumnWidth] = Arbitrary {
-    Gen.oneOf(genFixedColumnWidth, genPercentageColumnWidth)
+    Gen.oneOf(genFixedColumnWidth, genVariableColumnWidth)
   }
 
   implicit val columnWidthCogen: Cogen[ColumnWidth] =
-    Cogen[Either[FixedColumnWidth, PercentageColumnWidth]].contramap {
+    Cogen[Either[FixedColumnWidth, VariableColumnWidth]].contramap {
       case x: FixedColumnWidth      => x.asLeft
-      case x: PercentageColumnWidth => x.asRight
+      case x: VariableColumnWidth => x.asRight
     }
 
   implicit val arbJsNumber: Arbitrary[JsNumber] = Arbitrary {

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableArbitraries.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableArbitraries.scala
@@ -30,8 +30,8 @@ trait TableArbitraries {
 
   val genVariableColumnWidth: Gen[VariableColumnWidth] =
     for {
-      w <- Gen.choose[Double](0, 100)
-      m <- Gen.choose[Double](0, 100)
+      w <- Gen.choose[Double](0, 1)
+      m <- Gen.choose[Double](0, 1)
     } yield VariableColumnWidth.unsafeFromDouble(w, m)
 
   implicit val VariableColumnWidthArb: Arbitrary[VariableColumnWidth] =

--- a/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
+++ b/modules/shared/web/client/src/test/scala/web/client/table/TableSpec.scala
@@ -10,7 +10,7 @@ import monocle.law.discipline.LensTests
 final class TableSpec extends CatsSuite with TableArbitraries {
   checkAll("Eq[UserModified]", EqTests[UserModified].eqv)
   checkAll("Eq[FixedColumnWidth]", EqTests[FixedColumnWidth].eqv)
-  checkAll("Eq[PercentageColumnWidth]", EqTests[PercentageColumnWidth].eqv)
+  checkAll("Eq[VariableColumnWidth]", EqTests[VariableColumnWidth].eqv)
   checkAll("Eq[ColumnWidth]", EqTests[ColumnWidth].eqv)
   checkAll("Eq[ColumnMeta[Int]]", EqTests[ColumnMeta[Int]].eqv)
   checkAll("Eq[TableState[Int]]", EqTests[TableState[Int]].eqv)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -68,7 +68,7 @@ object Settings {
     val scalaVersion = "2.12.8"
 
     // ScalaJS libraries
-    val scalaDom                = "0.9.6"
+    val scalaDom                = "0.9.7"
     val scalajsReact            = "1.3.1"
     val booPickle               = "1.3.0"
     val diode                   = "1.1.4"
@@ -78,7 +78,7 @@ object Settings {
     val scalaJSReactCommon      = "0.1.0"
     val scalaJSReactVirtualized = "0.5.0"
     val scalaJSReactClipboard   = "0.6.1"
-    val scalaJSReactDraggable   = "0.3.2"
+    val scalaJSReactDraggable   = "0.3.3"
     val scalaJSReactSortable    = "0.1.2"
 
     // Scala libraries
@@ -88,8 +88,8 @@ object Settings {
     val fs2Version              = "1.0.4"
     val shapelessVersion        = "2.3.3"
     val attoVersion             = "0.6.5"
-    val scalaParsersVersion     = "1.1.1"
-    val scalaXmlVerson          = "1.1.1"
+    val scalaParsersVersion     = "1.1.2"
+    val scalaXmlVerson          = "1.2.0"
 
     val http4sVersion           = "0.20.0"
     val squants                 = "1.4.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -45,4 +45,4 @@ addSbtPlugin("ch.epfl.scala"      % "sbt-scalajs-bundler"      % "0.14.0")
 addSbtPlugin("net.virtual-void"   % "sbt-dependency-graph"     % "0.9.0")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.3.4")
 
-onLoad in Global := { s => "dependencyUpdates" :: s }
+// onLoad in Global := { s => "dependencyUpdates" :: s }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -45,4 +45,4 @@ addSbtPlugin("ch.epfl.scala"      % "sbt-scalajs-bundler"      % "0.14.0")
 addSbtPlugin("net.virtual-void"   % "sbt-dependency-graph"     % "0.9.0")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.3.4")
 
-// onLoad in Global := { s => "dependencyUpdates" :: s }
+onLoad in Global := { s => "dependencyUpdates" :: s }


### PR DESCRIPTION
This started as a smallish task and become a large refactoring

On the tables with variable content we make a guess of how wide it is thus chopping it sometimes. This PR will try to calculate the width and use that. Additionally we enable resizing the columns on the step table (SEQNG-987)
![screencast 2019-05-08 16-33-23](https://user-images.githubusercontent.com/3615303/57407440-30008000-71b1-11e9-8425-803146f8ff0b.gif)

Along the way I discovered multiple opportunities for improvement including:
* Remove of duplicated components
* Standardize how all the tables are built
* Automate showing/hiding columns on window resizes

There are a few small regressions which will be addressed in future work