### PR TITLE
SEQNG-777: Display sequences state on the day cal table

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -679,6 +679,11 @@ body {
   justify-content: center;
 }
 
+.SeqexecStyles-fullCell {
+  width: 100%;
+  height: 100%;
+}
+
 .SeqexecStyles-settingsCellHeader {
   display: flex;
   align-items: center;

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -218,6 +218,8 @@ object SeqexecStyles {
 
   val centeredCell: GStyle = GStyle.fromString("SeqexecStyles-centeredCell")
 
+  val fullCell: GStyle = GStyle.fromString("SeqexecStyles-fullCell")
+
   val tableHeaderIcons: GStyle =
     GStyle.fromString("SeqexecStyles-tableHeaderIcons")
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -534,7 +534,7 @@ object SessionQueueTable extends Columns {
     ((i, p.rowGetter(i)) match {
       case (-1, _) =>
         SeqexecStyles.headerRowStyle
-      case (_, r: SessionQueueRow) if r.status == SequenceState.Completed =>
+      case (_, r: SessionQueueRow) if r.status === SequenceState.Completed =>
         draggableRow |+| SeqexecStyles.rowPositive
       case (_, r: SessionQueueRow) if r.status.isRunning =>
         draggableRow |+| SeqexecStyles.rowWarning
@@ -718,9 +718,11 @@ object SessionQueueTable extends Columns {
   private def initialState(p: Props): State =
     State.tableState.set(p.sequences.tableState)(State.InitialState)
 
-  private def onResize(b: Backend): Size => Callback = s =>
-    b.setStateL(State.lastSize)(s.some) *>
-      b.modStateL(State.tableState)(_.recalculateWidths(s, b.props.visibleColumns, b.props.columnWidths))
+  private def onResize(b: Backend): Size => Callback =
+    s =>
+      b.setStateL(State.lastSize)(s.some) *>
+        b.modStateL(State.tableState)(
+          _.recalculateWidths(s, b.props.visibleColumns, b.props.columnWidths))
 
   private val component = ScalaComponent
     .builder[Props]("SessionQueueTable")


### PR DESCRIPTION
When a day cal is running there is no display of exactly what is running. They are shown on the session queue table but not on day cal

This PR improves that:
![Seqexec - Daycal queue 2019-06-12 17-00-45](https://user-images.githubusercontent.com/3615303/59387652-b9b6e680-8d37-11e9-9db4-de0a20178ea1.png)
