### PR TITLE
SEQNG-975: Auto reload the client ui if the server version changes

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
@@ -56,13 +56,14 @@ object events {
     case _                      => false
   }
 
-  final case class ConnectionOpenEvent(u:        Option[UserDetails],
-                                       clientId: ClientId)
+  final case class ConnectionOpenEvent(userDetails:   Option[UserDetails],
+                                       clientId:      ClientId,
+                                       serverVersion: String)
       extends SeqexecEvent
 
   object ConnectionOpenEvent {
     implicit lazy val equal: Eq[ConnectionOpenEvent] =
-      Eq.by(x => (x.u, x.clientId))
+      Eq.by(x => (x.userDetails, x.clientId, x.serverVersion))
   }
 
   object SeqexecModelUpdate {

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -22,7 +22,8 @@ trait SequenceEventsArbitraries extends ArbTime with ArbNotification {
     for {
       u  <- arbitrary[Option[UserDetails]]
       id <- arbitrary[ClientId]
-    } yield ConnectionOpenEvent(u, id)
+      v  <- arbitrary[String]
+    } yield ConnectionOpenEvent(u, id, v)
   }
 
   implicit val sseArb = Arbitrary[SequenceStart] {
@@ -217,7 +218,8 @@ trait SequenceEventsArbitraries extends ArbTime with ArbNotification {
   }
 
   implicit val coeCogen: Cogen[ConnectionOpenEvent] =
-    Cogen[Option[UserDetails]].contramap(_.u)
+    Cogen[(Option[UserDetails], ClientId, String)]
+      .contramap(x => (x.userDetails, x.clientId, x.serverVersion))
 
   implicit val smuCogen: Cogen[SeqexecModelUpdate] =
     Cogen[SequencesQueue[SequenceView]].contramap(_.view)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/WebSocketFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/WebSocketFocus.scala
@@ -20,13 +20,21 @@ final case class WebSocketsFocus(location:        Pages.SeqexecPages,
                                  defaultObserver: Observer,
                                  clientId:        Option[ClientId],
                                  site:            Option[Site],
-                                 sound:           SoundSelection)
+                                 sound:           SoundSelection,
+                                 serverVersion:   Option[String])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object WebSocketsFocus {
   implicit val eq: Eq[WebSocketsFocus] =
-    Eq.by(x =>
-      (x.location, x.sequences, x.user, x.defaultObserver, x.clientId, x.site))
+    Eq.by(
+      x =>
+        (x.location,
+         x.sequences,
+         x.user,
+         x.defaultObserver,
+         x.clientId,
+         x.site,
+         x.serverVersion))
 
   val webSocketFocusL: Lens[SeqexecAppRootModel, WebSocketsFocus] =
     Lens[SeqexecAppRootModel, WebSocketsFocus](
@@ -37,13 +45,17 @@ object WebSocketsFocus {
                         m.uiModel.defaultObserver,
                         m.clientId,
                         m.site,
-                        m.uiModel.sound))(
+                        m.uiModel.sound,
+                        m.serverVersion))(
       v =>
         m =>
-          m.copy(sequences = v.sequences,
-                 uiModel = m.uiModel.copy(user = v.user,
-                                          defaultObserver = v.defaultObserver,
-                                          sound           = v.sound),
-                 clientId = v.clientId,
-                 site     = v.site))
+          m.copy(
+            sequences = v.sequences,
+            uiModel = m.uiModel.copy(user = v.user,
+                                     defaultObserver = v.defaultObserver,
+                                     sound           = v.sound),
+            clientId      = v.clientId,
+            site          = v.site,
+            serverVersion = v.serverVersion
+      ))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OpenConnectionHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OpenConnectionHandler.scala
@@ -20,7 +20,7 @@ class OpenConnectionHandler[M](modelRW: ModelRW[M, CalibrationQueues])
     with Handlers[M, CalibrationQueues] {
 
   override def handle: PartialFunction[Any, ActionResult[M]] = {
-    case ServerMessage(ConnectionOpenEvent(u, _)) =>
+    case ServerMessage(ConnectionOpenEvent(u, _, _)) =>
       val ts = u
         .as(CalQueueTable.State.EditableTableState)
         .getOrElse(CalQueueTable.State.ROTableState)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -32,11 +32,12 @@ import web.client.table._
   * Root of the UI Model of the application
   */
 @Lenses
-final case class SeqexecAppRootModel(sequences: SequencesQueue[SequenceView],
-                                     ws:        WebSocketConnection,
-                                     site:      Option[Site],
-                                     clientId:  Option[ClientId],
-                                     uiModel:   SeqexecUIModel)
+final case class SeqexecAppRootModel(sequences:     SequencesQueue[SequenceView],
+                                     ws:            WebSocketConnection,
+                                     site:          Option[Site],
+                                     clientId:      Option[ClientId],
+                                     uiModel:       SeqexecUIModel,
+                                     serverVersion: Option[String])
 
 @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object SeqexecAppRootModel {
@@ -52,7 +53,8 @@ object SeqexecAppRootModel {
     WebSocketConnection.Empty,
     None,
     None,
-    SeqexecUIModel.Initial)
+    SeqexecUIModel.Initial,
+    None)
 
   val logDisplayL: Lens[SeqexecAppRootModel, SectionVisibilityState] =
     SeqexecAppRootModel.uiModel ^|->
@@ -102,5 +104,5 @@ object SeqexecAppRootModel {
       at(CalibrationQueueId)).asGetter
 
   implicit val eq: Eq[SeqexecAppRootModel] =
-    Eq.by(x => (x.sequences, x.ws, x.site, x.clientId, x.uiModel))
+    Eq.by(x => (x.sequences, x.ws, x.site, x.clientId, x.uiModel, x.serverVersion))
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -793,6 +793,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         clientId    <- arbitrary[Option[ClientId]]
         site        <- arbitrary[Option[Site]]
         sound       <- arbitrary[SoundSelection]
+        serverVer   <- arbitrary[Option[String]]
       } yield
         WebSocketsFocus(navLocation,
                         sequences,
@@ -800,7 +801,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
                         observer,
                         clientId,
                         site,
-                        sound)
+                        sound,
+                        serverVer)
     }
 
   implicit val wsfCogen: Cogen[WebSocketsFocus] =
@@ -810,7 +812,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
            Observer,
            Option[ClientId],
            Option[Site],
-           SoundSelection)]
+           SoundSelection,
+           Option[String])]
       .contramap(
         x =>
           (x.location,
@@ -819,7 +822,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
            x.defaultObserver,
            x.clientId,
            x.site,
-           x.sound))
+           x.sound,
+           x.serverVersion))
 
   implicit val arbInitialSyncFocus: Arbitrary[InitialSyncFocus] =
     Arbitrary {
@@ -842,7 +846,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         site      <- arbitrary[Option[Site]]
         clientId  <- arbitrary[Option[ClientId]]
         uiModel   <- arbitrary[SeqexecUIModel]
-      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel)
+        version   <- arbitrary[Option[String]]
+      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel, version)
     }
 
   implicit val arbAppTableStates: Arbitrary[AppTableStates] =

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -17,6 +17,7 @@ import seqexec.web.server.security.AuthenticationService.AuthResult
 import seqexec.web.server.security.AuthenticationService
 import seqexec.web.server.security.Http4sAuthentication
 import seqexec.web.server.security.TokenRefresher
+import seqexec.web.server.OcsBuildInfo
 import seqexec.web.common.LogMessage
 import fs2.concurrent.Topic
 import fs2.Pipe
@@ -134,7 +135,7 @@ class SeqexecUIApiRoutes(site: String,
         // Create a client specific process
 
         def initialEvent(clientId: ClientId): Stream[IO, WebSocketFrame] =
-          Stream.emit(Binary(ByteVector(trimmedArray(ConnectionOpenEvent(user.toOption, clientId): SeqexecEvent))))
+          Stream.emit(Binary(ByteVector(trimmedArray(ConnectionOpenEvent(user.toOption, clientId, OcsBuildInfo.version): SeqexecEvent))))
 
         def engineEvents(clientId: ClientId): Stream[IO, WebSocketFrame]  =
           engineOutput.subscribe(1).map(anonymizeF).filter(filterOutNull).filter(filterOutOnClientId(clientId)).map(v => Binary(ByteVector(trimmedArray(v))))


### PR DESCRIPTION
As the Seqexec UI often runs for a long time, when a new version is released old clients may remain using the old client requiring a user reload
This PR sends the version to the client. If the client detects a version change it will self reload