### PR TITLE
Upgrade scalajs-react to 1.4.2 and react to 16.7.0

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
@@ -10,7 +10,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import seqexec.web.client.actions.SelectCalibrationQueue
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.model.WebSocketConnection

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -11,7 +11,7 @@ import gem.enum.Site
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.vdom.html_<^._
 import java.time.Instant

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -8,7 +8,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import gem.enum.Site
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.model.Pages._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
@@ -87,7 +87,7 @@ object SeqexecUI {
         .onPostRender((_, next) =>
           Callback.when(next === SoundTest)(SeqexecCircuit.dispatchCB(RequestSoundEcho)) *>
           Callback.when(next =!= SeqexecCircuit.zoom(_.uiModel.navLocation).value)(SeqexecCircuit.dispatchCB(NavigateSilentTo(next))))
-        .renderWith { case (_, r) => <.div(r.render()).render}
+        .renderWith { case (_, r) => <.div(r.render()) }
         .setTitle(pageTitle(site))
         .logToConsole
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueArea.scala
@@ -9,7 +9,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.router.RouterCtl
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import web.client.style._
 
 /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -12,7 +12,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.raw.JsNumber

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTableFilter.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTableFilter.scala
@@ -8,7 +8,7 @@ import seqexec.web.client.circuit._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import seqexec.web.client.model.SessionQueueFilter
 import seqexec.web.client.model.ObsClass
 import seqexec.web.client.actions.UpdateSessionFilter

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SoundControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SoundControl.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.actions.FlipSoundOnOff
 import seqexec.web.client.model.SoundSelection

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/TableContainer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/TableContainer.scala
@@ -7,7 +7,7 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import react.virtualized._
 import web.client.style._
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/UserNotificationBox.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/UserNotificationBox.scala
@@ -5,7 +5,7 @@ package seqexec.web.client.components
 
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.component.Scala.Unmounted
 import seqexec.model.Notification
 import seqexec.web.client.semanticui.elements.icon.Icon.IconCheckmark

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import seqexec.model.CalibrationQueueId
 import seqexec.web.client.semanticui._
 import seqexec.web.client.semanticui.elements.message.IconMessage

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -13,7 +13,7 @@ import japgolly.scalajs.react.CallbackTo
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.extra.TimerSupport
 import monocle.macros.Lenses

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueToolbar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueToolbar.scala
@@ -8,7 +8,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import seqexec.model.QueueId
 import seqexec.web.client.circuit._
 import seqexec.web.client.actions.RequestAllSelectedSequences

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
@@ -8,7 +8,7 @@ import gem.Observation
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.extra.TimerSupport
 import monocle.macros.Lenses
 import seqexec.model.dhs.ImageFileId

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import seqexec.model.Step
 import seqexec.model.OffsetAxis
 import seqexec.web.client.model.StepItems._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/RunFromStep.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/RunFromStep.scala
@@ -5,7 +5,7 @@ package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ScalaComponent

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
@@ -8,7 +8,7 @@ import diode.react.ReactConnectProxy
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
 import seqexec.model.Step
 import seqexec.web.client.circuit._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
@@ -6,7 +6,7 @@ package seqexec.web.client.components.sequence.steps
 import gem.Observation
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import seqexec.model.Step
 import seqexec.web.client.actions.FlipSkipStep

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -11,7 +11,7 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import cats.implicits._
 import react.virtualized._
 import scala.scalajs.js

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -8,7 +8,7 @@ import gem.Observation
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.ActionStatus
 import seqexec.model.enum.Resource

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -6,7 +6,7 @@ package seqexec.web.client.components.sequence.steps
 import cats.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import gem.Observation

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client.components.sequence.steps
 
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ScalaComponent

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -13,7 +13,7 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.component.builder.Lifecycle.ComponentWillReceiveProps
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.raw.JsNumber
 import monocle.Lens

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
@@ -6,7 +6,7 @@ package seqexec.web.client.components.sequence.steps
 import cats.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import gem.Observation
 import seqexec.model.Step

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -9,8 +9,8 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.ReactEvent
-import japgolly.scalajs.react.extra.Reusability
-import japgolly.scalajs.react.extra.Reusability._
+import japgolly.scalajs.react.Reusability
+import japgolly.scalajs.react.Reusability._
 import gem.Observation
 
 import scala.collection.immutable.SortedMap

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceControl.scala
@@ -8,7 +8,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import gem.Observation
 import mouse.all._
 import seqexec.web.client.circuit._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/CalibrationQueueTab.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/CalibrationQueueTab.scala
@@ -9,7 +9,7 @@ import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react._
 import monocle.macros.Lenses

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SeqexecTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SeqexecTabs.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react._
 import seqexec.model.SequenceState
 import seqexec.web.client.model.Pages._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SequenceTab.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SequenceTab.scala
@@ -9,7 +9,7 @@ import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react._
 import seqexec.model.Observer
 import seqexec.model.SequenceState

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/TabsArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/TabsArea.scala
@@ -8,7 +8,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.React
 import japgolly.scalajs.react.component.Scala.Unmounted
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages.SeqexecPages

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import gem.Observation
 import gem.enum.Site
 import japgolly.scalajs.react.CatsReact._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import scala.collection.immutable.SortedMap
 import seqexec.model.enum.ActionStatus
 import seqexec.model.enum.Instrument

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/icon/Icon.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/icon/Icon.scala
@@ -10,7 +10,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ReactEvent
 import japgolly.scalajs.react.ScalaComponent
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import scala.scalajs.js
 import web.client.style._
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/label/FormLabel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/label/FormLabel.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client.semanticui.elements.label
 
 import japgolly.scalajs.react.ScalaComponent
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/label/Label.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/label/Label.scala
@@ -6,7 +6,7 @@ package seqexec.web.client.semanticui.elements.label
 import seqexec.web.client.semanticui.Size
 import seqexec.web.client.semanticui.elements.icon.Icon
 import japgolly.scalajs.react.ScalaComponent
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import cats.implicits._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/modal/Header.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/modal/Header.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client.semanticui.elements.modal
 
 import japgolly.scalajs.react.ScalaComponent
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/size.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/size.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client.semanticui
 
 import cats.Eq
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 
 sealed trait Size
 

--- a/modules/shared/web/client/src/main/scala/web/client/style/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/style/package.scala
@@ -7,7 +7,7 @@ import cats.Eq
 import cats.Monoid
 import cats.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 
 package style {
   final case class GStyle(htmlClasses: List[String]) {

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnMeta.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnMeta.scala
@@ -5,7 +5,7 @@ package web.client.table
 
 import cats.Eq
 import cats.implicits._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import monocle.macros.Lenses
 
 /**

--- a/modules/shared/web/client/src/main/scala/web/client/table/ColumnWidth.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/ColumnWidth.scala
@@ -5,7 +5,7 @@ package web.client.table
 
 import cats.Eq
 import cats.implicits._
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.CatsReact._
 import mouse.boolean._
 

--- a/modules/shared/web/client/src/main/scala/web/client/table/UserModified.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/UserModified.scala
@@ -4,7 +4,7 @@
 package web.client.table
 
 import cats.Eq
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 
 sealed trait UserModified extends Product with Serializable
 case object IsModified    extends UserModified

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -11,8 +11,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.React
-import japgolly.scalajs.react.extra.Reusability
-import japgolly.scalajs.react.extra._
+import japgolly.scalajs.react.Reusability
 import org.scalajs.dom.MouseEvent
 import scala.scalajs.js
 import scala.math.max

--- a/modules/shared/web/client/src/main/scala/web/client/utils.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/utils.scala
@@ -4,7 +4,7 @@
 package web.client
 
 import japgolly.scalajs.react.raw.JsNumber
-import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.CatsReact._
 import org.scalajs.dom
 import org.scalajs.dom.html

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -69,17 +69,17 @@ object Settings {
 
     // ScalaJS libraries
     val scalaDom                = "0.9.7"
-    val scalajsReact            = "1.3.1"
+    val scalajsReact            = "1.4.2"
     val booPickle               = "1.3.0"
-    val diode                   = "1.1.4"
-    val diodeReact              = "1.1.4.131"
+    val diode                   = "1.1.5"
+    val diodeReact              = "1.1.5.142"
     val javaTimeJS              = "2.0.0-RC1"
     val scalaJQuery             = "1.2"
-    val scalaJSReactCommon      = "0.1.0"
-    val scalaJSReactVirtualized = "0.5.0"
-    val scalaJSReactClipboard   = "0.6.1"
-    val scalaJSReactDraggable   = "0.3.3"
-    val scalaJSReactSortable    = "0.1.2"
+    val scalaJSReactCommon      = "0.2.0"
+    val scalaJSReactVirtualized = "0.6.0b"
+    val scalaJSReactClipboard   = "0.7.0"
+    val scalaJSReactDraggable   = "0.4.0"
+    val scalaJSReactSortable    = "0.2.0"
 
     // Scala libraries
     val catsEffectVersion       = "1.3.0"
@@ -119,13 +119,13 @@ object Settings {
     val scalaMock               = "4.1.0"
 
     // Pure JS libraries
-    val reactJS                 = "16.5.1"
+    val reactJS                 = "16.7.0"
     val jQuery                  = "3.2.1"
     val semanticUI              = "2.3.1"
     val ocsVersion              = "2019101.1.3"
     val uglifyJs                = "1.2.4"
     val reactVirtualized        = "9.21.0"
-    val reactDraggable          = "3.1.1"
+    val reactDraggable          = "3.3.0"
 
     val apacheXMLRPC            = "3.1.3"
     val opencsv                 = "2.1"


### PR DESCRIPTION
I have been sitting on this upgrade for a while as dependencies (diode) weren't yet updated

With this PR we can upgrade no a newer react version