### PR TITLE
SEQNG-824: Display icons on the tab while a subsystem is active

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
@@ -9,7 +9,9 @@ import cats.implicits._
 
 /** A Seqexec resource represents any system that can be only used by one single agent. */
 sealed abstract class Resource(val ordinal: Int, val label: String)
-  extends Product with Serializable
+  extends Product with Serializable {
+  def isInstrument: Boolean = false
+}
 
 object Resource {
 
@@ -34,10 +36,13 @@ object Resource {
   implicit val ordering: Ordering[Resource] =
     order.toOrdering
 
+  val common: List[Resource] = List(TCS, Gcal)
 }
 
 sealed abstract class Instrument(ordinal: Int, label: String)
-  extends Resource(ordinal, label)
+  extends Resource(ordinal, label) {
+  override def isInstrument: Boolean = true
+}
 
 object Instrument {
 

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -46,9 +46,41 @@ body {
   }
 }
 
+.ui.yellow.label.SeqexecStyles-activeResourceLabel {
+  background-image: linear-gradient(90deg, @borderColor 50%, transparent 50%),
+    linear-gradient(90deg, @borderColor 50%, transparent 50%),
+    linear-gradient(0deg, @borderColor 50%, transparent 50%),
+    linear-gradient(0deg, @borderColor 50%, transparent 50%);
+  background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
+  background-size: 5px 3px, 5px 3px, 3px 5px, 3px 5px;
+  background-position: left top, right bottom, left bottom, right top;
+  animation: border-dance 4s infinite linear;
+}
+
+@keyframes border-dance {
+  0% {
+    background-position: left top, right bottom, left bottom, right top;
+  }
+  100% {
+    background-position: left 20px top, right 20px bottom, left bottom 20px,
+      right top 20px;
+  }
+}
+
 .SeqexecStyles-activeInstrumentLabel {
   padding-bottom: 0.2em;
   text-align: center;
+}
+
+.SeqexecStyles-instrumentAndResourcesLabel {
+  display: flex;
+  margin-bottom: -6px;
+}
+
+.SeqexecStyles-resourceLabels {
+  display: flex;
+  position: relative;
+  bottom: 8px;
 }
 
 .SeqexecStyles-filterActiveButton {
@@ -83,6 +115,11 @@ body {
 }
 
 .SeqexecStyles-previewTabLoadButton {
+  align-self: flex-end;
+  margin-left: auto;
+}
+
+.SeqexecStyles-resourcesTabLabels {
   align-self: flex-end;
   margin-left: auto;
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/TabFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/TabFocus.scala
@@ -13,7 +13,8 @@ import seqexec.web.client.model._
 final case class TabFocus(
   canOperate:      Boolean,
   tabs:            NonEmptyList[Either[CalibrationQueueTabActive, AvailableTab]],
-  defaultObserver: Observer)
+  defaultObserver: Observer
+)
 
 object TabFocus {
   implicit val eq: Eq[TabFocus] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -20,6 +20,15 @@ object SeqexecStyles {
   val activeInstrumentLabel: GStyle =
     GStyle.fromString("SeqexecStyles-activeInstrumentLabel")
 
+  val activeResourceLabel: GStyle =
+    GStyle.fromString("SeqexecStyles-activeResourceLabel")
+
+  val resourceLabels: GStyle =
+    GStyle.fromString("SeqexecStyles-resourceLabels")
+
+  val instrumentAndResourcesLabel: GStyle =
+    GStyle.fromString("SeqexecStyles-instrumentAndResourcesLabel")
+
   val tab: GStyle = GStyle.fromString("SeqexecStyles-tab")
 
   val tabLabel: GStyle = GStyle.fromString("SeqexecStyles-tabLabel")
@@ -31,6 +40,9 @@ object SeqexecStyles {
 
   val previewTabLoadButton: GStyle =
     GStyle.fromString("SeqexecStyles-previewTabLoadButton")
+
+  val resourcesTabLabels: GStyle =
+    GStyle.fromString("SeqexecStyles-resourcesTabLabels")
 
   val activeTabContent: GStyle =
     GStyle.fromString("SeqexecStyles-activeTabContent")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -929,7 +929,7 @@ object StepsTable extends Columns {
     // The selected step may have changed externally
     val selectedStepChange: Callback =
       (cur.selectedStep, next.selectedStep).mapN { (c, n) =>
-        b.modState(State.selected.set(n.some)).when(c =!= n).void
+        b.setStateL(State.selected)(n.some).when(c =!= n).void
       }.getOrEmpty
 
     // If the step is running recalculate height
@@ -940,9 +940,15 @@ object StepsTable extends Columns {
         none
       }
 
-    selectStep *> selectedStepChange *> (running.toList ::: selected.toList ::: differentStepsStates).minimumOption.map {
-      recomputeRowHeightsCB
-    }.getOrEmpty
+    // Decide from what row to recalculate
+    val recalculateHeight: Callback =
+      (running.toList ::: selected.toList ::: differentStepsStates).minimumOption.map {
+        recomputeRowHeightsCB
+      }.getOrEmpty
+
+    selectStep *>
+      selectedStepChange *>
+      recalculateHeight
   }
 
   // Wire it up from VDOM

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SeqexecTabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SeqexecTabs.scala
@@ -31,7 +31,7 @@ object SeqexecTabs {
         val tabsL = x().tabs.toList
         val runningInstruments = tabsL.collect {
           case Right(
-              AvailableTab(_, SequenceState.Running(_, _), i, _, _, false, _, _)) =>
+              AvailableTab(_, SequenceState.Running(_, _), i, _, _, false, _, _, _)) =>
             i
         }
         val tabs = tabsL

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
@@ -163,6 +163,13 @@ object TabOperations {
       case r                  => r
     })
 
+  // Set the resource operations in the map to idle.
+  def clearCommonResourceCompleted(re: Resource): TabOperations => TabOperations =
+    TabOperations.resourceRunRequested.modify(_.map {
+      case (r, s) if re === r && s === ResourceRunOperation.ResourceRunCompleted => r -> ResourceRunOperation.ResourceRunIdle
+      case r                                                                     => r
+    })
+
   val Default: TabOperations =
     TabOperations(
       RunOperation.RunIdle,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -12,6 +12,7 @@ import monocle.Prism
 import monocle.macros.GenPrism
 import monocle.macros.Lenses
 import monocle.std.either._
+import scala.collection.immutable.SortedMap
 import seqexec.model.Observer
 import seqexec.model.StepId
 import seqexec.model.SequenceState
@@ -28,7 +29,8 @@ final case class AvailableTab(id:            Observation.Id,
                               nextStepToRun: Option[Int],
                               isPreview:     Boolean,
                               active:        TabSelected,
-                              loading:       Boolean)
+                              loading:       Boolean,
+                              resourceOperations: SortedMap[Resource, ResourceRunOperation])
 
 object AvailableTab {
   implicit val eq: Eq[AvailableTab] =
@@ -41,7 +43,8 @@ object AvailableTab {
          x.nextStepToRun,
          x.isPreview,
          x.active,
-         x.loading))
+         x.loading,
+         x.resourceOperations))
 }
 
 final case class CalibrationQueueTabActive(calibrationTab: CalibrationQueueTab,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/icon/Icon.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/icon/Icon.scala
@@ -209,4 +209,5 @@ object Icon {
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def apply(s: String, children: VdomNode*): Icon = Icon(Props(s), children)
+
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/label/Label.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/label/Label.scala
@@ -34,6 +34,7 @@ object Label {
     tag                      : Boolean = false,
     basic                    : Boolean = false,
     link                     : Boolean = false,
+    circular                 : Boolean = false,
     size                     : Size = Size.NotSized,
     pointing                 : Pointing = Pointing.None,
     icon                     : Option[Icon] = None,
@@ -47,6 +48,7 @@ object Label {
     ^.classSet(
       "basic"          -> p.basic,
       "tag"            -> p.tag,
+      "circular"       -> p.circular,
       "tiny"           -> (p.size === Size.Tiny),
       "mini"           -> (p.size === Size.Mini),
       "small"          -> (p.size === Size.Small),

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -12,6 +12,7 @@ import gem.Observation
 import gem.enum.Site
 import scala.collection.immutable.SortedMap
 import seqexec.model.enum.Instrument
+import seqexec.model.enum.Resource
 import seqexec.model.enum.BatchExecState
 import seqexec.model.enum.QueueManipulationOp
 import seqexec.model.ClientId
@@ -406,7 +407,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         p <- arbitrary[Boolean]
         a <- arbitrary[TabSelected]
         l <- arbitrary[Boolean]
-      } yield AvailableTab(d, s, i, r, n, p, a, l)
+        o <- arbitrary[SortedMap[Resource, ResourceRunOperation]]
+      } yield AvailableTab(d, s, i, r, n, p, a, l, o)
     }
 
   implicit val availableTabCogen: Cogen[AvailableTab] =


### PR DESCRIPTION
When a system is active in another tab we want to show it to the other tabs
This PR adds little icons to the tabs as shown below:

![screencast 2019-05-31 22-22-16](https://user-images.githubusercontent.com/3615303/58742821-60c08780-83f4-11e9-8144-5188fd5e4efc.gif)
