### PR TITLE
SEQNG-986 Display the guide config info on the footer

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/M1Source.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/M1Source.scala
@@ -19,17 +19,19 @@ object M1Source {
   val all: List[M1Source] =
     List(PWFS1, PWFS2, OIWFS, GAOS, HRWFS)
 
+  def tag(s: M1Source): String = s match {
+    case PWFS1 => "PWFS1"
+    case PWFS2 => "PWFS2"
+    case OIWFS => "OIWFS"
+    case GAOS  => "GAOS"
+    case HRWFS => "HRWFS"
+  }
+
   /** @group Typeclass Instances */
   implicit val M1SourceEnumerated: Enumerated[M1Source] =
     new Enumerated[M1Source] {
       def all = M1Source.all
-      def tag(a: M1Source): String = a match {
-        case PWFS1 => "PWFS1"
-        case PWFS2 => "PWFS2"
-        case OIWFS => "OIWFS"
-        case GAOS  => "GAOS"
-        case HRWFS => "HRWFS"
-      }
+      def tag(a: M1Source): String = M1Source.tag(a)
     }
 
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/TipTiltSource.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/TipTiltSource.scala
@@ -18,15 +18,17 @@ object TipTiltSource {
   val all: List[TipTiltSource] =
     List(PWFS1, PWFS2, OIWFS, GAOS)
 
+  def tag(s: TipTiltSource): String = s match {
+    case PWFS1 => "PWFS1"
+    case PWFS2 => "PWFS2"
+    case OIWFS => "OIWFS"
+    case GAOS  => "GAOS"
+  }
+
   /** @group Typeclass Instances */
   implicit val TipTiltSourceEnumerated: Enumerated[TipTiltSource] =
     new Enumerated[TipTiltSource] {
       def all = TipTiltSource.all
-      def tag(a: TipTiltSource): String = a match {
-        case PWFS1 => "PWFS1"
-        case PWFS2 => "PWFS2"
-        case OIWFS => "OIWFS"
-        case GAOS  => "GAOS"
-      }
+      def tag(a: TipTiltSource): String = TipTiltSource.tag(a)
     }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideConfigDb.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideConfigDb.scala
@@ -52,18 +52,18 @@ object GuideConfigDb {
 
   implicit val altairDecoder: Decoder[AltairConfig] = Decoder.instance[AltairConfig]{
     c =>
-      c.downField("aoOn").as[Boolean].flatMap{
+      c.downField("aoOn").as[Boolean].flatMap {
         if(_) {
-          c.downField("mode").as[String].flatMap{
+          c.downField("mode").as[String].flatMap {
             case "NGS" => for{
               blnd <- c.downField("oiBlend").as[Boolean]
               gsx  <- c.downField("aogsx").as[Double]
               gsy  <- c.downField("aogsy").as[Double]
             } yield Ngs(blnd, (Millimeters(gsx), Millimeters(gsy)))
-            case "LGS" => c.downField("useP1").as[Boolean].flatMap{
+            case "LGS" => c.downField("useP1").as[Boolean].flatMap {
               if(_) Right(LgsWithP1)
               else {
-                c.downField("useOI").as[Boolean].flatMap{
+                c.downField("useOI").as[Boolean].flatMap {
                   if(_) Right(LgsWithOi)
                   else for {
                     strapLoop <- c.downField("strapOn").as[Boolean]
@@ -90,7 +90,7 @@ object GuideConfigDb {
   implicit val mountGuideDecoder: Decoder[MountGuideOption] =
     Decoder.decodeBoolean.map(_.fold(MountGuideOn, MountGuideOff))
 
-  implicit val m1GuideSourceDecoder: Decoder[M1Source] = Decoder.decodeString.flatMap{
+  implicit val m1GuideSourceDecoder: Decoder[M1Source] = Decoder.decodeString.flatMap {
     case "PWFS1" => Decoder.const(M1Source.PWFS1)
     case "PWFS2" => Decoder.const(M1Source.PWFS2)
     case "OIWFS" => Decoder.const(M1Source.OIWFS)
@@ -108,7 +108,7 @@ object GuideConfigDb {
     }
   }
 
-  implicit val m2GuideSourceDecoder: Decoder[TipTiltSource] = Decoder.decodeString.flatMap{
+  implicit val m2GuideSourceDecoder: Decoder[TipTiltSource] = Decoder.decodeString.flatMap {
     case "PWFS1" => Decoder.const(TipTiltSource.PWFS1)
     case "PWFS2" => Decoder.const(TipTiltSource.PWFS2)
     case "OIWFS" => Decoder.const(TipTiltSource.OIWFS)
@@ -119,7 +119,7 @@ object GuideConfigDb {
   implicit val comaDecoder: Decoder[ComaOption] = Decoder.decodeBoolean.map(_.fold(ComaOn, ComaOff))
 
   implicit val m2GuideDecoder: Decoder[M2GuideConfig] = Decoder.instance[M2GuideConfig]{ c =>
-    c.downField("on").as[Boolean].flatMap{
+    c.downField("on").as[Boolean].flatMap {
       if(_) for {
         srcs <- c.downField("sources").as[Set[TipTiltSource]]
         coma <- c.downField("comaOn").as[ComaOption]

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -68,6 +68,10 @@ body {
   }
 }
 
+.SeqexecStyles-activeGuide {
+  background-color: @greenHeaderColor !important;
+}
+
 .SeqexecStyles-activeInstrumentLabel {
   padding-bottom: 0.2em;
   text-align: center;

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/WebSocketFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/WebSocketFocus.scala
@@ -21,7 +21,8 @@ final case class WebSocketsFocus(location:        Pages.SeqexecPages,
                                  clientId:        Option[ClientId],
                                  site:            Option[Site],
                                  sound:           SoundSelection,
-                                 serverVersion:   Option[String])
+                                 serverVersion:   Option[String],
+                                 guideConfig:     TelescopeGuideConfig)
 
 object WebSocketsFocus {
   implicit val eq: Eq[WebSocketsFocus] =
@@ -33,7 +34,8 @@ object WebSocketsFocus {
          x.defaultObserver,
          x.clientId,
          x.site,
-         x.serverVersion))
+         x.serverVersion,
+         x.guideConfig))
 
   val webSocketFocusL: Lens[SeqexecAppRootModel, WebSocketsFocus] =
     Lens[SeqexecAppRootModel, WebSocketsFocus](
@@ -45,7 +47,8 @@ object WebSocketsFocus {
                         m.clientId,
                         m.site,
                         m.uiModel.sound,
-                        m.serverVersion))(
+                        m.serverVersion,
+                        m.guideConfig))(
       v =>
         m =>
           m.copy(
@@ -55,6 +58,7 @@ object WebSocketsFocus {
                                      sound           = v.sound),
             clientId      = v.clientId,
             site          = v.site,
-            serverVersion = v.serverVersion
+            serverVersion = v.serverVersion,
+            guideConfig   = v.guideConfig
       ))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/ConnectionState.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/ConnectionState.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components
+
+import diode.react.ModelProxy
+import diode.react.ReactPot._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.Reusability
+import react.common.implicits._
+import seqexec.web.client.model.WebSocketConnection
+import seqexec.web.client.semanticui.elements.icon.Icon._
+import seqexec.web.client.reusability._
+
+/**
+  * Alert message when the connection disappears
+  */
+object ConnectionState {
+
+  final case class Props(u: WebSocketConnection)
+
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+
+  def formatTime(delay: Int): String =
+    if (delay < 1000) {
+      f"${delay / 1000.0}%.1f"
+    } else {
+      f"${delay / 1000}%d"
+    }
+
+  private val component = ScalaComponent
+    .builder[Props]("ConnectionState")
+    .stateless
+    .render_P(
+      p =>
+        <.div(
+          ^.cls := "ui header item sub",
+          p.u.ws.renderPending(
+            _ =>
+              <.div(
+                IconAttention.copyIcon(color = Option("red")),
+                <.span(
+                  SeqexecStyles.errorText,
+                  s"Connection lost, retrying in ${formatTime(p.u.nextAttempt)} [s] ..."
+                )
+              )
+          )
+        )
+    )
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(u: ModelProxy[WebSocketConnection]): Unmounted[Props, Unit, Unit] =
+    component(Props(u()))
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/ControlMenu.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/ControlMenu.scala
@@ -3,7 +3,6 @@
 
 package seqexec.web.client.components
 
-import diode.react.ModelProxy
 import seqexec.web.client.actions.Logout
 import seqexec.web.client.actions.OpenLoginBox
 import seqexec.web.client.model.ClientStatus
@@ -22,27 +21,26 @@ import japgolly.scalajs.react.vdom.html_<^._
   */
 object ControlMenu {
 
-  final case class Props(status: ModelProxy[ClientStatus])
+  final case class Props(status: ClientStatus)
 
   private val soundConnect =
     SeqexecCircuit.connect(SeqexecCircuit.soundSettingReader)
 
-  def openLogin[A](proxy: ModelProxy[A]): Callback =
-    proxy.dispatchCB(OpenLoginBox)
-  def logout[A](proxy: ModelProxy[A]): Callback = proxy.dispatchCB(Logout)
+  private val openLogin: Callback =
+    SeqexecCircuit.dispatchCB(OpenLoginBox)
+  private val logout: Callback =
+    SeqexecCircuit.dispatchCB(Logout)
 
-  private def loginButton[A](proxy: ModelProxy[A], enabled: Boolean) =
+  private def loginButton(enabled: Boolean) =
     Button(Button.Props(size     = Size.Medium,
-                        onClick  = openLogin(proxy),
+                        onClick  = openLogin,
                         disabled = !enabled,
                         inverted = true),
            "Login")
 
-  private def logoutButton[A](proxy:   ModelProxy[A],
-                              text:    String,
-                              enabled: Boolean) =
+  private def logoutButton(text: String, enabled: Boolean) =
     Button(Button.Props(size     = Size.Medium,
-                        onClick  = logout(proxy),
+                        onClick  = logout,
                         icon     = Some(IconSignOut),
                         disabled = !enabled,
                         inverted = true),
@@ -52,7 +50,7 @@ object ControlMenu {
     .builder[Props]("SeqexecTopMenu")
     .stateless
     .render_P { p =>
-      val status = p.status()
+      val status = p.status
       <.div(
         ^.cls := "ui secondary right menu",
         SeqexecStyles.notInMobile,
@@ -60,43 +58,45 @@ object ControlMenu {
           <.div(
             ^.cls := "ui item",
             soundConnect(x => SoundControl(SoundControl.Props(x()))),
-            loginButton(p.status, status.isConnected)
+            loginButton(status.isConnected)
           )
-        )(u =>
-          <.div(
-            ^.cls := "ui secondary right menu",
+        )(
+          u =>
             <.div(
-              ^.cls := "ui header item",
-              SeqexecStyles.notInMobile,
-              u.displayName
-            ),
-            <.div(
-              ^.cls := "ui header item",
-              SeqexecStyles.onlyMobile,
-              // Ideally we'd do this with css text-overflow but it is not
-              // working properly inside a header item, let's abbreviate in code
-              u.displayName
-                .split("\\s")
-                .headOption
-                .map(_.substring(0, 10) + "...")
-                .getOrElse[String]("")
-            ),
-            <.div(
-              ^.cls := "ui item",
-              SeqexecStyles.notInMobile,
-              soundConnect(x => SoundControl(SoundControl.Props(x()))),
-              logoutButton(p.status, "Logout", status.isConnected)
-            ),
-            <.div(
-              ^.cls := "ui item",
-              SeqexecStyles.onlyMobile,
-              logoutButton(p.status, "", status.isConnected)
+              ^.cls := "ui secondary right menu",
+              <.div(
+                ^.cls := "ui header item",
+                SeqexecStyles.notInMobile,
+                u.displayName
+              ),
+              <.div(
+                ^.cls := "ui header item",
+                SeqexecStyles.onlyMobile,
+                // Ideally we'd do this with css text-overflow but it is not
+                // working properly inside a header item, let's abbreviate in code
+                u.displayName
+                  .split("\\s")
+                  .headOption
+                  .map(_.substring(0, 10) + "...")
+                  .getOrElse[String]("")
+              ),
+              <.div(
+                ^.cls := "ui item",
+                SeqexecStyles.notInMobile,
+                soundConnect(x => SoundControl(SoundControl.Props(x()))),
+                logoutButton("Logout", status.isConnected)
+              ),
+              <.div(
+                ^.cls := "ui item",
+                SeqexecStyles.onlyMobile,
+                logoutButton("", status.isConnected)
+              )
             )
-        ))
+        )
       )
     }
     .build
 
-  def apply(u: ModelProxy[ClientStatus]): Unmounted[Props, Unit, Unit] =
+  def apply(u: ClientStatus): Unmounted[Props, Unit, Unit] =
     component(Props(u))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
@@ -3,8 +3,6 @@
 
 package seqexec.web.client.components
 
-import diode.react.ModelProxy
-import diode.react.ReactPot._
 import gem.enum.Site
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.router.RouterCtl
@@ -14,10 +12,8 @@ import japgolly.scalajs.react.Reusability
 import react.common.implicits._
 import seqexec.web.client.actions.SelectCalibrationQueue
 import seqexec.web.client.circuit.SeqexecCircuit
-import seqexec.web.client.model.WebSocketConnection
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.OcsBuildInfo
-import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.elements.menu.HeaderItem
 import seqexec.web.client.reusability._
 
@@ -30,7 +26,6 @@ object Footer {
   implicit val propsReuse: Reusability[Props] = Reusability.by(_.site)
 
   private val userConnect = SeqexecCircuit.connect(SeqexecCircuit.statusReader)
-  private val wsConnect   = SeqexecCircuit.connect(_.ws)
 
   private def goHome(p: Props)(e: ReactEvent): Callback =
     e.preventDefaultCB *>
@@ -39,70 +34,45 @@ object Footer {
   private val component = ScalaComponent
     .builder[Props]("SeqexecAppBar")
     .stateless
-    .render_P(p =>
-      <.div(
-        ^.cls := "ui footer inverted menu",
-        <.a(
-          ^.cls := "header item",
-          ^.onClick ==> goHome(p),
-          s"Seqexec - ${p.site.shortName}"
-        ),
-        HeaderItem(HeaderItem.Props(OcsBuildInfo.version, sub = true)),
-        wsConnect(ConnectionState.apply),
-        userConnect(ControlMenu.apply)
-    ))
-    .componentDidMount(ctx =>
-      Callback {
-        // Mount the Semantic component using jQuery
-        import org.querki.jquery.$
-        import web.client.facades.semanticui.SemanticUIVisibility._
+    .render_P(
+      p =>
+        <.div(
+          ^.cls := "ui footer inverted menu",
+          <.a(
+            ^.cls := "header item",
+            ^.onClick ==> goHome(p),
+            SeqexecStyles.notInMobile,
+            s"Seqexec - ${p.site.shortName}"
+          ),
+          <.a(
+            ^.cls := "header item",
+            ^.onClick ==> goHome(p),
+            SeqexecStyles.onlyMobile,
+            p.site.shortName
+          ),
+          HeaderItem(
+            HeaderItem.Props(OcsBuildInfo.version,
+                             sub         = true,
+                             extraStyles = List(SeqexecStyles.notInMobile))
+          ),
+          userConnect(FooterStatus.apply)
+        )
+    )
+    .componentDidMount(
+      ctx =>
+        Callback {
+          // Mount the Semantic component using jQuery
+          import org.querki.jquery.$
+          import web.client.facades.semanticui.SemanticUIVisibility._
 
-        // Pick the top bar and make it stay visible regardless of scrolling
-        val dom = ctx.getDOMNode.asMounted().asElement()
-        $(dom).visibility(
-          JsVisiblityOptions.visibilityType("fixed").offset(0))
-    })
+          // Pick the top bar and make it stay visible regardless of scrolling
+          val dom = ctx.getDOMNode.asMounted().asElement()
+          $(dom)
+            .visibility(JsVisiblityOptions.visibilityType("fixed").offset(0))
+        }
+    )
     .configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
-}
-
-/**
-  * Alert message when the connection disappears
-  */
-object ConnectionState {
-
-  final case class Props(u: WebSocketConnection)
-
-  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
-
-  def formatTime(delay: Int): String =
-    if (delay < 1000) {
-      f"${delay / 1000.0}%.1f"
-    } else {
-      f"${delay / 1000}%d"
-    }
-
-  private val component = ScalaComponent
-    .builder[Props]("ConnectionState")
-    .stateless
-    .render_P(p =>
-      <.div(
-        ^.cls := "ui header item sub",
-        p.u.ws.renderPending(
-          _ =>
-            <.div(
-              IconAttention.copyIcon(color = Option("red")),
-              <.span(
-                SeqexecStyles.errorText,
-                s"Connection lost, retrying in ${formatTime(p.u.nextAttempt)} [s] ..."
-              )
-          ))
-    ))
-    .configure(Reusability.shouldComponentUpdate)
-    .build
-
-  def apply(u: ModelProxy[WebSocketConnection]): Unmounted[Props, Unit, Unit] =
-    component(Props(u()))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/FooterStatus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/FooterStatus.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components
+
+import diode.react.ModelProxy
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.Reusability
+import react.common.implicits._
+import seqexec.web.client.model.ClientStatus
+import seqexec.web.client.circuit.SeqexecCircuit
+import seqexec.web.client.reusability._
+
+/**
+  * Chooses to display either the guide config or a connection status info
+  */
+object FooterStatus {
+
+  final case class Props(status: ClientStatus)
+
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+  private val wsConnect                       = SeqexecCircuit.connect(_.ws)
+  private val gcConnect                       = SeqexecCircuit.connect(_.guideConfig)
+
+  private val component = ScalaComponent
+    .builder[Props]("FooterStatus")
+    .stateless
+    .render_P(
+      p =>
+        React.Fragment(
+          <.div(SeqexecStyles.notInMobile,
+                ^.cls := s"ui header item sub",
+                wsConnect(ConnectionState.apply).unless(p.status.isConnected)),
+          <.div(^.cls := s"ui header item sub",
+                gcConnect(GuideConfigStatus.apply).when(p.status.isConnected)),
+          ControlMenu(p.status)
+        )
+    )
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(u: ModelProxy[ClientStatus]): Unmounted[Props, Unit, Unit] =
+    component(Props(u()))
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/GuideConfigStatus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/GuideConfigStatus.scala
@@ -1,0 +1,97 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components
+
+import cats.Show
+import cats.implicits._
+import diode.react.ModelProxy
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.Reusability
+import react.common.implicits._
+import seqexec.model.TelescopeGuideConfig
+import seqexec.model.enum.ComaOption
+import seqexec.model.enum.M1Source
+import seqexec.model.enum.MountGuideOption
+import seqexec.model.enum.TipTiltSource
+import seqexec.model.M1GuideConfig
+import seqexec.model.M2GuideConfig
+import seqexec.web.client.reusability._
+
+/**
+  * Alert message when the connection disappears
+  */
+object GuideConfigStatus {
+  final case class Props(config: TelescopeGuideConfig)
+
+  implicit val mountGuideShow = Show.show[MountGuideOption] {
+    case MountGuideOption.MountGuideOn  => "On"
+    case MountGuideOption.MountGuideOff => "Off"
+  }
+
+  implicit val comaOptionShow = Show.show[ComaOption] {
+    case ComaOption.ComaOn  => "On"
+    case ComaOption.ComaOff => "Off"
+  }
+
+  implicit val m1GuideShow = Show.show[M1GuideConfig] {
+    case M1GuideConfig.M1GuideOn(s) => M1Source.tag(s)
+    case M1GuideConfig.M1GuideOff   => "Off"
+  }
+
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+
+  private val component = ScalaComponent
+    .builder[Props]("GuideConfigStatus")
+    .stateless
+    .render_P { p =>
+      React.Fragment(
+        <.span(
+          ^.cls := "header item",
+          SeqexecStyles.activeGuide
+            .when(p.config.mountGuide === MountGuideOption.MountGuideOn),
+          s"Mount: ${p.config.mountGuide.show}"
+        ),
+        <.span(
+          ^.cls := "header item",
+          SeqexecStyles.activeGuide
+            .when(p.config.m1Guide =!= M1GuideConfig.M1GuideOff),
+          s"M1: ${p.config.m1Guide.show}"
+        ),
+        p.config.m2Guide match {
+          case M2GuideConfig.M2GuideOn(c, s) =>
+            React.Fragment(
+              <.span(
+                ^.cls := "header item",
+                SeqexecStyles.activeGuide.when(s.nonEmpty),
+                s"Tip/Tilt: ${s.map(TipTiltSource.tag).mkString("+")}".when(s.nonEmpty),
+                s"Tip/Tilt: Off".when(s.isEmpty)
+              ),
+              <.span(
+                ^.cls := "header item",
+                SeqexecStyles.activeGuide.when(c === ComaOption.ComaOn),
+                s"Coma: ${c.show}"
+              )
+            )
+          case M2GuideConfig.M2GuideOff =>
+            React.Fragment(
+              <.span(
+                ^.cls := "header item",
+                "Tip/Tilt: Off"
+              ),
+              <.span(
+                ^.cls := "header item",
+                "Coma: Off"
+              )
+            )
+        }
+      )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(u: ModelProxy[TelescopeGuideConfig]): Unmounted[Props, Unit, Unit] =
+    component(Props(u()))
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -17,6 +17,9 @@ object SeqexecStyles {
   val TableBorderWidth: Double = 1.0
   val TableRightPadding: Int   = 13
 
+  val activeGuide: Css =
+    Css("SeqexecStyles-activeGuide")
+
   val activeInstrumentLabel: Css =
     Css("SeqexecStyles-activeInstrumentLabel")
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
@@ -258,6 +258,11 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       effectOnly(Effect(Future(RunResourceFailed(sid, stepId, r, actualMsg))))
   }
 
+  val guideConfigMessage: PartialFunction[Any, ActionResult[M]] = {
+    case ServerMessage(r: GuideConfigUpdate) =>
+      updatedL(WebSocketsFocus.guideConfig.set(r.telescope))
+  }
+
   val defaultMessage: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(_) =>
       // Ignore unknown events
@@ -284,6 +289,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       sequencePauseCancelMessage,
       modelUpdateMessage,
       singleRunCompleteMessage,
+      guideConfigMessage,
       defaultMessage
     ).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -6,15 +6,11 @@ package seqexec.web.client
 import diode.data.PotState
 import cats.implicits._
 import gem.Observation
-import gem.enum.Site
+import gem.util.Enumerated
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
 import scala.collection.immutable.SortedMap
-import seqexec.model.enum.ActionStatus
-import seqexec.model.enum.Instrument
-import seqexec.model.enum.BatchExecState
 import seqexec.model.enum.Resource
-import seqexec.model.enum.SystemName
 import seqexec.model.enum.ServerLogLevel
 import seqexec.model.Observer
 import seqexec.model.QueueId
@@ -23,6 +19,9 @@ import seqexec.model.StepConfig
 import seqexec.model.StepState
 import seqexec.model.UserDetails
 import seqexec.model.SequenceState
+import seqexec.model.M1GuideConfig
+import seqexec.model.M2GuideConfig
+import seqexec.model.TelescopeGuideConfig
 import seqexec.web.client.model.AvailableTab
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.SectionVisibilityState
@@ -42,12 +41,10 @@ import seqexec.web.client.model.GlobalLog
 import seqexec.web.client.circuit._
 
 package object reusability {
-  implicit val actionStatuReuse: Reusability[ActionStatus]  = Reusability.byEq
+  implicit def enumeratedReuse[A <: AnyRef: Enumerated]: Reusability[A] =
+    Reusability.byRef
   implicit val stepStateReuse: Reusability[StepState]       = Reusability.byEq
-  implicit val instrumentReuse: Reusability[Instrument]     = Reusability.byEq
-  implicit val resourceReuse: Reusability[Resource]         = Reusability.byEq
   implicit val obsIdReuse: Reusability[Observation.Id]      = Reusability.byEq
-  implicit val siteReuse: Reusability[Site]                 = Reusability.byEq
   implicit val observerReuse: Reusability[Observer]         = Reusability.byEq
   implicit val stepConfigReuse: Reusability[StepConfig]     = Reusability.byEq
   implicit val stepReuse: Reusability[Step]                 = Reusability.byEq
@@ -61,7 +58,6 @@ package object reusability {
   implicit val sCFocusReuse: Reusability[SequenceControlFocus] =
     Reusability.byEq
   implicit val tabSelReuse: Reusability[TabSelected] = Reusability.byRef
-  implicit val sysnReuse: Reusability[SystemName]    = Reusability.byRef
   implicit val sectReuse: Reusability[SectionVisibilityState] =
     Reusability.byRef
   implicit val potStateReuse: Reusability[PotState] = Reusability.byRef
@@ -84,10 +80,8 @@ package object reusability {
   implicit val qfReuse: Reusability[CalQueueControlFocus]  = Reusability.byEq
   implicit val cqfReuse: Reusability[CalQueueFocus]        = Reusability.byEq
   implicit val qidReuse: Reusability[QueueId]              = Reusability.byEq
-  implicit val bexReuse: Reusability[BatchExecState]       = Reusability.byRef
   implicit val soundReuse: Reusability[SoundSelection]     = Reusability.byRef
   implicit val globalLogReuse: Reusability[GlobalLog]      = Reusability.byEq
-  implicit val sllReuse: Reusability[ServerLogLevel]       = Reusability.byEq
   implicit val resMap: Reusability[Map[Resource, ResourceRunOperation]] =
     Reusability.map
   implicit val sllbMap: Reusability[Map[ServerLogLevel, Boolean]] =
@@ -96,4 +90,10 @@ package object reusability {
     Reusability.by(_.toMap)
   implicit val tabOpsMap: Reusability[TabOperations] =
     Reusability.byEq
+  implicit val m1gReuse: Reusability[M1GuideConfig] =
+    Reusability.derive[M1GuideConfig]
+  implicit val m2gReuse: Reusability[M2GuideConfig] =
+    Reusability.derive[M2GuideConfig]
+  implicit val configReuse: Reusability[TelescopeGuideConfig] =
+    Reusability.derive[TelescopeGuideConfig]
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -29,9 +29,11 @@ import seqexec.model.UserDetails
 import seqexec.model.ObservationProgress
 import seqexec.model.RunningStep
 import seqexec.model.ObservationProgress
+import seqexec.model.TelescopeGuideConfig
 import seqexec.model.events.ServerLogMessage
 import seqexec.model.arb.ArbRunningStep._
 import seqexec.model.arb.ArbNotification._
+import seqexec.model.arb.ArbTelescopeGuideConfig._
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.SequenceEventsArbitraries.slmArb
 import seqexec.model.SequenceEventsArbitraries.slmCogen
@@ -794,6 +796,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         site        <- arbitrary[Option[Site]]
         sound       <- arbitrary[SoundSelection]
         serverVer   <- arbitrary[Option[String]]
+        guideConf   <- arbitrary[TelescopeGuideConfig]
       } yield
         WebSocketsFocus(navLocation,
                         sequences,
@@ -802,7 +805,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
                         clientId,
                         site,
                         sound,
-                        serverVer)
+                        serverVer,
+                        guideConf)
     }
 
   implicit val wsfCogen: Cogen[WebSocketsFocus] =
@@ -813,7 +817,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
            Option[ClientId],
            Option[Site],
            SoundSelection,
-           Option[String])]
+           Option[String],
+           TelescopeGuideConfig)]
       .contramap(
         x =>
           (x.location,
@@ -823,7 +828,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
            x.clientId,
            x.site,
            x.sound,
-           x.serverVersion))
+           x.serverVersion,
+           x.guideConfig))
 
   implicit val arbInitialSyncFocus: Arbitrary[InitialSyncFocus] =
     Arbitrary {
@@ -847,7 +853,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         clientId  <- arbitrary[Option[ClientId]]
         uiModel   <- arbitrary[SeqexecUIModel]
         version   <- arbitrary[Option[String]]
-      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel, version)
+        guideConf <- arbitrary[TelescopeGuideConfig]
+      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel, version, guideConf)
     }
 
   implicit val arbAppTableStates: Arbitrary[AppTableStates] =


### PR DESCRIPTION
With this PR we display the guide configuration at the page's footer

e.g: no guiding
<img width="892" alt="image" src="https://user-images.githubusercontent.com/3615303/60055877-0b069480-96ad-11e9-89f9-ac718549fc44.png">

all enabled
<img width="886" alt="image" src="https://user-images.githubusercontent.com/3615303/60055901-21145500-96ad-11e9-879c-e2b78e91f8a3.png">

Some other combinations
<img width="821" alt="image" src="https://user-images.githubusercontent.com/3615303/60055959-4f923000-96ad-11e9-9fa3-514c42580491.png">


