### PR TITLE
SEQNG-998 Properly decide when the status step has changed for redrawing the UI

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
@@ -15,6 +15,7 @@ sealed trait Step {
   def skip: Boolean
   def fileId: Option[dhs.ImageFileId]
 }
+
 object Step {
   val Zero: Step = StandardStep(id = -1, config = Map.empty, status = StepState.Pending, breakpoint = false, skip = false, fileId = None, configStatus = Nil, observeStatus = ActionStatus.Pending)
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/StepState.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/StepState.scala
@@ -4,6 +4,7 @@
 package seqexec.model
 
 import cats.Eq
+import cats.implicits._
 
 sealed abstract class StepState(val canRunFrom: Boolean)
   extends Product with Serializable
@@ -18,6 +19,14 @@ object StepState {
         case object Paused              extends StepState(true)
 
   implicit val equal: Eq[StepState] =
-    Eq.fromUniversalEquals
+    Eq.instance {
+      case (Pending, Pending)     => true
+      case (Completed, Completed) => true
+      case (Skipped, Skipped)     => true
+      case (Failed(a), Failed(b)) => a === b
+      case (Running, Running)     => true
+      case (Paused, Paused)       => true
+      case _                      => false
+    }
 
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecModelArbitraries.scala
@@ -17,8 +17,9 @@ import scala.concurrent.duration.Duration
 import squants.time._
 import seqexec.model.enum._
 import seqexec.model.events.SingleActionEvent
+import seqexec.model.arb.ArbStepState
 
-trait SeqexecModelArbitraries extends ArbObservation {
+trait SeqexecModelArbitraries extends ArbObservation with ArbStepState {
 
   private val maxListSize = 2
 
@@ -118,18 +119,6 @@ trait SeqexecModelArbitraries extends ArbObservation {
       o <- arbitrary[Option[Observer]]
       n <- Gen.alphaStr
     } yield SequenceMetadata(i, o, n)
-  }
-
-  implicit val spsArb = Arbitrary[StepState] {
-    for {
-      v1 <- Gen.oneOf(StepState.Pending,
-                      StepState.Completed,
-                      StepState.Skipped,
-                      StepState.Running,
-                      StepState.Paused)
-      v2 <- Gen.alphaStr.map(StepState.Failed.apply)
-      r  <- Gen.oneOf(v1, v2)
-    } yield r
   }
 
   implicit val acsArb = Arbitrary[ActionStatus](
@@ -267,9 +256,6 @@ trait SeqexecModelArbitraries extends ArbObservation {
 
   implicit val obCogen: Cogen[Observer] =
     Cogen[String].contramap(_.value)
-
-  implicit val stsCogen: Cogen[StepState] =
-    Cogen[String].contramap(_.productPrefix)
 
   implicit val stParams: Cogen[StepConfig] =
     Cogen[String].contramap(_.mkString(","))

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbStepState.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbStepState.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.arb
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Cogen
+import seqexec.model.StepState
+
+trait ArbStepState {
+  implicit val stepStateArb = Arbitrary[StepState] {
+    for {
+      v1 <- Gen.oneOf(StepState.Pending,
+                      StepState.Completed,
+                      StepState.Skipped,
+                      StepState.Running,
+                      StepState.Paused)
+      v2 <- Gen.alphaStr.map(StepState.Failed.apply)
+      r  <- Gen.oneOf(v1, v2)
+    } yield r
+  }
+
+  implicit val stepStateCogen: Cogen[StepState] =
+    Cogen[String].contramap(_.productPrefix)
+
+}
+
+object ArbStepState extends ArbStepState

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -461,8 +461,8 @@ object StepsTable extends Columns {
     Reusability.caseClassExcept('config)
   implicit val stepReuse: Reusability[Step] =
     Reusability {
-      case (a: StandardStep, b: StandardStep) => stdStepReuse.testNot(a, b)
-      case _ => false
+      case (a: StandardStep, b: StandardStep) => stdStepReuse.test(a, b)
+      case _                                  => false
     }
   implicit val propsReuse: Reusability[Props] =
     Reusability.by(x => (x.canOperate, x.selectedStep, x.stepsList))


### PR DESCRIPTION
This bug slipped through on the last large refactoring leading to some situations where the steps table didn't update when it should