### PR TITLE
SEQNG-1006 Reset execution state on the proper place

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -85,15 +85,7 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
 
   def handleRequestResourceRun: PartialFunction[Any, ActionResult[M]] = {
     case RequestResourceRun(id, _, r) =>
-      // reset others instrument that may have run common resources
-      val resetOthers: SequencesOnDisplay => SequencesOnDisplay =
-        if (Resource.common.contains(r)) {
-          SequencesOnDisplay.resetCommonResourceOperations(id, r)
-        } else {
-          identity
-        }
       updatedL(
-        resetOthers >>>
         SequencesOnDisplay.markOperations(
           id,
           TabOperations
@@ -114,7 +106,15 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
           TabOperations.syncRequested.set(SyncOperation.SyncIdle)))
 
     case RunResourceRemote(id, s, r) =>
+      // reset others instrument that may have run common resources
+      val resetOthers: SequencesOnDisplay => SequencesOnDisplay =
+        if (Resource.common.contains(r)) {
+          SequencesOnDisplay.resetCommonResourceOperations(id, r)
+        } else {
+          identity
+        }
       updatedLE(
+        resetOthers >>>
         SequencesOnDisplay.markOperations(
           id,
           TabOperations


### PR DESCRIPTION
On SEQNG-821 We started showing the state of common resources (tcs, gcal) on the tab. There is a bug with respect to clients not doing the configuration:
<img width="643" alt="Seqexec - GS-2018B-Q-0-101 2019-06-13 10-33-35" src="https://user-images.githubusercontent.com/3615303/59442655-a99b1780-8dc8-11e9-9de1-eae723b88776.png">

This PR fixes it
<img width="519" alt="Seqexec - GS-2018B-Q-0-101 2019-06-13 10-39-51" src="https://user-images.githubusercontent.com/3615303/59442666-ad2e9e80-8dc8-11e9-811e-9aa5aaa7f2bb.png">
