### PR TITLE
SEQNG-887: Final touches on SEQNG-887

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -6,7 +6,6 @@ package seqexec.server
 import cats._
 import cats.data.EitherT
 import cats.data.Nested
-import cats.effect.IO
 import cats.effect.Sync
 import cats.effect.Async
 import cats.implicits._
@@ -23,7 +22,6 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 import edu.gemini.epics.acm._
 import mouse.boolean._
 import org.log4s._
-import seqexec.server.EpicsCommand.safe
 import seqexec.server.SeqexecFailure.SeqexecException
 import seqexec.server.SeqexecFailure.NullEpicsError
 import squants.Time
@@ -32,38 +30,6 @@ import scala.collection.JavaConverters._
 
 trait EpicsCommand {
   import EpicsCommand._
-
-  protected val cs: Option[CaCommandSender]
-
-  def post: SeqAction[Result] =
-    safe {
-      EitherT {
-        IO.async[TrySeq[Result]] { (f: Either[Throwable, TrySeq[Result]] => Unit) =>
-          cs.map { ccs =>
-            ccs.postCallback {
-              new CaCommandListener {
-                override def onSuccess(): Unit = f(TrySeq(Completed).asRight)
-                override def onPause(): Unit = f(TrySeq(Paused).asRight)
-                override def onFailure(cause: Exception): Unit = f(cause.asLeft)
-              }
-            }
-          // It should call f on all execution paths, thanks @tpolecat
-          }.void.getOrElse(f(TrySeq.fail(SeqexecFailure.Unexpected("Unable to trigger command.")).asRight))
-        }
-      }
-    }
-
-  def mark: SeqAction[Unit] = safe(EitherT(IO.apply {
-      cs.map(_.mark().asRight).getOrElse(SeqexecFailure.Unexpected("Unable to mark command.").asLeft)
-    })
-  )
-
-  def setTimeout(t: Time): SeqAction[Unit] = EpicsUtil.setTimeout(cs.map(_.getApplySender), t)
-}
-
-trait EpicsCommandF {
-  import EpicsCommand._
-
   protected val cs: Option[CaCommandSender]
 
   def post[F[_]: Async]: F[Result] =
@@ -124,33 +90,18 @@ trait EpicsSystem[T] {
 
 object EpicsCommand {
 
-  sealed trait Result
-  object Paused extends Result
-  object Completed extends Result
+  sealed trait Result extends Product with Serializable
+  case object Paused extends Result
+  case object Completed extends Result
 
-  def safe[A](a: SeqAction[A]): SeqAction[A] = EitherT(a.value.attempt.map {
-    case Left(e)  => SeqexecException(e).asLeft
-    case Right(r) => r
-  })
-
-  def setParameter[A, T](p: Option[CaParameter[T]], v: A, f: A => T): SeqAction[Unit] =
-    safe(SeqAction.either {
-      p.map(_.set(f(v)).asRight).getOrElse(SeqexecFailure.Unexpected("Unable to set parameter.").asLeft)
-    } )
-
-  def setParameter[T](p: Option[CaParameter[T]], v: T): SeqAction[Unit] =
-    safe(SeqAction.either {
-      p.map(_.set(v).asRight).getOrElse(SeqexecFailure.Unexpected("Unable to set parameter.").asLeft)
-    } )
-
-  def setParameterF[F[_]: Sync, T](p: Option[CaParameter[T]], v: T): F[Unit] =
+  def setParameter[F[_]: Sync, T](p: Option[CaParameter[T]], v: T): F[Unit] =
     Sync[F].delay {
       p.map(_.set(v))
     }.adaptError {
       case _ => SeqexecFailure.Unexpected("Unable to set parameter.")
     }.void
 
-  def setParameterF[F[_]: Sync, T, A](p: Option[CaParameter[T]], v: A, f: A => T): F[Unit] =
+  def setParameter[F[_]: Sync, T, A](p: Option[CaParameter[T]], v: A, f: A => T): F[Unit] =
     Sync[F].delay {
       p.map(_.set(f(v)))
     }.adaptError {
@@ -159,41 +110,7 @@ object EpicsCommand {
 
 }
 
-trait ObserveCommand {
-  import ObserveCommand._
-
-  protected val cs: Option[CaCommandSender]
-  protected val os: Option[CaApplySender]
-
-  def post: SeqAction[Result] =
-    EpicsCommand.safe {
-      EitherT {
-        IO.async[TrySeq[Result]] { (f: Either[Throwable, TrySeq[Result]] => Unit) =>
-          os.map { oos =>
-            oos.postCallback {
-              new CaCommandListener {
-                override def onSuccess(): Unit = f(TrySeq(Success).asRight)
-                override def onPause(): Unit = f(TrySeq(Paused).asRight)
-                override def onFailure(cause: Exception): Unit = cause match {
-                  case _: CaObserveStopped => f(TrySeq(Stopped).asRight)
-                  case _: CaObserveAborted => f(TrySeq(Aborted).asRight)
-                  case _                   => f(cause.asLeft)
-                }
-              }
-            }
-          }.void.getOrElse(f(TrySeq.fail(SeqexecFailure.Unexpected("Unable to trigger command.")).asRight))
-        }
-      }
-    }
-
-  def mark: SeqAction[Unit] = safe(EitherT(IO.apply {
-    cs.map(_.mark().asRight).getOrElse(SeqexecFailure.Unexpected("Unable to mark command.").asLeft)
-  }))
-
-  def setTimeout(t: Time): SeqAction[Unit] = EpicsUtil.setTimeout(cs.map(_.getApplySender), t)
-}
-
-trait ObserveCommandF {
+trait ObserveCommand     {
   import ObserveCommand._
 
   protected val cs: Option[CaCommandSender]
@@ -262,6 +179,10 @@ object EpicsCodex {
 }
 
 object EpicsUtil {
+  def safe[A](a: SeqAction[A]): SeqAction[A] = EitherT(a.value.attempt.map {
+    case Left(e)  => SeqexecException(e).asLeft
+    case Right(r) => r
+  })
 
   //`locked` gets a piece of code and runs it protected by `lock`
   private def locked[A](lock: ReentrantLock)(f: => A): A = {
@@ -272,58 +193,6 @@ object EpicsUtil {
       lock.unlock()
     }
   }
-
-  def waitForValues[T](attr: CaAttribute[T], vv: Seq[T], timeout: Time, name: String): SeqAction[T] =
-    EpicsCommand.safe(EitherT(IO.async[TrySeq[T]]((f) => {
-      //The task is created with IO.async. So we do whatever we need to do,
-      // and then call `f` to signal the completion of the task.
-
-      //`resultGuard` and `lock` are used for synchronization.
-      val resultGuard = new AtomicInteger(1)
-      val lock = new ReentrantLock()
-
-      // First we verify that the attribute doesn't already have the required value.
-      if (!attr.values().isEmpty && vv.contains(attr.value)) {
-        f(TrySeq(attr.value).asRight)
-      } else {
-        // If not, we set a timer for the timeout, and a listener for the EPICS
-        // channel. The timer and the listener can both complete the IO. The
-        // first one to do it cancels the other.The use of `resultGuard`
-        // guarantees that only one of them will complete the IO.
-        val timer = new Timer
-        val statusListener = new CaAttributeListener[T] {
-          override def onValueChange(newVals: util.List[T]): Unit = {
-            if (!newVals.isEmpty && vv.contains(newVals.get(0)) && resultGuard.getAndDecrement() === 1) {
-              locked(lock) {
-                attr.removeListener(this)
-                timer.cancel()
-              }
-              // This `right` looks a bit confusing because is not related to
-              // the `TrySeq`, but to the result of `IO`.
-              f(TrySeq(newVals.get(0)).asRight)
-            }
-          }
-
-          override def onValidityChange(newValidity: Boolean): Unit = {}
-        }
-
-        locked(lock) {
-          if (timeout.toMilliseconds.toLong > 0) {
-            timer.schedule(new TimerTask {
-              override def run(): Unit = if (resultGuard.getAndDecrement() === 1) {
-                locked(lock) {
-                  attr.removeListener(statusListener)
-                }
-                f(TrySeq.fail(SeqexecFailure.Timeout(name)).asRight)
-              }
-            }, timeout.toMilliseconds.toLong)
-          }
-          attr.addListener(statusListener)
-        }
-      }
-    })))
-
-  def waitForValue[T](attr: CaAttribute[T], v: T, timeout: Time, name: String): SeqAction[Unit] = waitForValues[T](attr, List(v), timeout, name).void
 
   def waitForValuesF[T, F[_]: Async](attr: CaAttribute[T], vv: Seq[T], timeout: Time, name: String): F[T] =
     Async[F].async[T] { (f: Either[Throwable, T] => Unit) =>
@@ -377,10 +246,6 @@ object EpicsUtil {
 
   def waitForValueF[T, F[_]: Async](attr: CaAttribute[T], v: T, timeout: Time, name: String): F[Unit] = waitForValuesF[T, F](attr, List(v), timeout, name).void
 
-  def setTimeout(os: Option[CaApplySender], t: Time): SeqAction[Unit] = SeqAction.either{
-    os.map(_.setTimeout(t.toMilliseconds.toLong, MILLISECONDS).asRight).getOrElse(SeqexecFailure.Unexpected("Unable to set timeout for EPICS command.").asLeft)
-  }
-
   def safeAttribute[F[_]: Sync, A](get: => CaAttribute[A]): F[Option[A]] =
     Sync[F].delay(Option(get.value))
 
@@ -416,9 +281,6 @@ object EpicsUtil {
 
   def safeAttributeSListSDouble[F[_]: Sync, A](get: => CaAttribute[JDouble]): F[Option[List[Double]]] =
     Nested(safeAttributeList(get)).map(_.map(_.toDouble)).value
-
-  def smartSetParam[A: Eq](v: A, get: => Option[A], set: SeqAction[Unit]): List[SeqAction[Unit]] =
-    if(get =!= v.some) List(set) else Nil
 
   /**
    * Decides to set a param comparing the current value and the value to be set
@@ -478,13 +340,6 @@ object EpicsUtil {
   // action
   def smartSetParamF[F[_]: Monad, A: Eq](v: A, get: F[Option[A]], set: F[Unit]): F[Option[F[Unit]]] =
     get.map(_ =!= v.some).map(_.option(set))
-
-  def smartSetDoubleParam(relTolerance: Double)(v: Double, get: => Option[Double], set: SeqAction[Unit]): List[SeqAction[Unit]] =
-    if (get.forall(areValuesDifferentEnough(relTolerance, _, v))) {
-      List(set)
-    } else {
-      Nil
-    }
 
   def smartSetDoubleParamF[F[_]: Functor](relTolerance: Double)(v: Double, get: F[Option[Double]], set: F[Unit]): F[Option[F[Unit]]] =
     get.map(g => (g.forall(areValuesDifferentEnough(relTolerance, _, v))).option(set))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentControllerSim.scala
@@ -61,12 +61,12 @@ object InstrumentControllerSim {
     private def observeTic(stop: Boolean, abort: Boolean, pause: Boolean, remain: Int, timeout: Option[Int]): F[ObserveCommand.Result] =
       if(remain < tic) {
         Log.info(s"Simulate $name observation completed")
-        ObserveCommand.Success.pure[F].widen
-      } else if(stop) ObserveCommand.Stopped.pure[F].widen
-        else if(abort) ObserveCommand.Aborted.pure[F].widen
+        ObserveCommand.Result.Success.pure[F].widen
+      } else if(stop) ObserveCommand.Result.Stopped.pure[F].widen
+        else if(abort) ObserveCommand.Result.Aborted.pure[F].widen
         else if(pause) {
           remainingTime.set(remain)
-          ObserveCommand.Paused.pure[F].widen
+          ObserveCommand.Result.Paused.pure[F].widen
         }
         else if(timeout.exists(_<= 0)) Sync[F].raiseError(SeqexecException(new TimeoutException()))
         else {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -125,10 +125,10 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
         SeqAction.fail(SeqexecFailure.Execution(s"Observation ${obsId.format} aborted by user."))
 
       r match {
-        case ObserveCommand.Success => successTail
-        case ObserveCommand.Stopped => stopTail
-        case ObserveCommand.Aborted => abortTail
-        case ObserveCommand.Paused  =>
+        case ObserveCommand.Result.Success => successTail
+        case ObserveCommand.Result.Stopped => stopTail
+        case ObserveCommand.Result.Aborted => abortTail
+        case ObserveCommand.Result.Paused  =>
           SeqActionF.liftF(inst.calcObserveTime(config))
             .map(e => Result.Paused(ObserveContext(observeTail(id, dataId), e)))
       }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairEpics.scala
@@ -9,8 +9,8 @@ import mouse.boolean._
 import edu.gemini.epics.acm._
 import edu.gemini.seqexec.server.altair.LgsSfoControl
 import org.log4s.{Logger, getLogger}
-import seqexec.server.{EpicsCommandF, EpicsSystem, EpicsUtil}
-import seqexec.server.EpicsCommand.setParameterF
+import seqexec.server.{EpicsCommand, EpicsSystem, EpicsUtil}
+import seqexec.server.EpicsCommand.setParameter
 import cats.implicits._
 import seqexec.server.EpicsUtil._
 import squants.Time
@@ -18,40 +18,40 @@ import squants.Time
 class AltairEpics[F[_]: Async](service: CaService, tops: Map[String, String]) {
   val AltairTop: String = tops.getOrElse("ao", "ao:")
 
-  object strapGateControl extends EpicsCommandF {
+  object strapGateControl extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(service.createTaskControlSender("aoStrap",
       s"${AltairTop}wfcs:strapGtCtl", "ALTAIR STRAP"))
 
     val gate: Option[CaParameter[Integer]] = cs.map(_.addInteger("gate", s"${AltairTop}wfcs:strapGtCtl.A",
       "Gate control", false))
-    def setGate(v: Int): F[Unit] = setParameterF(gate, Integer.valueOf(v))
+    def setGate(v: Int): F[Unit] = setParameter(gate, Integer.valueOf(v))
   }
 
-  object strapControl extends EpicsCommandF {
+  object strapControl extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(service.createTaskControlSender("strapCorrCtl",
       s"${AltairTop}wfcs:strapCorrCtl", "ALTAIR SFO"))
 
     val active: Option[CaParameter[Integer]] = cs.map(_.addInteger("onoff", s"${AltairTop}wfcs:strapCorrCtl.A",
       "Strap onoff loop control", false))
-    def setActive(v: Int): F[Unit] = setParameterF(active, Integer.valueOf(v))
+    def setActive(v: Int): F[Unit] = setParameter(active, Integer.valueOf(v))
   }
 
   // sfoControl is a bit weird, in that changing the 'active' parameter takes effect immediately.
-  object sfoControl extends EpicsCommandF {
+  object sfoControl extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] =
       Option(service.getCommandSender("aoSfoLoop"))
 
     val active: Option[CaParameter[LgsSfoControl]] = cs.map(_.addEnum[LgsSfoControl]("active",
       s"${AltairTop}cc:lgszoomSfoLoop.VAL", classOf[LgsSfoControl], false))
-    def setActive(v: LgsSfoControl): F[Unit] = setParameterF(active, v)
+    def setActive(v: LgsSfoControl): F[Unit] = setParameter(active, v)
   }
 
-  object btoLoopControl extends EpicsCommandF {
+  object btoLoopControl extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] =
       Option(service.getCommandSender("btoFsaLoopCtrl"))
 
     val active: Option[CaParameter[String]] = cs.map(_.getString("loop"))
-    def setActive(v: String): F[Unit] = setParameterF(active, v)
+    def setActive(v: String): F[Unit] = setParameter(active, v)
   }
 
   val status: CaStatusAcceptor = service.getStatusAcceptor("aostate")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairKeywordReader.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.altair
 
-import cats.effect.LiftIO
 import cats.effect.Sync
 import cats.Applicative
 import cats.data.Nested
@@ -80,8 +79,7 @@ trait AltairKeywordReaderLUT {
 }
 
 object AltairKeywordReaderEpics extends AltairKeywordReaderLUT {
-  def apply[F[_]: Sync: LiftIO]: AltairKeywordReader[F] = new AltairKeywordReader[F] {
-    val sys = AltairEpics.instance
+  def apply[F[_]: Sync](sys: AltairEpics[F]): AltairKeywordReader[F] = new AltairKeywordReader[F] {
 
     override def aofreq: F[Double] =
       Nested(sys.aoexpt)
@@ -89,24 +87,23 @@ object AltairKeywordReaderEpics extends AltairKeywordReaderLUT {
         .map(1 / _.toDouble)
         .value
         .safeValOrDefault
-        .to[F]
-    override def aocounts: F[Double] = sys.aocounts.safeValOrDefault.to[F]
+    override def aocounts: F[Double] = sys.aocounts.safeValOrDefault
     override def aoseeing: F[Double] =
-      Nested(sys.aoseeing).map(_.toDouble).value.safeValOrDefault.to[F]
-    override def aowfsx: F[Double]   = sys.aowfsx.safeValOrDefault.to[F]
-    override def aowfsy: F[Double]   = sys.aowfsy.safeValOrDefault.to[F]
-    override def aowfsz: F[Double]   = sys.aowfsz.safeValOrDefault.to[F]
-    override def aogain: F[Double]   = sys.aogain.safeValOrDefault.to[F]
-    override def aoncpa: F[String]   = sys.aoncpa.safeValOrDefault.to[F]
-    override def ngndfilt: F[String] = sys.ngndfilt.safeValOrDefault.to[F]
+      Nested(sys.aoseeing).map(_.toDouble).value.safeValOrDefault
+    override def aowfsx: F[Double]   = sys.aowfsx.safeValOrDefault
+    override def aowfsy: F[Double]   = sys.aowfsy.safeValOrDefault
+    override def aowfsz: F[Double]   = sys.aowfsz.safeValOrDefault
+    override def aogain: F[Double]   = sys.aogain.safeValOrDefault
+    override def aoncpa: F[String]   = sys.aoncpa.safeValOrDefault
+    override def ngndfilt: F[String] = sys.ngndfilt.safeValOrDefault
     override def astar: F[String] =
-      sys.astar.safeValOrDefault.map(AOFlensKeywordLUT.getOrElse(_, "OUT")).to[F]
-    override def aoflex: F[String]   = sys.aoflex.safeValOrDefault.to[F]
-    override def lgustage: F[String] = sys.lgustage.safeValOrDefault.to[F]
-    override def aobs: F[String]     = sys.aobs.safeValOrDefault.to[F]
+      sys.astar.safeValOrDefault.map(AOFlensKeywordLUT.getOrElse(_, "OUT"))
+    override def aoflex: F[String]   = sys.aoflex.safeValOrDefault
+    override def lgustage: F[String] = sys.lgustage.safeValOrDefault
+    override def aobs: F[String]     = sys.aobs.safeValOrDefault
 
     // LGS
-    override def lgdfocus: F[Double] = sys.lgdfocus.safeValOrDefault.to[F]
+    override def lgdfocus: F[Double] = sys.lgdfocus.safeValOrDefault
     override def lgttcnts: F[Double] =
       (for {
         apd1 <- sys.apd1
@@ -116,13 +113,13 @@ object AltairKeywordReaderEpics extends AltairKeywordReaderLUT {
       } yield
         (apd1, apd2, apd3, apd4)
           .mapN(_ + _ + _ + _)
-          .map(_.toDouble)).safeValOrDefault.to[F]
-    override def lgttexp: F[Int]     = sys.lgttexp.safeValOrDefault.to[F]
-    override def lgsfcnts: F[Double] = sys.lgsfcnts.safeValOrDefault.to[F]
-    override def lgsfexp: F[Double]  = sys.lgsfexp.safeValOrDefault.to[F]
-    override def fsmtip: F[Double]   = sys.fsmtip.safeValOrDefault.to[F]
-    override def fsmtilt: F[Double]  = sys.fsmtilt.safeValOrDefault.to[F]
-    override def lgzmpos: F[Double]  = sys.lgzmpos.safeValOrDefault.to[F]
+          .map(_.toDouble)).safeValOrDefault
+    override def lgttexp: F[Int]     = sys.lgttexp.safeValOrDefault
+    override def lgsfcnts: F[Double] = sys.lgsfcnts.safeValOrDefault
+    override def lgsfexp: F[Double]  = sys.lgsfexp.safeValOrDefault
+    override def fsmtip: F[Double]   = sys.fsmtip.safeValOrDefault
+    override def fsmtilt: F[Double]  = sys.fsmtilt.safeValOrDefault
+    override def lgzmpos: F[Double]  = sys.lgzmpos.safeValOrDefault
     override def naalt: F[Double] = {
       val modela: Double = 210.0
       val modelb: Double = 1.01
@@ -138,10 +135,10 @@ object AltairKeywordReaderEpics extends AltairKeywordReaderLUT {
           r * math.cos(za.toRadians) / 1000.0
         }
       }
-      r.safeValOrDefault.to[F]
+      r.safeValOrDefault
     }
-    override def nathick: F[Double]  = sys.nathick.safeValOrDefault.to[F]
-    override def lgndfilt: F[String] = sys.lgndfilt.safeValOrDefault.to[F]
-    override def lgttiris: F[String] = sys.lgttiris.safeValOrDefault.to[F]
+    override def nathick: F[Double]  = sys.nathick.safeValOrDefault
+    override def lgndfilt: F[String] = sys.lgndfilt.safeValOrDefault
+    override def lgttiris: F[String] = sys.lgttiris.safeValOrDefault
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
@@ -133,7 +133,7 @@ object Flamingos2ControllerEpics extends Flamingos2Encoders {
       _ <- sys.observeCmd.setLabel(fileId)
       _ <- sys.observeCmd.setTimeout[F](expTime + ReadoutTimeout)
       _ <- sys.observeCmd.post[F]
-    } yield ObserveCommand.Success
+    } yield ObserveCommand.Result.Success
 
     override def endObserve: F[Unit] = for {
       _ <- Async[F].delay(Log.debug("Send endObserve to Flamingos2"))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Epics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Epics.scala
@@ -6,8 +6,8 @@ package seqexec.server.flamingos2
 import cats.effect.IO
 import cats.effect.Async
 import edu.gemini.epics.acm._
-import seqexec.server.{EpicsCommand, EpicsCommandF, EpicsSystem}
-import seqexec.server.EpicsCommand.setParameterF
+import seqexec.server.{EpicsCommand, EpicsSystem}
+import seqexec.server.EpicsCommand.setParameter
 import seqexec.server.EpicsUtil._
 import org.log4s.{Logger, getLogger}
 
@@ -17,69 +17,69 @@ final class Flamingos2Epics[F[_]: Async](epicsService: CaService, tops: Map[Stri
 
   def post: F[EpicsCommand.Result] = configCmd.post[F]
 
-  object dcConfigCmd extends EpicsCommandF {
+  object dcConfigCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::dcconfig"))
 
     private val biasMode = cs.map(_.getString("biasMode"))
-    def setBiasMode(v: String): F[Unit] = setParameterF(biasMode, v)
+    def setBiasMode(v: String): F[Unit] = setParameter(biasMode, v)
 
     private val numReads = cs.map(_.getInteger("numReads"))
-    def setNumReads(v: Integer): F[Unit] = setParameterF(numReads, v)
+    def setNumReads(v: Integer): F[Unit] = setParameter(numReads, v)
 
     private val readoutMode = cs.map(_.getString("readoutMode"))
-    def setReadoutMode(v: String): F[Unit] = setParameterF(readoutMode, v)
+    def setReadoutMode(v: String): F[Unit] = setParameter(readoutMode, v)
 
     private val exposureTime: Option[CaParameter[java.lang.Double]] = cs.map(_.getDouble("exposureTime"))
-    def setExposureTime(v: Double): F[Unit] = setParameterF[F, java.lang.Double](exposureTime, v)
+    def setExposureTime(v: Double): F[Unit] = setParameter[F, java.lang.Double](exposureTime, v)
 
   }
 
-  object abortCmd extends EpicsCommandF {
+  object abortCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::abort"))
   }
 
-  object stopCmd extends EpicsCommandF {
+  object stopCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::stop"))
   }
 
-  object observeCmd extends EpicsCommandF {
+  object observeCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::observe"))
 
     private val label = cs.map(_.getString("label"))
-    def setLabel(v: String): F[Unit] = setParameterF(label, v)
+    def setLabel(v: String): F[Unit] = setParameter(label, v)
   }
 
-  object endObserveCmd extends EpicsCommandF {
+  object endObserveCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::endObserve"))
   }
 
-  object configCmd extends EpicsCommandF {
+  object configCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("flamingos2::config"))
 
     private val useElectronicOffsetting = cs.map(_.addInteger("useElectronicOffsetting",
       s"${F2Top}wfs:followA.K", "Enable electronic Offsets", false))
-    def setUseElectronicOffsetting(v: Integer): F[Unit] = setParameterF(useElectronicOffsetting, v)
+    def setUseElectronicOffsetting(v: Integer): F[Unit] = setParameter(useElectronicOffsetting, v)
 
     private val filter = cs.map(_.getString("filter"))
-    def setFilter(v: String): F[Unit] = setParameterF(filter, v)
+    def setFilter(v: String): F[Unit] = setParameter(filter, v)
 
     private val mos = cs.map(_.getString("mos"))
-    def setMOS(v: String): F[Unit] = setParameterF(mos, v)
+    def setMOS(v: String): F[Unit] = setParameter(mos, v)
 
     private val grism = cs.map(_.getString("grism"))
-    def setGrism(v: String): F[Unit] = setParameterF(grism, v)
+    def setGrism(v: String): F[Unit] = setParameter(grism, v)
 
     private val mask = cs.map(_.getString("mask"))
-    def setMask(v: String): F[Unit] = setParameterF(mask, v)
+    def setMask(v: String): F[Unit] = setParameter(mask, v)
 
     private val decker = cs.map(_.getString("decker"))
-    def setDecker(v: String): F[Unit] = setParameterF(decker, v)
+    def setDecker(v: String): F[Unit] = setParameter(decker, v)
 
     private val lyot = cs.map(_.getString("lyot"))
-    def setLyot(v: String): F[Unit] = setParameterF(lyot, v)
+    def setLyot(v: String): F[Unit] = setParameter(lyot, v)
 
     private val windowCover = cs.map(_.getString("windowCover"))
-    def setWindowCover(v: String): F[Unit] = setParameterF(windowCover, v)
+    def setWindowCover(v: String): F[Unit] = setParameter(windowCover, v)
 
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -5,7 +5,6 @@ package seqexec.server.flamingos2
 
 import cats.Applicative
 import cats.data.EitherT
-import cats.effect.LiftIO
 import cats.effect.Sync
 import cats.implicits._
 import gem.Observation
@@ -111,12 +110,11 @@ object Flamingos2Header {
   }
 
   object InstKeywordReaderEpics {
-    def apply[F[_]: Sync: LiftIO]: InstKeywordsReader[F] =
+    def apply[F[_]: Sync](sys: Flamingos2Epics[F]): InstKeywordsReader[F] =
       new InstKeywordsReader[F] {
-        private val sys                   = Flamingos2Epics.instance
-        override def getHealth: F[String] = sys.health.safeValOrDefault.to[F]
+        override def getHealth: F[String] = sys.health
 
-        override def getState: F[String] = sys.state.safeValOrDefault.to[F]
+        override def getState: F[String] = sys.state
       }
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalEpics.scala
@@ -10,8 +10,8 @@ import edu.gemini.epics.acm.{CaAttribute, CaCommandSender, CaService, CaStatusAc
 import edu.gemini.seqexec.server.gcal.BinaryOnOff
 import seqexec.server.EpicsSystem
 import seqexec.server.EpicsCommand
-import seqexec.server.EpicsCommandF
-import seqexec.server.EpicsCommand.setParameterF
+import seqexec.server.EpicsCommand
+import seqexec.server.EpicsCommand.setParameter
 import seqexec.server.EpicsUtil.safeAttribute
 import org.log4s.{Logger, getLogger}
 
@@ -26,67 +26,67 @@ class GcalEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String])
 
   def post: F[EpicsCommand.Result] = lampsCmd.post
 
-  object shutterCmd extends EpicsCommandF {
+  object shutterCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gcal::shutter"))
 
     private val position = cs.map(_.getString("position"))
-    def setPosition(v: String): F[Unit] = setParameterF(position, v)
+    def setPosition(v: String): F[Unit] = setParameter(position, v)
   }
 
-  object filterCmd extends EpicsCommandF {
+  object filterCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gcal::filtSel"))
 
     private val name = cs.map(_.getString("name"))
-    def setName(v: String): F[Unit] = setParameterF(name, v)
+    def setName(v: String): F[Unit] = setParameter(name, v)
   }
 
-  object diffuserCmd extends EpicsCommandF {
+  object diffuserCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gcal::diffuseSel"))
 
     private val name = cs.map(_.getString("name"))
-    def setName(v: String): F[Unit] = setParameterF(name, v)
+    def setName(v: String): F[Unit] = setParameter(name, v)
   }
 
   private def toLampState(v: BinaryOnOff): String = v.name
 
-  object lampsCmd extends EpicsCommandF {
+  object lampsCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gcal::lampSel"))
 
     private val nameAr = cs.map(_.getString("nameAr"))
-    def setArLampName(v: String): F[Unit] = setParameterF(nameAr, v)
+    def setArLampName(v: String): F[Unit] = setParameter(nameAr, v)
 
     private val stateAr = cs.map(_.getString("stateAr"))
-    def setArLampOn(v: BinaryOnOff): F[Unit] = setParameterF(stateAr, v, toLampState)
+    def setArLampOn(v: BinaryOnOff): F[Unit] = setParameter(stateAr, v, toLampState)
 
     private val nameCuAr = cs.map(_.getString("nameCuAr"))
-    def setCuArLampName(v: String): F[Unit] = setParameterF(nameCuAr, v)
+    def setCuArLampName(v: String): F[Unit] = setParameter(nameCuAr, v)
 
     private val stateCuAr = cs.map(_.getString("stateCuAr"))
-    def setCuArLampOn(v: BinaryOnOff): F[Unit] = setParameterF(stateCuAr, v, toLampState)
+    def setCuArLampOn(v: BinaryOnOff): F[Unit] = setParameter(stateCuAr, v, toLampState)
 
     private val nameIR = cs.map(_.getString("nameIR"))
-    def setIRLampName(v: String): F[Unit] = setParameterF(nameIR, v)
+    def setIRLampName(v: String): F[Unit] = setParameter(nameIR, v)
 
     private val stateIR = cs.map(_.getString("stateIR"))
-    def setIRLampOn(v: BinaryOnOff): F[Unit] = setParameterF(stateIR, v, toLampState)
+    def setIRLampOn(v: BinaryOnOff): F[Unit] = setParameter(stateIR, v, toLampState)
 
     private val nameQH = cs.map(_.getString("nameQH"))
-    def setQHLampName(v: String): F[Unit] = setParameterF(nameQH, v)
+    def setQHLampName(v: String): F[Unit] = setParameter(nameQH, v)
 
     private val stateQH = cs.map(_.getString("stateQH"))
-    def setQHLampOn(v: BinaryOnOff): F[Unit] = setParameterF(stateQH, v, toLampState)
+    def setQHLampOn(v: BinaryOnOff): F[Unit] = setParameter(stateQH, v, toLampState)
 
     private val nameXe = cs.map(_.getString("nameXe"))
-    def setXeLampName(v: String): F[Unit] = setParameterF(nameXe, v)
+    def setXeLampName(v: String): F[Unit] = setParameter(nameXe, v)
 
     private val stateXe = cs.map(_.getString("stateXe"))
-    def setXeLampOn(v: BinaryOnOff): F[Unit] = setParameterF(stateXe, v, toLampState)
+    def setXeLampOn(v: BinaryOnOff): F[Unit] = setParameter(stateXe, v, toLampState)
 
     private val nameThAr = cs.map(_.getString("nameThAr"))
-    def setThArLampName(v: String): F[Unit] = setParameterF(nameThAr, v)
+    def setThArLampName(v: String): F[Unit] = setParameter(nameThAr, v)
 
     private val stateThAr = cs.map(_.getString("stateThAr"))
-    def setThArLampOn(v: BinaryOnOff): F[Unit] = setParameterF(stateThAr, v, toLampState)
+    def setThArLampOn(v: BinaryOnOff): F[Unit] = setParameter(stateThAr, v, toLampState)
   }
 
   private val state = epicsService.getStatusAcceptor("gcal::status")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalKeywordReader.scala
@@ -7,7 +7,6 @@ import cats.Applicative
 import cats.Eq
 import cats.data.Nested
 import cats.effect.Sync
-import cats.effect.LiftIO
 import cats.implicits._
 import edu.gemini.seqexec.server.gcal.BinaryOnOff
 import seqexec.server.keywords._
@@ -34,13 +33,12 @@ object DummyGcalKeywordsReader {
 
 object GcalKeywordsReaderEpics {
 
-  def apply[F[_]: Sync: LiftIO]: GcalKeywordReader[F] = new GcalKeywordReader[F] {
-    val sys = GcalEpics.instance
+  def apply[F[_]: Sync](sys: GcalEpics[F]): GcalKeywordReader[F] = new GcalKeywordReader[F] {
     implicit val eq: Eq[BinaryOnOff] = Eq.by(_.ordinal())
 
-    def diffuser: F[String] = sys.diffuser.safeValOrDefault.to[F]
+    def diffuser: F[String] = sys.diffuser.safeValOrDefault
 
-    def filter: F[String] = sys.filter.safeValOrDefault.to[F]
+    def filter: F[String] = sys.filter.safeValOrDefault
 
     def lamp: F[String] = {
       val noValue = none[String].pure[F]
@@ -62,6 +60,6 @@ object GcalKeywordsReaderEpics {
       case "OPEN"  => "OPEN"
       case "CLOSE" => "CLOSED"
       case _       => "INDEF"
-    }.value.safeValOrDefault.to[F]
+    }.value.safeValOrDefault
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsEpics.scala
@@ -9,8 +9,8 @@ import cats.implicits._
 import edu.gemini.epics.acm.{CaCommandSender, CaService, CaStatusAcceptor}
 import edu.gemini.seqexec.server.gems.{ApdState, BinaryOnOff, LoopState, ReadyState}
 import org.log4s.{Logger, getLogger}
-import seqexec.server.{EpicsCommandF, EpicsSystem}
-import seqexec.server.EpicsCommand.setParameterF
+import seqexec.server.{EpicsCommand, EpicsSystem}
+import seqexec.server.EpicsCommand.setParameter
 import seqexec.server.EpicsUtil.{safeAttribute, safeAttributeSDouble, safeAttributeSFloat, safeAttributeSInt}
 
 class GemsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String]) {
@@ -19,22 +19,22 @@ class GemsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String])
   private val RtcTop = tops.getOrElse("rtc", "rtc:")
   private val AomTop = tops.getOrElse("aom", "aom:")
 
-  object LoopControl extends EpicsCommandF {
+  object LoopControl extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gems::seqLoopCtrl"))
 
-    def setCommand(v: String): F[Unit] = setParameterF(cs.map(_.getString("cmd")), v)
+    def setCommand(v: String): F[Unit] = setParameter(cs.map(_.getString("cmd")), v)
 
-    def setReasons(v: String): F[Unit] = setParameterF(cs.map(_.getString("reasons")), v)
+    def setReasons(v: String): F[Unit] = setParameter(cs.map(_.getString("reasons")), v)
   }
 
-  object ApdControl extends EpicsCommandF {
+  object ApdControl extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gems::ttApdCtrl"))
 
-    def setApd1Cmd(v: String): F[Unit] = setParameterF(cs.map(_.getString("apd1Cmd")), v)
+    def setApd1Cmd(v: String): F[Unit] = setParameter(cs.map(_.getString("apd1Cmd")), v)
 
-    def setApd2Cmd(v: String): F[Unit] = setParameterF(cs.map(_.getString("apd2Cmd")), v)
+    def setApd2Cmd(v: String): F[Unit] = setParameter(cs.map(_.getString("apd2Cmd")), v)
 
-    def setApd3Cmd(v: String): F[Unit] = setParameterF(cs.map(_.getString("apd3Cmd")), v)
+    def setApd3Cmd(v: String): F[Unit] = setParameter(cs.map(_.getString("apd3Cmd")), v)
   }
 
   val mystStatus: CaStatusAcceptor = epicsService.getStatusAcceptor("gems::status")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -50,7 +50,7 @@ final case class Ghost[F[_]: Sync](controller: GhostController[F])
       SeqActionF.embedF(calcObserveTime(config).flatMap { x =>
         controller
           .observe(fileId, x)
-          .as(ObserveCommand.Success: ObserveCommand.Result)
+          .as(ObserveCommand.Result.Success: ObserveCommand.Result)
       })
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -330,9 +330,9 @@ object GmosControllerEpics extends GmosEncoders {
         IO(Log.info("Start Gmos configuration")) *>
           IO(Log.debug(s"Gmos configuration: ${config.show}")) *>
           warnOnDHSNotConected *>
-          ((params.sequence *>
+          (params.sequence *>
             sys.configCmd.setTimeout[IO](ConfigTimeout) *>
-            sys.post)
+            sys.post
           ).unlessA(params.isEmpty) *>
           IO(Log.info("Completed Gmos configuration"))
       }
@@ -385,7 +385,7 @@ object GmosControllerEpics extends GmosEncoders {
         _   <- sys.stopAndWaitCmd.mark[IO]
         ret <- sys.stopAndWaitCmd.post[IO]
         _   <- IO(Log.info("Completed stopping Gmos observation"))
-      } yield if(ret === ObserveCommand.Success) ObserveCommand.Stopped else ret
+      } yield if(ret === ObserveCommand.Result.Success) ObserveCommand.Result.Stopped else ret
 
       override def abortPaused: IO[ObserveCommand.Result] = for {
         _   <- IO(Log.info("Abort Gmos paused observation"))
@@ -393,7 +393,7 @@ object GmosControllerEpics extends GmosEncoders {
         _   <- sys.abortAndWait.mark[IO]
         ret <- sys.abortAndWait.post[IO]
         _   <- IO(Log.info("Completed aborting Gmos observation"))
-      } yield if(ret === ObserveCommand.Success) ObserveCommand.Aborted else ret
+      } yield if(ret === ObserveCommand.Result.Success) ObserveCommand.Result.Aborted else ret
 
       override def observeProgress(total: Time, elapsed: ElapsedTime): Stream[IO, Progress] = {
         implicit val ioTimer: Timer[IO] = IO.timer(ExecutionContext.global)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
@@ -11,13 +11,13 @@ import edu.gemini.epics.acm._
 import java.lang.{Double => JDouble}
 import mouse.all._
 import org.log4s.{Logger, getLogger}
-import seqexec.server.EpicsCommand.setParameterF
+import seqexec.server.EpicsCommand.setParameter
 import seqexec.server.gmos.GmosEpics.{RoiParameters, RoiStatus}
 import seqexec.server.{EpicsCommand, EpicsSystem}
 import seqexec.server.EpicsUtil._
 import seqexec.server.SeqexecFailure._
-import seqexec.server.EpicsCommandF
-import seqexec.server.ObserveCommandF
+import seqexec.server.EpicsCommand
+import seqexec.server.ObserveCommand
 import scala.collection.breakOut
 import scala.concurrent.duration._
 
@@ -27,50 +27,50 @@ class GmosEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String])
 
   def post: F[EpicsCommand.Result] = configCmd.post[F]
 
-  object configCmd extends EpicsCommandF {
+  object configCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::config"))
 
     val disperserMode: Option[CaParameter[String]] = cs.map(_.getString("disperserMode"))
-    def setDisperserMode(v: String): F[Unit] = setParameterF(disperserMode, v)
+    def setDisperserMode(v: String): F[Unit] = setParameter(disperserMode, v)
 
     val disperser: Option[CaParameter[String]] = cs.map(_.getString("disperser"))
-    def setDisperser(v: String): F[Unit] = setParameterF(disperser, v)
+    def setDisperser(v: String): F[Unit] = setParameter(disperser, v)
 
     val stageMode: Option[CaParameter[String]] = cs.map(_.getString("stageMode"))
-    def setStageMode(v: String): F[Unit] = setParameterF(stageMode, v)
+    def setStageMode(v: String): F[Unit] = setParameter(stageMode, v)
 
     val useElectronicOffsetting: Option[CaParameter[Integer]] = cs.map(_.addInteger
     ("useElectronicOffsetting", s"${GmosTop}wfs:followA.K", "Enable electronic Offsets", false))
-    def setElectronicOffsetting(v: Integer): F[Unit] = setParameterF(useElectronicOffsetting, v)
+    def setElectronicOffsetting(v: Integer): F[Unit] = setParameter(useElectronicOffsetting, v)
 
     val filter1: Option[CaParameter[String]] = cs.map(_.getString("filter1"))
-    def setFilter1(v: String): F[Unit] = setParameterF(filter1, v)
+    def setFilter1(v: String): F[Unit] = setParameter(filter1, v)
 
     val filter2: Option[CaParameter[String]] = cs.map(_.getString("filter2"))
-    def setFilter2(v: String): F[Unit] = setParameterF(filter2, v)
+    def setFilter2(v: String): F[Unit] = setParameter(filter2, v)
 
     val dtaXOffset: Option[CaParameter[JDouble]] = cs.map(_.getDouble("dtaXOffset"))
-    def setDtaXOffset(v: Double): F[Unit] = setParameterF(dtaXOffset, JDouble.valueOf(v))
+    def setDtaXOffset(v: Double): F[Unit] = setParameter(dtaXOffset, JDouble.valueOf(v))
 
     val inBeam: Option[CaParameter[String]] = cs.map(_.getString("inbeam"))
-    def setInBeam(v: String): F[Unit] = setParameterF(inBeam, v)
+    def setInBeam(v: String): F[Unit] = setParameter(inBeam, v)
 
     val disperserOrder: Option[CaParameter[String]] = cs.map(_.getString("disperserOrder"))
-    def setDisperserOrder(v: String): F[Unit] = setParameterF(disperserOrder, v)
+    def setDisperserOrder(v: String): F[Unit] = setParameter(disperserOrder, v)
 
     val disperserLambda: Option[CaParameter[JDouble]] = cs.map(_.getDouble("disperserLambda"))
-    def setDisperserLambda(v: Double): F[Unit] = setParameterF(disperserLambda, JDouble.valueOf(v))
+    def setDisperserLambda(v: Double): F[Unit] = setParameter(disperserLambda, JDouble.valueOf(v))
 
     val fpu: Option[CaParameter[String]] = cs.map(_.getString("fpu"))
-    def setFpu(v: String): F[Unit] = setParameterF(fpu, v)
+    def setFpu(v: String): F[Unit] = setParameter(fpu, v)
 
   }
 
-  object endObserveCmd extends EpicsCommandF {
+  object endObserveCmd extends EpicsCommand {
     override protected val cs:Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::endObserve"))
   }
 
-  object pauseCmd extends EpicsCommandF {
+  object pauseCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::pause"))
   }
 
@@ -78,87 +78,87 @@ class GmosEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String])
   private val observeAS: Option[CaApplySender] = Option(epicsService.createObserveSender("gmos::observeCmd",
       s"${GmosTop}apply", s"${GmosTop}applyC", s"${GmosTop}dc:observeC", false, s"${GmosTop}stop", s"${GmosTop}abort", ""))
 
-  object continueCmd extends ObserveCommandF {
+  object continueCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::continue"))
     override protected val os: Option[CaApplySender] = observeAS
   }
 
-  object stopCmd extends EpicsCommandF {
+  object stopCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = stopCS
   }
 
-  object stopAndWaitCmd extends ObserveCommandF {
+  object stopAndWaitCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = stopCS
     override protected val os: Option[CaApplySender] = observeAS
   }
 
   private val abortCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::abort"))
 
-  object abortCmd extends EpicsCommandF {
+  object abortCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = abortCS
   }
 
-  object abortAndWait extends ObserveCommandF {
+  object abortAndWait extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = abortCS
     override protected val os: Option[CaApplySender] = observeAS
   }
 
-  object observeCmd extends ObserveCommandF {
+  object observeCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::observe"))
     override protected val os: Option[CaApplySender] = observeAS
 
     val label: Option[CaParameter[String]] = cs.map(_.getString("label"))
-    def setLabel(v: String): F[Unit] = setParameterF(label, v)
+    def setLabel(v: String): F[Unit] = setParameter(label, v)
   }
 
-  object configDCCmd extends EpicsCommandF {
+  object configDCCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("gmos::dcconfig"))
 
     private val roiNumUsed: Option[CaParameter[JDouble]] =
       cs.map(_.addDouble("roiNumUsed", s"${GmosTop}dc:roiNumrois", "Number of ROI used", false))
-    def setRoiNumUsed(v: Int): F[Unit] = setParameterF(roiNumUsed, java.lang.Double.valueOf(v.toDouble))
+    def setRoiNumUsed(v: Int): F[Unit] = setParameter(roiNumUsed, java.lang.Double.valueOf(v.toDouble))
 
     val rois: Map[Int, RoiParameters[F]] = (1 to 5).map(i => i -> RoiParameters[F](cs, i))(breakOut)
 
     private val shutterState: Option[CaParameter[String]] =
       cs.map(_.getString("shutterState"))
-    def setShutterState(v: String): F[Unit] = setParameterF(shutterState, v)
+    def setShutterState(v: String): F[Unit] = setParameter(shutterState, v)
 
     private val exposureTime: Option[CaParameter[JDouble]] =
       cs.map(_.getDouble("exposureTime"))
-    def setExposureTime(v: Duration): F[Unit] = setParameterF(exposureTime, JDouble.valueOf(v.toSeconds.toDouble))
+    def setExposureTime(v: Duration): F[Unit] = setParameter(exposureTime, JDouble.valueOf(v.toSeconds.toDouble))
 
     private val ampCount: Option[CaParameter[String]] =
       cs.map(_.getString("ampCount"))
-    def setAmpCount(v: String): F[Unit] = setParameterF(ampCount, v)
+    def setAmpCount(v: String): F[Unit] = setParameter(ampCount, v)
 
     private val ampReadMode: Option[CaParameter[String]] =
       cs.map(_.getString("ampReadMode"))
-    def setAmpReadMode(v: String): F[Unit] = setParameterF(ampReadMode, v)
+    def setAmpReadMode(v: String): F[Unit] = setParameter(ampReadMode, v)
 
     private val gainSetting: Option[CaParameter[Integer]] =
       cs.map(_.getInteger("gainSetting"))
-    def setGainSetting(v: Int): F[Unit] = setParameterF(gainSetting, Integer.valueOf(v))
+    def setGainSetting(v: Int): F[Unit] = setParameter(gainSetting, Integer.valueOf(v))
 
     private val ccdXBinning: Option[CaParameter[JDouble]] =
       cs.map(_.addDouble("ccdXBinning", s"${GmosTop}dc:roiXBin", "CCD X Binning Value", false))
-    def setCcdXBinning(v: Int): F[Unit] = setParameterF(ccdXBinning, java.lang.Double.valueOf(v.toDouble))
+    def setCcdXBinning(v: Int): F[Unit] = setParameter(ccdXBinning, java.lang.Double.valueOf(v.toDouble))
 
     private val ccdYBinning: Option[CaParameter[JDouble]] =
       cs.map(_.addDouble("ccdYBinning", s"${GmosTop}dc:roiYBin", "CCD Y Binning Value", false))
-    def setCcdYBinning(v: Int): F[Unit] = setParameterF(ccdYBinning, java.lang.Double.valueOf(v.toDouble))
+    def setCcdYBinning(v: Int): F[Unit] = setParameter(ccdYBinning, java.lang.Double.valueOf(v.toDouble))
 
     private val nsPairs: Option[CaParameter[Integer]] =
       cs.map(_.getInteger("nsPairs"))
-    def setNsPairs(v: Integer): F[Unit] = setParameterF(nsPairs, v)
+    def setNsPairs(v: Integer): F[Unit] = setParameter(nsPairs, v)
 
     private val nsRows: Option[CaParameter[Integer]] =
       cs.map(_.getInteger("nsRows"))
-    def setNsRows(v: Integer): F[Unit] = setParameterF(nsRows, v)
+    def setNsRows(v: Integer): F[Unit] = setParameter(nsRows, v)
 
     private val nsState: Option[CaParameter[String]] =
       cs.map(_.getString("ns_state"))
-    def setNsState(v: String): F[Unit] = setParameterF(nsState, v)
+    def setNsState(v: String): F[Unit] = setParameter(nsState, v)
 
   }
 
@@ -324,16 +324,16 @@ object GmosEpics extends EpicsSystem[GmosEpics[IO]] {
 
   final case class RoiParameters[F[_]: Sync](cs: Option[CaCommandSender], i: Int) {
     val ccdXstart: Option[CaParameter[Integer]] = cs.map(_.getInteger(s"ccdXstart$i"))
-    def setCcdXstart1(v: Integer): F[Unit] = setParameterF(ccdXstart, v)
+    def setCcdXstart1(v: Integer): F[Unit] = setParameter(ccdXstart, v)
 
     val ccdYstart: Option[CaParameter[Integer]] = cs.map(_.getInteger(s"ccdYstart$i"))
-    def setCcdYstart1(v: Integer): F[Unit] = setParameterF(ccdYstart, v)
+    def setCcdYstart1(v: Integer): F[Unit] = setParameter(ccdYstart, v)
 
     val ccdXsize: Option[CaParameter[Integer]] = cs.map(_.getInteger(s"ccdXsize$i"))
-    def setCcdXsize1(v: Integer): F[Unit] = setParameterF(ccdXsize, v)
+    def setCcdXsize1(v: Integer): F[Unit] = setParameter(ccdXsize, v)
 
     val ccdYsize: Option[CaParameter[Integer]] = cs.map(_.getInteger(s"ccdYsize$i"))
-    def setCcdYsize1(v: Integer): F[Unit] = setParameterF(ccdYsize, v)
+    def setCcdYsize1(v: Integer): F[Unit] = setParameter(ccdYsize, v)
   }
 
   final case class RoiStatus[F[_]: Sync](sa: CaStatusAcceptor, i: Int) {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -298,9 +298,9 @@ object GnirsControllerEpics extends GnirsEncoders {
         IO(Log.info("Start GNIRS observe")) *>
           checkDhs *>
           checkArray *>
-          epicsSys.observeCmd.setLabel(fileId).widenRethrowT *>
-          epicsSys.observeCmd.setTimeout(expTime + ReadoutTimeout).widenRethrowT *>
-          epicsSys.observeCmd.post.widenRethrowT
+          epicsSys.observeCmd.setLabel(fileId) *>
+          epicsSys.observeCmd.setTimeout[IO](expTime + ReadoutTimeout) *>
+          epicsSys.observeCmd.post[IO]
 
       override def endObserve: IO[Unit] =
         IO(Log.debug("Send endObserve to GNIRS")) *>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsEpics.scala
@@ -12,91 +12,91 @@ import edu.gemini.seqexec.server.gnirs.{DetectorState => JDetectorState}
 import java.lang.{Double => JDouble}
 import org.log4s.{Logger, getLogger}
 import seqexec.server.EpicsCommand.setParameter
-import seqexec.server.EpicsCommand.setParameterF
+import seqexec.server.EpicsCommand.setParameter
 import seqexec.server.EpicsUtil.safeAttribute
 import seqexec.server.EpicsUtil.safeAttributeSDouble
 import seqexec.server.EpicsUtil.safeAttributeSInt
-import seqexec.server.{EpicsSystem, ObserveCommand, SeqAction}
-import seqexec.server.EpicsCommandF
+import seqexec.server.{EpicsSystem, ObserveCommand}
+import seqexec.server.EpicsCommand
 
 class GnirsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String]) {
 
   val GnirsTop: String = tops.getOrElse("nirs", "nirs:")
 
-  object configCCCmd extends EpicsCommandF {
+  object configCCCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("nirs::config"))
 
     private val cover: Option[CaParameter[String]] = cs.map(_.getString("cover"))
-    def setCover(v: String): F[Unit] = setParameterF(cover, v)
+    def setCover(v: String): F[Unit] = setParameter(cover, v)
 
     private val filter1: Option[CaParameter[String]] = cs.map(_.getString("filter1"))
-    def setFilter1(v: String): F[Unit] = setParameterF(filter1, v)
+    def setFilter1(v: String): F[Unit] = setParameter(filter1, v)
 
     private val filter2: Option[CaParameter[String]] = cs.map(_.getString("filter2"))
-    def setFilter2(v: String): F[Unit] = setParameterF(filter2, v)
+    def setFilter2(v: String): F[Unit] = setParameter(filter2, v)
 
     private val focus: Option[CaParameter[Integer]] = cs.map(_.getInteger("focus"))
-    def setFocus(v: Int): F[Unit] = setParameterF(focus, Integer.valueOf(v))
+    def setFocus(v: Int): F[Unit] = setParameter(focus, Integer.valueOf(v))
 
     private val tilt: Option[CaParameter[String]] = cs.map(_.getString("tilt"))
-    def setTilt(v: String): F[Unit] = setParameterF(tilt, v)
+    def setTilt(v: String): F[Unit] = setParameter(tilt, v)
 
     private val prism: Option[CaParameter[String]] = cs.map(_.getString("prism"))
-    def setPrism(v: String): F[Unit] = setParameterF(prism, v)
+    def setPrism(v: String): F[Unit] = setParameter(prism, v)
 
     private val acqMirror: Option[CaParameter[String]] = cs.map(_.getString("acqMirror"))
-    def setAcqMirror(v: String): F[Unit] = setParameterF(acqMirror, v)
+    def setAcqMirror(v: String): F[Unit] = setParameter(acqMirror, v)
 
     private val focusbest: Option[CaParameter[String]] = cs.map(_.getString("focusbest"))
-    def setFocusBest(v: String): F[Unit] = setParameterF(focusbest, v)
+    def setFocusBest(v: String): F[Unit] = setParameter(focusbest, v)
 
     private val centralWavelength: Option[CaParameter[JDouble]] = cs.map(_.getDouble("centralWavelength"))
-    def setCentralWavelength(v: Double): F[Unit] = setParameterF(centralWavelength, JDouble.valueOf(v))
+    def setCentralWavelength(v: Double): F[Unit] = setParameter(centralWavelength, JDouble.valueOf(v))
 
     private val camera: Option[CaParameter[String]] = cs.map(_.getString("camera"))
-    def setCamera(v: String): F[Unit] = setParameterF(camera, v)
+    def setCamera(v: String): F[Unit] = setParameter(camera, v)
 
     private val gratingMode: Option[CaParameter[String]] = cs.map(_.getString("gratingMode"))
-    def setGratingMode(v: String): F[Unit] = setParameterF(gratingMode, v)
+    def setGratingMode(v: String): F[Unit] = setParameter(gratingMode, v)
 
     private val gratingOrder: Option[CaParameter[Integer]] = cs.map(_.getInteger("order"))
-    def setOrder(v: Int): F[Unit] = setParameterF(gratingOrder, Integer.valueOf(v))
+    def setOrder(v: Int): F[Unit] = setParameter(gratingOrder, Integer.valueOf(v))
 
     private val grating: Option[CaParameter[String]] = cs.map(_.getString("grating"))
-    def setGrating(v: String): F[Unit] = setParameterF(grating, v)
+    def setGrating(v: String): F[Unit] = setParameter(grating, v)
 
     private val slitWidth: Option[CaParameter[String]] = cs.map(_.getString("slitWidth"))
-    def setSlitWidth(v: String): F[Unit] = setParameterF(slitWidth, v)
+    def setSlitWidth(v: String): F[Unit] = setParameter(slitWidth, v)
 
     private val decker: Option[CaParameter[String]] = cs.map(_.getString("decker"))
-    def setDecker(v: String): F[Unit] = setParameterF(decker, v)
+    def setDecker(v: String): F[Unit] = setParameter(decker, v)
 
   }
 
-  object configDCCmd extends EpicsCommandF {
+  object configDCCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("nirs::dcconfig"))
 
     private val lowNoise: Option[CaParameter[Integer]] = cs.map(_.getInteger("lowNoise"))
-    def setLowNoise(v: Int): F[Unit] = setParameterF(lowNoise, Integer.valueOf(v))
+    def setLowNoise(v: Int): F[Unit] = setParameter(lowNoise, Integer.valueOf(v))
 
     private val exposureTime: Option[CaParameter[JDouble]] = cs.map(_.getDouble("exposureTime"))
-    def setExposureTime(v: Double): F[Unit] = setParameterF(exposureTime, JDouble.valueOf(v))
+    def setExposureTime(v: Double): F[Unit] = setParameter(exposureTime, JDouble.valueOf(v))
 
     private val wcs: Option[CaParameter[String]] = cs.map(_.getString("wcs"))
-    def setWcs(v: String): F[Unit] = setParameterF(wcs, v)
+    def setWcs(v: String): F[Unit] = setParameter(wcs, v)
 
     private val digitalAvgs: Option[CaParameter[Integer]] = cs.map(_.getInteger("digitalAvgs"))
-    def setDigitalAvgs(v: Int): F[Unit] = setParameterF(digitalAvgs, Integer.valueOf(v))
+    def setDigitalAvgs(v: Int): F[Unit] = setParameter(digitalAvgs, Integer.valueOf(v))
 
     private val detBias: Option[CaParameter[JDouble]] = cs.map(_.getDouble("detBias"))
-    def setDetBias(v: Double): F[Unit] = setParameterF(detBias, JDouble.valueOf(v))
+    def setDetBias(v: Double): F[Unit] = setParameter(detBias, JDouble.valueOf(v))
 
     private val coadds: Option[CaParameter[JDouble]] = cs.map(_.getDouble("coadds"))
-    def setCoadds(v: Int): F[Unit] = setParameterF(coadds, JDouble.valueOf(v.toDouble))
+    def setCoadds(v: Int): F[Unit] = setParameter(coadds, JDouble.valueOf(v.toDouble))
 
   }
 
-  object endObserveCmd extends EpicsCommandF {
+  object endObserveCmd extends EpicsCommand {
     override protected val cs:Option[CaCommandSender] = Option(epicsService.getCommandSender("nirs::endObserve"))
   }
 
@@ -105,7 +105,7 @@ class GnirsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String])
     "nirs::observeCmd", s"${GnirsTop}dc:apply", s"${GnirsTop}dc:applyC", s"${GnirsTop}dc:observeC",
     true, s"${GnirsTop}dc:stop", s"${GnirsTop}dc:abort", ""))
 
-  object stopCmd extends EpicsCommandF {
+  object stopCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = stopCS
   }
 
@@ -116,7 +116,7 @@ class GnirsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String])
 
   private val abortCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("nirs::abort"))
 
-  object abortCmd extends EpicsCommandF {
+  object abortCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = abortCS
   }
 
@@ -130,7 +130,7 @@ class GnirsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String])
     override protected val os: Option[CaApplySender] = observeAS
 
     val label: Option[CaParameter[String]] = cs.map(_.getString("label"))
-    def setLabel(v: String): SeqAction[Unit] = setParameter(label, v)
+    def setLabel(v: String): F[Unit] = setParameter(label, v)
   }
 
   private val state: CaStatusAcceptor = epicsService.getStatusAcceptor("nirs::status")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsKeywordReader.scala
@@ -5,7 +5,6 @@ package seqexec.server.gnirs
 
 import cats.Applicative
 import cats.effect.Sync
-import cats.effect.LiftIO
 import seqexec.server.keywords._
 
 trait GnirsKeywordReader[F[_]] {
@@ -67,34 +66,31 @@ object GnirsKeywordReaderDummy {
 }
 
 object GnirsKeywordReaderEpics {
-  def apply[F[_]: Sync: LiftIO]: GnirsKeywordReader[F] = new GnirsKeywordReader[F] {
-    private val sys = GnirsEpics.instance
-
-    // TODO make GnirsEpics referentially transparent
-    override def arrayId: F[String] = sys.arrayId.safeValOrDefault.to[F]
-    override def arrayType: F[String] = sys.arrayType.safeValOrDefault.to[F]
-    override def detectorBias: F[Double] = sys.detBias.safeValOrDefault.to[F]
-    override def filter1: F[String] = sys.filter1.safeValOrDefault.to[F]
-    override def filterWheel1Pos: F[Int] = sys.filter1Eng.safeValOrDefault.to[F]
-    override def filter2: F[String] = sys.filter2.safeValOrDefault.to[F]
-    override def filterWheel2Pos: F[Int] = sys.filter2Eng.safeValOrDefault.to[F]
-    override def camera: F[String] = sys.camera.safeValOrDefault.to[F]
-    override def cameraPos: F[Int] = sys.cameraEng.safeValOrDefault.to[F]
-    override def decker: F[String] = sys.decker.safeValOrDefault.to[F]
-    override def deckerPos: F[Int] = sys.deckerEng.safeValOrDefault.to[F]
-    override def slit: F[String] = sys.slitWidth.safeValOrDefault.to[F]
-    override def slitPos: F[Int] = sys.slitEng.safeValOrDefault.to[F]
-    override def prism: F[String] = sys.prism.safeValOrDefault.to[F]
-    override def prismPos: F[Int] = sys.prismEng.safeValOrDefault.to[F]
-    override def grating: F[String] = sys.grating.safeValOrDefault.to[F]
-    override def gratingPos: F[Int] = sys.gratingEng.safeValOrDefault.to[F]
-    override def gratingWavelength: F[Double] = sys.centralWavelength.safeValOrDefault.to[F]
-    override def gratingOrder: F[Int] = sys.gratingOrder.safeValOrDefault.to[F]
-    override def gratingTilt: F[Double] = sys.gratingTilt.safeValOrDefault.to[F]
-    override def focus: F[String] = sys.focus.safeValOrDefault.to[F]
-    override def focusPos: F[Int] = sys.focusEng.safeValOrDefault.to[F]
-    override def acquisitionMirror: F[String] = sys.acqMirror.safeValOrDefault.to[F]
-    override def windowCover: F[String] = sys.cover.safeValOrDefault.to[F]
-    override def obsEpoch: F[Double] = sys.obsEpoch.safeValOrDefault.to[F]
+  def apply[F[_]: Sync](sys: GnirsEpics[F]): GnirsKeywordReader[F] = new GnirsKeywordReader[F] {
+    override def arrayId: F[String] = sys.arrayId.safeValOrDefault
+    override def arrayType: F[String] = sys.arrayType.safeValOrDefault
+    override def detectorBias: F[Double] = sys.detBias.safeValOrDefault
+    override def filter1: F[String] = sys.filter1.safeValOrDefault
+    override def filterWheel1Pos: F[Int] = sys.filter1Eng.safeValOrDefault
+    override def filter2: F[String] = sys.filter2.safeValOrDefault
+    override def filterWheel2Pos: F[Int] = sys.filter2Eng.safeValOrDefault
+    override def camera: F[String] = sys.camera.safeValOrDefault
+    override def cameraPos: F[Int] = sys.cameraEng.safeValOrDefault
+    override def decker: F[String] = sys.decker.safeValOrDefault
+    override def deckerPos: F[Int] = sys.deckerEng.safeValOrDefault
+    override def slit: F[String] = sys.slitWidth.safeValOrDefault
+    override def slitPos: F[Int] = sys.slitEng.safeValOrDefault
+    override def prism: F[String] = sys.prism.safeValOrDefault
+    override def prismPos: F[Int] = sys.prismEng.safeValOrDefault
+    override def grating: F[String] = sys.grating.safeValOrDefault
+    override def gratingPos: F[Int] = sys.gratingEng.safeValOrDefault
+    override def gratingWavelength: F[Double] = sys.centralWavelength.safeValOrDefault
+    override def gratingOrder: F[Int] = sys.gratingOrder.safeValOrDefault
+    override def gratingTilt: F[Double] = sys.gratingTilt.safeValOrDefault
+    override def focus: F[String] = sys.focus.safeValOrDefault
+    override def focusPos: F[Int] = sys.focusEng.safeValOrDefault
+    override def acquisitionMirror: F[String] = sys.acqMirror.safeValOrDefault
+    override def windowCover: F[String] = sys.cover.safeValOrDefault
+    override def obsEpoch: F[Double] = sys.obsEpoch.safeValOrDefault
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -68,7 +68,7 @@ final case class Gpi[F[_]: Sync: Timer](controller: GpiController[F])
       SeqActionF.embedF(calcObserveTime(config).flatMap { ot =>
         controller
           .observe(fileId, timeoutTolerance + ot)
-          .as(ObserveCommand.Success: ObserveCommand.Result)
+          .as(ObserveCommand.Result.Success: ObserveCommand.Result)
       })
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsKeywordReader.scala
@@ -5,7 +5,6 @@ package seqexec.server.gws
 
 import cats.Applicative
 import cats.implicits._
-import cats.effect.LiftIO
 import cats.effect.Sync
 import seqexec.server.EpicsHealth
 import seqexec.server.keywords._
@@ -80,28 +79,27 @@ object DummyGwsKeywordsReader extends GwsDefaults {
 }
 
 object GwsKeywordsReaderEpics extends GwsDefaults {
-  def apply[F[_]: Sync: LiftIO]: GwsKeywordReader[F] = new GwsKeywordReader[F] {
-    private val sys = GwsEpics.instance
+  def apply[F[_]: Sync](sys: GwsEpics[F]): GwsKeywordReader[F] = new GwsKeywordReader[F] {
 
     override def temperature: F[Temperature] =
-      sys.ambientT.to[F]
+      sys.ambientT
 
     override def dewPoint: F[Temperature @@ DewPoint] =
-      sys.dewPoint.map(tag[DewPoint][Temperature](_)).to[F]
+      sys.dewPoint.map(tag[DewPoint][Temperature](_))
 
     override def airPressure: F[Pressure] =
-      sys.airPressure.to[F]
+      sys.airPressure
 
     override def windVelocity: F[Velocity] =
-      sys.windVelocity.to[F]
+      sys.windVelocity
 
     override def windDirection: F[Angle] =
-      sys.windDirection.to[F]
+      sys.windDirection
 
     override def humidity: F[Double] =
-      sys.humidity.to[F]
+      sys.humidity
 
     override def health: F[EpicsHealth] =
-      sys.health.to[F]
+      sys.health
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsEpics.scala
@@ -13,77 +13,77 @@ import java.lang.{Double => JDouble}
 import org.log4s.{Logger, getLogger}
 import seqexec.server.ObserveCommand
 import seqexec.server.EpicsSystem
-import seqexec.server.EpicsCommandF
-import seqexec.server.ObserveCommandF
+import seqexec.server.EpicsCommand
+import seqexec.server.ObserveCommand
 import seqexec.server.EpicsUtil.safeAttribute
 import seqexec.server.EpicsUtil.safeAttributeSDouble
 import seqexec.server.EpicsUtil.safeAttributeSInt
-import seqexec.server.EpicsCommand.setParameterF
+import seqexec.server.EpicsCommand.setParameter
 
 class NifsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String]) {
   val NifsTop = tops.getOrElse("nifs", "nifs:")
 
-  object ccConfigCmd extends EpicsCommandF {
+  object ccConfigCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] =
       Option(epicsService.getCommandSender("nifs::config"))
 
     val disperser: Option[CaParameter[String]] = cs.map(_.getString("disperser"))
-    def setDisperser(v: String): F[Unit] = setParameterF(disperser, v)
+    def setDisperser(v: String): F[Unit] = setParameter(disperser, v)
 
     val filter: Option[CaParameter[String]] = cs.map(_.getString("filter"))
-    def setFilter(v: String): F[Unit] = setParameterF(filter, v)
+    def setFilter(v: String): F[Unit] = setParameter(filter, v)
 
     val windowCover: Option[CaParameter[String]] = cs.map(_.getString("windowCover"))
-    def setWindowCover(v: String): F[Unit] = setParameterF(windowCover, v)
+    def setWindowCover(v: String): F[Unit] = setParameter(windowCover, v)
 
     val maskOffset: Option[CaParameter[JDouble]] = cs.map(_.getDouble("maskOffset"))
-    def setMaskOffset(v: Double): F[Unit] = setParameterF(maskOffset, JDouble.valueOf(v))
+    def setMaskOffset(v: Double): F[Unit] = setParameter(maskOffset, JDouble.valueOf(v))
 
     val imagingMirror: Option[CaParameter[String]] = cs.map(_.getString("imagingMirror"))
-    def setImagingMirror(v: String): F[Unit] = setParameterF(imagingMirror, v)
+    def setImagingMirror(v: String): F[Unit] = setParameter(imagingMirror, v)
 
     val mask: Option[CaParameter[String]] = cs.map(_.getString("mask"))
-    def setMask(v: String): F[Unit] = setParameterF(mask, v)
+    def setMask(v: String): F[Unit] = setParameter(mask, v)
 
     val centralWavelength: Option[CaParameter[JDouble]] = cs.map(_.getDouble("centralWavelength"))
-    def setCentralWavelength(v: Double): F[Unit] = setParameterF(centralWavelength, JDouble.valueOf(v))
+    def setCentralWavelength(v: Double): F[Unit] = setParameter(centralWavelength, JDouble.valueOf(v))
 
   }
 
-  object dcConfigCmd extends EpicsCommandF {
+  object dcConfigCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] =
       Option(epicsService.getCommandSender("nifs::dcconfig"))
 
     private val coadds: Option[CaParameter[Integer]] = cs.map(_.getInteger("coadds"))
-    def setCoadds(v: Int): F[Unit] = setParameterF(coadds, Integer.valueOf(v))
+    def setCoadds(v: Int): F[Unit] = setParameter(coadds, Integer.valueOf(v))
 
     private val exposureTime: Option[CaParameter[JDouble]] = cs.map(_.getDouble("exposureTime"))
-    def setExposureTime(v: Double): F[Unit] = setParameterF(exposureTime, JDouble.valueOf(v))
+    def setExposureTime(v: Double): F[Unit] = setParameter(exposureTime, JDouble.valueOf(v))
 
     private val fowlerSamples: Option[CaParameter[Integer]] = cs.map(_.getInteger("numberOfFowSamples"))
-    def setFowlerSamples(v: Int): F[Unit] = setParameterF(fowlerSamples, Integer.valueOf(v))
+    def setFowlerSamples(v: Int): F[Unit] = setParameter(fowlerSamples, Integer.valueOf(v))
 
     private val period: Option[CaParameter[JDouble]] = cs.map(_.getDouble("period"))
-    def setPeriod(v: Double): F[Unit] = setParameterF(period, JDouble.valueOf(v))
+    def setPeriod(v: Double): F[Unit] = setParameter(period, JDouble.valueOf(v))
 
     private val readMode: Option[CaParameter[ReadMode]] = cs.map(c =>
       c.addEnum[ReadMode]("readMode", s"${NifsTop}dc:obs_readMode", classOf[ReadMode], false)
     )
-    def setReadMode(v: ReadMode): F[Unit] = setParameterF(readMode, v)
+    def setReadMode(v: ReadMode): F[Unit] = setParameter(readMode, v)
 
     private val numberOfResets: Option[CaParameter[Integer]] = cs.map(_.getInteger("numberOfResets"))
     def setnumberOfResets(v: Int): F[Unit] =
-      setParameterF(numberOfResets, Integer.valueOf(v))
+      setParameter(numberOfResets, Integer.valueOf(v))
 
     private val numberOfPeriods: Option[CaParameter[Integer]] = cs.map(_.getInteger("numberOfPeriods"))
     def setnumberOfPeriods(v: Int): F[Unit] =
-      setParameterF(numberOfPeriods, Integer.valueOf(v))
+      setParameter(numberOfPeriods, Integer.valueOf(v))
 
     private val timeMode: Option[CaParameter[TimeMode]] = cs.map(c =>
       c.addEnum[TimeMode]("timeMode", s"${NifsTop}dc:obs_timeMode", classOf[TimeMode], false)
     )
     def setTimeMode(v: TimeMode): F[Unit] =
-      setParameterF(timeMode, v)
+      setParameter(timeMode, v)
   }
 
   private val stopCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("nifs::stop"))
@@ -92,7 +92,7 @@ class NifsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String]) 
     "nifs::observeCmd", s"${NifsTop}dc:nifsApply", s"${NifsTop}dc:applyC", s"${NifsTop}dc:observeC",
     false, s"${NifsTop}dc:stop", s"${NifsTop}dc:abort", ""))
 
-  object stopCmd extends EpicsCommandF {
+  object stopCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = stopCS
   }
 
@@ -103,7 +103,7 @@ class NifsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String]) 
 
   private val abortCS: Option[CaCommandSender] = Option(epicsService.getCommandSender("nifs::abort"))
 
-  object abortCmd extends EpicsCommandF {
+  object abortCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = abortCS
   }
 
@@ -112,16 +112,16 @@ class NifsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String]) 
     override protected val os: Option[CaApplySender] = observeAS
   }
 
-  object observeCmd extends ObserveCommandF {
+  object observeCmd extends ObserveCommand {
     override protected val cs: Option[CaCommandSender] = Option(
       epicsService.getCommandSender("nifs::observe"))
     override protected val os: Option[CaApplySender] = observeAS
 
     private val label: Option[CaParameter[String]] = cs.map(_.getString("label"))
-    def setLabel(v: String): F[Unit] = setParameterF(label, v)
+    def setLabel(v: String): F[Unit] = setParameter(label, v)
   }
 
-  object endObserveCmd extends EpicsCommandF {
+  object endObserveCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(
       epicsService.getCommandSender("nifs::endObserve"))
   }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsKeywordReader.scala
@@ -5,7 +5,6 @@ package seqexec.server.nifs
 
 import cats.Applicative
 import cats.effect.Sync
-import cats.effect.LiftIO
 import cats.implicits._
 import seqexec.server.keywords._
 
@@ -90,51 +89,50 @@ trait NifsKeywordReaderLUT {
 }
 
 object NifsKeywordReaderEpics extends NifsKeywordReaderLUT {
-  def apply[F[_]: Sync: LiftIO]: NifsKeywordReader[F] = new NifsKeywordReader[F] {
-    val sys = NifsEpics.instance
+  def apply[F[_]: Sync](sys: NifsEpics[F]): NifsKeywordReader[F] = new NifsKeywordReader[F] {
     override def aperture: F[String] =
       sys.mask
         .map(_ === Invalid)
         .ifM(sys.lastSelectedMask, sys.mask)
         .map(_.flatMap(MaskKeywordLUT.get))
-        .safeValOrDefault.to[F]
+        .safeValOrDefault
 
-    override def biasPwr: F[Double] = sys.biasPwr.safeValOrDefault.to[F]
+    override def biasPwr: F[Double] = sys.biasPwr.safeValOrDefault
 
     override def centralWavelength: F[Double] =
-      sys.centralWavelength.safeValOrDefault.to[F]
+      sys.centralWavelength.safeValOrDefault
 
-    override def coadds: F[Int]          = sys.coadds.safeValOrDefault.to[F]
+    override def coadds: F[Int]          = sys.coadds.safeValOrDefault
 
-    override def dcName: F[String]       = sys.dcName.safeValOrDefault.to[F]
+    override def dcName: F[String]       = sys.dcName.safeValOrDefault
 
-    override def exposureTime: F[Double] = sys.exposureTime.safeValOrDefault.to[F]
+    override def exposureTime: F[Double] = sys.exposureTime.safeValOrDefault
 
-    override def exposureMode: F[String] = sys.exposureMode.safeValOrDefault.to[F]
+    override def exposureMode: F[String] = sys.exposureMode.safeValOrDefault
 
     override def filter: F[String] =
-      sys.filter.map(_.flatMap(FilterKeywordLUT.get)).safeValOrDefault.to[F]
+      sys.filter.map(_.flatMap(FilterKeywordLUT.get)).safeValOrDefault
 
     override def grating: F[String] =
       sys.disperser
         .map(_ === Invalid)
         .ifM(sys.lastSelectedDisperser, sys.disperser)
         .map(_.flatMap(DisperserKeywordLUT.get))
-        .safeValOrDefault.to[F]
+        .safeValOrDefault
 
-    override def imagingMirror: F[String] = sys.imagingMirror.safeValOrDefault.to[F]
+    override def imagingMirror: F[String] = sys.imagingMirror.safeValOrDefault
 
-    override def maskOffset: F[Double]    = sys.maskOffset.safeValOrDefault.to[F]
+    override def maskOffset: F[Double]    = sys.maskOffset.safeValOrDefault
 
     override def numberOfFowSamples: F[Int] =
-      sys.numberOfFowSamples.safeValOrDefault.to[F]
+      sys.numberOfFowSamples.safeValOrDefault
 
-    override def numberOfPeriods: F[Int] = sys.numberOfPeriods.safeValOrDefault.to[F]
+    override def numberOfPeriods: F[Int] = sys.numberOfPeriods.safeValOrDefault
 
-    override def period: F[Double]       = sys.period.safeValOrDefault.to[F]
+    override def period: F[Double]       = sys.period.safeValOrDefault
 
-    override def readTime: F[Double]     = sys.readTime.safeValOrDefault.to[F]
+    override def readTime: F[Double]     = sys.readTime.safeValOrDefault
 
-    override def windowCover: F[String]  = sys.windowCover.safeValOrDefault.to[F]
+    override def windowCover: F[String]  = sys.windowCover.safeValOrDefault
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
@@ -294,7 +294,7 @@ object NiriControllerEpics extends NiriEncoders {
       val paramsDC = configDC(config.dc)
       val params =  paramsDC ++ configCC(config.cc)
 
-      val cfgActions1 = if(params.isEmpty) IO.pure(EpicsCommand.Completed)
+      val cfgActions1 = if(params.isEmpty) IO.pure(EpicsCommand.Result.Completed)
                         else executeIfNeeded(params,
                           epicsSys.configCmd.setTimeout[IO](ConfigTimeout) *>
                           epicsSys.configCmd.post[IO])

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
@@ -6,7 +6,6 @@ package seqexec.server.niri
 import cats.Applicative
 import cats.data.Nested
 import cats.effect.Sync
-import cats.effect.LiftIO
 import cats.implicits._
 import seqexec.server.keywords._
 
@@ -82,33 +81,32 @@ object NiriKeywordReaderDummy {
 }
 
 object NiriKeywordReaderEpics {
-  def apply[F[_]: Sync: LiftIO]: NiriKeywordReader[F] = new NiriKeywordReader[F] {
-    val sys = NiriEpics.instance
-    override def arrayId: F[String] = sys.arrayId.safeValOrDefault.to[F]
-    override def arrayType: F[String] = sys.arrayType.safeValOrDefault.to[F]
-    override def camera: F[String] = sys.camera.safeValOrDefault.to[F]
-    override def coadds: F[Int] = sys.coadds.safeValOrDefault.to[F]
+  def apply[F[_]: Sync](sys: NiriEpics[F]): NiriKeywordReader[F] = new NiriKeywordReader[F] {
+    override def arrayId: F[String] = sys.arrayId.safeValOrDefault
+    override def arrayType: F[String] = sys.arrayType.safeValOrDefault
+    override def camera: F[String] = sys.camera.safeValOrDefault
+    override def coadds: F[Int] = sys.coadds.safeValOrDefault
     override def exposureTime: F[Double] =
       (for {
         it <- sys.integrationTime
         mi <- sys.minIntegration
-      } yield (it, mi).mapN(_ + _)).safeValOrDefault.to[F]
-    override def filter1: F[String] = sys.filter1.safeValOrDefault.to[F]
-    override def filter2: F[String] = sys.filter2.safeValOrDefault.to[F]
-    override def filter3: F[String] = sys.filter3.safeValOrDefault.to[F]
-    override def focusName: F[String] = sys.focus.safeValOrDefault.to[F]
-    override def focusPosition: F[Double] = sys.focusPosition.safeValOrDefault.to[F]
-    override def focalPlaneMask: F[String] = sys.mask.safeValOrDefault.to[F]
-    override def beamSplitter: F[String] = sys.beamSplitter.safeValOrDefault.to[F]
-    override def windowCover: F[String] = sys.windowCover.safeValOrDefault.to[F]
-    override def framesPerCycle: F[Int] = sys.framesPerCycle.safeValOrDefault.to[F]
+      } yield (it, mi).mapN(_ + _)).safeValOrDefault
+    override def filter1: F[String] = sys.filter1.safeValOrDefault
+    override def filter2: F[String] = sys.filter2.safeValOrDefault
+    override def filter3: F[String] = sys.filter3.safeValOrDefault
+    override def focusName: F[String] = sys.focus.safeValOrDefault
+    override def focusPosition: F[Double] = sys.focusPosition.safeValOrDefault
+    override def focalPlaneMask: F[String] = sys.mask.safeValOrDefault
+    override def beamSplitter: F[String] = sys.beamSplitter.safeValOrDefault
+    override def windowCover: F[String] = sys.windowCover.safeValOrDefault
+    override def framesPerCycle: F[Int] = sys.framesPerCycle.safeValOrDefault
     override def headerTiming: F[String] = Nested(sys.hdrTiming).map {
       case 1 => "BEFORE"
       case 2 => "AFTER"
       case 3 => "BOTH"
       case _ => "INDEF"
-    }.value.safeValOrDefault.to[F]
-    override def lnrs: F[Int] = sys.lnrs.safeValOrDefault.to[F]
+    }.value.safeValOrDefault
+    override def lnrs: F[Int] = sys.lnrs.safeValOrDefault
     override def mode: F[String] = Nested(sys.mode).map {
       case 0 => "STARE"
       case 1 => "SEP"
@@ -116,26 +114,26 @@ object NiriKeywordReaderEpics {
       case 3 => "CHOP2"
       case 4 => "TEST"
       case _ => "INDEF"
-    }.value.safeValOrDefault.to[F]
-    override def numberDigitalAverage: F[Int] = sys.digitalAverageCount.safeValOrDefault.to[F]
-    override def pupilViewer: F[String] = sys.pupilViewer.safeValOrDefault.to[F]
-    override def detectorTemperature: F[Double] = sys.detectorTemp.safeValOrDefault.to[F]
-    override def mountTemperature: F[Double] = sys.mountTemp.safeValOrDefault.to[F]
-    override def µcodeName: F[String] = sys.µcodeName.safeValOrDefault.to[F]
+    }.value.safeValOrDefault
+    override def numberDigitalAverage: F[Int] = sys.digitalAverageCount.safeValOrDefault
+    override def pupilViewer: F[String] = sys.pupilViewer.safeValOrDefault
+    override def detectorTemperature: F[Double] = sys.detectorTemp.safeValOrDefault
+    override def mountTemperature: F[Double] = sys.mountTemp.safeValOrDefault
+    override def µcodeName: F[String] = sys.µcodeName.safeValOrDefault
     override def µcodeType: F[String] = Nested(sys.µcodeType).map {
       case 1 => "RRD"
       case 2 => "RDD"
       case 3 => "RD"
       case 4 => "SRB"
       case _ => "INDEF"
-    }.value.safeValOrDefault.to[F]
-    override def cl1VoltageDD: F[Double] = sys.vddCl1.safeValOrDefault.to[F]
-    override def cl2VoltageDD: F[Double] = sys.vddCl2.safeValOrDefault.to[F]
-    override def ucVoltage: F[Double] = sys.vddUc.safeValOrDefault.to[F]
-    override def detectorVoltage: F[Double] = sys.detectorVDetBias.safeValOrDefault.to[F]
-    override def cl1VoltageGG: F[Double] = sys.vggCl1.safeValOrDefault.to[F]
-    override def cl2VoltageGG: F[Double] = sys.vggCl2.safeValOrDefault.to[F]
-    override def setVoltage: F[Double] = sys.detectorVSetBias.safeValOrDefault.to[F]
-    override def observationEpoch: F[Double] = sys.obsEpoch.safeValOrDefault.to[F]
+    }.value.safeValOrDefault
+    override def cl1VoltageDD: F[Double] = sys.vddCl1.safeValOrDefault
+    override def cl2VoltageDD: F[Double] = sys.vddCl2.safeValOrDefault
+    override def ucVoltage: F[Double] = sys.vddUc.safeValOrDefault
+    override def detectorVoltage: F[Double] = sys.detectorVDetBias.safeValOrDefault
+    override def cl1VoltageGG: F[Double] = sys.vggCl1.safeValOrDefault
+    override def cl2VoltageGG: F[Double] = sys.vggCl2.safeValOrDefault
+    override def setVoltage: F[Double] = sys.detectorVSetBias.safeValOrDefault
+    override def observationEpoch: F[Double] = sys.obsEpoch.safeValOrDefault
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpics.scala
@@ -26,7 +26,7 @@ import seqexec.model.TelescopeGuideConfig
 import seqexec.server.altair.Altair
 import seqexec.server.gems.Gems
 import seqexec.server.tcs.TcsController._
-import seqexec.server.{EpicsCodex, EpicsCommandF, SeqexecFailure}
+import seqexec.server.{EpicsCodex, EpicsCommand, SeqexecFailure}
 import seqexec.server.tcs.Gaos.{GaosGuideOff, GaosGuideOn, OffsetMove, OffsetReached, OiOff, OiOn, P1Off, P1On, PauseCondition, PauseResume, ResumeCondition}
 import seqexec.server.tcs.TcsEpics.{ProbeFollowCmd, ProbeGuideCmd}
 import shapeless.tag
@@ -147,7 +147,7 @@ class TcsControllerEpics private extends TcsController[IO] {
       "Incompatible configuration: useAO is false but sequence uses Altair")) }.some
   }
 
-  private def setGuiderWfs[F[_]: Sync](on: TcsEpics.WfsObserveCmd[F], off: EpicsCommandF)(c: GuiderSensorOption)
+  private def setGuiderWfs[F[_]: Sync](on: TcsEpics.WfsObserveCmd[F], off: EpicsCommand)(c: GuiderSensorOption)
   : F[Unit] = {
     val NonStopExposures = -1
     c match {
@@ -615,7 +615,7 @@ object TcsControllerEpics {
   object EpicsTcsConfig
 
   final case class GuideControl[F[_]: Async](subs: Subsystem,
-                                             parkCmd: EpicsCommandF,
+                                             parkCmd: EpicsCommand,
                                              nodChopGuideCmd: ProbeGuideCmd[F],
                                              followCmd: ProbeFollowCmd[F]
                                             )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
@@ -11,7 +11,7 @@ import edu.gemini.seqexec.server.tcs.{BinaryOnOff, BinaryYesNo}
 import org.log4s.{Logger, getLogger}
 import seqexec.server.EpicsCommand._
 import seqexec.server.EpicsUtil._
-import seqexec.server.{EpicsCommandF, EpicsSystem}
+import seqexec.server.{EpicsCommand, EpicsSystem}
 import squants.Time
 import squants.space.Degrees
 import squants.time.TimeConversions._
@@ -35,126 +35,126 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
   // Triggering that command will trigger all the marked commands.
   def post: F[Result] = m1GuideCmd.post
 
-  object m1GuideCmd extends EpicsCommandF {
+  object m1GuideCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("m1Guide"))
     private val state = cs.map(_.getString("state"))
 
-    def setState(v: String): F[Unit] = setParameterF(state, v)
+    def setState(v: String): F[Unit] = setParameter(state, v)
   }
 
-  object m2GuideCmd extends EpicsCommandF {
+  object m2GuideCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("m2Guide"))
     private val state = cs.map(_.getString("state"))
 
-    def setState(v: String): F[Unit] = setParameterF(state, v)
+    def setState(v: String): F[Unit] = setParameter(state, v)
   }
 
-  object m2GuideModeCmd extends EpicsCommandF {
+  object m2GuideModeCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("m2GuideMode"))
 
     private val coma = cs.map(_.getString("coma"))
-    def setComa(v: String): F[Unit] = setParameterF(coma, v)
+    def setComa(v: String): F[Unit] = setParameter(coma, v)
   }
 
-  object m2GuideConfigCmd extends EpicsCommandF {
+  object m2GuideConfigCmd extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("m2GuideConfig"))
 
     private val source = cs.map(_.getString("source"))
-    def setSource(v: String): F[Unit] = setParameterF(source, v)
+    def setSource(v: String): F[Unit] = setParameter(source, v)
 
     private val beam = cs.map(_.getString("beam"))
-    def setBeam(v: String): F[Unit] = setParameterF(beam, v)
+    def setBeam(v: String): F[Unit] = setParameter(beam, v)
 
     private val reset = cs.map(_.getString("reset"))
-    def setReset(v: String): F[Unit] = setParameterF(reset, v)
+    def setReset(v: String): F[Unit] = setParameter(reset, v)
   }
 
-  object mountGuideCmd extends EpicsCommandF {
+  object mountGuideCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("mountGuide"))
 
     private val source = cs.map(_.getString("source"))
 
-    def setSource(v: String): F[Unit] = setParameterF(source, v)
+    def setSource(v: String): F[Unit] = setParameter(source, v)
 
     private val p1weight = cs.map(_.getDouble("p1weight"))
 
-    def setP1Weight(v: Double): F[Unit] = setParameterF[F, java.lang.Double](p1weight, v)
+    def setP1Weight(v: Double): F[Unit] = setParameter[F, java.lang.Double](p1weight, v)
 
     private val p2weight = cs.map(_.getDouble("p2weight"))
 
-    def setP2Weight(v: Double): F[Unit] = setParameterF[F, java.lang.Double](p2weight, v)
+    def setP2Weight(v: Double): F[Unit] = setParameter[F, java.lang.Double](p2weight, v)
 
     private val mode = cs.map(_.getString("mode"))
 
-    def setMode(v: String): F[Unit] = setParameterF(mode, v)
+    def setMode(v: String): F[Unit] = setParameter(mode, v)
   }
 
-  object offsetACmd extends EpicsCommandF {
+  object offsetACmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("offsetPoA1"))
 
     private val x = cs.map(_.getDouble("x"))
 
-    def setX(v: Double): F[Unit] = setParameterF[F, java.lang.Double](x, v)
+    def setX(v: Double): F[Unit] = setParameter[F, java.lang.Double](x, v)
 
     private val y = cs.map(_.getDouble("y"))
 
-    def setY(v: Double): F[Unit] = setParameterF[F, java.lang.Double](y, v)
+    def setY(v: Double): F[Unit] = setParameter[F, java.lang.Double](y, v)
   }
 
-  object offsetBCmd extends EpicsCommandF {
+  object offsetBCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("offsetPoB1"))
 
     private val x = cs.map(_.getDouble("x"))
 
-    def setX(v: Double): F[Unit] = setParameterF[F, java.lang.Double](x, v)
+    def setX(v: Double): F[Unit] = setParameter[F, java.lang.Double](x, v)
 
     private val y = cs.map(_.getDouble("y"))
 
-    def setY(v: Double): F[Unit] = setParameterF[F, java.lang.Double](y, v)
+    def setY(v: Double): F[Unit] = setParameter[F, java.lang.Double](y, v)
   }
 
-  object offsetCCmd extends EpicsCommandF {
+  object offsetCCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("offsetPoC1"))
 
     private val x = cs.map(_.getDouble("x"))
 
-    def setX(v: Double): F[Unit] = setParameterF[F, java.lang.Double](x, v)
+    def setX(v: Double): F[Unit] = setParameter[F, java.lang.Double](x, v)
 
     private val y = cs.map(_.getDouble("y"))
 
-    def setY(v: Double): F[Unit] = setParameterF[F, java.lang.Double](y, v)
+    def setY(v: Double): F[Unit] = setParameter[F, java.lang.Double](y, v)
   }
 
-  object wavelSourceA extends EpicsCommandF {
+  object wavelSourceA extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelSourceA"))
 
     private val wavel = cs.map(_.getDouble("wavel"))
 
-    def setWavel(v: Double): F[Unit] = setParameterF[F, java.lang.Double](wavel, v)
+    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
   }
 
-  object wavelSourceB extends EpicsCommandF {
+  object wavelSourceB extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelSourceB"))
 
     private val wavel = cs.map(_.getDouble("wavel"))
 
-    def setWavel(v: Double): F[Unit] = setParameterF[F, java.lang.Double](wavel, v)
+    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
   }
 
-  object wavelSourceC extends EpicsCommandF {
+  object wavelSourceC extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelSourceC"))
 
     private val wavel = cs.map(_.getDouble("wavel"))
 
-    def setWavel(v: Double): F[Unit] = setParameterF[F, java.lang.Double](wavel, v)
+    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
   }
 
-  object m2Beam extends EpicsCommandF {
+  object m2Beam extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("m2Beam"))
 
     private val beam = cs.map(_.getString("beam"))
 
-    def setBeam(v: String): F[Unit] = setParameterF(beam, v)
+    def setBeam(v: String): F[Unit] = setParameter(beam, v)
   }
 
   val pwfs1ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("pwfs1Guide", epicsService)
@@ -171,27 +171,27 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
 
   val aoProbeFollowCmd: ProbeFollowCmd[F] = new ProbeFollowCmd("aoFollow", epicsService)
 
-  object pwfs1Park extends EpicsCommandF {
+  object pwfs1Park extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("pwfs1Park"))
   }
 
-  object pwfs2Park extends EpicsCommandF {
+  object pwfs2Park extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("pwfs2Park"))
   }
 
-  object oiwfsPark extends EpicsCommandF {
+  object oiwfsPark extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("oiwfsPark"))
   }
 
-  object pwfs1StopObserveCmd extends EpicsCommandF {
+  object pwfs1StopObserveCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("pwfs1StopObserve"))
   }
 
-  object pwfs2StopObserveCmd extends EpicsCommandF {
+  object pwfs2StopObserveCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("pwfs2StopObserve"))
   }
 
-  object oiwfsStopObserveCmd extends EpicsCommandF {
+  object oiwfsStopObserveCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("oiwfsStopObserve"))
   }
 
@@ -201,104 +201,104 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
 
   val oiwfsObserveCmd: WfsObserveCmd[F] = new WfsObserveCmd("oiwfsObserve", epicsService)
 
-  object hrwfsParkCmd extends EpicsCommandF {
+  object hrwfsParkCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("hrwfsPark"))
   }
 
-  object hrwfsPosCmd extends EpicsCommandF {
+  object hrwfsPosCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("hrwfs"))
 
     private val hrwfsPos = cs.map(_.getString("hrwfsPos"))
 
-    def setHrwfsPos(v: String): F[Unit] = setParameterF(hrwfsPos, v)
+    def setHrwfsPos(v: String): F[Unit] = setParameter(hrwfsPos, v)
   }
 
-  object scienceFoldParkCmd extends EpicsCommandF {
+  object scienceFoldParkCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("scienceFoldPark"))
   }
 
-  object scienceFoldPosCmd extends EpicsCommandF {
+  object scienceFoldPosCmd extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("scienceFold"))
 
     private val scfold = cs.map(_.getString("scfold"))
 
-    def setScfold(v: String): F[Unit] = setParameterF(scfold, v)
+    def setScfold(v: String): F[Unit] = setParameter(scfold, v)
   }
 
-  object observe extends EpicsCommandF {
+  object observe extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("tcs::observe"))
   }
 
-  object endObserve extends EpicsCommandF {
+  object endObserve extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("tcs::endObserve"))
   }
 
-  object aoCorrect extends EpicsCommandF {
+  object aoCorrect extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("aoCorrect"))
 
     private val correct = cs.map(_.getString("correct"))
-    def setCorrections(v: String): F[Unit] = setParameterF(correct, v)
+    def setCorrections(v: String): F[Unit] = setParameter(correct, v)
 
     private val gains = cs.map(_.getInteger("gains"))
-    def setGains(v: Int): F[Unit] = setParameterF[F, java.lang.Integer](gains, v)
+    def setGains(v: Int): F[Unit] = setParameter[F, java.lang.Integer](gains, v)
 
     private val matrix = cs.map(_.getInteger("matrix"))
-    def setMatrix(v: Int): F[Unit] = setParameterF[F, java.lang.Integer](matrix, v)
+    def setMatrix(v: Int): F[Unit] = setParameter[F, java.lang.Integer](matrix, v)
   }
 
-  object aoPrepareControlMatrix extends EpicsCommandF {
+  object aoPrepareControlMatrix extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("aoPrepareCm"))
 
     private val x = cs.map(_.getDouble("x"))
-    def setX(v: Double): F[Unit] = setParameterF[F, java.lang.Double](x, v)
+    def setX(v: Double): F[Unit] = setParameter[F, java.lang.Double](x, v)
 
     private val y = cs.map(_.getDouble("y"))
-    def setY(v: Double): F[Unit] = setParameterF[F, java.lang.Double](y, v)
+    def setY(v: Double): F[Unit] = setParameter[F, java.lang.Double](y, v)
 
     private val seeing = cs.map(_.getDouble("seeing"))
-    def setSeeing(v: Double): F[Unit] = setParameterF[F, java.lang.Double](seeing, v)
+    def setSeeing(v: Double): F[Unit] = setParameter[F, java.lang.Double](seeing, v)
 
     private val starMagnitude = cs.map(_.getDouble("gsmag"))
-    def setStarMagnitude(v: Double): F[Unit] = setParameterF[F, java.lang.Double](starMagnitude, v)
+    def setStarMagnitude(v: Double): F[Unit] = setParameter[F, java.lang.Double](starMagnitude, v)
 
     private val windSpeed = cs.map(_.getDouble("windspeed"))
-    def setWindSpeed(v: Double): F[Unit] = setParameterF[F, java.lang.Double](windSpeed, v)
+    def setWindSpeed(v: Double): F[Unit] = setParameter[F, java.lang.Double](windSpeed, v)
   }
 
-  object aoFlatten extends EpicsCommandF {
+  object aoFlatten extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("aoFlatten"))
   }
 
-  object aoStatistics extends EpicsCommandF {
+  object aoStatistics extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("aoStats"))
 
     private val fileName = cs.map(_.getString("filename"))
-    def setFileName(v: String): F[Unit] = setParameterF(fileName, v)
+    def setFileName(v: String): F[Unit] = setParameter(fileName, v)
 
     private val samples = cs.map(_.getInteger("samples"))
-    def setSamples(v: Int): F[Unit] = setParameterF[F, java.lang.Integer](samples, v)
+    def setSamples(v: Int): F[Unit] = setParameter[F, java.lang.Integer](samples, v)
 
     private val interval = cs.map(_.getDouble("interval"))
-    def setInterval(v: Double): F[Unit] = setParameterF[F, java.lang.Double](interval, v)
+    def setInterval(v: Double): F[Unit] = setParameter[F, java.lang.Double](interval, v)
 
     private val triggerTime = cs.map(_.getDouble("trigtime"))
-    def setTriggerTimeInterval(v: Double): F[Unit] = setParameterF[F, java.lang.Double](triggerTime, v)
+    def setTriggerTimeInterval(v: Double): F[Unit] = setParameter[F, java.lang.Double](triggerTime, v)
   }
 
-  object targetFilter extends EpicsCommandF {
+  object targetFilter extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("filter1"))
 
     private val bandwidth = cs.map(_.getDouble("bandwidth"))
-    def setBandwidth(v: Double): F[Unit] = setParameterF[F, java.lang.Double](bandwidth, v)
+    def setBandwidth(v: Double): F[Unit] = setParameter[F, java.lang.Double](bandwidth, v)
 
     private val maxVelocity = cs.map(_.getDouble("maxv"))
-    def setMaxVelocity(v: Double): F[Unit] = setParameterF[F, java.lang.Double](maxVelocity, v)
+    def setMaxVelocity(v: Double): F[Unit] = setParameter[F, java.lang.Double](maxVelocity, v)
 
     private val grabRadius = cs.map(_.getDouble("grab"))
-    def setGrabRadius(v: Double): F[Unit] = setParameterF[F, java.lang.Double](grabRadius, v)
+    def setGrabRadius(v: Double): F[Unit] = setParameter[F, java.lang.Double](grabRadius, v)
 
     private val shortCircuit = cs.map(_.getString("shortCircuit"))
-    def setShortCircuit(v: String): F[Unit] = setParameterF(shortCircuit, v)
+    def setShortCircuit(v: String): F[Unit] = setParameter(shortCircuit, v)
   }
 
   private val tcsState = epicsService.getStatusAcceptor("tcsstate")
@@ -585,67 +585,67 @@ object TcsEpics extends EpicsSystem[TcsEpics[IO]] {
 
   override def build(service: CaService, tops: Map[String, String]) = new TcsEpics[IO](service, tops)
 
-  sealed class ProbeGuideCmd[F[_]: Async](csName: String, epicsService: CaService) extends EpicsCommandF {
+  sealed class ProbeGuideCmd[F[_]: Async](csName: String, epicsService: CaService) extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender(csName))
 
     private val nodachopa = cs.map(_.getString("nodachopa"))
-    def setNodachopa(v: String): F[Unit] = setParameterF(nodachopa, v)
+    def setNodachopa(v: String): F[Unit] = setParameter(nodachopa, v)
 
     private val nodachopb = cs.map(_.getString("nodachopb"))
-    def setNodachopb(v: String): F[Unit] = setParameterF(nodachopb, v)
+    def setNodachopb(v: String): F[Unit] = setParameter(nodachopb, v)
 
     private val nodachopc = cs.map(_.getString("nodachopc"))
-    def setNodachopc(v: String): F[Unit] = setParameterF(nodachopc, v)
+    def setNodachopc(v: String): F[Unit] = setParameter(nodachopc, v)
 
     private val nodbchopa = cs.map(_.getString("nodbchopa"))
-    def setNodbchopa(v: String): F[Unit] = setParameterF(nodbchopa, v)
+    def setNodbchopa(v: String): F[Unit] = setParameter(nodbchopa, v)
 
     private val nodbchopb = cs.map(_.getString("nodbchopb"))
-    def setNodbchopb(v: String): F[Unit] = setParameterF(nodbchopb, v)
+    def setNodbchopb(v: String): F[Unit] = setParameter(nodbchopb, v)
 
     private val nodbchopc = cs.map(_.getString("nodbchopc"))
-    def setNodbchopc(v: String): F[Unit] = setParameterF(nodbchopc, v)
+    def setNodbchopc(v: String): F[Unit] = setParameter(nodbchopc, v)
 
     private val nodcchopa = cs.map(_.getString("nodcchopa"))
-    def setNodcchopa(v: String): F[Unit] = setParameterF(nodcchopa, v)
+    def setNodcchopa(v: String): F[Unit] = setParameter(nodcchopa, v)
 
     private val nodcchopb = cs.map(_.getString("nodcchopb"))
-    def setNodcchopb(v: String): F[Unit] = setParameterF(nodcchopb, v)
+    def setNodcchopb(v: String): F[Unit] = setParameter(nodcchopb, v)
 
     private val nodcchopc = cs.map(_.getString("nodcchopc"))
-    def setNodcchopc(v: String): F[Unit] = setParameterF(nodcchopc, v)
+    def setNodcchopc(v: String): F[Unit] = setParameter(nodcchopc, v)
   }
 
-  sealed class WfsObserveCmd[F[_]: Async](csName: String, epicsService: CaService) extends EpicsCommandF {
+  sealed class WfsObserveCmd[F[_]: Async](csName: String, epicsService: CaService) extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender(csName))
 
     private val noexp = cs.map(_.getInteger("noexp"))
-    def setNoexp(v: Integer): F[Unit] = setParameterF(noexp, v)
+    def setNoexp(v: Integer): F[Unit] = setParameter(noexp, v)
 
     private val int = cs.map(_.getDouble("int"))
-    def setInt(v: Double): F[Unit] = setParameterF[F, java.lang.Double](int, v)
+    def setInt(v: Double): F[Unit] = setParameter[F, java.lang.Double](int, v)
 
     private val outopt = cs.map(_.getString("outopt"))
-    def setOutopt(v: String): F[Unit] = setParameterF(outopt, v)
+    def setOutopt(v: String): F[Unit] = setParameter(outopt, v)
 
     private val label = cs.map(_.getString("label"))
-    def setLabel(v: String): F[Unit] = setParameterF(label, v)
+    def setLabel(v: String): F[Unit] = setParameter(label, v)
 
     private val output = cs.map(_.getString("output"))
-    def setOutput(v: String): F[Unit] = setParameterF(output, v)
+    def setOutput(v: String): F[Unit] = setParameter(output, v)
 
     private val path = cs.map(_.getString("path"))
-    def setPath(v: String): F[Unit] = setParameterF(path, v)
+    def setPath(v: String): F[Unit] = setParameter(path, v)
 
     private val name = cs.map(_.getString("name"))
-    def setName(v: String): F[Unit] = setParameterF(name, v)
+    def setName(v: String): F[Unit] = setParameter(name, v)
   }
 
-  final class ProbeFollowCmd[F[_]: Async](csName: String, epicsService: CaService) extends EpicsCommandF {
+  final class ProbeFollowCmd[F[_]: Async](csName: String, epicsService: CaService) extends EpicsCommand {
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender(csName))
 
     private val follow = cs.map(_.getString("followState"))
-    def setFollowState(v: String): F[Unit] = setParameterF(follow, v)
+    def setFollowState(v: String): F[Unit] = setParameter(follow, v)
   }
 
   class ProbeGuideConfig[F[_]: Sync](protected val prefix: String, protected val tcsState: CaStatusAcceptor) {

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
@@ -6,17 +6,13 @@ package seqexec.server
 import gem.arb.ArbEnumerated._
 import gem.Observation
 import org.scalacheck.Arbitrary._
-import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalacheck.{Arbitrary, Cogen}
 import seqexec.model.BatchCommandState
 import seqexec.model.enum.Instrument
 import seqexec.model.{Conditions, Operator}
 import seqexec.model.SeqexecModelArbitraries._
 
 trait SeqexecServerArbitraries {
-
-  implicit val observeCommandArb: Arbitrary[ObserveCommand.Result] = Arbitrary(Gen.oneOf(ObserveCommand.Success, ObserveCommand.Paused, ObserveCommand.Aborted, ObserveCommand.Stopped))
-  implicit val observeCommandCogen: Cogen[ObserveCommand.Result] =
-    Cogen[String].contramap(_.productPrefix)
 
   implicit val selectedCoGen: Cogen[Map[Instrument, Observation.Id]] =
     Cogen[List[(Instrument, Observation.Id)]].contramap(_.toList)
@@ -41,9 +37,4 @@ trait SeqexecServerArbitraries {
     Cogen[(String, BatchCommandState, List[Observation.Id])]
       .contramap(x => (x.name, x.cmdState, x.queue))
 
-  implicit val epicsHealthArb: Arbitrary[EpicsHealth] =
-    Arbitrary(Gen.oneOf(EpicsHealth.Good, EpicsHealth.Bad))
-
-  implicit val epicsHealthCogen: Cogen[EpicsHealth] =
-    Cogen[String].contramap(_.productPrefix)
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerSpec.scala
@@ -5,6 +5,7 @@ package seqexec.server
 
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
+import gem.arb.ArbEnumerated._
 
 /**
   * Tests SeqexecServer typeclasses


### PR DESCRIPTION
I've been doing this large refactoring to make all epics reads referentially transparent. While some improvements can still be done we should close this

This PR removes some duplicated code that was able to work on the old and new world and rename `EpicsCommandF` to `EpicsCommand` and `ObsecveCommandF` to `ObserveCommand`

As changes go this PR is fairly mechanical