### PR TITLE
SEQNG-1024 Properly mark start from operation as complete

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/OperationsStateHandler.scala
@@ -72,7 +72,7 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
         SequencesOnDisplay.markOperations(
           id,
           TabOperations.startFromRequested
-            .set(StartFromOperation.StartFromInFlight)))
+            .set(StartFromOperation.StartFromIdle)))
 
     case RunResourceComplete(id, _, r) =>
       updatedL(


### PR DESCRIPTION
I noted a small bug while testing. If you start a sequences from a step using the start from button, the observation control buttons are disabled:
![Seqexec - GS-2018B-Q-0-71 2019-07-18 12-19-10](https://user-images.githubusercontent.com/3615303/61478181-02794500-a95f-11e9-9da3-60213e505749.png)

The issue was setting the wrong state when `RunFrom` completes