### PR TITLE
SEQNG-1001 Improved navigation for sequences' urls without a step

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecUI.scala
@@ -7,6 +7,7 @@ import diode.ModelRO
 import cats.implicits._
 import cats.effect.IO
 import monocle.Prism
+import monocle.Iso
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.Callback
@@ -35,31 +36,46 @@ object SeqexecUI {
   }
 
   // Prism from url params to config page
-  def configPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), SequenceConfigPage] = Prism[(String, String, Int), SequenceConfigPage] {
-    case (i, s, step) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequenceConfigPage(_, _, step))
-  } {
-    p => (p.instrument.show, p.obsId.format, p.step)
-  }
+  def configPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), SequenceConfigPage] =
+    Prism[(String, String, Int), SequenceConfigPage] {
+      case (i, s, step) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequenceConfigPage(_, _, step))
+    } {
+      p => (p.instrument.show, p.obsId.format, p.step)
+    }
   // Prism from url params to sequence page
-  def sequencePageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), SequencePage] = Prism[(String, String, Int), SequencePage] {
-    case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequencePage(_, _, StepIdDisplayed(st - 1)))
-  } {
-    p => (p.instrument.show, p.obsId.format, p.step.step + 1)
-  }
+  def sequencePageSP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), SequencePage] =
+    Prism[(String, String, Int), SequencePage] {
+      case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequencePage(_, _, StepIdDisplayed(st - 1)))
+    } {
+      p => (p.instrument.show, p.obsId.format, p.step.step + 1)
+    }
+
+  private def defaultStepIso[A]: Iso[Tuple2[A, A], Tuple3[A, A, Int]] =
+    Iso[Tuple2[A, A], Tuple3[A, A, Int]](x => (x._1, x._2, 0))(x => (x._1, x._2))
+
+  // Prism from url params to sequence page
+  def sequencePageP(instrumentNames: Map[String, Instrument]): Prism[(String, String), SequencePage] =
+    defaultStepIso[String] ^<-? sequencePageSP(instrumentNames)
+
+  // Prism from url params to the preview page to a given step
+  def previewPageSP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), PreviewPage] =
+    Prism[(String, String, Int), PreviewPage] {
+      case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewPage(_, _, StepIdDisplayed(st - 1)))
+    } {
+      p => (p.instrument.show, p.obsId.format, p.step.step + 1)
+    }
 
   // Prism from url params to the preview page
-  def previewPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), PreviewPage] = Prism[(String, String, Int), PreviewPage] {
-    case (i, s, st) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewPage(_, _, StepIdDisplayed(st - 1)))
-  } {
-    p => (p.instrument.show, p.obsId.format, p.step.step + 1)
-  }
+  def previewPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String), PreviewPage] =
+    defaultStepIso ^<-? previewPageSP(instrumentNames)
 
   // Prism from url params to the preview page with config
-  def previewConfigPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), PreviewConfigPage] = Prism[(String, String, Int), PreviewConfigPage] {
-    case (i, s, step) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewConfigPage(_, _, step))
-  } {
-    p => (p.instrument.show, p.obsId.format, p.step)
-  }
+  def previewConfigPageP(instrumentNames: Map[String, Instrument]): Prism[(String, String, Int), PreviewConfigPage] =
+    Prism[(String, String, Int), PreviewConfigPage] {
+      case (i, s, step) => (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewConfigPage(_, _, step))
+    } {
+      p => (p.instrument.show, p.obsId.format, p.step)
+    }
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def router(site: Site): IO[Router[SeqexecPages]] = {
@@ -75,8 +91,12 @@ object SeqexecUI {
       | dynamicRouteCT(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/configuration/" ~ int)
         .pmapL(configPageP(instrumentNames))) ~> dynRenderR((_: SequenceConfigPage, r) => SeqexecMain(site, r))
       | dynamicRouteCT(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/step/" ~ int)
+        .pmapL(sequencePageSP(instrumentNames))) ~> dynRenderR((_: SequencePage, r) => SeqexecMain(site, r))
+      | dynamicRouteCT(("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+"))
         .pmapL(sequencePageP(instrumentNames))) ~> dynRenderR((_: SequencePage, r) => SeqexecMain(site, r))
       | dynamicRouteCT(("/preview/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/step/" ~ int)
+        .pmapL(previewPageSP(instrumentNames))) ~> dynRenderR((_: PreviewPage, r) => SeqexecMain(site, r))
+      | dynamicRouteCT(("/preview/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+"))
         .pmapL(previewPageP(instrumentNames))) ~> dynRenderR((_: PreviewPage, r) => SeqexecMain(site, r))
       | dynamicRouteCT(("/preview/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/configuration/" ~ int)
         .pmapL(previewConfigPageP(instrumentNames))) ~> dynRenderR((_: PreviewConfigPage, r) => SeqexecMain(site, r))


### PR DESCRIPTION
This is a small bug fix. Seqexec urls should be navigable. If you go to
http://localhost:9090/preview/GNIRS/GS-2019B-Q-30-2/step/1 it should jump to that

However urls without the step are ignored
This PR fixes that supporting urls like
http://localhost:9090/preview/GNIRS/GS-2019B-Q-30-2