### PR TITLE
Use Enumerated on the client

### DIFF
--- a/modules/core/js/src/main/scala/gem/syntax/package.scala
+++ b/modules/core/js/src/main/scala/gem/syntax/package.scala
@@ -1,0 +1,6 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+object all extends ToEnumeratedOps

--- a/modules/core/jvm/src/main/scala/gem/syntax/package.scala
+++ b/modules/core/jvm/src/main/scala/gem/syntax/package.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+object all extends ToStreamOps
+  with ToEnumeratedOps

--- a/modules/core/shared/src/main/scala/gem/syntax/EnumeratedSyntax.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/EnumeratedSyntax.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.syntax
+
+import gem.util.Enumerated
+
+final class EnumeratedOps[A: Enumerated](a: A) {
+  def tag: String = Enumerated[A].tag(a)
+}
+
+trait ToEnumeratedOps {
+  implicit def ToEnumeratedOps[A: Enumerated](a: A): EnumeratedOps[A] =
+    new EnumeratedOps[A](a)
+}
+
+object enumerated extends ToEnumeratedOps

--- a/modules/core/shared/src/main/scala/gem/util/Enumerated.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Enumerated.scala
@@ -35,6 +35,13 @@ trait Enumerated[A] extends Order[A] {
 
 object Enumerated {
   def apply[A](implicit ev: Enumerated[A]): ev.type = ev
+
+  def of[A <: Product](a: A, as: A*): Enumerated[A] =
+    new Enumerated[A] {
+      def all: List[A] = a :: as.toList
+      def tag(a: A): String = a.productPrefix
+    }
+
 }
 
 /** @group Typeclasses */

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ActionStatus.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ActionStatus.scala
@@ -20,19 +20,7 @@ object ActionStatus {
   /** Action run but failed to complete. */
   case object Failed extends ActionStatus
 
-  val all: List[ActionStatus] =
-    List(Pending, Completed, Running, Paused, Failed)
-
   /** @group Typeclass Instances */
   implicit val ActionStatusEnumerated: Enumerated[ActionStatus] =
-    new Enumerated[ActionStatus] {
-      def all = ActionStatus.all
-      def tag(a: ActionStatus): String = a match {
-        case Pending => "Pending"
-        case Completed => "Completed"
-        case Running => "Running"
-        case Paused => "Paused"
-        case Failed => "Failed"
-      }
-    }
+    Enumerated.of(Pending, Completed, Running, Paused, Failed)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/BatchExecState.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/BatchExecState.scala
@@ -31,13 +31,7 @@ object BatchExecState {
     case Completed => "Completed"
   }
 
-  val all: List[BatchExecState] =
-    List(Idle, Running, Waiting, Stopping, Completed)
-
   /** @group Typeclass Instances */
   implicit val BatchExecStateEnumerated: Enumerated[BatchExecState] =
-    new Enumerated[BatchExecState] {
-      def all = BatchExecState.all
-      def tag(a: BatchExecState): String = BatchExecState.tag(a)
-    }
+    Enumerated.of(Idle, Running, Waiting, Stopping, Completed)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/CloudCover.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/CloudCover.scala
@@ -3,7 +3,6 @@
 
 package seqexec.model.enum
 
-import cats.Show
 import gem.util.Enumerated
 
 sealed abstract class CloudCover(val toInt: Int, val label: String)
@@ -16,16 +15,7 @@ object CloudCover {
   case object Percent80 extends CloudCover(80,  "80%/Cloudy")
   case object Any       extends CloudCover(100, "Any")
 
-  val all: List[CloudCover] =
-    List(Percent50, Percent70, Percent80, Any)
-
-  implicit val showCloudCover: Show[CloudCover] =
-    Show.show(_.label)
-
   /** @group Typeclass Instances */
   implicit val CloudCoverEnumerated: Enumerated[CloudCover] =
-    new Enumerated[CloudCover] {
-      def all = CloudCover.all
-      def tag(a: CloudCover): String = a.label
-    }
+    Enumerated.of(Percent50, Percent70, Percent80, Any)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ComaOption.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ComaOption.scala
@@ -12,16 +12,7 @@ object ComaOption {
   case object ComaOn  extends ComaOption
   case object ComaOff extends ComaOption
 
-  val all: List[ComaOption] =
-    List(ComaOn, ComaOff)
-
   /** @group Typeclass Instances */
   implicit val CommaOptionEnumerated: Enumerated[ComaOption] =
-    new Enumerated[ComaOption] {
-      def all = ComaOption.all
-      def tag(a: ComaOption): String = a match {
-        case ComaOn => "ComaOn"
-        case ComaOff => "ComaOff"
-      }
-    }
+    Enumerated.of(ComaOn, ComaOff)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/FPUMode.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/FPUMode.scala
@@ -14,16 +14,10 @@ object FPUMode {
   case object BuiltIn extends FPUMode("BUILTIN")
   case object Custom  extends FPUMode("CUSTOM_MASK")
 
-  val all: List[FPUMode] =
-    List(BuiltIn, Custom)
-
   def fromString(s: String): Option[FPUMode] =
-    all.find(_.label === s)
+    FPUModeEnumerated.all.find(_.label === s)
 
   /** @group Typeclass Instances */
   implicit val FPUModeEnumerated: Enumerated[FPUMode] =
-    new Enumerated[FPUMode] {
-      def all = FPUMode.all
-      def tag(a: FPUMode): String = a.label
-    }
+    Enumerated.of(BuiltIn, Custom)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/Guiding.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/Guiding.scala
@@ -15,17 +15,11 @@ object Guiding {
   case object Park   extends Guiding("park")
   case object Freeze extends Guiding("freeze")
 
-  val all: List[Guiding] =
-    List(Guide, Park, Freeze)
-
   def fromString(s: String): Option[Guiding] =
-    all.find(_.configValue === s)
+    GuidingEnumerated.all.find(_.configValue === s)
 
   /** @group Typeclass Instances */
   implicit val GuidingEnumerated: Enumerated[Guiding] =
-    new Enumerated[Guiding] {
-      def all = Guiding.all
-      def tag(a: Guiding): String = a.configValue
-    }
+    Enumerated.of(Guide, Park, Freeze)
 
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ImageQuality.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ImageQuality.scala
@@ -3,7 +3,6 @@
 
 package seqexec.model.enum
 
-import cats.Show
 import gem.util.Enumerated
 
 sealed abstract class ImageQuality(val toInt: Int, val label: String)
@@ -16,16 +15,7 @@ object ImageQuality {
   case object Percent85 extends ImageQuality(85,  "85%/Poor")
   case object Any       extends ImageQuality(100, "Any")
 
-  val all: List[ImageQuality] =
-    List(Percent20, Percent70, Percent85, Any)
-
-  implicit val showImageQuality: Show[ImageQuality] =
-    Show.show(_.label)
-
   /** @group Typeclass Instances */
   implicit val ImageQualityEnumerated: Enumerated[ImageQuality] =
-    new Enumerated[ImageQuality] {
-      def all = ImageQuality.all
-      def tag(a: ImageQuality): String = a.label
-    }
+    Enumerated.of(Percent20, Percent70, Percent85, Any)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/M1Source.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/M1Source.scala
@@ -15,23 +15,8 @@ object M1Source {
   case object GAOS  extends M1Source
   case object HRWFS extends M1Source
 
-  /** All members of M1Source, in canonical order. */
-  val all: List[M1Source] =
-    List(PWFS1, PWFS2, OIWFS, GAOS, HRWFS)
-
-  def tag(s: M1Source): String = s match {
-    case PWFS1 => "PWFS1"
-    case PWFS2 => "PWFS2"
-    case OIWFS => "OIWFS"
-    case GAOS  => "GAOS"
-    case HRWFS => "HRWFS"
-  }
-
   /** @group Typeclass Instances */
   implicit val M1SourceEnumerated: Enumerated[M1Source] =
-    new Enumerated[M1Source] {
-      def all = M1Source.all
-      def tag(a: M1Source): String = M1Source.tag(a)
-    }
+    Enumerated.of(PWFS1, PWFS2, OIWFS, GAOS, HRWFS)
 
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/MountGuideOption.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/MountGuideOption.scala
@@ -12,16 +12,7 @@ object MountGuideOption {
   case object MountGuideOff extends MountGuideOption
   case object MountGuideOn  extends MountGuideOption
 
-  val all: List[MountGuideOption] =
-    List(MountGuideOff, MountGuideOn)
-
   /** @group Typeclass Instances */
   implicit val MountGuideOptionEnumerated: Enumerated[MountGuideOption] =
-    new Enumerated[MountGuideOption] {
-      def all = MountGuideOption.all
-      def tag(a: MountGuideOption): String = a match {
-        case MountGuideOff => "MountGuideOff"
-        case MountGuideOn  => "MountGuideOn"
-      }
-    }
+    Enumerated.of(MountGuideOff, MountGuideOn)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/Resource.scala
@@ -33,10 +33,7 @@ object Resource {
 
   /** @group Typeclass Instances */
   implicit val ResourceEnumerated: Enumerated[Resource] =
-    new Enumerated[Resource] {
-      def all = Instrument.allResources.toList
-      def tag(a: Resource): String = a.label
-    }
+    Enumerated.of(Instrument.allResources.head, Instrument.allResources.tail: _*)
 }
 
 sealed abstract class Instrument(ordinal: Int, label: String)
@@ -73,8 +70,5 @@ object Instrument {
 
   /** @group Typeclass Instances */
   implicit val InstrumentEnumerated: Enumerated[Instrument] =
-    new Enumerated[Instrument] {
-      def all = Instrument.all.toList
-      def tag(a: Instrument): String = a.label
-    }
+    Enumerated.of(all.head, all.tail: _*)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ServerLogLevel.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ServerLogLevel.scala
@@ -3,7 +3,6 @@
 
 package seqexec.model.enum
 
-import cats._
 import gem.util.Enumerated
 
 sealed abstract class ServerLogLevel(val label: String)
@@ -15,16 +14,7 @@ object ServerLogLevel {
   case object WARN  extends ServerLogLevel("WARNING")
   case object ERROR extends ServerLogLevel("ERROR")
 
-  implicit val show: Show[ServerLogLevel] =
-    Show.show(_.label)
-
-  val all: List[ServerLogLevel] =
-    List(INFO, WARN, ERROR)
-
   /** @group Typeclass Instances */
   implicit val ServerLogLevelEnumerated: Enumerated[ServerLogLevel] =
-    new Enumerated[ServerLogLevel] {
-      def all = ServerLogLevel.all
-      def tag(a: ServerLogLevel): String = a.label
-    }
+    Enumerated.of(INFO, WARN, ERROR)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/SkyBackground.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/SkyBackground.scala
@@ -3,7 +3,6 @@
 
 package seqexec.model.enum
 
-import cats.Show
 import gem.util.Enumerated
 
 sealed abstract class SkyBackground(val toInt: Int, val label: String)
@@ -16,16 +15,7 @@ object SkyBackground {
   case object Percent80 extends SkyBackground(80 , "80%/Grey")
   case object Any       extends SkyBackground(100, "Any/Bright")
 
-  val all: List[SkyBackground] =
-    List(Percent20, Percent50, Percent80, Any)
-
-  implicit val showSkyBackground: Show[SkyBackground] =
-    Show.show(_.label)
-
   /** @group Typeclass Instances */
   implicit val SkyBackgroundEnumerated: Enumerated[SkyBackground] =
-    new Enumerated[SkyBackground] {
-      def all = SkyBackground.all
-      def tag(a: SkyBackground): String = a.label
-    }
+    Enumerated.of(Percent20, Percent50, Percent80, Any)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/StepType.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/StepType.scala
@@ -23,17 +23,11 @@ object StepType {
   implicit val show: Show[StepType] =
     Show.show(_.label)
 
-  val all: List[StepType] =
-    List(Object, Arc, Flat, Bias, Dark, Calibration, AlignAndCalib)
-
   def fromString(s: String): Option[StepType] =
-    all.find(_.label === s)
+    StepTypeEnumerated.all.find(_.label === s)
 
   /** @group Typeclass Instances */
   implicit val StepTypeEnumerated: Enumerated[StepType] =
-    new Enumerated[StepType] {
-      def all = StepType.all
-      def tag(a: StepType): String = a.label
-    }
+    Enumerated.of(Object, Arc, Flat, Bias, Dark, Calibration, AlignAndCalib)
 
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/SystemName.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/SystemName.scala
@@ -6,7 +6,7 @@ package seqexec.model.enum
 import cats.implicits._
 import gem.util.Enumerated
 
-sealed abstract class SystemName(val system: String) {
+sealed abstract class SystemName(val system: String) extends Product with Serializable {
 
   def withParam(p: String): String =
     s"$system:$p"
@@ -24,19 +24,13 @@ object SystemName {
   case object Meta           extends SystemName("meta")
   case object AdaptiveOptics extends SystemName("adaptive optics")
 
-  val all: List[SystemName] =
-    List(Ocs, Observe, Instrument, Telescope, Gcal, Calibration, Meta, AdaptiveOptics)
-
   def fromString(system: String): Option[SystemName] =
-    all.find(_.system === system)
+    SystemNameEnumerated.all.find(_.system === system)
 
   def unsafeFromString(system: String): SystemName =
     fromString(system).getOrElse(sys.error(s"Unknown system name $system"))
 
   /** @group Typeclass Instances */
   implicit val SystemNameEnumerated: Enumerated[SystemName] =
-    new Enumerated[SystemName] {
-      def all = SystemName.all
-      def tag(a: SystemName): String = a.system
-    }
+    Enumerated.of(Ocs, Observe, Instrument, Telescope, Gcal, Calibration, Meta, AdaptiveOptics)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/TipTiltSource.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/TipTiltSource.scala
@@ -14,21 +14,7 @@ object TipTiltSource {
   case object OIWFS extends TipTiltSource
   case object GAOS  extends TipTiltSource
 
-  /** All members of TipTiltSource, in canonical order. */
-  val all: List[TipTiltSource] =
-    List(PWFS1, PWFS2, OIWFS, GAOS)
-
-  def tag(s: TipTiltSource): String = s match {
-    case PWFS1 => "PWFS1"
-    case PWFS2 => "PWFS2"
-    case OIWFS => "OIWFS"
-    case GAOS  => "GAOS"
-  }
-
   /** @group Typeclass Instances */
   implicit val TipTiltSourceEnumerated: Enumerated[TipTiltSource] =
-    new Enumerated[TipTiltSource] {
-      def all = TipTiltSource.all
-      def tag(a: TipTiltSource): String = TipTiltSource.tag(a)
-    }
+    Enumerated.of(PWFS1, PWFS2, OIWFS, GAOS)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/WaterVapor.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/WaterVapor.scala
@@ -3,7 +3,6 @@
 
 package seqexec.model.enum
 
-import cats.Show
 import gem.util.Enumerated
 
 sealed abstract class WaterVapor(val toInt: Int, val label: String)
@@ -16,17 +15,8 @@ object WaterVapor {
   case object Percent80 extends WaterVapor(80,  "85%/High")
   case object Any       extends WaterVapor(100, "Any")
 
-  val all: List[WaterVapor] =
-    List(Percent20, Percent50, Percent80, Any)
-
-  implicit val showWaterVapor: Show[WaterVapor] =
-    Show.show(_.label)
-
   /** @group Typeclass Instances */
   implicit val WaterVaporEnumerated: Enumerated[WaterVapor] =
-    new Enumerated[WaterVapor] {
-      def all = WaterVapor.all
-      def tag(a: WaterVapor): String = a.label
-    }
+    Enumerated.of(Percent20, Percent50, Percent80, Any)
 
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/GuideConfigStatus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/GuideConfigStatus.scala
@@ -5,6 +5,7 @@ package seqexec.web.client.components
 
 import cats.Show
 import cats.implicits._
+import gem.syntax.all._
 import diode.react.ModelProxy
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -13,9 +14,7 @@ import japgolly.scalajs.react.Reusability
 import react.common.implicits._
 import seqexec.model.TelescopeGuideConfig
 import seqexec.model.enum.ComaOption
-import seqexec.model.enum.M1Source
 import seqexec.model.enum.MountGuideOption
-import seqexec.model.enum.TipTiltSource
 import seqexec.model.M1GuideConfig
 import seqexec.model.M2GuideConfig
 import seqexec.web.client.reusability._
@@ -37,7 +36,7 @@ object GuideConfigStatus {
   }
 
   implicit val m1GuideShow = Show.show[M1GuideConfig] {
-    case M1GuideConfig.M1GuideOn(s) => M1Source.tag(s)
+    case M1GuideConfig.M1GuideOn(s) => s.tag
     case M1GuideConfig.M1GuideOff   => "Off"
   }
 
@@ -66,7 +65,7 @@ object GuideConfigStatus {
               <.span(
                 ^.cls := "header item",
                 SeqexecStyles.activeGuide.when(s.nonEmpty),
-                s"Tip/Tilt: ${s.map(TipTiltSource.tag).mkString("+")}".when(s.nonEmpty),
+                s"Tip/Tilt: ${s.map(_.tag).mkString("+")}".when(s.nonEmpty),
                 s"Tip/Tilt: Off".when(s.isEmpty)
               ),
               <.span(

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/HeadersSideBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/HeadersSideBar.scala
@@ -6,6 +6,7 @@ package seqexec.web.client.components
 import diode.react.ModelProxy
 import cats.implicits._
 import cats.Eq
+import cats.Show
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.BackendScope
 import japgolly.scalajs.react.Callback
@@ -42,6 +43,19 @@ import seqexec.web.client.actions.UpdateWaterVapor
   * Display to show headers per sequence
   */
 object HeadersSideBar {
+
+  implicit val showSkyBackground: Show[SkyBackground] =
+    Show.show(_.label)
+
+  implicit val showWaterVapor: Show[WaterVapor] =
+    Show.show(_.label)
+
+  implicit val showCloudCover: Show[CloudCover] =
+    Show.show(_.label)
+
+  implicit val showImageQuality: Show[ImageQuality] =
+    Show.show(_.label)
+
   final case class Props(model: ModelProxy[HeaderSideBarFocus]) {
     def canOperate: Boolean = model().status.canOperate
     def selectedObserver
@@ -179,14 +193,14 @@ object HeadersSideBar {
               DropdownMenu.Props("Image Quality",
                                  p.model().conditions.iq.some,
                                  "Select",
-                                 ImageQuality.all,
+                                 ImageQuality.ImageQualityEnumerated.all,
                                  disabled = !enabled,
                                  iqChanged)),
             DropdownMenu(
               DropdownMenu.Props("Cloud Cover",
                                  p.model().conditions.cc.some,
                                  "Select",
-                                 CloudCover.all,
+                                 CloudCover.CloudCoverEnumerated.all,
                                  disabled = !enabled,
                                  ccChanged))
           ),
@@ -197,14 +211,14 @@ object HeadersSideBar {
               DropdownMenu.Props("Water Vapor",
                                  p.model().conditions.wv.some,
                                  "Select",
-                                 WaterVapor.all,
+                                 WaterVapor.WaterVaporEnumerated.all,
                                  disabled = !enabled,
                                  wvChanged)),
             DropdownMenu(
               DropdownMenu.Props("Sky Background",
                                  p.model().conditions.sb.some,
                                  "Select",
-                                 SkyBackground.all,
+                                 SkyBackground.SkyBackgroundEnumerated.all,
                                  disabled = !enabled,
                                  sbChanged))
           )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -4,6 +4,7 @@
 package seqexec.web.client.components
 
 import cats.Eq
+import cats.Show
 import cats.data.NonEmptyList
 import cats.implicits._
 import mouse.all._
@@ -37,7 +38,7 @@ import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.button.Button.LeftLabeled
 import seqexec.web.client.semanticui.{ Size => SSize }
 import seqexec.web.client.model.GlobalLog
-import seqexec.web.client.model.SectionOpen
+import seqexec.web.client.model.SectionVisibilityState.SectionOpen
 import seqexec.web.client.actions.ToggleLogArea
 import seqexec.web.common.FixedLengthBuffer
 import seqexec.web.client.reusability._
@@ -68,6 +69,9 @@ object CopyLogToClipboard {
   */
 object LogArea {
   type Backend = RenderScope[Props, State, Unit]
+
+  implicit val show: Show[ServerLogLevel] =
+    Show.show(_.label)
 
   sealed trait TableColumn
   case object TimestampColumn extends TableColumn
@@ -162,7 +166,7 @@ object LogArea {
                                                         ClipboardColumnMeta))
 
     val Default: State =
-      State(SortedMap(ServerLogLevel.all.map(_ -> true): _*), DefaultTableState)
+      State(SortedMap(ServerLogLevel.ServerLogLevelEnumerated.all.map(_ -> true): _*), DefaultTableState)
   }
 
   private val ClipboardWidth    = 37.0

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LoginBox.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LoginBox.scala
@@ -14,6 +14,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import seqexec.model.UserDetails
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.model._
+import seqexec.web.client.model.SectionVisibilityState._
 import seqexec.web.client.actions.CloseLoginBox
 import seqexec.web.client.actions.LoggedIn
 import seqexec.web.client.circuit.SeqexecCircuit

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/UserNotificationBox.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/UserNotificationBox.scala
@@ -11,6 +11,7 @@ import seqexec.model.Notification
 import seqexec.web.client.semanticui.elements.icon.Icon.IconCheckmark
 import seqexec.web.client.semanticui.elements.modal.{Content, Header}
 import seqexec.web.client.model._
+import seqexec.web.client.model.SectionVisibilityState._
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.actions.CloseUserNotificationBox
 import seqexec.web.client.reusability._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
@@ -14,8 +14,8 @@ import seqexec.web.client.semanticui._
 import seqexec.web.client.semanticui.elements.message.IconMessage
 import seqexec.web.client.semanticui.elements.icon.Icon.IconInbox
 import seqexec.web.client.circuit.SeqexecCircuit
-import seqexec.web.client.model.SectionClosed
-import seqexec.web.client.model.SectionOpen
+import seqexec.web.client.model.SectionVisibilityState.SectionClosed
+import seqexec.web.client.model.SectionVisibilityState.SectionOpen
 import seqexec.web.client.model.SectionVisibilityState
 import seqexec.web.client.model.TabSelected
 import seqexec.web.client.components.SeqexecStyles

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
@@ -14,8 +14,8 @@ import react.common.implicits._
 import seqexec.model.Step
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages.SeqexecPages
-import seqexec.web.client.model.SectionClosed
-import seqexec.web.client.model.SectionOpen
+import seqexec.web.client.model.SectionVisibilityState.SectionClosed
+import seqexec.web.client.model.SectionVisibilityState.SectionOpen
 import seqexec.web.client.semanticui.{ Size => _, _ }
 import seqexec.web.client.components.sequence.toolbars.SequenceDefaultToolbar
 import seqexec.web.client.components.sequence.toolbars.StepConfigToolbar

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ModalBoxHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ModalBoxHandler.scala
@@ -6,6 +6,7 @@ package seqexec.web.client.handlers
 import cats.implicits._
 import diode.{ Action, ActionHandler, ActionResult, ModelRW }
 import seqexec.web.client.model._
+import seqexec.web.client.model.SectionVisibilityState._
 
 /**
   * Handles actions related to opening/closing a modal

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/QueueOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/QueueOperations.scala
@@ -5,45 +5,46 @@ package seqexec.web.client.model
 
 import cats.Eq
 import cats.implicits._
+import gem.util.Enumerated
 import monocle.macros.Lenses
 
 sealed trait AddDayCalOperation extends Product with Serializable
 object AddDayCalOperation {
-  case object AddDayCalInFlight extends AddDayCalOperation
   case object AddDayCalIdle extends AddDayCalOperation
+  case object AddDayCalInFlight extends AddDayCalOperation
 
-  implicit val eq: Eq[AddDayCalOperation] =
-    Eq.fromUniversalEquals
+  implicit val AddDayCalOperationEnumerated: Enumerated[AddDayCalOperation] =
+    Enumerated.of(AddDayCalIdle, AddDayCalInFlight)
 
 }
 
 sealed trait ClearAllCalOperation extends Product with Serializable
 object ClearAllCalOperation {
-  case object ClearAllCalInFlight extends ClearAllCalOperation
   case object ClearAllCalIdle extends ClearAllCalOperation
+  case object ClearAllCalInFlight extends ClearAllCalOperation
 
-  implicit val eq: Eq[ClearAllCalOperation] =
-    Eq.fromUniversalEquals
+  implicit val ClearAllCalOperationEnumerated: Enumerated[ClearAllCalOperation] =
+    Enumerated.of(ClearAllCalIdle, ClearAllCalInFlight)
 
 }
 
 sealed trait RunCalOperation extends Product with Serializable
 object RunCalOperation {
-  case object RunCalInFlight extends RunCalOperation
   case object RunCalIdle extends RunCalOperation
+  case object RunCalInFlight extends RunCalOperation
 
-  implicit val eq: Eq[RunCalOperation] =
-    Eq.fromUniversalEquals
+  implicit val RunCalOperationEnumerated: Enumerated[RunCalOperation] =
+    Enumerated.of(RunCalIdle, RunCalInFlight)
 
 }
 
 sealed trait StopCalOperation extends Product with Serializable
 object StopCalOperation {
-  case object StopCalInFlight extends StopCalOperation
   case object StopCalIdle extends StopCalOperation
+  case object StopCalInFlight extends StopCalOperation
 
-  implicit val eq: Eq[StopCalOperation] =
-    Eq.fromUniversalEquals
+  implicit val StopCalOperationEnumerated: Enumerated[StopCalOperation] =
+    Enumerated.of(StopCalIdle, StopCalInFlight)
 
 }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/QueueSeqOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/QueueSeqOperations.scala
@@ -5,16 +5,16 @@ package seqexec.web.client.model
 
 import cats.Eq
 import cats.implicits._
+import gem.util.Enumerated
 import monocle.macros.Lenses
 
 sealed trait RemoveSeqQueue extends Product with Serializable
 object RemoveSeqQueue {
-  case object RemoveSeqQueueInFlight extends RemoveSeqQueue
   case object RemoveSeqQueueIdle extends RemoveSeqQueue
+  case object RemoveSeqQueueInFlight extends RemoveSeqQueue
 
-  implicit val eq: Eq[RemoveSeqQueue] =
-    Eq.fromUniversalEquals
-
+  implicit val RemoveSeqQueueEnumerated: Enumerated[RemoveSeqQueue] =
+    Enumerated.of(RemoveSeqQueueIdle, RemoveSeqQueueInFlight)
 }
 
 sealed trait MoveSeqQueue extends Product with Serializable
@@ -22,9 +22,8 @@ object MoveSeqQueue {
   case object MoveSeqQueueInFlight extends MoveSeqQueue
   case object MoveSeqQueueIdle extends MoveSeqQueue
 
-  implicit val eq: Eq[MoveSeqQueue] =
-    Eq.fromUniversalEquals
-
+  implicit val MoveSeqQueueEnumerated: Enumerated[MoveSeqQueue] =
+    Enumerated.of(MoveSeqQueueIdle, MoveSeqQueueInFlight)
 }
 
 /**

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SectionVisibilityState.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SectionVisibilityState.scala
@@ -3,13 +3,17 @@
 
 package seqexec.web.client.model
 
-import cats._
+import gem.util.Enumerated
 
 // UI model
 sealed trait SectionVisibilityState extends Product with Serializable
-case object SectionOpen extends SectionVisibilityState
-case object SectionClosed extends SectionVisibilityState
 
 object SectionVisibilityState {
-  implicit val eq: Eq[SectionVisibilityState] = Eq.fromUniversalEquals
+  case object SectionOpen extends SectionVisibilityState
+  case object SectionClosed extends SectionVisibilityState
+
+  /** @group Typeclass Instances */
+  implicit val SectionVisibilityStateEnumerated: Enumerated[SectionVisibilityState] =
+    Enumerated.of(SectionOpen, SectionClosed)
+
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecUIModel.scala
@@ -5,10 +5,12 @@ package seqexec.web.client.model
 
 import cats.Eq
 import cats.implicits._
+import gem.util.Enumerated
 import monocle.macros.Lenses
 import seqexec.model.Observer
 import seqexec.model.UserDetails
 import seqexec.web.common.FixedLengthBuffer
+import seqexec.web.client.model.SectionVisibilityState.SectionClosed
 
 sealed trait SoundSelection extends Product with Serializable
 
@@ -16,7 +18,9 @@ object SoundSelection {
   case object SoundOn extends SoundSelection
   case object SoundOff extends SoundSelection
 
-  implicit val eq: Eq[SoundSelection] = Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val SoundSelectionEnumerated: Enumerated[SoundSelection] =
+    Enumerated.of(SoundOn, SoundOff)
 
   def flip: SoundSelection => SoundSelection = _ match {
     case SoundSelection.SoundOn  => SoundSelection.SoundOff

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SessionQueueFilter.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SessionQueueFilter.scala
@@ -5,6 +5,7 @@ package seqexec.web.client.model
 
 import cats.Eq
 import cats.implicits._
+import gem.util.Enumerated
 import monocle.macros.Lenses
 import seqexec.model.SequenceView
 import seqexec.web.client.circuit.SequenceInSessionQueue
@@ -17,8 +18,9 @@ object ObsClass {
   case object Daytime extends ObsClass
   case object Nighttime extends ObsClass
 
-  implicit val eq: Eq[ObsClass] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val ObsClassEnumerated: Enumerated[ObsClass] =
+    Enumerated.of(All, Daytime, Nighttime)
 
   def fromString(s: String): ObsClass = s match {
     case "dayCal" => Daytime

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/TabOperations.scala
@@ -5,6 +5,7 @@ package seqexec.web.client.model
 
 import cats.Eq
 import cats.implicits._
+import gem.util.Enumerated
 import monocle.Lens
 import monocle.macros.Lenses
 import monocle.function.At.at
@@ -14,82 +15,90 @@ import scala.collection.immutable.SortedMap
 
 sealed trait RunOperation extends Product with Serializable
 object RunOperation {
-  case object RunInFlight extends RunOperation
   case object RunIdle extends RunOperation
+  case object RunInFlight extends RunOperation
 
-  implicit val eq: Eq[RunOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val RunOperationEnumerated: Enumerated[RunOperation] =
+    Enumerated.of(RunIdle, RunInFlight)
 
 }
 
 sealed trait StopOperation extends Product with Serializable
 object StopOperation {
-  case object StopInFlight extends StopOperation
   case object StopIdle extends StopOperation
+  case object StopInFlight extends StopOperation
 
-  implicit val eq: Eq[StopOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val StopOperationEnumerated: Enumerated[StopOperation] =
+    Enumerated.of(StopIdle, StopInFlight)
 
 }
 
 sealed trait AbortOperation extends Product with Serializable
 object AbortOperation {
-  case object AbortInFlight extends AbortOperation
   case object AbortIdle extends AbortOperation
+  case object AbortInFlight extends AbortOperation
 
-  implicit val eq: Eq[AbortOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val AbortOperationEnumerated: Enumerated[AbortOperation] =
+    Enumerated.of(AbortIdle, AbortInFlight)
 
 }
 
 sealed trait PauseOperation extends Product with Serializable
 object PauseOperation {
-  case object PauseInFlight extends PauseOperation
   case object PauseIdle extends PauseOperation
+  case object PauseInFlight extends PauseOperation
 
-  implicit val eq: Eq[PauseOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val PauseOperationEnumerated: Enumerated[PauseOperation] =
+    Enumerated.of(PauseIdle, PauseInFlight)
 
 }
 
 sealed trait CancelPauseOperation extends Product with Serializable
 object CancelPauseOperation {
-  case object CancelPauseInFlight extends CancelPauseOperation
   case object CancelPauseIdle extends CancelPauseOperation
+  case object CancelPauseInFlight extends CancelPauseOperation
 
-  implicit val eq: Eq[CancelPauseOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val CancelPauseOperationEnumerated: Enumerated[CancelPauseOperation] =
+    Enumerated.of(CancelPauseIdle, CancelPauseInFlight)
 
 }
 
 sealed trait ResumeOperation extends Product with Serializable
 object ResumeOperation {
-  case object ResumeInFlight extends ResumeOperation
   case object ResumeIdle extends ResumeOperation
+  case object ResumeInFlight extends ResumeOperation
 
-  implicit val eq: Eq[ResumeOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val ResumeOperationEnumerated: Enumerated[ResumeOperation] =
+    Enumerated.of(ResumeIdle, ResumeInFlight)
 
 }
 
 sealed trait SyncOperation extends Product with Serializable
 object SyncOperation {
-  case object SyncInFlight extends SyncOperation
   case object SyncIdle extends SyncOperation
+  case object SyncInFlight extends SyncOperation
 
-  implicit val eq: Eq[SyncOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val SyncOperationEnumerated: Enumerated[SyncOperation] =
+    Enumerated.of(SyncIdle, SyncInFlight)
 
 }
 
 sealed trait ResourceRunOperation extends Product with Serializable
 object ResourceRunOperation {
+  case object ResourceRunIdle extends ResourceRunOperation
   case object ResourceRunInFlight extends ResourceRunOperation
   case object ResourceRunCompleted extends ResourceRunOperation
-  case object ResourceRunIdle extends ResourceRunOperation
 
-  implicit val eq: Eq[ResourceRunOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val ResourceRunOperationEnumerated: Enumerated[ResourceRunOperation] =
+    Enumerated.of(ResourceRunIdle, ResourceRunInFlight, ResourceRunCompleted)
 
 }
 
@@ -98,8 +107,9 @@ object StartFromOperation {
   case object StartFromInFlight extends StartFromOperation
   case object StartFromIdle extends StartFromOperation
 
-  implicit val eq: Eq[StartFromOperation] =
-    Eq.fromUniversalEquals
+  /** @group Typeclass Instances */
+  implicit val StartFromOperationEnumerated: Enumerated[StartFromOperation] =
+    Enumerated.of(StartFromIdle, StartFromInFlight)
 
 }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/UserNotificationState.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/UserNotificationState.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.implicits._
 import monocle.macros.Lenses
 import seqexec.model.Notification
+import seqexec.web.client.model.SectionVisibilityState.SectionClosed
 
 /**
   * Utility class to display a generic notification sent by the server

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/package.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.implicits._
 import diode.data._
 import org.scalajs.dom.WebSocket
+import seqexec.web.client.model.SectionVisibilityState._
 
 package object model {
   implicit val eqWebSocket: Eq[WebSocket] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/tabs.scala
@@ -6,6 +6,7 @@ package seqexec.web.client.model
 import cats._
 import cats.implicits._
 import gem.Observation
+import gem.util.Enumerated
 import monocle.Lens
 import monocle.Optional
 import monocle.Prism
@@ -60,10 +61,11 @@ object TabSelected {
   case object Selected extends TabSelected
   case object Background extends TabSelected
 
-  implicit val eq: Eq[TabSelected] =
-    Eq.fromUniversalEquals
-
   def fromBoolean(b: Boolean): TabSelected = if (b) Selected else Background
+
+  /** @group Typeclass Instances */
+  implicit val TabSelectedEnumerated: Enumerated[TabSelected] =
+    Enumerated.of(Selected, Background)
 
 }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -27,7 +27,6 @@ import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.SectionVisibilityState
 import seqexec.web.client.model.UserNotificationState
 import seqexec.web.client.model.WebSocketConnection
-import seqexec.web.client.model.AddDayCalOperation
 import seqexec.web.client.model.PauseOperation
 import seqexec.web.client.model.QueueOperations
 import seqexec.web.client.model.RunOperation
@@ -75,7 +74,6 @@ package object reusability {
   implicit val userDetailsReuse: Reusability[UserDetails]    = Reusability.byEq
   implicit val usrNotReuse: Reusability[UserNotificationState] =
     Reusability.byEq
-  implicit val dcAddReuse: Reusability[AddDayCalOperation] = Reusability.byRef
   implicit val qoReuse: Reusability[QueueOperations]       = Reusability.byEq
   implicit val qfReuse: Reusability[CalQueueControlFocus]  = Reusability.byEq
   implicit val cqfReuse: Reusability[CalQueueFocus]        = Reusability.byEq

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -42,6 +42,7 @@ import seqexec.web.common.FixedLengthBuffer
 import seqexec.web.common.Zipper
 import seqexec.web.common.ArbitrariesWebCommon._
 import seqexec.web.client.model._
+import seqexec.web.client.model.SectionVisibilityState._
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.model.Formatting.OffsetsDisplay
@@ -60,42 +61,6 @@ import web.client.table.TableState
 
 trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with ArbTabOperations {
 
-  implicit val arbTabSelected: Arbitrary[TabSelected] =
-    Arbitrary(Gen.oneOf(TabSelected.Selected, TabSelected.Background))
-
-  implicit val tsCogen: Cogen[TabSelected] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbAddDayCalOperation: Arbitrary[AddDayCalOperation] =
-    Arbitrary(
-      Gen.oneOf(AddDayCalOperation.AddDayCalIdle,
-                AddDayCalOperation.AddDayCalInFlight))
-
-  implicit val adCogen: Cogen[AddDayCalOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbClearAllCalOperation: Arbitrary[ClearAllCalOperation] =
-    Arbitrary(
-      Gen.oneOf(ClearAllCalOperation.ClearAllCalIdle,
-                ClearAllCalOperation.ClearAllCalInFlight))
-
-  implicit val caqCogen: Cogen[ClearAllCalOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbRunCalOperation: Arbitrary[RunCalOperation] =
-    Arbitrary(
-      Gen.oneOf(RunCalOperation.RunCalIdle, RunCalOperation.RunCalInFlight))
-
-  implicit val rcCogen: Cogen[RunCalOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbStopCalOperation: Arbitrary[StopCalOperation] =
-    Arbitrary(
-      Gen.oneOf(StopCalOperation.StopCalIdle, StopCalOperation.StopCalInFlight))
-
-  implicit val scCogen: Cogen[StopCalOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
   implicit val arbQueueOperations: Arbitrary[QueueOperations] =
     Arbitrary {
       for {
@@ -108,24 +73,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
 
   implicit val qoCogen: Cogen[QueueOperations] =
     Cogen[AddDayCalOperation].contramap(x => x.addDayCalRequested)
-
-  implicit val arbRemoveSeqQueue: Arbitrary[RemoveSeqQueue] =
-    Arbitrary {
-      Gen.oneOf(RemoveSeqQueue.RemoveSeqQueueIdle,
-                RemoveSeqQueue.RemoveSeqQueueInFlight)
-    }
-
-  implicit val rsqCogen: Cogen[RemoveSeqQueue] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbMoveSeqQueue: Arbitrary[MoveSeqQueue] =
-    Arbitrary {
-      Gen.oneOf(MoveSeqQueue.MoveSeqQueueIdle,
-                MoveSeqQueue.MoveSeqQueueInFlight)
-    }
-
-  implicit val msqCogen: Cogen[MoveSeqQueue] =
-    Cogen[String].contramap(_.productPrefix)
 
   implicit val arbCalibrationQueueTab: Arbitrary[CalibrationQueueTab] =
     Arbitrary {
@@ -322,12 +269,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
 
   implicit val cssCogen: Cogen[ClientStatus] =
     Cogen[(Option[UserDetails], WebSocketConnection)].contramap(x => (x.u, x.w))
-
-  implicit val arbSection: Arbitrary[SectionVisibilityState] =
-    Arbitrary(Gen.oneOf(SectionOpen, SectionClosed))
-
-  implicit val sectionCogen: Cogen[SectionVisibilityState] =
-    Cogen[String].contramap(_.productPrefix)
 
   implicit val arbTableType: Arbitrary[StepsTableTypeSelection] =
     Arbitrary(
@@ -701,12 +642,6 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
   implicit val obsQueueFilter: Cogen[SessionQueueFilter] =
     Cogen[ObsClass]
       .contramap(_.obsClass)
-
-  implicit val arbSoundSelection: Arbitrary[SoundSelection] =
-    Arbitrary(Gen.oneOf(SoundSelection.SoundOn, SoundSelection.SoundOff))
-
-  implicit val soundSelClassCogen: Cogen[SoundSelection] =
-    Cogen[String].contramap(_.productPrefix)
 
   implicit val arbSeqexecUIModel: Arbitrary[SeqexecUIModel] =
     Arbitrary {

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -6,6 +6,7 @@ package seqexec.web.client
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import diode.data._
+import gem.arb.ArbEnumerated._
 import monocle.law.discipline.LensTests
 import org.scalajs.dom.WebSocket
 import seqexec.web.client.components.sequence.steps.StepConfigTable

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/arb/ArbTabOperations.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/arb/ArbTabOperations.scala
@@ -12,67 +12,6 @@ import seqexec.web.client.model._
 import seqexec.web.client.model.RunOperation
 
 trait ArbTabOperations {
-  implicit val arbRunOperation: Arbitrary[RunOperation] =
-    Arbitrary(Gen.oneOf(RunOperation.RunIdle, RunOperation.RunInFlight))
-
-  implicit val roCogen: Cogen[RunOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbSyncOperation: Arbitrary[SyncOperation] =
-    Arbitrary(Gen.oneOf(SyncOperation.SyncIdle, SyncOperation.SyncInFlight))
-
-  implicit val soCogen: Cogen[SyncOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbPauseOperation: Arbitrary[PauseOperation] =
-    Arbitrary(Gen.oneOf(PauseOperation.PauseIdle, PauseOperation.PauseInFlight))
-
-  implicit val poCogen: Cogen[PauseOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbStopOperation: Arbitrary[StopOperation] =
-    Arbitrary(Gen.oneOf(StopOperation.StopIdle, StopOperation.StopInFlight))
-
-  implicit val stoCogen: Cogen[StopOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbAbortOperation: Arbitrary[AbortOperation] =
-    Arbitrary(Gen.oneOf(AbortOperation.AbortIdle, AbortOperation.AbortInFlight))
-
-  implicit val abtCogen: Cogen[AbortOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbResumeOperation: Arbitrary[ResumeOperation] =
-    Arbitrary(Gen.oneOf(ResumeOperation.ResumeIdle, ResumeOperation.ResumeInFlight))
-
-  implicit val resCogen: Cogen[ResumeOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbResourceRunOperation: Arbitrary[ResourceRunOperation] =
-    Arbitrary(
-      Gen.oneOf(ResourceRunOperation.ResourceRunIdle,
-                ResourceRunOperation.ResourceRunInFlight,
-                ResourceRunOperation.ResourceRunCompleted))
-
-  implicit val rruCogen: Cogen[ResourceRunOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbStartFromOperation: Arbitrary[StartFromOperation] =
-    Arbitrary(
-      Gen.oneOf(StartFromOperation.StartFromIdle,
-                StartFromOperation.StartFromInFlight))
-
-  implicit val sfoCogen: Cogen[StartFromOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
-  implicit val arbCancelPauseOperation: Arbitrary[CancelPauseOperation] =
-    Arbitrary(
-      Gen.oneOf(CancelPauseOperation.CancelPauseIdle,
-                CancelPauseOperation.CancelPauseInFlight))
-
-  implicit val cpuCogen: Cogen[CancelPauseOperation] =
-    Cogen[String].contramap(_.productPrefix)
-
   implicit val arbTabOperations: Arbitrary[TabOperations] = {
     implicit val ordering: Ordering[Resource] =
       cats.Order[Resource].toOrdering

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -53,7 +53,7 @@ trait ModelBooPicklers extends GemModelBooPicklers {
 
   implicit val operatorPickler = generatePickler[Operator]
 
-  val sysNameIdx = valuesMap(SystemName.all, (x: SystemName) => x.system)
+  val sysNameIdx = valuesMap(SystemName.SystemNameEnumerated.all, (x: SystemName) => x.system)
 
   implicit val systemNamePickler = valuesMapPickler(sysNameIdx)
 
@@ -64,21 +64,21 @@ trait ModelBooPicklers extends GemModelBooPicklers {
   implicit val instantPickler =
     transformPickler((t: Long) => Instant.ofEpochMilli(t))(_.toEpochMilli)
 
-  val cloudCoverIdx = valuesMap(CloudCover.all, (x: CloudCover) => x.toInt)
+  val cloudCoverIdx = valuesMap(CloudCover.CloudCoverEnumerated.all, (x: CloudCover) => x.toInt)
 
   implicit val cloudCoverPickler = valuesMapPickler(cloudCoverIdx)
 
   val imageQualityIdx =
-    valuesMap(ImageQuality.all, (x: ImageQuality) => x.toInt)
+    valuesMap(ImageQuality.ImageQualityEnumerated.all, (x: ImageQuality) => x.toInt)
 
   implicit val imageQualityPickler = valuesMapPickler(imageQualityIdx)
 
   val skyBackgroundIdx =
-    valuesMap(SkyBackground.all, (x: SkyBackground) => x.toInt)
+    valuesMap(SkyBackground.SkyBackgroundEnumerated.all, (x: SkyBackground) => x.toInt)
 
   implicit val skyBackgroundPickler = valuesMapPickler(skyBackgroundIdx)
 
-  val waterVaporIdx = valuesMap(WaterVapor.all, (x: WaterVapor) => x.toInt)
+  val waterVaporIdx = valuesMap(WaterVapor.WaterVaporEnumerated.all, (x: WaterVapor) => x.toInt)
 
   implicit val waterVaporPickler = valuesMapPickler(waterVaporIdx)
 


### PR DESCRIPTION
This PR expands the use of `Enumerated` on the client side letting me remove some amount of code. I added `Enumerated.of` to further simplify construction

I also moved some `Show` instances to local instances as it maybe risky to use them everywhere