### PR TITLE
SEQNG-974 Fix for GNIRS observe.

### DIFF
--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandMonitor.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandMonitor.java
@@ -50,6 +50,19 @@ public interface CaCommandMonitor {
     void waitDone() throws InterruptedException;
 
     /**
+     * Blocks the current thread while the command is active.
+     *
+     * @param timeout
+     *            time to wait for the command inactivity, in seconds.
+     * @throws TimeoutException
+     * @return the end state of the command
+     */
+    State waitInactive(long timeout, TimeUnit unit) throws TimeoutException,
+            InterruptedException;
+
+    State waitInactive() throws InterruptedException;
+
+    /**
      * Retrieves the current execution state of the command.
      * 
      * @return the execution state of the command.

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -716,7 +716,7 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
                         failCommandWithCarError(cm);
                         return idleState;
                     } else if (carState.isBusy()) {
-                        return new CaObserveSenderImpl.WaitApplyBusy(cm, val, carState, observeState);
+                        return new CaObserveSenderImpl.WaitApplyIdle(cm, val, carState, observeState);
                     }
                 }
                 return new CaObserveSenderImpl.WaitApplyBusy(cm, val, carState, observeState);
@@ -803,7 +803,12 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
                 return idleState;
             }
             else {
-                return this;
+                if(val.isIdle() && observeState != idleObserveState) {
+                    return (new CaObserveSenderImpl.WaitApplyIdle(cm, clid, val, observeState)).onCarValChange(val);
+                }
+                else {
+                    return this;
+                }
             }
         }
 


### PR DESCRIPTION
Sometimes during a GNIRS observation, the event of the main DC apply record going BUSY is not received (or is not generated by the instrument?), causing Seqexec to wait forever for it (ending in a timeout). This PR fixes it. It also adds tests cases for GNIRS, and factors some of the test code.