### PR TITLE
Ensures runFrom button is hidden if user is logged off

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -163,7 +163,7 @@ object StepProgressCell {
                           props.step.id,
                           props.tabOperations.resourceInFlight,
                           props.tabOperations.startFromRequested))
-        .when(props.step.canRunFrom),
+        .when(props.step.canRunFrom && props.clientStatus.canOperate),
       <.div(
         SeqexecStyles.specialStateLabel,
         props.step.show


### PR DESCRIPTION
Small bugfix. Under some circumstances the `runFrom` button may show up even when the user is logged off. This is harmless as the server rejects unauthenticated requests but still it should be rather not be available