### PR TITLE
Small bug fixes

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -508,7 +508,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
     }
   }
 
-  private def commonHeaders[F[_]: Sync](epics: TcsEpics[F], config: Config, tcsSubsystems: List[TcsController.Subsystem],
+  private def commonHeaders[F[_]: Sync](epics: => TcsEpics[F], config: Config, tcsSubsystems: List[TcsController.Subsystem],
                             inst: InstrumentSystem[F])(ctx: HeaderExtraData): Header[F] =
     new StandardHeader(
       inst,
@@ -518,19 +518,19 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
       tcsSubsystems
     )
 
-  private def gwsHeaders[F[_]: Sync](epics: GwsEpics[F], i: InstrumentSystem[F]): Header[F] = GwsHeader.header(i,
+  private def gwsHeaders[F[_]: Sync](epics: => GwsEpics[F], i: InstrumentSystem[F]): Header[F] = GwsHeader.header(i,
     if (settings.gwsKeywords) GwsKeywordsReaderEpics[F](epics) else DummyGwsKeywordsReader[F])
 
-  private def gcalHeader[F[_]: Sync](epics: GcalEpics[F], i: InstrumentSystem[F]): Header[F] = GcalHeader.header(i,
+  private def gcalHeader[F[_]: Sync](epics: => GcalEpics[F], i: InstrumentSystem[F]): Header[F] = GcalHeader.header(i,
     if (settings.gcalKeywords) GcalKeywordsReaderEpics[F](epics) else DummyGcalKeywordsReader[F] )
 
-  private def altairHeader[F[_]: Sync: LiftIO](epics: AltairEpics[F], instrument: InstrumentSystem[F], tcsKReader: TcsKeywordsReader[F]): Header[F] =
+  private def altairHeader[F[_]: Sync: LiftIO](epics: => AltairEpics[F], instrument: InstrumentSystem[F], tcsKReader: TcsKeywordsReader[F]): Header[F] =
     AltairHeader.header[F](
       instrument,
       if (settings.altairKeywords) AltairKeywordReaderEpics[F](epics) else AltairKeywordReaderDummy[F],
       tcsKReader)
 
-  private def altairLgsHeader[F[_]: Sync](epics: AltairEpics[F], guideStar: GuideStarType, instrument: InstrumentSystem[F]): Header[F] =
+  private def altairLgsHeader[F[_]: Sync](epics: => AltairEpics[F], guideStar: GuideStarType, instrument: InstrumentSystem[F]): Header[F] =
     if (guideStar === GuideStarType.LGS) {
       AltairLgsHeader.header(instrument,
         if (settings.altairKeywords) AltairKeywordReaderEpics[F](epics) else AltairKeywordReaderDummy[F])

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
@@ -179,9 +179,9 @@ class GmosEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String])
   def rois: F[Map[Int, RoiStatus[F]]] =
     Sync[F].delay((1 to 5).map(i => i -> RoiStatus[F](dcState, i)).toMap)
 
-  def ccdXBinning: F[Int] = dcReadI("ccdXBinning")
+  def ccdXBinning: F[Int] = dcReadD("ccdXBinning").map(_.toInt)
 
-  def ccdYBinning: F[Int] = dcReadI("ccdYBinning")
+  def ccdYBinning: F[Int] = dcReadD("ccdYBinning").map(_.toInt)
 
   def currentCycle: F[Int] = dcReadI("currentCycle")
 


### PR DESCRIPTION
This PR contains three bug fixes
* First we need to pass the `TcsEpics` items per ref as the initialization logic is handled in another place of the app. This is not an issue in production but affects us in simulation. The fix in the current PR is a workaround until we have a better fix
* Two gmos channels were being read as int while they are doubles
* During testing I noted that N&S guidingWithBeam can come on the sequences as a String or as `StandardGuideOptions.Value`