### PR TITLE
SEQNG-887: Make epics reads for GMOS referentially transparent

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -420,6 +420,18 @@ object EpicsUtil {
   def smartSetParam[A: Eq](v: A, get: => Option[A], set: SeqAction[Unit]): List[SeqAction[Unit]] =
     if(get =!= v.some) List(set) else Nil
 
+  def applyParam[F[_]: Applicative, A: Eq](c: A, d: A, f: A => F[Unit]): Option[F[Unit]] =
+    if (c =!= d) f(d).some else none
+
+  def applyParamT[F[_]: Functor](
+    relTolerance: Double
+  )(c: Double, d: Double, set: Double => F[Unit]): Option[F[Unit]] =
+    if (!(d === 0.0 && c === 0.0) || (d === 0.0 || abs((c - d)/d) > relTolerance)) {
+      set(d).some
+    } else {
+      none
+    }
+
   // This method takes a list of actions returning possible actions
   // If at least one is defined it will execute them and then executes `after`
   def executeIfNeeded[F[_]: Monad, A](i:     List[F[Option[F[Unit]]]],
@@ -444,8 +456,11 @@ object EpicsUtil {
     get.map(_ =!= v.some).map(_.option(set))
 
   def smartSetDoubleParam(relTolerance: Double)(v: Double, get: => Option[Double], set: SeqAction[Unit]): List[SeqAction[Unit]] =
-    if(get.forall(x => (v === 0.0 && x =!= 0.0) || abs((x - v)/v) > relTolerance))
-  List(set) else Nil
+    if (get.forall(x => !(v === 0.0 && x === 0.0) || (v === 0.0 || abs((x - v)/v) > relTolerance))) {
+      List(set)
+    } else {
+      Nil
+    }
 
   def smartSetDoubleParamF[F[_]: Functor](relTolerance: Double)(v: Double, get: F[Option[Double]], set: F[Unit]): F[Option[F[Unit]]] =
     get.map(g => (g.forall(x => (v === 0.0 && x =!= 0.0) || abs((x - v)/v) > relTolerance)).option(set))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -420,13 +420,37 @@ object EpicsUtil {
   def smartSetParam[A: Eq](v: A, get: => Option[A], set: SeqAction[Unit]): List[SeqAction[Unit]] =
     if(get =!= v.some) List(set) else Nil
 
+  /**
+   * Decides to set a param comparing the current value and the value to be set
+   * @param c Current value on the system
+   * @param d Value to be set
+   * @param f Action to set the parameter
+   */
   def applyParam[F[_]: Applicative, A: Eq](c: A, d: A, f: A => F[Unit]): Option[F[Unit]] =
     if (c =!= d) f(d).some else none
 
+  /**
+   * Test if we should set a value d given that the current value c and
+   * a given tolerance
+   * @param t Max relative tolerance allowed between the current and destination value
+   * @param c Current value on the system
+   * @param d Value to be set
+   */
+  private def toleranceTest(t: Double, c: Double, d: Double): Boolean =
+    (!(d === 0.0 && c === 0.0) && (d === 0.0 || abs((c - d)/d) > t))
+
+  /**
+   * Decides to set a param comparing the current value and the value to be set with
+   * a given tolerance
+   * @param relTolerance Max relative tolerance allowed between the current and destination value
+   * @param c Current value on the system
+   * @param d Value to be set
+   * @param f Action to set the parameter
+   */
   def applyParamT[F[_]: Functor](
     relTolerance: Double
   )(c: Double, d: Double, set: Double => F[Unit]): Option[F[Unit]] =
-    if (!(d === 0.0 && c === 0.0) || (d === 0.0 || abs((c - d)/d) > relTolerance)) {
+    if (toleranceTest(relTolerance, c, d)) {
       set(d).some
     } else {
       none
@@ -463,7 +487,7 @@ object EpicsUtil {
     }
 
   def smartSetDoubleParamF[F[_]: Functor](relTolerance: Double)(v: Double, get: F[Option[Double]], set: F[Unit]): F[Option[F[Unit]]] =
-    get.map(g => (g.forall(x => (v === 0.0 && x =!= 0.0) || abs((x - v)/v) > relTolerance)).option(set))
+    get.map(g => (g.forall(toleranceTest(relTolerance, _, v))).option(set))
 
   def countdown[F[_]: Apply: cats.effect.Timer](total: Time, remT: F[Option[Time]],
                               obsState: F[Option[CarStateGeneric]]): Stream[F, Progress] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -34,7 +34,7 @@ import seqexec.server.gpi.{Gpi, GpiHeader}
 import seqexec.server.ghost.{Ghost, GhostHeader}
 import seqexec.server.gsaoi._
 import seqexec.server.gcal._
-import seqexec.server.gmos.{GmosHeader, GmosObsKeywordsReader, GmosKeywordReaderDummy, GmosKeywordReaderEpics, GmosNorth, GmosSouth}
+import seqexec.server.gmos.{GmosHeader, GmosEpics, GmosObsKeywordsReader, GmosKeywordReaderDummy, GmosKeywordReaderEpics, GmosNorth, GmosSouth}
 import seqexec.server.gws.{DummyGwsKeywordsReader, GwsHeader, GwsKeywordsReaderEpics}
 import seqexec.server.tcs._
 import seqexec.server.tcs.TcsController.LightPath
@@ -483,7 +483,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
         Flamingos2Header.header[IO](sys, Flamingos2Header.ObsKeywordsReaderODB(config), tcsKReader).asRight
       case Instrument.GmosS |
            Instrument.GmosN  =>
-        val gmosInstReader = if (settings.gmosKeywords) GmosKeywordReaderEpics[IO] else GmosKeywordReaderDummy[IO]
+        val gmosInstReader = if (settings.gmosKeywords) GmosKeywordReaderEpics[IO](GmosEpics.instance) else GmosKeywordReaderDummy[IO]
         GmosHeader.header[IO](sys, GmosObsKeywordsReader(config), gmosInstReader, tcsKReader).asRight
       case Instrument.Gnirs  =>
         val gnirsReader = if(settings.gnirsKeywords) GnirsKeywordReaderEpics[IO] else GnirsKeywordReaderDummy[IO]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
@@ -76,7 +76,6 @@ object Altair {
 
   }
 
-
   def fromConfig[F[_]: Sync](config: Config, controller: AltairController[F]): TrySeq[Altair[F]] =
     config.extractAs[FieldLens](new ItemKey(AO_CONFIG_NAME) / FIELD_LENSE_PROP).map { fieldLens =>
       new AltairImpl[F](controller, fieldLens)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -213,7 +213,7 @@ object AltairControllerEpics extends AltairController[IO] {
     reasons: Set[Gaos.ResumeCondition]): Option[IO[Unit]] =
     resumeNgsOrLgsMode(starPos, currCfg)(reasons).filter(_ => strap || sfo).map(_ *> ttgsOn(strap, sfo, currCfg))
 
-  /*
+  /**
    * Modes LgsWithP1 and LgsWithOi don't use an Altair target. The only action required is to start or stop corrections
    */
   private def pauseResumeLgsWithXX(currCfg: EpicsAltairConfig)(
@@ -311,13 +311,6 @@ object AltairControllerEpics extends AltairController[IO] {
     strapGate: Int,
     aoLoop: Boolean
   )
-
-  object EpicsAltairConfig
-
-  /*
-   * Helper function to be used until TcsEpics is converted to use F[_]
-   */
-  //def convertTcsAction[T](a: SeqAction[T]): IO[T] = a.value.flatMap(_.fold(IO.raiseError(_), IO(_)))
 
   // This is a bit convoluted. AO follow state is read from Altair, but set as part of TCS configuration
   override def isFollowing: IO[Option[Boolean]] = AltairEpics.instance.aoFollow

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -178,21 +178,21 @@ object Gmos {
 
   // It seems this is unused but it shows up on the DC apply config
   private def biasTimeObserveType(observeType: String): BiasTime = observeType match {
-    case SCIENCE_OBSERVE_TYPE => BiasTimeUnset
-    case FLAT_OBSERVE_TYPE    => BiasTimeUnset
-    case ARC_OBSERVE_TYPE     => BiasTimeEmpty
-    case DARK_OBSERVE_TYPE    => BiasTimeEmpty
-    case BIAS_OBSERVE_TYPE    => BiasTimeUnset
-    case _                    => BiasTimeUnset
+    case SCIENCE_OBSERVE_TYPE => BiasTime.BiasTimeUnset
+    case FLAT_OBSERVE_TYPE    => BiasTime.BiasTimeUnset
+    case ARC_OBSERVE_TYPE     => BiasTime.BiasTimeEmpty
+    case DARK_OBSERVE_TYPE    => BiasTime.BiasTimeEmpty
+    case BIAS_OBSERVE_TYPE    => BiasTime.BiasTimeUnset
+    case _                    => BiasTime.BiasTimeUnset
   }
 
   private def shutterStateObserveType(observeType: String): ShutterState = observeType match {
-    case SCIENCE_OBSERVE_TYPE => OpenShutter
-    case FLAT_OBSERVE_TYPE    => OpenShutter
-    case ARC_OBSERVE_TYPE     => OpenShutter
-    case DARK_OBSERVE_TYPE    => CloseShutter
-    case BIAS_OBSERVE_TYPE    => CloseShutter
-    case _                    => UnsetShutter
+    case SCIENCE_OBSERVE_TYPE => ShutterState.OpenShutter
+    case FLAT_OBSERVE_TYPE    => ShutterState.OpenShutter
+    case ARC_OBSERVE_TYPE     => ShutterState.OpenShutter
+    case DARK_OBSERVE_TYPE    => ShutterState.CloseShutter
+    case BIAS_OBSERVE_TYPE    => ShutterState.CloseShutter
+    case _                    => ShutterState.UnsetShutter
   }
 
   private def customROIs(config: Config): List[ROI] = {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -90,28 +90,29 @@ object GmosController {
     type PosAngle            = edu.gemini.spModel.core.Angle
 
     // I'm not totally sure this is being used
-    sealed trait BiasTime
+    sealed trait BiasTime extends Product with Serializable
 
-    case object BiasTimeSet extends BiasTime
-
-    case object BiasTimeEmpty extends BiasTime
-
-    case object BiasTimeUnset extends BiasTime
+    object BiasTime {
+      case object BiasTimeSet extends BiasTime
+      case object BiasTimeEmpty extends BiasTime
+      case object BiasTimeUnset extends BiasTime
+    }
 
     // Used for the shutterState
-    sealed trait ShutterState
+    sealed trait ShutterState extends Product with Serializable
 
-    case object UnsetShutter extends ShutterState
+    object ShutterState {
+      case object UnsetShutter extends ShutterState
+      case object OpenShutter extends ShutterState
+      case object CloseShutter extends ShutterState
+    }
 
-    case object OpenShutter extends ShutterState
+    sealed trait Beam extends Product with Serializable
 
-    case object CloseShutter extends ShutterState
-
-    sealed trait Beam
-
-    case object InBeam extends Beam
-
-    case object OutOfBeam extends Beam
+    object Beam {
+      case object InBeam extends Beam
+      case object OutOfBeam extends Beam
+    }
 
     sealed trait GmosFPU
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorthControllerEpics.scala
@@ -7,7 +7,7 @@ import cats.effect.IO
 import cats.implicits._
 import seqexec.server.EpicsCodex
 import seqexec.server.EpicsCodex.EncodeEpicsValue
-import seqexec.server.gmos.GmosController.Config._
+import seqexec.server.gmos.GmosController.Config.Beam
 import seqexec.server.gmos.GmosController.{NorthTypes, northConfigTypes}
 import seqexec.server.gmos.GmosControllerEpics.ROIValues
 import edu.gemini.spModel.gemini.gmos.GmosCommonType
@@ -51,23 +51,23 @@ object GmosNorthEncoders extends GmosControllerEpics.Encoders[NorthTypes] {
   override val fpu: EpicsCodex.EncodeEpicsValue[NorthTypes#FPU, (Option[String], Option[String])] = EncodeEpicsValue{
     a => {
       val r = a match {
-        case FPU.FPU_NONE    => (none, OutOfBeam.some)
-        case FPU.LONGSLIT_1  => ("0.25arcsec".some, InBeam.some)
-        case FPU.LONGSLIT_2  => ("0.5arcsec".some, InBeam.some)
-        case FPU.LONGSLIT_3  => ("0.75arcsec".some, InBeam.some)
-        case FPU.LONGSLIT_4  => ("1.0arcsec".some, InBeam.some)
-        case FPU.LONGSLIT_5  => ("1.5arcsec".some, InBeam.some)
-        case FPU.LONGSLIT_6  => ("2.0arcsec".some, InBeam.some)
-        case FPU.LONGSLIT_7  => ("5.0arcsec".some, InBeam.some)
-        case FPU.IFU_1       => ("IFU-2".some, InBeam.some)
-        case FPU.IFU_2       => ("IFU-B".some, InBeam.some)
-        case FPU.IFU_3       => ("IFU-R".some, InBeam.some)
-        case FPU.NS_0        => ("NS0.25arcsec".some, InBeam.some)
-        case FPU.NS_1        => ("NS0.5arcsec".some, InBeam.some)
-        case FPU.NS_2        => ("NS0.75arcsec".some, InBeam.some)
-        case FPU.NS_3        => ("NS1.0arcsec".some, InBeam.some)
-        case FPU.NS_4        => ("NS1.5arcsec".some, InBeam.some)
-        case FPU.NS_5        => ("NS2.0arcsec".some, InBeam.some)
+        case FPU.FPU_NONE    => (none, Beam.OutOfBeam.some)
+        case FPU.LONGSLIT_1  => ("0.25arcsec".some, Beam.InBeam.some)
+        case FPU.LONGSLIT_2  => ("0.5arcsec".some, Beam.InBeam.some)
+        case FPU.LONGSLIT_3  => ("0.75arcsec".some, Beam.InBeam.some)
+        case FPU.LONGSLIT_4  => ("1.0arcsec".some, Beam.InBeam.some)
+        case FPU.LONGSLIT_5  => ("1.5arcsec".some, Beam.InBeam.some)
+        case FPU.LONGSLIT_6  => ("2.0arcsec".some, Beam.InBeam.some)
+        case FPU.LONGSLIT_7  => ("5.0arcsec".some, Beam.InBeam.some)
+        case FPU.IFU_1       => ("IFU-2".some, Beam.InBeam.some)
+        case FPU.IFU_2       => ("IFU-B".some, Beam.InBeam.some)
+        case FPU.IFU_3       => ("IFU-R".some, Beam.InBeam.some)
+        case FPU.NS_0        => ("NS0.25arcsec".some, Beam.InBeam.some)
+        case FPU.NS_1        => ("NS0.5arcsec".some, Beam.InBeam.some)
+        case FPU.NS_2        => ("NS0.75arcsec".some, Beam.InBeam.some)
+        case FPU.NS_3        => ("NS1.0arcsec".some, Beam.InBeam.some)
+        case FPU.NS_4        => ("NS1.5arcsec".some, Beam.InBeam.some)
+        case FPU.NS_5        => ("NS2.0arcsec".some, Beam.InBeam.some)
         case FPU.CUSTOM_MASK => (none, none)
       }
       (r._1, r._2.map(GmosControllerEpics.beamEncoder.encode))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouthControllerEpics.scala
@@ -6,7 +6,7 @@ package seqexec.server.gmos
 import cats.effect.IO
 import cats.implicits._
 import seqexec.server.EpicsCodex.EncodeEpicsValue
-import seqexec.server.gmos.GmosController.Config.{InBeam, OutOfBeam}
+import seqexec.server.gmos.GmosController.Config.Beam
 import seqexec.server.gmos.GmosController.{SouthTypes, southConfigTypes}
 import seqexec.server.gmos.GmosControllerEpics.ROIValues
 import edu.gemini.spModel.gemini.gmos.GmosCommonType
@@ -26,26 +26,26 @@ object GmosSouthEncoders extends GmosControllerEpics.Encoders[SouthTypes] {
 
   override val fpu: EncodeEpicsValue[SouthTypes#FPU, (Option[String], Option[String])] = EncodeEpicsValue{ a => {
     val r = a match {
-      case FPU.FPU_NONE    => (none, OutOfBeam.some)
-      case FPU.LONGSLIT_1  => ("0.25arcsec".some, InBeam.some)
-      case FPU.LONGSLIT_2  => ("0.5arcsec".some, InBeam.some)
-      case FPU.LONGSLIT_3  => ("0.75arcsec".some, InBeam.some)
-      case FPU.LONGSLIT_4  => ("1.0arcsec".some, InBeam.some)
-      case FPU.LONGSLIT_5  => ("1.5arcsec".some, InBeam.some)
-      case FPU.LONGSLIT_6  => ("2.0arcsec".some, InBeam.some)
-      case FPU.LONGSLIT_7  => ("5.0arcsec".some, InBeam.some)
-      case FPU.IFU_1       => ("IFU-2".some, InBeam.some)
-      case FPU.IFU_2       => ("IFU-B".some, InBeam.some)
-      case FPU.IFU_3       => ("IFU-R".some, InBeam.some)
+      case FPU.FPU_NONE    => (none, Beam.OutOfBeam.some)
+      case FPU.LONGSLIT_1  => ("0.25arcsec".some, Beam.InBeam.some)
+      case FPU.LONGSLIT_2  => ("0.5arcsec".some, Beam.InBeam.some)
+      case FPU.LONGSLIT_3  => ("0.75arcsec".some, Beam.InBeam.some)
+      case FPU.LONGSLIT_4  => ("1.0arcsec".some, Beam.InBeam.some)
+      case FPU.LONGSLIT_5  => ("1.5arcsec".some, Beam.InBeam.some)
+      case FPU.LONGSLIT_6  => ("2.0arcsec".some, Beam.InBeam.some)
+      case FPU.LONGSLIT_7  => ("5.0arcsec".some, Beam.InBeam.some)
+      case FPU.IFU_1       => ("IFU-2".some, Beam.InBeam.some)
+      case FPU.IFU_2       => ("IFU-B".some, Beam.InBeam.some)
+      case FPU.IFU_3       => ("IFU-R".some, Beam.InBeam.some)
       case FPU.BHROS       => (none, none)
-      case FPU.IFU_N       => ("IFU-NS-2".some, InBeam.some)
-      case FPU.IFU_N_B     => ("IFU-NS-B".some, InBeam.some)
-      case FPU.IFU_N_R     => ("IFU-NS-R".some, InBeam.some)
-      case FPU.NS_1        => ("NS0.5arcsec".some, InBeam.some)
-      case FPU.NS_2        => ("NS0.75arcsec".some, InBeam.some)
-      case FPU.NS_3        => ("NS1.0arcsec".some, InBeam.some)
-      case FPU.NS_4        => ("NS1.5arcsec".some, InBeam.some)
-      case FPU.NS_5        => ("NS2.0arcsec".some, InBeam.some)
+      case FPU.IFU_N       => ("IFU-NS-2".some, Beam.InBeam.some)
+      case FPU.IFU_N_B     => ("IFU-NS-B".some, Beam.InBeam.some)
+      case FPU.IFU_N_R     => ("IFU-NS-R".some, Beam.InBeam.some)
+      case FPU.NS_1        => ("NS0.5arcsec".some, Beam.InBeam.some)
+      case FPU.NS_2        => ("NS0.75arcsec".some, Beam.InBeam.some)
+      case FPU.NS_3        => ("NS1.0arcsec".some, Beam.InBeam.some)
+      case FPU.NS_4        => ("NS1.5arcsec".some, Beam.InBeam.some)
+      case FPU.NS_5        => ("NS2.0arcsec".some, Beam.InBeam.some)
       case FPU.CUSTOM_MASK => (none, none)
     }
     (r._1, r._2.map(GmosControllerEpics.beamEncoder.encode))


### PR DESCRIPTION
Gmos is the last instrument to get the treatment of SEQNG-887. This is a largish update and it would be good to be reviewed in detail and test it on hardware

Main changes are:
* Put all epics reads inside an `F[_]`
* Reform on the way the decision to apply a param is done. Now we take a full snapshot of the instrument state and use that to decide

There is space for further improvements but I'm trying to keep this constrained on the change size and time invested