### PR TITLE
SEQNG-887/SEQNG-1004: Refactor StandardKeywordHeader and a bug fix

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -520,7 +520,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
         val gnirsReader = if(settings.gnirsKeywords) GnirsKeywordReaderEpics[IO] else GnirsKeywordReaderDummy[IO]
         GnirsHeader.header[IO](sys, gnirsReader, tcsKReader).asRight
       case Instrument.Gpi    =>
-        GpiHeader.header[IO](systems.gpi.gdsClient, tcsKReader, ObsKeywordReaderImpl[IO](config, site)).asRight
+        GpiHeader.header[IO](systems.gpi.gdsClient, tcsKReader, ObsKeywordReader[IO](config, site)).asRight
       case Instrument.Ghost  =>
         GhostHeader.header[IO].asRight
       case Instrument.Niri   =>
@@ -542,7 +542,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
                             inst: InstrumentSystem[F])(ctx: HeaderExtraData): Header[F] =
     new StandardHeader(
       inst,
-      ObsKeywordReaderImpl(config, site),
+      ObsKeywordReader[F](config, site),
       if (settings.tcsKeywords) TcsKeywordsReaderEpics[F] else DummyTcsKeywordsReader[F],
       StateKeywordsReader[F](ctx.conditions, ctx.operator, ctx.observer),
       tcsSubsystems

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
@@ -30,7 +30,7 @@ object GpiHeader {
                         KeywordName.PAR_ANG),
             buildInt32S(tcsKeywordsReader.gpiInstPort,
                        KeywordName.INPORT),
-            buildBoolean(obsKeywordsReader.getAstrometicField,
+            buildBooleanS(obsKeywordsReader.astrometicField,
                          KeywordName.ASTROMTC),
             buildStringS(tcsKeywordsReader.crFollow.map(
                           _.map(CRFollow.keywordValue).getOrElse("INDEF")),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/ObsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/ObsKeywordReader.scala
@@ -3,10 +3,11 @@
 
 package seqexec.server.keywords
 
-import cats.Show
 import cats.implicits._
 import cats.effect.Sync
-import gem.enum.Site
+import cats.Eq
+import cats.data.EitherT
+import cats.data.Nested
 import edu.gemini.spModel.config2.{Config, ItemKey}
 import edu.gemini.spModel.dataflow.GsaAspect.Visibility
 import edu.gemini.spModel.dataflow.GsaSequenceEditor.{HEADER_VISIBILITY_KEY, PROPRIETARY_MONTHS_KEY}
@@ -16,39 +17,45 @@ import edu.gemini.spModel.obscomp.InstConstants._
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import edu.gemini.spModel.target.obsComp.TargetObsCompConstants._
 import edu.gemini.spModel.gemini.gpi.Gpi.ASTROMETRIC_FIELD_PROP
+import gem.enum.Site
+import gem.syntax.string._
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
-import mouse.all._
-import scala.collection.breakOut
+import mouse.boolean._
+import seqexec.server.ConfigUtilOps
+import seqexec.server.SeqexecFailure
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.tcs.Tcs
-import seqexec.server.{ConfigUtilOps, SeqActionF, SeqexecFailure}
 
-trait ObsKeywordsReader[F[_]] {
-  def getObsType: SeqActionF[F, String]
-  def getObsClass: SeqActionF[F, String]
-  def getGemPrgId: SeqActionF[F, String]
-  def getObsId: SeqActionF[F, String]
-  def getDataLabel: SeqActionF[F, String]
-  def getObservatory: SeqActionF[F, String]
-  def getTelescope: SeqActionF[F, String]
-  def getPwfs1Guide: SeqActionF[F, StandardGuideOptions.Value]
-  def getPwfs2Guide: SeqActionF[F, StandardGuideOptions.Value]
-  def getOiwfsGuide: SeqActionF[F, StandardGuideOptions.Value]
-  def getAowfsGuide: SeqActionF[F, StandardGuideOptions.Value]
-  def getHeaderPrivacy: SeqActionF[F, Boolean]
-  def getProprietaryMonths: SeqActionF[F, String]
-  def getObsObject: SeqActionF[F, String]
-  def getGeminiQA: SeqActionF[F, String]
-  def getPIReq: SeqActionF[F, String]
-  def getSciBand: SeqActionF[F, Option[Int]]
-  def getRequestedAirMassAngle: Map[String, SeqActionF[F, Double]]
-  def getTimingWindows: List[(Int, TimingWindowKeywords[F])]
-  def getRequestedConditions: Map[String, SeqActionF[F, String]]
-  def getAstrometicField: SeqActionF[F, Boolean]
+sealed trait ObsKeywordsReader[F[_]] {
+  def obsType: F[String]
+  def obsClass: F[String]
+  def gemPrgId: F[String]
+  def obsId: F[String]
+  def dataLabel: F[String]
+  def observatory: F[String]
+  def telescope: F[String]
+  def pwfs1Guide: F[StandardGuideOptions.Value]
+  def pwfs1GuideS: F[String]
+  def pwfs2Guide: F[StandardGuideOptions.Value]
+  def pwfs2GuideS: F[String]
+  def oiwfsGuide: F[StandardGuideOptions.Value]
+  def oiwfsGuideS: F[String]
+  def aowfsGuide: F[StandardGuideOptions.Value]
+  def aowfsGuideS: F[String]
+  def headerPrivacy: F[Boolean]
+  def proprietaryMonths: F[String]
+  def obsObject: F[String]
+  def geminiQA: F[String]
+  def pIReq: F[String]
+  def sciBand: F[Int]
+  def requestedAirMassAngle: F[Map[String, Double]]
+  def timingWindows: F[List[(Int, TimingWindowKeywords)]]
+  def requestedConditions: F[Map[String, String]]
+  def astrometicField: F[Boolean]
 }
 
-object ObsKeywordsReader {
+trait ObsKeywordsReaderConstants {
   // Constants taken from SPSiteQualityCB
   // TODO Make them public in SPSiteQualityCB
   val MIN_HOUR_ANGLE: String         = "MinHourAngle"
@@ -67,143 +74,230 @@ object ObsKeywordsReader {
   val WV: String = WATER_VAPOR_PROP.getName
 }
 
-// A Timing window always have 4 keywords
-final case class TimingWindowKeywords[F[_]](start: SeqActionF[F, String], duration: SeqActionF[F, Double], repeat: SeqActionF[F, Int], period: SeqActionF[F, Double])
+// A Timing window always has 4 keywords
+final case class TimingWindowKeywords(
+  start: String,
+  duration: Double,
+  repeat: Int,
+  period: Double
+)
 
-final case class ObsKeywordReaderImpl[F[_]: Sync](config: Config, site: Site) extends ObsKeywordsReader[F] {
-  // Format used on FITS keywords
-  val telescope: String = site match {
-    case Site.GN => "Gemini-North"
-    case Site.GS => "Gemini-South"
-  }
-  import ObsKeywordsReader._
+object ObsKeywordReader extends ObsKeywordsReaderConstants {
+  // scalastyle:off
+  def apply[F[_]: Sync](config: Config, site: Site): ObsKeywordsReader[F] = new ObsKeywordsReader[F] {
+    private val F = implicitly[Sync[F]]
+    // Format used on FITS keywords
+    val telescopeName: String = site match {
+      case Site.GN => "Gemini-North"
+      case Site.GS => "Gemini-South"
+    }
 
-  implicit private val show: Show[AnyRef] = Show.fromToString
+    override def obsType: F[String] = F.delay(
+      s"${config.getItemValue(new ItemKey(OBSERVE_KEY, OBSERVE_TYPE_PROP))}").safeValOrDefault
 
-  override def getObsType: SeqActionF[F, String] = SeqActionF(
-    config.getItemValue(new ItemKey(OBSERVE_KEY, OBSERVE_TYPE_PROP)).show)
+    override def obsClass: F[String] = F.delay(
+      s"${config.getItemValue(new ItemKey(OBSERVE_KEY, OBS_CLASS_PROP))}").safeValOrDefault
 
-  override def getObsClass: SeqActionF[F, String] = SeqActionF(
-    config.getItemValue(new ItemKey(OBSERVE_KEY, OBS_CLASS_PROP)).show)
+    override def gemPrgId: F[String] = F.delay(
+      s"${config.getItemValue(new ItemKey(OCS_KEY, PROGRAMID_PROP))}").safeValOrDefault
 
-  override def getGemPrgId: SeqActionF[F, String] = SeqActionF(
-    config.getItemValue(new ItemKey(OCS_KEY, PROGRAMID_PROP)).show)
+    override def obsId: F[String] = F.delay(
+      s"${config.getItemValue(new ItemKey(OCS_KEY, OBSERVATIONID_PROP))}").safeValOrDefault
 
-  override def getObsId: SeqActionF[F, String] = SeqActionF(
-    config.getItemValue(new ItemKey(OCS_KEY, OBSERVATIONID_PROP)).show)
+    private def explainExtractError(e: ExtractFailure): SeqexecFailure =
+      SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))
 
-  def explainExtractError(e: ExtractFailure): SeqexecFailure =
-    SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))
+    override def requestedAirMassAngle: F[Map[String, Double]] = {
+      val keys: F[List[Option[(String, Double)]]] =
+        List(MAX_AIRMASS, MAX_HOUR_ANGLE, MIN_AIRMASS, MIN_HOUR_ANGLE).map { key =>
+          val value: F[Option[Double]] = F.delay {
+            config.extractAs[String](new ItemKey(OCS_KEY, "obsConditions:" + key))
+              .toOption
+              .flatMap(_.parseDoubleOption)
+          }
+          Nested(value).map(key -> _).value
+          .handleError(_ => none) // If there is an error ignore the key
+        }.sequence
+      keys.map {_.mapFilter(identity).toMap}
+    }
 
-  override def getRequestedAirMassAngle: Map[String, SeqActionF[F, Double]] =
-    List(MAX_AIRMASS, MAX_HOUR_ANGLE, MIN_AIRMASS, MIN_HOUR_ANGLE).flatMap { key =>
-      val value = config.extractAs[Double](new ItemKey(OCS_KEY, "obsConditions:" + key)).toOption
-      value.toList.map(v => key -> SeqActionF(v))
-    }(breakOut)
+    override def requestedConditions: F[Map[String, String]] = {
+      val keys: F[List[(String, String)]] =
+        List(SB, CC, IQ, WV).map { key =>
+        val value: F[String] = F.delay {
+          config.extractAs[String](new ItemKey(OCS_KEY, "obsConditions:" + key))
+            .map { d => (d === "100").fold("Any", s"$d-percentile") }
+            .toOption
+          }.safeValOrDefault
+        value.map(key -> _)
+      }.sequence
+      keys.map(_.toMap)
+    }
 
-  override def getRequestedConditions: Map[String, SeqActionF[F, String]]  =
-    List(SB, CC, IQ, WV).flatMap { key =>
-      val value: Option[String] = config.extractAs[String](new ItemKey(OCS_KEY, "obsConditions:" + key)).map { d =>
-        (d === "100").fold("Any", s"$d-percentile")
-      }.toOption
-      value.toList.map(v => key -> SeqActionF(v))
-    }(breakOut)
+    override def timingWindows: F[List[(Int, TimingWindowKeywords)]] = {
+      def calcDuration(duration: String): Option[Double] =
+        duration.parseDoubleOption.map { d => (d < 0).fold(d, d / 1000) }
 
-  override def getTimingWindows: List[(Int, TimingWindowKeywords[F])] = {
-    def calcDuration(duration: String): Either[NumberFormatException, SeqActionF[F, Double]] =
-      duration.parseDouble.map { d => SeqActionF((d < 0).fold(d, d / 1000))}
+      def calcRepeat(repeat: String): Option[Int] =
+        repeat.parseIntOption
 
-    def calcRepeat(repeat: String): Either[NumberFormatException, SeqActionF[F, Int]] =
-      repeat.parseInt.map(SeqActionF(_))
+      def calcPeriod(period: String): Option[Double] =
+        period.parseDoubleOption.map(p => (p/1000))
 
-    def calcPeriod(period: String): Either[NumberFormatException, SeqActionF[F, Double]] =
-      period.parseDouble.map(p => SeqActionF(p/1000))
+      def calcStart(start: String): Option[String] =
+        start.parseLongOption.map { s =>
+          LocalDateTime.ofInstant(Instant.ofEpochMilli(s),
+            ZoneId.of("GMT")).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        }
 
-    def calcStart(start: String): Either[NumberFormatException, SeqActionF[F, String]] =
-      start.parseLong.map { s =>
-        val timeStr = LocalDateTime.ofInstant(Instant.ofEpochMilli(s), ZoneId.of("GMT")).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-        SeqActionF(timeStr)
+      val prefixes =
+        List(
+          TIMING_WINDOW_START,
+          TIMING_WINDOW_DURATION,
+          TIMING_WINDOW_REPEAT,
+          TIMING_WINDOW_PERIOD)
+      val windows = for {
+        w <- (0 until 99).toList
+      } yield {
+        // Keys on the ocs use the prefix and the value and they are always Strings
+        val keys = prefixes.map(p => f"$p$w")
+        keys.map { k =>
+          F.delay(s"${config.getItemValue(new ItemKey(OCS_KEY, "obsConditions:" + k))}")
+        }.sequence.map {
+          case start :: duration :: repeat :: period :: Nil =>
+            (calcStart(start), calcDuration(duration), calcRepeat(repeat), calcPeriod(period))
+              .mapN(TimingWindowKeywords.apply)
+              .map(w -> _)
+          case _ => none
+        }
+      }
+      windows.sequence.map(_.mapFilter(identity))
+    }
+
+    override def dataLabel: F[String] =
+      (OBSERVE_KEY / DATA_LABEL_PROP).toString.pure[F]
+
+    override def observatory: F[String] = telescopeName.pure[F]
+
+    override def telescope: F[String] = telescopeName.pure[F]
+
+    private def decodeGuide(v: StandardGuideOptions.Value): String = v match {
+      case StandardGuideOptions.Value.park   => "parked"
+      case StandardGuideOptions.Value.guide  => "guiding"
+      case StandardGuideOptions.Value.freeze => "frozen"
+    }
+
+    override def pwfs1Guide: F[StandardGuideOptions.Value] =
+      EitherT(F.delay(
+        config.extractAs[StandardGuideOptions.Value](new ItemKey(TELESCOPE_KEY, Tcs.GUIDE_WITH_PWFS1_PROP))
+          .leftMap(explainExtractError))
+      ).widenRethrowT
+
+    override def pwfs1GuideS: F[String] =
+      pwfs1Guide
+        .map(decodeGuide)
+        .safeValOrDefault
+
+    override def pwfs2Guide: F[StandardGuideOptions.Value] =
+      EitherT(F.delay(
+        config.extractAs[StandardGuideOptions.Value](new ItemKey(TELESCOPE_KEY, Tcs.GUIDE_WITH_PWFS2_PROP))
+          .leftMap(explainExtractError))
+      ).widenRethrowT
+
+    override def pwfs2GuideS: F[String] =
+      pwfs2Guide
+        .map(decodeGuide)
+        .safeValOrDefault
+
+    override def oiwfsGuide: F[StandardGuideOptions.Value] =
+      EitherT(F.delay(
+        config.extractAs[StandardGuideOptions.Value](new ItemKey(TELESCOPE_KEY, GUIDE_WITH_OIWFS_PROP))
+        .recoverWith {
+          case ConfigUtilOps.KeyNotFound(_) => StandardGuideOptions.Value.park.asRight
+        }
+        .leftMap(explainExtractError))
+      ).widenRethrowT
+
+    override def oiwfsGuideS: F[String] =
+      oiwfsGuide
+        .map(decodeGuide)
+        .safeValOrDefault
+
+    override def aowfsGuide: F[StandardGuideOptions.Value] =
+      EitherT(F.delay(
+        config.extractAs[StandardGuideOptions.Value](new ItemKey(TELESCOPE_KEY, Tcs.GUIDE_WITH_AOWFS_PROP))
+        .recoverWith {
+          case ConfigUtilOps.KeyNotFound(_)         => StandardGuideOptions.Value.park.asRight
+        }
+        .leftMap(explainExtractError))
+      ).widenRethrowT
+
+    override def aowfsGuideS: F[String] =
+      aowfsGuide
+        .map(decodeGuide)
+        .safeValOrDefault
+
+    private implicit val eqVisibility: Eq[Visibility] = Eq.by(_.ordinal())
+
+    private val headerPrivacyF: F[Boolean] =
+      F.delay(config.extractAs[Visibility](HEADER_VISIBILITY_KEY).getOrElse(Visibility.PUBLIC)).map {
+        _ === Visibility.PRIVATE
       }
 
-    val prefixes = List(TIMING_WINDOW_START, TIMING_WINDOW_DURATION, TIMING_WINDOW_REPEAT, TIMING_WINDOW_PERIOD)
-    val windows = for {
-      w <- (0 until 99).toList
-    } yield {
-      // Keys on the ocs use the prefix and the value and they are always Strings
-      val keys = prefixes.map(p => f"$p$w")
-      keys.map { k =>
-        Option(config.getItemValue(new ItemKey(OCS_KEY, "obsConditions:" + k))).map(_.show)
-      }.sequence.collect {
-        case start :: duration :: repeat :: period :: Nil =>
-          (calcStart(start), calcDuration(duration), calcRepeat(repeat), calcPeriod(period)).mapN(TimingWindowKeywords.apply)
-          .map(w -> _).toOption
-      }.collect { case Some(x) => x }
-    }
-    windows.collect { case Some(x) => x }
+    override def headerPrivacy: F[Boolean] = headerPrivacyF
+      .handleError(_ => false) // Matches the default on `headerPrivacy` where we make it PUBLIC
+
+    private val noProprietaryMonths: F[String] =
+      F.delay(LocalDate.now(ZoneId.of("GMT")).format(DateTimeFormatter.ISO_LOCAL_DATE))
+
+    private val calcProprietaryMonths: F[String] =
+      EitherT(
+        F.delay(
+          config.extractAs[Integer](PROPRIETARY_MONTHS_KEY)
+            .recoverWith {
+              case ConfigUtilOps.KeyNotFound(_) => new Integer(0).asRight
+            }
+            .leftMap(explainExtractError)
+            .map { v =>
+              LocalDate.now(ZoneId.of("GMT")).plusMonths(v.toLong).format(DateTimeFormatter.ISO_LOCAL_DATE)
+            }
+        ))
+      .widenRethrowT
+
+    override def proprietaryMonths: F[String] =
+      headerPrivacyF
+        .ifM(calcProprietaryMonths, noProprietaryMonths)
+        .safeValOrDefault
+
+    private val manualDarkValue = "Manual Dark"
+    private val manualDarkOverride = "Dark"
+
+    override def obsObject: F[String] =
+      F.delay(
+        config.extractAs[String](OBSERVE_KEY / OBJECT_PROP)
+          .map(v => if (v === manualDarkValue) manualDarkOverride else v)
+          .toOption)
+      .safeValOrDefault
+
+    override def geminiQA: F[String] = "UNKNOWN".pure[F]
+
+    override def pIReq: F[String] = "UNKNOWN".pure[F]
+
+    override def sciBand: F[Int] =
+      F.delay(
+        config.extractAs[Integer](OBSERVE_KEY / SCI_BAND)
+        .map(_.toInt)
+        .toOption)
+      .safeValOrDefault
+
+    def astrometicField: F[Boolean] =
+      F.delay(
+        config.extractAs[java.lang.Boolean](INSTRUMENT_KEY / ASTROMETRIC_FIELD_PROP)
+        .toOption
+        .map(Boolean.unbox)
+        .getOrElse(false)
+      )
+      .handleError(_ => false)
   }
-
-  override def getDataLabel: SeqActionF[F, String] = SeqActionF(
-    config.getItemValue(OBSERVE_KEY / DATA_LABEL_PROP).show
-  )
-
-  override def getObservatory: SeqActionF[F, String] = SeqActionF(telescope)
-
-  override def getTelescope: SeqActionF[F, String] = SeqActionF(telescope)
-
-  override def getPwfs1Guide: SeqActionF[F, StandardGuideOptions.Value] =
-    SeqActionF.either(config.extractAs[StandardGuideOptions.Value](new ItemKey(TELESCOPE_KEY, Tcs.GUIDE_WITH_PWFS1_PROP))
-      .leftMap(explainExtractError))
-
-  override def getPwfs2Guide: SeqActionF[F, StandardGuideOptions.Value] =
-    SeqActionF.either(config.extractAs[StandardGuideOptions.Value](new ItemKey(TELESCOPE_KEY, Tcs.GUIDE_WITH_PWFS2_PROP))
-      .leftMap(explainExtractError))
-
-  override def getOiwfsGuide: SeqActionF[F, StandardGuideOptions.Value] =
-    SeqActionF.either(config.extractAs[StandardGuideOptions.Value](new ItemKey(TELESCOPE_KEY, GUIDE_WITH_OIWFS_PROP))
-      .recoverWith[ConfigUtilOps.ExtractFailure, StandardGuideOptions.Value] {
-        case ConfigUtilOps.KeyNotFound(_)         => StandardGuideOptions.Value.park.asRight
-        case e@ConfigUtilOps.ConversionError(_,_) => e.asLeft
-      }.leftMap(explainExtractError))
-
-  override def getAowfsGuide: SeqActionF[F, StandardGuideOptions.Value] =
-    SeqActionF.either(config.extractAs[StandardGuideOptions.Value](new ItemKey(TELESCOPE_KEY, Tcs.GUIDE_WITH_AOWFS_PROP))
-      .recoverWith[ConfigUtilOps.ExtractFailure, StandardGuideOptions.Value] {
-        case ConfigUtilOps.KeyNotFound(_)         => StandardGuideOptions.Value.park.asRight
-        case e@ConfigUtilOps.ConversionError(_,_) => e.asLeft
-      }.leftMap(explainExtractError))
-
-  private val headerPrivacy: Boolean = config.extractAs[Visibility](HEADER_VISIBILITY_KEY).getOrElse(Visibility.PUBLIC) match {
-    case Visibility.PRIVATE => true
-    case _                  => false
-  }
-
-  override def getHeaderPrivacy: SeqActionF[F, Boolean] = SeqActionF(headerPrivacy)
-
-  override def getProprietaryMonths: SeqActionF[F, String] =
-    if(headerPrivacy) {
-      SeqActionF.either(
-        config.extractAs[Integer](PROPRIETARY_MONTHS_KEY).recoverWith[ConfigUtilOps.ExtractFailure, Integer]{
-          case ConfigUtilOps.KeyNotFound(_) => new Integer(0).asRight
-          case e@ConfigUtilOps.ConversionError(_, _) => e.asLeft
-        }.leftMap(explainExtractError)
-          .map(v => LocalDate.now(ZoneId.of("GMT")).plusMonths(v.toLong).format(DateTimeFormatter.ISO_LOCAL_DATE)))
-    }
-    else SeqActionF(LocalDate.now(ZoneId.of("GMT")).format(DateTimeFormatter.ISO_LOCAL_DATE))
-
-  private val manualDarkValue = "Manual Dark"
-  private val manualDarkOverride = "Dark"
-  override def getObsObject: SeqActionF[F, String] =
-    SeqActionF.either(config.extractAs[String](OBSERVE_KEY / OBJECT_PROP)
-      .map(v => if(v === manualDarkValue) manualDarkOverride else v).leftMap(explainExtractError))
-
-  override def getGeminiQA: SeqActionF[F, String] = SeqActionF("UNKNOWN")
-
-  override def getPIReq: SeqActionF[F, String] = SeqActionF("UNKNOWN")
-
-  override def getSciBand: SeqActionF[F, Option[Int]] =
-    SeqActionF(config.extractAs[Integer](OBSERVE_KEY / SCI_BAND).map(_.toInt).toOption)
-
-  def getAstrometicField: SeqActionF[F, Boolean] =
-    SeqActionF.either(config.extractAs[java.lang.Boolean](INSTRUMENT_KEY / ASTROMETRIC_FIELD_PROP)
-      .leftMap(explainExtractError)).map(Boolean.unbox)
+  // scalastyle:on
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/StandardHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/StandardHeader.scala
@@ -4,29 +4,30 @@
 package seqexec.server.keywords
 
 import cats.Applicative
-import cats.data.EitherT
 import cats.implicits._
 import cats.effect.Sync
+import cats.data.Nested
 import edu.gemini.spModel.guide.StandardGuideOptions
 import gem.Observation
 import gem.enum.KeywordName
 import seqexec.model.Conditions
 import seqexec.model.{Observer, Operator}
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.{InstrumentSystem, OcsBuildInfo, SeqActionF, sgoEq}
+import seqexec.server.{InstrumentSystem, OcsBuildInfo, sgoEq}
 import seqexec.server.tcs.{TargetKeywordsReader, TcsController, TcsKeywordsReader}
 
-// TODO: Replace Unit by something that can read the state for real
-final case class StateKeywordsReader[F[_]: Sync](conditions: Conditions, operator: Option[Operator], observer: Option[Observer]) {
-  def encodeCondition(c: Int): String = if(c === 100) "Any" else s"$c-percentile"
+final case class StateKeywordsReader[F[_]: Applicative](
+  conditions: Conditions,
+  operator: Option[Operator],
+  observer: Option[Observer]) {
+  private def encodeCondition(c: Int): F[String] = (if(c === 100) "Any" else s"$c-percentile").pure[F]
 
-  // TODO: "observer" should be the default when not set in state
-  def getObserverName: SeqActionF[F, String] = SeqActionF(observer.map(_.value).filter(_.nonEmpty).getOrElse("observer"))
-  def getOperatorName: SeqActionF[F, String] = SeqActionF(operator.map(_.value).filter(_.nonEmpty).getOrElse("ssa"))
-  def getRawImageQuality: SeqActionF[F, String] = SeqActionF(encodeCondition(conditions.iq.toInt))
-  def getRawCloudCover: SeqActionF[F, String] = SeqActionF(encodeCondition(conditions.cc.toInt))
-  def getRawWaterVapor: SeqActionF[F, String] = SeqActionF(encodeCondition(conditions.wv.toInt))
-  def getRawBackgroundLight: SeqActionF[F, String] = SeqActionF(encodeCondition(conditions.sb.toInt))
+  def observerName: F[String] = observer.map(_.value).filter(_.nonEmpty).getOrElse("observer").pure[F]
+  def operatorName: F[String] = operator.map(_.value).filter(_.nonEmpty).getOrElse("ssa").pure[F]
+  def rawImageQuality: F[String] = encodeCondition(conditions.iq.toInt)
+  def rawCloudCover: F[String] = encodeCondition(conditions.cc.toInt)
+  def rawWaterVapor: F[String] = encodeCondition(conditions.wv.toInt)
+  def rawBackgroundLight: F[String] = encodeCondition(conditions.sb.toInt)
 }
 
 class StandardHeader[F[_]: Sync](
@@ -34,48 +35,44 @@ class StandardHeader[F[_]: Sync](
   obsReader: ObsKeywordsReader[F],
   tcsReader: TcsKeywordsReader[F],
   stateReader: StateKeywordsReader[F],
-  tcsSubsystems: List[TcsController.Subsystem]) extends Header[F] {
+  tcsSubsystems: List[TcsController.Subsystem]) extends Header[F] with ObsKeywordsReaderConstants {
 
-  val obsObject: SeqActionF[F, Option[String]] = for {
-    obsType   <- obsReader.getObsType
-    obsObject <- obsReader.getObsObject
-    tcsObject <- EitherT.liftF(tcsReader.sourceATarget.objectName)
-  } yield if (obsType === "OBJECT" && obsObject =!= "Twilight" && obsObject =!= "Domeflat") Some(tcsObject)
-          else Some(obsObject)
-
-  private def decodeGuide(v: StandardGuideOptions.Value): String = v match {
-    case StandardGuideOptions.Value.park   => "parked"
-    case StandardGuideOptions.Value.guide  => "guiding"
-    case StandardGuideOptions.Value.freeze => "frozen"
-  }
+  val obsObject: F[String] = (for {
+    obsType   <- obsReader.obsType
+    obsObject <- obsReader.obsObject
+    tcsObject <- tcsReader.sourceATarget.objectName
+  } yield if (obsType === "OBJECT" && obsObject =!= "Twilight" && obsObject =!= "Domeflat") tcsObject.some
+          else obsObject.some).safeValOrDefault
 
   private def optTcsKeyword[B](s: TcsController.Subsystem)(v: F[B])(implicit d: DefaultHeaderValue[B]) : F[B] =
-    if(tcsSubsystems.contains(s)) v
-    else d.default.pure[F]
+    if (tcsSubsystems.contains(s)) v.safeValOrDefault else d.default.pure[F]
 
-  private def mountTcsKeyword[B](v: F[B])(implicit d: DefaultHeaderValue[B]) = optTcsKeyword[B](TcsController.Subsystem.Mount)(v)(d)
+  private def mountTcsKeyword[B: DefaultHeaderValue](v: F[B]) =
+    optTcsKeyword[B](TcsController.Subsystem.Mount)(v)
 
-  private def m2TcsKeyword[B](v: F[B])(implicit d: DefaultHeaderValue[B]) = optTcsKeyword[B](TcsController.Subsystem.M2)(v)(d)
+  private def m2TcsKeyword[B: DefaultHeaderValue](v: F[B]) =
+    optTcsKeyword[B](TcsController.Subsystem.M2)(v)
 
-  private def sfTcsKeyword[B](v: F[B])(implicit d: DefaultHeaderValue[B]) = optTcsKeyword[B](TcsController.Subsystem.AGUnit)(v)(d)
+  private def sfTcsKeyword[B: DefaultHeaderValue](v: F[B]) =
+    optTcsKeyword[B](TcsController.Subsystem.AGUnit)(v)
 
   private val baseKeywords = List(
-    buildString(SeqActionF(OcsBuildInfo.version), KeywordName.SEQEXVER),
-    buildString(obsObject.orDefault, KeywordName.OBJECT),
-    buildString(obsReader.getObsType, KeywordName.OBSTYPE),
-    buildString(obsReader.getObsClass, KeywordName.OBSCLASS),
-    buildString(obsReader.getGemPrgId, KeywordName.GEMPRGID),
-    buildString(obsReader.getObsId, KeywordName.OBSID),
-    buildString(obsReader.getDataLabel, KeywordName.DATALAB),
-    buildString(stateReader.getObserverName, KeywordName.OBSERVER),
-    buildString(obsReader.getObservatory, KeywordName.OBSERVAT),
-    buildString(obsReader.getTelescope, KeywordName.TELESCOP),
+    buildStringS(OcsBuildInfo.version.pure[F], KeywordName.SEQEXVER),
+    buildStringS(obsObject, KeywordName.OBJECT),
+    buildStringS(obsReader.obsType, KeywordName.OBSTYPE),
+    buildStringS(obsReader.obsClass, KeywordName.OBSCLASS),
+    buildStringS(obsReader.gemPrgId, KeywordName.GEMPRGID),
+    buildStringS(obsReader.obsId, KeywordName.OBSID),
+    buildStringS(obsReader.dataLabel, KeywordName.DATALAB),
+    buildStringS(stateReader.observerName, KeywordName.OBSERVER),
+    buildStringS(obsReader.observatory, KeywordName.OBSERVAT),
+    buildStringS(obsReader.telescope, KeywordName.TELESCOP),
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.parallax), KeywordName.PARALLAX),
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.radialVelocity), KeywordName.RADVEL),
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.epoch), KeywordName.EPOCH),
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.equinox), KeywordName.EQUINOX),
     buildDoubleS(mountTcsKeyword(tcsReader.trackingEquinox), KeywordName.TRKEQUIN),
-    buildString(stateReader.getOperatorName, KeywordName.SSA),
+    buildStringS(stateReader.operatorName, KeywordName.SSA),
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.ra), KeywordName.RA),
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.dec), KeywordName.DEC),
     buildDoubleS(tcsReader.elevation, KeywordName.ELEVATIO),
@@ -91,12 +88,12 @@ class StandardHeader[F[_]: Sync](
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.properMotionDec), KeywordName.PMDEC),
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.properMotionRA), KeywordName.PMRA),
     buildDoubleS(mountTcsKeyword(tcsReader.sourceATarget.wavelength), KeywordName.WAVELENG),
-    buildString(stateReader.getRawImageQuality, KeywordName.RAWIQ),
-    buildString(stateReader.getRawCloudCover, KeywordName.RAWCC),
-    buildString(stateReader.getRawWaterVapor, KeywordName.RAWWV),
-    buildString(stateReader.getRawBackgroundLight, KeywordName.RAWBG),
-    buildString(obsReader.getPIReq, KeywordName.RAWPIREQ),
-    buildString(obsReader.getGeminiQA, KeywordName.RAWGEMQA),
+    buildStringS(stateReader.rawImageQuality, KeywordName.RAWIQ),
+    buildStringS(stateReader.rawCloudCover, KeywordName.RAWCC),
+    buildStringS(stateReader.rawWaterVapor, KeywordName.RAWWV),
+    buildStringS(stateReader.rawBackgroundLight, KeywordName.RAWBG),
+    buildStringS(obsReader.pIReq, KeywordName.RAWPIREQ),
+    buildStringS(obsReader.geminiQA, KeywordName.RAWGEMQA),
     buildStringS(tcsReader.carouselMode, KeywordName.CGUIDMOD),
     buildStringS(tcsReader.ut, KeywordName.UT),
     buildStringS(tcsReader.date, KeywordName.DATE),
@@ -117,92 +114,104 @@ class StandardHeader[F[_]: Sync](
     buildDoubleS(sfTcsKeyword(tcsReader.sfTilt), KeywordName.SFTILT),
     buildDoubleS(sfTcsKeyword(tcsReader.sfLinear), KeywordName.SFLINEAR),
     buildStringS(mountTcsKeyword(tcsReader.aoFoldName), KeywordName.AOFOLD),
-    buildString(obsReader.getPwfs1Guide.map(decodeGuide), KeywordName.PWFS1_ST),
-    buildString(obsReader.getPwfs2Guide.map(decodeGuide), KeywordName.PWFS2_ST),
-    buildString(obsReader.getOiwfsGuide.map(decodeGuide), KeywordName.OIWFS_ST),
-    buildString(obsReader.getAowfsGuide.map(decodeGuide), KeywordName.AOWFS_ST),
-    buildInt32(obsReader.getSciBand.orDefault, KeywordName.SCIBAND)
+    buildStringS(obsReader.pwfs1GuideS, KeywordName.PWFS1_ST),
+    buildStringS(obsReader.pwfs2GuideS, KeywordName.PWFS2_ST),
+    buildStringS(obsReader.oiwfsGuideS, KeywordName.OIWFS_ST),
+    buildStringS(obsReader.aowfsGuideS, KeywordName.AOWFS_ST),
+    buildInt32S(obsReader.sciBand, KeywordName.SCIBAND)
   )
 
   def timinigWindows(id: ImageFileId): F[Unit] = {
-    val timingWindows = obsReader.getTimingWindows
-    val windows = timingWindows.flatMap {
+    val timingWindows = obsReader.timingWindows
+    val windows = Nested(timingWindows).map {
       case (i, tw) =>
         List(
-          KeywordName.fromTag(f"REQTWS${i + 1}%02d").map(buildString(tw.start, _)),
-          KeywordName.fromTag(f"REQTWD${i + 1}%02d").map(buildDouble(tw.duration, _)),
-          KeywordName.fromTag(f"REQTWN${i + 1}%02d").map(buildInt32(tw.repeat, _)),
-          KeywordName.fromTag(f"REQTWP${i + 1}%02d").map(buildDouble(tw.period, _))
-        ).collect { case Some(k) => k }
+          KeywordName.fromTag(f"REQTWS${i + 1}%02d").map(buildStringS(tw.start.pure[F], _)),
+          KeywordName.fromTag(f"REQTWD${i + 1}%02d").map(buildDoubleS(tw.duration.pure[F], _)),
+          KeywordName.fromTag(f"REQTWN${i + 1}%02d").map(buildInt32S(tw.repeat.pure[F], _)),
+          KeywordName.fromTag(f"REQTWP${i + 1}%02d").map(buildDoubleS(tw.period.pure[F], _))
+        ).mapFilter(identity)
     }
-    val windowsCount = buildInt32(SeqActionF(timingWindows.length), KeywordName.NUMREQTW)
-    sendKeywords(id, inst, windowsCount :: windows)
+    .value
+    .handleError(_ => Nil)
+
+    (timingWindows.map(_.length), windows).mapN {(l, w) =>
+      val windowsCount = buildInt32S(l.pure[F], KeywordName.NUMREQTW)
+      sendKeywords(id, inst, windowsCount :: w.flatten)
+    }.flatten
+    .handleError(_ => ()) // In case there is an error ignore it
   }
 
+  // TODO abstract requestedConditions/requestedAirMassAngle
   def requestedConditions(id: ImageFileId): F[Unit] = {
-    import ObsKeywordsReader._
     val keys = List(
       KeywordName.REQIQ -> IQ,
       KeywordName.REQCC -> CC,
       KeywordName.REQBG -> SB,
       KeywordName.REQWV -> WV)
-    val requested = keys.flatMap {
-      case (keyword, value) => obsReader.getRequestedConditions.get(value).toList.map(buildString(_, keyword))
+    obsReader.requestedConditions.flatMap { requestedConditions =>
+      val requested = keys.map {
+        case (keyword, value) =>
+          requestedConditions.get(value).map(v => buildStringS(v.pure[F], keyword))
+      }.mapFilter(identity)
+      sendKeywords(id, inst, requested).whenA(requested.nonEmpty)
     }
-    sendKeywords(id, inst, requested)
+    .handleError(_ => ()) // In case there is an error ignore it
   }
 
   def requestedAirMassAngle(id: ImageFileId): F[Unit] = {
-    import ObsKeywordsReader._
     val keys = List(
       KeywordName.REQMAXAM -> MAX_AIRMASS,
       KeywordName.REQMAXHA -> MAX_HOUR_ANGLE,
       KeywordName.REQMINAM -> MIN_AIRMASS,
       KeywordName.REQMINHA -> MIN_HOUR_ANGLE)
-    val requested = keys.flatMap {
-      case (keyword, value) => obsReader.getRequestedAirMassAngle.get(value).toList.map(buildDouble(_, keyword))
+    obsReader.requestedAirMassAngle.flatMap { airMassAngle =>
+      val requested = keys.map {
+        case (keyword, value) =>
+          airMassAngle.get(value).map(v => buildDoubleS(v.pure[F], keyword))
+      }.mapFilter(identity)
+      sendKeywords[F](id, inst, requested).whenA(requested.nonEmpty)
     }
-
-    sendKeywords[F](id, inst, requested).whenA(requested.nonEmpty)
+    .handleError(_ => ()) // In case there is an error ignore it
   }
 
   override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] = {
     def guiderKeywords(guideWith: F[StandardGuideOptions.Value], baseName: String, target: TargetKeywordsReader[F],
                        extras: List[KeywordBag => F[KeywordBag]]): F[Unit] = guideWith.flatMap { g =>
       val keywords: List[KeywordBag => F[KeywordBag]] = List(
-        KeywordName.fromTag(baseName + "ARA").map(buildDoubleS(target.ra, _)),
-        KeywordName.fromTag(baseName + "ADEC").map(buildDoubleS(target.dec, _)),
-        KeywordName.fromTag(baseName + "ARV").map(buildDoubleS(target.radialVelocity, _)),
-        KeywordName.fromTag(baseName + "AWAVEL").map(buildDoubleS(target.wavelength, _)),
-        KeywordName.fromTag(baseName + "AEPOCH").map(buildDoubleS(target.epoch, _)),
-        KeywordName.fromTag(baseName + "AEQUIN").map(buildDoubleS(target.equinox, _)),
-        KeywordName.fromTag(baseName + "AFRAME").map(buildStringS(target.frame, _)),
-        KeywordName.fromTag(baseName + "AOBJEC").map(buildStringS(target.objectName, _)),
-        KeywordName.fromTag(baseName + "APMDEC").map(buildDoubleS(target.properMotionDec, _)),
-        KeywordName.fromTag(baseName + "APMRA").map(buildDoubleS(target.properMotionRA, _)),
-        KeywordName.fromTag(baseName + "APARAL").map(buildDoubleS(target.parallax, _))
-      ).collect { case Some(k) => k }
+        KeywordName.fromTag(s"${baseName}ARA").map(buildDoubleS(target.ra, _)),
+        KeywordName.fromTag(s"${baseName}ADEC").map(buildDoubleS(target.dec, _)),
+        KeywordName.fromTag(s"${baseName}ARV").map(buildDoubleS(target.radialVelocity, _)),
+        KeywordName.fromTag(s"${baseName}AWAVEL").map(buildDoubleS(target.wavelength, _)),
+        KeywordName.fromTag(s"${baseName}AEPOCH").map(buildDoubleS(target.epoch, _)),
+        KeywordName.fromTag(s"${baseName}AEQUIN").map(buildDoubleS(target.equinox, _)),
+        KeywordName.fromTag(s"${baseName}AFRAME").map(buildStringS(target.frame, _)),
+        KeywordName.fromTag(s"${baseName}AOBJEC").map(buildStringS(target.objectName, _)),
+        KeywordName.fromTag(s"${baseName}APMDEC").map(buildDoubleS(target.properMotionDec, _)),
+        KeywordName.fromTag(s"${baseName}APMRA").map(buildDoubleS(target.properMotionRA, _)),
+        KeywordName.fromTag(s"${baseName}APARAL").map(buildDoubleS(target.parallax, _))
+      ).mapFilter(identity)
 
-      if (g === StandardGuideOptions.Value.guide) sendKeywords[F](id, inst, keywords ++ extras)
-      else Applicative[F].unit
+      sendKeywords[F](id, inst, keywords ++ extras).whenA(g === StandardGuideOptions.Value.guide)
     }
+    .handleError(_ => ()) // Errors are caught here
 
     def standardGuiderKeywords(guideWith: F[StandardGuideOptions.Value], baseName: String,
                                target: TargetKeywordsReader[F], extras: List[KeywordBag => F[KeywordBag]]): F[Unit] = {
-      val ext = KeywordName.fromTag(baseName + "FOCUS").map(buildDoubleS(tcsReader.m2UserFocusOffset, _)).toList ++ extras
+      val ext = KeywordName.fromTag(s"${baseName}FOCUS").map(buildDoubleS(tcsReader.m2UserFocusOffset, _)).toList ++ extras
       guiderKeywords(guideWith, baseName, target, ext)
     }
 
-    val oiwfsKeywords = guiderKeywords(obsReader.getOiwfsGuide.liftF, "OI", tcsReader.oiwfsTarget,
+    val oiwfsKeywords = guiderKeywords(obsReader.oiwfsGuide, "OI", tcsReader.oiwfsTarget,
       List(buildDoubleS(tcsReader.oiwfsFreq, KeywordName.OIFREQ)))
 
-    val pwfs1Keywords = standardGuiderKeywords(obsReader.getPwfs1Guide.liftF, "P1", tcsReader.pwfs1Target,
+    val pwfs1Keywords = standardGuiderKeywords(obsReader.pwfs1Guide, "P1", tcsReader.pwfs1Target,
       List(buildDoubleS(tcsReader.pwfs1Freq, KeywordName.P1FREQ)))
 
-    val pwfs2Keywords = standardGuiderKeywords(obsReader.getPwfs2Guide.liftF, "P2", tcsReader.pwfs2Target,
+    val pwfs2Keywords = standardGuiderKeywords(obsReader.pwfs2Guide, "P2", tcsReader.pwfs2Target,
       List(buildDoubleS(tcsReader.pwfs2Freq, KeywordName.P2FREQ)))
 
-    val aowfsKeywords = standardGuiderKeywords(obsReader.getAowfsGuide.liftF, "AO", tcsReader.aowfsTarget, Nil)
+    val aowfsKeywords = standardGuiderKeywords(obsReader.aowfsGuide, "AO", tcsReader.aowfsTarget, Nil)
 
     sendKeywords(id, inst, baseKeywords) *>
     requestedConditions(id) *>
@@ -219,7 +228,7 @@ class StandardHeader[F[_]: Sync](
       buildDoubleS(tcsReader.airMass, KeywordName.AIRMASS),
       buildDoubleS(tcsReader.startAirMass, KeywordName.AMSTART),
       buildDoubleS(tcsReader.endAirMass, KeywordName.AMEND),
-      buildBoolean(obsReader.getHeaderPrivacy, KeywordName.PROP_MD),
-      buildString(obsReader.getProprietaryMonths, KeywordName.RELEASE)
+      buildBooleanS(obsReader.headerPrivacy, KeywordName.PROP_MD),
+      buildStringS(obsReader.proprietaryMonths, KeywordName.RELEASE)
     ))
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -255,9 +255,11 @@ package object keywords {
     def orDefault: A = a.getOrElse(d.default)
   }
 
-  implicit class A2SeqAction[A: DefaultHeaderValue](val v: Option[A]) {
-    // Convert to a SeqAction or use the default
-    def toSeqActionDefault: SeqAction[A] = SeqAction(v.orDefault)
+  implicit class DefaultValueFOps[F[_]: Functor, A: DefaultHeaderValue](
+      val v: F[Option[A]]) {
+    private val D: DefaultHeaderValue[A] = DefaultHeaderValue[A]
+
+    def orDefault: F[A] = v.map(_.getOrElse(D.default))
   }
 
   // Keywords are read and they can fail or be missing
@@ -277,11 +279,6 @@ package object keywords {
     // use the default
     def safeValOrDefault: F[A] =
       v.handleError(_ => DefaultHeaderValue[A].default)
-  }
-
-  implicit class SeqActionOption2SeqActionF[F[_]: Functor, A: DefaultHeaderValue](
-      val v: F[Option[A]]) {
-    def orDefault: F[A] = v.map(_.orDefault)
   }
 
   def buildKeywordF[F[_]: Functor, A](get: F[A], name: KeywordName, f: (KeywordName, A) => Keyword[A]): KeywordBag => F[KeywordBag] =


### PR DESCRIPTION
This is (i think) the last Pr to reform the keyword header readers. There will be a last PR cleaning up some unused code.
This PR changes `ObsKeywordReader` which gathers data from the ODB. I'm treating ODB reads as potentially dangerous coming from Java although it is mostly memory reads
Along the process a bug was found where the keywords for MAXAIRMASS are not properly read. Testing on instrument show them missing