### PR TITLE
SEQNG-1009: Invalid data label

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/ObsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/ObsKeywordReader.scala
@@ -175,7 +175,9 @@ object ObsKeywordReader extends ObsKeywordsReaderConstants {
     }
 
     override def dataLabel: F[String] =
-      (OBSERVE_KEY / DATA_LABEL_PROP).toString.pure[F]
+      F.delay(
+        s"${config.getItemValue(OBSERVE_KEY / DATA_LABEL_PROP)}"
+      )
 
     override def observatory: F[String] = telescopeName.pure[F]
 


### PR DESCRIPTION
Fixes a bug that slipped on a refactoring. Properly read the datalabel from the sequence config