### PR TITLE
SEQNG-245: Restore autoscrolling to the steps table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -465,10 +465,6 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
     useYarn                                  := true,
     // JS dependencies via npm
     npmDependencies in Compile ++= Seq(
-      "react"                   -> LibraryVersions.reactJS,
-      "react-dom"               -> LibraryVersions.reactJS,
-      "react-virtualized"       -> LibraryVersions.reactVirtualized,
-      "react-draggable"         -> LibraryVersions.reactDraggable,
       "jquery"                  -> LibraryVersions.jQuery,
       "semantic-ui-dropdown"    -> LibraryVersions.semanticUI,
       "semantic-ui-modal"       -> LibraryVersions.semanticUI,

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -1061,6 +1061,7 @@ body {
 }
 .ReactVirtualized__Grid__innerScrollContainer {
   .borderBottom();
+  scroll-behavior: smooth;
 }
 .ReactVirtualized__Table__row {
   display: flex;

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -24,6 +24,7 @@ import monocle.function.At.atSortedMap
 import react.virtualized._
 import react.clipboard._
 import scala.scalajs.js
+import scala.math.max
 import scala.collection.immutable.SortedMap
 import seqexec.model.enum.ServerLogLevel
 import seqexec.model.events._
@@ -289,28 +290,32 @@ object LogArea {
     * Build the table log
     */
   private def table(b: Backend)(size: Size): VdomNode =
-    Table(
-      Table.props(
-        disableHeader = false,
-        noRowsRenderer = () =>
-          <.div(
-            ^.cls := "ui center aligned segment noRows",
-            SeqexecStyles.noRowsSegment,
-            ^.height := 270.px,
-            "No log entries"
+    if (size.width > 0) {
+      Table(
+        Table.props(
+          disableHeader = false,
+          noRowsRenderer = () =>
+            <.div(
+              ^.cls := "ui center aligned segment noRows",
+              SeqexecStyles.noRowsSegment,
+              ^.height := 270.px,
+              "No log entries"
+          ),
+          overscanRowCount = SeqexecStyles.overscanRowCount,
+          height           = 200,
+          rowCount         = b.props.rowCount(b.state),
+          rowHeight        = SeqexecStyles.rowHeight,
+          rowClassName     = rowClassName(b) _,
+          width            = max(1, size.width),
+          rowGetter        = b.props.rowGetter(b.state) _,
+          headerClassName  = SeqexecStyles.tableHeader.htmlClass,
+          headerHeight     = SeqexecStyles.headerHeight
         ),
-        overscanRowCount = SeqexecStyles.overscanRowCount,
-        height           = 200,
-        rowCount         = b.props.rowCount(b.state),
-        rowHeight        = SeqexecStyles.rowHeight,
-        rowClassName     = rowClassName(b) _,
-        width            = size.width,
-        rowGetter        = b.props.rowGetter(b.state) _,
-        headerClassName  = SeqexecStyles.tableHeader.htmlClass,
-        headerHeight     = SeqexecStyles.headerHeight
-      ),
-      b.state.tableState.columnBuilder(size, colBuilder(b, size)): _*
-    ).vdomElement
+        b.state.tableState.columnBuilder(size, colBuilder(b, size)): _*
+      ).vdomElement
+    } else {
+      <.div()
+    }
 
   private def onResize(b: Backend): Size => Callback = s =>
     b.modStateL(State.tableState)(_.recalculateWidths(s, _ => true, columnWidths))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTable.scala
@@ -20,6 +20,7 @@ import monocle.macros.Lenses
 import react.virtualized._
 import react.sortable._
 import scala.scalajs.js
+import scala.math.max
 import scala.concurrent.duration._
 import react.common._
 import seqexec.model.QueueId
@@ -347,11 +348,11 @@ object CalQueueTable {
             "Cal queue empty"
         ),
         overscanRowCount = SeqexecStyles.overscanRowCount,
-        height           = size.height.toInt,
+        height           = max(1, size.height.toInt),
         rowCount         = p.rowCount,
         rowHeight        = SeqexecStyles.rowHeight,
         rowClassName     = rowClassName(p, s) _,
-        width            = size.width.toInt,
+        width            = max(1, size.width.toInt),
         rowGetter        = p.rowGetter(s) _,
         headerClassName  = SeqexecStyles.tableHeader.htmlClass,
         scrollTop        = s.tableState.scrollPosition,
@@ -402,21 +403,25 @@ object CalQueueTable {
         TableContainer.Props(
           p.canOperate,
           size => {
-            val sortableList = SortableContainer.wrapC(
-              Table.component,
-              s.tableState
-                .columnBuilder(size, colBuilder(p, s, size))
-                .map(_.vdomElement))
+            if (size.width > 0) {
+              val sortableList = SortableContainer.wrapC(
+                Table.component,
+                s.tableState
+                  .columnBuilder(size, colBuilder(p, s, size))
+                  .map(_.vdomElement))
 
-            // If distance is 0 we can miss some events
-            val cp = SortableContainer.Props(
-              onSortEnd         = requestMove,
-              shouldCancelStart = _ => CallbackTo(!p.data.canOperate),
-              helperClass =
-                (SeqexecStyles.noselect |+| SeqexecStyles.draggedRowHelper).htmlClass,
-              distance = 3
-            )
-            sortableList(cp)(table(p, s)(size))
+              // If distance is 0 we can miss some events
+              val cp = SortableContainer.Props(
+                onSortEnd         = requestMove,
+                shouldCancelStart = _ => CallbackTo(!p.data.canOperate),
+                helperClass =
+                  (SeqexecStyles.noselect |+| SeqexecStyles.draggedRowHelper).htmlClass,
+                distance = 3
+              )
+              sortableList(cp)(table(p, s)(size))
+            } else {
+              <.div()
+            }
           },
           onResize = _ => Callback.empty
         ))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -15,6 +15,7 @@ import japgolly.scalajs.react.Reusability
 import cats.implicits._
 import react.virtualized._
 import scala.scalajs.js
+import scala.math.max
 import seqexec.model.Step
 import seqexec.model.enum.SystemName
 import seqexec.web.client.components.SeqexecStyles
@@ -165,11 +166,11 @@ object StepConfigTable {
           "No configuration for step"
       ),
       overscanRowCount = SeqexecStyles.overscanRowCount,
-      height           = size.height.toInt,
+      height           = max(1, size.height.toInt),
       rowCount         = b.props.rowCount,
       rowHeight        = SeqexecStyles.rowHeight,
       rowClassName     = rowClassName(b.props) _,
-      width            = size.width.toInt,
+      width            = max(1, size.width.toInt),
       rowGetter        = b.props.rowGetter _,
       scrollTop        = b.state.scrollPosition,
       headerClassName  = SeqexecStyles.tableHeader.htmlClass,
@@ -182,9 +183,13 @@ object StepConfigTable {
     .initialStateFromProps(_.startState)
     .render ( b =>
       TableContainer(TableContainer.Props(true, size =>
-        Table(settingsTableProps(b, size),
-              b.state.columnBuilder(size, colBuilder(b, size)): _*),
-              onResize = _ => Callback.empty))
+        if (size.width > 0) {
+          Table(settingsTableProps(b, size),
+                b.state.columnBuilder(size, colBuilder(b, size)): _*)
+        } else {
+          <.div()
+        },
+      onResize = _ => Callback.empty))
     )
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -799,11 +799,11 @@ object StepsTable extends Columns {
           "No Steps"
       ),
       overscanRowCount = SeqexecStyles.overscanRowCount,
-      height           = size.height.toInt,
+      height           = max(1, size.height.toInt),
       rowCount         = b.props.rowCount,
       rowHeight        = rowHeight(b) _,
       rowClassName     = rowClassName(b) _,
-      width            = size.width.toInt,
+      width            = max(1, size.width.toInt),
       rowGetter        = b.props.rowGetter _,
       scrollToIndex    = startScrollToIndex(b),
       scrollTop        = startScrollTop(b.state),
@@ -962,9 +962,13 @@ object StepsTable extends Columns {
               .columnBuilder(size, colBuilder(b, size), b.props.columnWidths)
               .map(_.vdomElement)
 
-          ref
-            .component(stepsTableProps(b)(size))(ts: _*)
-            .vdomElement
+          if (size.width > 0) {
+            ref
+              .component(stepsTableProps(b)(size))(ts: _*)
+              .vdomElement
+          } else {
+            <.div()
+          }
         },
         onResize = s =>
           b.modStateL(State.tableState)(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -79,7 +79,7 @@ object Settings {
     val scalaJSReactVirtualized = "0.6.2"
     val scalaJSReactClipboard   = "0.8.0"
     val scalaJSReactDraggable   = "0.4.1"
-    val scalaJSReactSortable    = "0.2.0"
+    val scalaJSReactSortable    = "0.2.1"
 
     // Scala libraries
     val catsEffectVersion       = "1.3.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -75,10 +75,10 @@ object Settings {
     val diodeReact              = "1.1.5.142"
     val javaTimeJS              = "2.0.0-RC2"
     val scalaJQuery             = "1.2"
-    val scalaJSReactCommon      = "0.2.0"
-    val scalaJSReactVirtualized = "0.6.0b"
-    val scalaJSReactClipboard   = "0.7.0"
-    val scalaJSReactDraggable   = "0.4.0"
+    val scalaJSReactCommon      = "0.2.1"
+    val scalaJSReactVirtualized = "0.6.2"
+    val scalaJSReactClipboard   = "0.8.0"
+    val scalaJSReactDraggable   = "0.4.1"
     val scalaJSReactSortable    = "0.2.0"
 
     // Scala libraries
@@ -98,7 +98,7 @@ object Settings {
     val unboundId               = "3.2.1"
     val jwt                     = "2.1.0"
     val slf4j                   = "1.7.26"
-    val log4s                   = "1.8.0"
+    val log4s                   = "1.8.1"
     val logback                 = "1.2.3"
     val janino                  = "3.0.12"
     val logstash                = "6.0"
@@ -119,13 +119,10 @@ object Settings {
     val scalaMock               = "4.1.0"
 
     // Pure JS libraries
-    val reactJS                 = "16.7.0"
     val jQuery                  = "3.2.1"
     val semanticUI              = "2.3.1"
     val ocsVersion              = "2019101.1.3"
     val uglifyJs                = "1.2.4"
-    val reactVirtualized        = "9.21.0"
-    val reactDraggable          = "3.3.0"
 
     val apacheXMLRPC            = "3.1.3"
     val opencsv                 = "2.1"


### PR DESCRIPTION
We had for a while the ability of the table to autoscroll when a sequence was running. it was lost in one of the refactorings and due to bugs on the upstream libraries

With the latest `react-virtualized` release we can restore it.

With this PR once you press run the sequence will jump to the next step to run and track the running step:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/3615303/59281677-a9b6de00-8c35-11e9-9f26-589b9c0903db.gif)

If we were out of view the table will jump to the running step
![ezgif com-video-to-gif(1)](https://user-images.githubusercontent.com/3615303/59281868-00241c80-8c36-11e9-99c0-d78e3fbcec61.gif)

If the user scrolls independently care is taken to avoid jumping back to the next step as that is likely confusing