### PR TITLE
SEQNG-993/994: GPI Align & Calib

### DIFF
--- a/modules/core/shared/src/main/scala/gem/enum/GiapiStatusApply.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GiapiStatusApply.scala
@@ -48,10 +48,11 @@ object GiapiStatusApply {
   /** @group Constructors */ case object GpiPPM extends GiapiStatusApply("GpiPPM", Instrument.Gpi, GiapiType.String, "gpi:ppmMask", "gpi:selectPupilPlaneMask.maskStr")
   /** @group Constructors */ case object GpiFPM extends GiapiStatusApply("GpiFPM", Instrument.Gpi, GiapiType.String, "gpi:fpmMask", "gpi:selectFocalPlaneMask.maskStr")
   /** @group Constructors */ case object GpiLyot extends GiapiStatusApply("GpiLyot", Instrument.Gpi, GiapiType.String, "gpi:lyotMask", "gpi:selectLyotMask.maskStr")
+  /** @group Constructors */ case object GpiAlignAndCalib extends GiapiStatusApply("GpiAlignAndCalib", Instrument.Gpi, GiapiType.Int, "gpi:alignAndCalib.part1", "gpi:alignAndCalib.part1")
 
   /** All members of GiapiStatusApply, in canonical order. */
   val all: List[GiapiStatusApply] =
-    List(GpiAdc, GpiUseAo, GpiAoOptimize, GpiUseCal, GpiFpmPinholeBias, GpiIntegrationTime, GpiNumCoadds, GpiMagI, GpiMagH, GpiCalEntranceShutter, GpiCalReferenceShutter, GpiCalScienceShutter, GpiEntranceShutter, GpiCalExitShutter, GpiPupilCamera, GpiSCPower, GpiSCAttenuation, GpiSrcVis, GpiSrcIR, GpiPolarizerDeplay, GpiPolarizerAngle, GpiObservationMode, GpiIFSFilter, GpiPPM, GpiFPM, GpiLyot)
+    List(GpiAdc, GpiUseAo, GpiAoOptimize, GpiUseCal, GpiFpmPinholeBias, GpiIntegrationTime, GpiNumCoadds, GpiMagI, GpiMagH, GpiCalEntranceShutter, GpiCalReferenceShutter, GpiCalScienceShutter, GpiEntranceShutter, GpiCalExitShutter, GpiPupilCamera, GpiSCPower, GpiSCAttenuation, GpiSrcVis, GpiSrcIR, GpiPolarizerDeplay, GpiPolarizerAngle, GpiObservationMode, GpiIFSFilter, GpiPPM, GpiFPM, GpiLyot, GpiAlignAndCalib)
 
   /** Select the member of GiapiStatusApply with the given tag, if any. */
   def fromTag(s: String): Option[GiapiStatusApply] =

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
@@ -44,6 +44,8 @@ sealed trait GpiClient[F[_]] extends GiapiClient[F] {
 
 
 object GpiClient {
+  val ALIGN_AND_CALIB_DEFAULT_MODE: Int = 4
+
   /**
     * Client for GPI
     */
@@ -51,8 +53,6 @@ object GpiClient {
                                           val statusDb:       GiapiStatusDb[F])
       extends GpiClient[F] {
     import GiapiClient.DefaultCommandTimeout
-
-    private val ALIGN_AND_CALIB_DEFAULT_MODE: Int = 4
 
     ///////////////
     // Status items

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -479,8 +479,10 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
               LightPath(TcsController.LightSource.AO, sys.sfName(config)),
               extractWavelength(config)),
             Gcal(systems.gcal, site == Site.GS)
-        )}
+        )
 
+      case AlignAndCalib         => List(sys).asRight
+      
       case _                     => TrySeq.fail(Unexpected(s"Unsupported step type $stepType"))
     }
   }
@@ -603,10 +605,6 @@ object SeqTranslate {
   def apply(site: Site, systems: Systems[IO], settings: TranslateSettings): SeqTranslate =
     new SeqTranslate(site, systems, settings)
 
-  private sealed trait StepType {
-    val instrument: Instrument
-  }
-
   private def extractInstrument(config: Config): TrySeq[Instrument] = {
     config.extractAs[String](INSTRUMENT_KEY / INSTRUMENT_NAME_PROP).asTrySeq.flatMap {
       case Flamingos2.name => TrySeq(Instrument.F2)
@@ -622,15 +620,11 @@ object SeqTranslate {
     }
   }
 
-  private final case class CelestialObject(override val instrument: Instrument) extends StepType
-  private final case class Dark(override val instrument: Instrument) extends StepType
-  private final case class NodAndShuffle(override val instrument: Instrument) extends StepType
-  private final case class Gems(override val instrument: Instrument) extends StepType
-  private final case class AltairObs(override val instrument: Instrument) extends StepType
-  private final case class FlatOrArc(override val instrument: Instrument) extends StepType
-  private final case class DarkOrBias(override val instrument: Instrument) extends StepType
-  private case object AlignAndCalib extends StepType {
-    override val instrument: Instrument = Instrument.Gpi
+  def isAlignAndCalib(config: Config): Option[StepType] = {
+    (config.extractAs[String](INSTRUMENT_KEY / INSTRUMENT_NAME_PROP), config.extractAs[String](OBSERVE_KEY / OBS_CLASS_PROP)).mapN {
+      case (Gpi.name, _) => {println("Abc");AlignAndCalib.some}
+      case _ => none
+    }.toOption.flatten
   }
 
   private def calcStepType(config: Config): TrySeq[StepType] = {
@@ -643,15 +637,17 @@ object SeqTranslate {
       case _                                                      => TrySeq.fail(Unexpected("Logical error reading AO system name"))
     }
 
-    (config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP).leftMap(explainExtractError), extractInstrument(config)).mapN { (obsType, inst) =>
-      obsType match {
-        case SCIENCE_OBSERVE_TYPE                     => extractGaos(inst)
-        case BIAS_OBSERVE_TYPE | DARK_OBSERVE_TYPE    => TrySeq(DarkOrBias(inst))
-        case FLAT_OBSERVE_TYPE | ARC_OBSERVE_TYPE | CAL_OBSERVE_TYPE
-                                                      => TrySeq(FlatOrArc(inst))
-        case _                                        => TrySeq.fail(Unexpected("Unknown step type " + obsType))
-      }
-    }.flatten
+    isAlignAndCalib(config).map(_.asRight[SeqexecFailure]).getOrElse {
+      (config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP).leftMap(explainExtractError), extractInstrument(config)).mapN { (obsType, inst) =>
+        obsType match {
+          case SCIENCE_OBSERVE_TYPE                     => extractGaos(inst)
+          case BIAS_OBSERVE_TYPE | DARK_OBSERVE_TYPE    => TrySeq(DarkOrBias(inst))
+          case FLAT_OBSERVE_TYPE | ARC_OBSERVE_TYPE | CAL_OBSERVE_TYPE
+                                                        => TrySeq(FlatOrArc(inst))
+          case _                                        => TrySeq.fail(Unexpected("Unknown step type " + obsType))
+        }
+      }.flatten
+    }
   }
 
   implicit class ResponseToResult(val r: Either[SeqexecFailure, Response]) extends AnyVal {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
@@ -7,6 +7,7 @@ import seqexec.model.enum.Instrument
 
 sealed trait StepType {
   val instrument: Instrument
+  val includesObserve: Boolean = true
 }
 
 final case class CelestialObject(override val instrument: Instrument) extends StepType
@@ -18,4 +19,5 @@ final case class FlatOrArc(override val instrument: Instrument) extends StepType
 final case class DarkOrBias(override val instrument: Instrument) extends StepType
 case object AlignAndCalib extends StepType {
   override val instrument: Instrument = Instrument.Gpi
+  override val includesObserve: Boolean = false
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import seqexec.model.enum.Instrument
+
+sealed trait StepType {
+  val instrument: Instrument
+}
+
+final case class CelestialObject(override val instrument: Instrument) extends StepType
+final case class Dark(override val instrument: Instrument) extends StepType
+final case class NodAndShuffle(override val instrument: Instrument) extends StepType
+final case class Gems(override val instrument: Instrument) extends StepType
+final case class AltairObs(override val instrument: Instrument) extends StepType
+final case class FlatOrArc(override val instrument: Instrument) extends StepType
+final case class DarkOrBias(override val instrument: Instrument) extends StepType
+case object AlignAndCalib extends StepType {
+  override val instrument: Instrument = Instrument.Gpi
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
@@ -107,7 +107,7 @@ object RegularGpiConfig extends GpiConfigEq {
 
 case object AlignAndCalibConfig extends GpiConfig {
   val config: Configuration =
-    Configuration.single("gpi:alignAndCalib.part1", GpiClient.ALIGN_AND_CALIB_DEFAULT_MODE)
+    Configuration.single(GpiAlignAndCalib.applyItem, GpiClient.ALIGN_AND_CALIB_DEFAULT_MODE)
 
   override def toString: String = s"$config"
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiStatusApply.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiStatusApply.scala
@@ -40,7 +40,7 @@ object GpiStatusApply extends GpiLookupTables {
     * falsely not set the obs mode
     */
   def overrideObsMode[F[_]: Sync](db:        GiapiStatusDb[F],
-                                  gpiConfig: GpiConfig,
+                                  gpiConfig: RegularGpiConfig,
                                   config:    Configuration): F[Configuration] =
     gpiConfig.mode match {
       case Right(_) => config.pure[F]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -155,7 +155,6 @@ package object server {
     Eq[Int].contramap(_.ordinal())
 
   type TrySeq[A]                 = Either[SeqexecFailure, A]
-  type ApplicativeErrorSeq[F[_]] = ApplicativeError[F, SeqexecFailure]
 
   object TrySeq {
     def apply[A](a: A): TrySeq[A]              = Either.right(a)
@@ -225,11 +224,6 @@ package object server {
   implicit class StreamIOOps[A](s: Stream[IO, A]) {
     def streamLiftIO[F[_]: LiftIO]: fs2.Stream[F, A] =
       s.translate(λ[IO ~> F](_.to))
-  }
-
-  implicit class MoreDisjunctionOps[A, B](ab: Either[A, B]) {
-    def validationNel: ValidatedNel[A, B] =
-      ab.fold(a => Validated.Invalid(NonEmptyList.of(a)), b => Validated.Valid(b))
   }
 
   implicit class EitherTFailureOps[F[_]: MonadError[?[_], Throwable], A](s: EitherT[F, SeqexecFailure, A]) {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsKeywordReader.scala
@@ -210,7 +210,6 @@ object DummyTargetKeywordsReader {
 
     override def properMotionRA: F[Double] = 0.0.pure[F]
   }
-
 }
 
 object DummyTcsKeywordsReader {

--- a/modules/seqexec/server/src/test/scala/seqexec/server/gpi/GpiArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/gpi/GpiArbitraries.scala
@@ -95,7 +95,7 @@ trait GpiArbitraries extends ArbTime {
     Cogen[(LegacyApodizer, LegacyFPM, LegacyLyot, LegacyFilter)]
       .contramap(x => (x.apodizer, x.fpm, x.lyot, x.filter))
 
-  implicit val gpiConfigArb: Arbitrary[GpiConfig] = Arbitrary {
+  implicit val gpiConfigArb: Arbitrary[RegularGpiConfig] = Arbitrary {
     for {
       adc   <- arbitrary[LegacyAdc]
       exp   <- arbitrary[Duration]
@@ -107,7 +107,7 @@ trait GpiArbitraries extends ArbTime {
       asu   <- arbitrary[ArtificialSources]
       pc    <- arbitrary[LegacyPupilCamera]
       ao    <- arbitrary[AOFlags]
-    } yield GpiConfig(adc, exp, coa, mode, disp, dispA, shut, asu, pc, ao)
+    } yield RegularGpiConfig(adc, exp, coa, mode, disp, dispA, shut, asu, pc, ao)
   }
 
   implicit val adcCogen: Cogen[LegacyAdc] =
@@ -116,7 +116,7 @@ trait GpiArbitraries extends ArbTime {
     Cogen[String].contramap(_.displayValue)
   implicit val ppCogen: Cogen[LegacyPupilCamera] =
     Cogen[String].contramap(_.displayValue)
-  implicit val gpiConfigCogen: Cogen[GpiConfig] =
+  implicit val gpiConfigCogen: Cogen[RegularGpiConfig] =
     Cogen[(LegacyAdc,
        Duration,
        Int,

--- a/modules/seqexec/server/src/test/scala/seqexec/server/gpi/GpiSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/gpi/GpiSpec.scala
@@ -14,5 +14,5 @@ final class GpiSpec extends CatsSuite with GpiArbitraries {
   checkAll("Eq[ArtificialSources]", EqTests[ArtificialSources].eqv)
   checkAll("Eq[Shutters]", EqTests[Shutters].eqv)
   checkAll("Eq[NonStandardModeParams]", EqTests[NonStandardModeParams].eqv)
-  checkAll("Eq[GPIConfig]", EqTests[GpiConfig].eqv)
+  checkAll("Eq[GPIConfig]", EqTests[RegularGpiConfig].eqv)
 }

--- a/modules/sql/src/main/resources/db/migration/V071__Gpi_Align_And_Calib.sql
+++ b/modules/sql/src/main/resources/db/migration/V071__Gpi_Align_And_Calib.sql
@@ -1,0 +1,7 @@
+---------------------------
+-- Gpi status apply for Align and calib
+---------------------------
+
+INSERT INTO e_giapi_status_apply(id, instrument_id, type, status_item, apply_item)
+VALUES
+	('AlignAndCalib', 'Gpi', 'Int', 'gpi:alignAndCalib.part1', 'gpi:alignAndCalib.part1');


### PR DESCRIPTION
This PR adds support for GPI Align And Calib. 
It supports the current mode of operation where you have a special sequence with a calibration and A&C, but it also supports a mode where all the steps are in one sequence:

<img width="183" alt="Gemini OT -  GS-2018B-Q-0  Science Program 2019-05-27 17-06-43" src="https://user-images.githubusercontent.com/3615303/58508362-deb93000-8161-11e9-86a4-e8c1ae72c1da.png">

This mode could eventually simplify night time operations but needs testing

There is still work on UI and actual testing but the core functionality is done in this PR

![Seqexec - GS-2018B-Q-0-104 2019-05-28 14-37-18](https://user-images.githubusercontent.com/3615303/58508703-a36b3100-8162-11e9-814e-2858979d4005.png)
