### PR TITLE
SEQNG-995A: Display A&C name while executing

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -271,6 +271,8 @@ object SeqexecStyles {
 
   val runningIcon: Css = Css("SeqexecStyles-runningIcon")
 
+  val errorIcon: Css = Css("SeqexecStyles-errorIcon")
+
   val completedIcon: Css = Css("SeqexecStyles-completedIcon")
 
   val breakPointOnIcon: Css =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -128,14 +128,16 @@ trait Columns {
     name    = "control",
     label   = "",
     visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(ControlWidth))
+    width   = FixedColumnWidth.unsafeFromDouble(ControlWidth)
+  )
 
   val StepMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     StepColumn,
     name    = "idx",
     label   = "Step",
     visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(StepWidth))
+    width   = FixedColumnWidth.unsafeFromDouble(StepWidth)
+  )
 
   val ExecutionMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExecutionColumn,
@@ -143,35 +145,40 @@ trait Columns {
     label   = "Execution Progress",
     visible = true,
     width   = VariableColumnWidth.unsafeFromDouble(0.1, ExecutionMinWidth),
-    grow    = 20)
+    grow    = 20
+  )
 
   val OffsetMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     OffsetColumn,
     name    = "offsets",
     label   = "Offsets",
     visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase))
+    width   = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase)
+  )
 
   val ObservingModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObservingModeColumn,
     name    = "obsMode",
     label   = "Observing Mode",
     visible = true,
-    width   = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth))
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth)
+  )
 
   val ExposureMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExposureColumn,
     name    = "exposure",
     label   = "Exposure",
     visible = true,
-    width   = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth))
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth)
+  )
 
   val DisperserMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DisperserColumn,
     name    = "disperser",
     label   = "Disperser",
     visible = true,
-    width   = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth))
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth)
+  )
 
   val FilterMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FilterColumn,
@@ -179,7 +186,8 @@ trait Columns {
     label      = "Filter",
     visible    = true,
     removeable = 2,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth)
+  )
 
   val FPUMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FPUColumn,
@@ -187,7 +195,8 @@ trait Columns {
     label      = "FPU",
     removeable = 3,
     visible    = true,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth)
+  )
 
   val CameraMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     CameraColumn,
@@ -195,7 +204,8 @@ trait Columns {
     label      = "Camera",
     visible    = true,
     removeable = 4,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth)
+  )
 
   val DeckerMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DeckerColumn,
@@ -203,7 +213,8 @@ trait Columns {
     label      = "Decker",
     removeable = 5,
     visible    = true,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth)
+  )
 
   val ReadModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ReadModeColumn,
@@ -211,7 +222,8 @@ trait Columns {
     label      = "ReadMode",
     visible    = true,
     removeable = 6,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth))
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth)
+  )
 
   val ImagingMirrorMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ImagingMirrorColumn,
@@ -228,14 +240,16 @@ trait Columns {
     label      = "Type",
     visible    = true,
     removeable = 1,
-    width      = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth))
+    width      = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth)
+  )
 
   val SettingsMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     SettingsColumn,
     name    = "set",
     label   = "",
     visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(SettingsWidth))
+    width   = FixedColumnWidth.unsafeFromDouble(SettingsWidth)
+  )
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] =
     NonEmptyList.of(
@@ -302,9 +316,11 @@ object StepsTable extends Columns {
     val Zero: StepRow = apply(Step.Zero)
   }
 
-  final case class Props(router:     RouterCtl[SeqexecPages],
-                         canOperate: Boolean,
-                         stepsTable: StepsTableAndStatusFocus) {
+  final case class Props(
+    router:     RouterCtl[SeqexecPages],
+    canOperate: Boolean,
+    stepsTable: StepsTableAndStatusFocus
+  ) {
     val status: ClientStatus             = stepsTable.status
     val steps: Option[StepsTableFocus]   = stepsTable.stepsTable
     val instrument: Option[Instrument]   = steps.map(_.instrument)
@@ -325,18 +341,20 @@ object StepsTable extends Columns {
     val showCamera: Boolean    = showProp(InstrumentProperties.Camera)
     val showDecker: Boolean    = showProp(InstrumentProperties.Decker)
     val showImagingMirror: Boolean = showProp(
-      InstrumentProperties.ImagingMirror)
+      InstrumentProperties.ImagingMirror
+    )
     val isPreview: Boolean        = steps.map(_.isPreview).getOrElse(false)
     val hasControls: Boolean      = canOperate && !isPreview
     val canSetBreakpoint: Boolean = canOperate && !isPreview
     val showObservingMode: Boolean = showProp(
-      InstrumentProperties.ObservingMode)
+      InstrumentProperties.ObservingMode
+    )
     val showReadMode: Boolean = showProp(InstrumentProperties.ReadMode)
 
     val sequenceState: Option[SequenceState] = steps.map(_.state)
 
     def stepSelectionAllowed(sid: StepId): Boolean =
-      canControlSubsystems(sid) && !tabOperations.resourceInFlight && !sequenceState
+      canControlSubsystems(sid) && !tabOperations.resourceInFlight(sid) && !sequenceState
         .exists(_.isRunning)
 
     def rowGetter(idx: Int): StepRow =
@@ -424,11 +442,13 @@ object StepsTable extends Columns {
   }
 
   @Lenses
-  final case class State(tableState:      TableState[TableColumn],
-                         breakpointHover: Option[Int],
-                         selected:        Option[StepId],
-                         scrollCount:     Int,
-                         scrollWhileRun:  Boolean) {
+  final case class State(
+    tableState:      TableState[TableColumn],
+    breakpointHover: Option[Int],
+    selected:        Option[StepId],
+    scrollCount:     Int,
+    scrollWhileRun:  Boolean
+  ) {
 
     def visibleCols(p: Props): State =
       State.columns.set(NonEmptyList.fromListUnsafe(p.shownForInstrument))(this)
@@ -491,7 +511,8 @@ object StepsTable extends Columns {
           rowBreakpointHoverOnCB,
           rowBreakpointHoverOffCB,
           recomputeHeightsCB
-        ))
+        )
+      )
 
   val stepIdRenderer: CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) => StepIdCell(row.step.id)
@@ -503,7 +524,8 @@ object StepsTable extends Columns {
     (_, _, _, row: StepRow, _) =>
       SettingsCell(
         SettingsCell
-          .Props(p.router, f.instrument, f.id, row.step.id, p.isPreview))
+          .Props(p.router, f.instrument, f.id, row.step.id, p.isPreview)
+      )
 
   def stepProgressRenderer(
     f: StepsTableFocus,
@@ -518,7 +540,8 @@ object StepsTable extends Columns {
                                row.step,
                                b.state.selected,
                                b.props.isPreview,
-                               b.props.tabOperations))
+                               b.props.tabOperations)
+      )
 
   def stepStatusRenderer(
     offsetsDisplay: OffsetsDisplay
@@ -706,7 +729,8 @@ object StepsTable extends Columns {
   // Columns for the table
   private def colBuilder(
     b:    Backend,
-    size: Size): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb => {
+    size: Size
+  ): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb => {
     def updateState(s: TableState[TableColumn]): Callback =
       (b.modState(State.tableState.set(s)) *> b.props.obsId
         .map(i => SeqexecCircuit.dispatchCB(UpdateStepTableState(i, s)))
@@ -725,11 +749,13 @@ object StepsTable extends Columns {
                               size,
                               updateState,
                               b.props.visibleColumns,
-                              b.props.columnWidths)),
+                              b.props.columnWidths)
+            ),
             headerClassName = headerClassName(meta.column).foldMap(_.htmlClass),
             cellRenderer    = columnCellRenderer(b, meta.column),
             className       = columnClassName(meta.column).foldMap(_.htmlClass)
-          ))
+          )
+        )
       case ColumnRenderArgs(meta, _, width, false) =>
         Column(
           Column.propsNoFlex(
@@ -740,7 +766,8 @@ object StepsTable extends Columns {
             headerClassName = headerClassName(meta.column).foldMap(_.htmlClass),
             cellRenderer    = columnCellRenderer(b, meta.column),
             className       = columnClassName(meta.column).foldMap(_.htmlClass)
-          ))
+          )
+        )
     }
   }
 
@@ -813,7 +840,7 @@ object StepsTable extends Columns {
           ^.cls := "ui center aligned segment noRows",
           ^.height := size.height.px,
           "No Steps"
-      ),
+        ),
       overscanRowCount = SeqexecStyles.overscanRowCount,
       height           = max(1, size.height.toInt),
       rowCount         = b.props.rowCount,
@@ -824,8 +851,8 @@ object StepsTable extends Columns {
       scrollToIndex    = startScrollToIndex(b),
       scrollTop        = startScrollTop(b.state),
       onRowClick       = singleClick(b),
-      onScroll = (a, _, pos) =>
-        updateScrollPosition(b, pos).when_(a.toDouble > 0),
+      onScroll =
+        (a, _, pos) => updateScrollPosition(b, pos).when_(a.toDouble > 0),
       scrollToAlignment = ScrollToAlignment.Center,
       headerClassName   = SeqexecStyles.tableHeader.htmlClass,
       headerHeight      = SeqexecStyles.headerHeight,
@@ -836,7 +863,8 @@ object StepsTable extends Columns {
   private def allowedClick(
     p:          Props,
     index:      Int,
-    onRowClick: Option[OnRowClick])(e: ReactMouseEvent): Callback =
+    onRowClick: Option[OnRowClick]
+  )(e:          ReactMouseEvent): Callback =
     // If alt is pressed or middle button flip the breakpoint
     if (e.altKey || e.button === MIDDLE_BUTTON) {
       (p.obsId, p.stepsList.find(_.id === index + 1))
@@ -844,8 +872,10 @@ object StepsTable extends Columns {
           (oid, step) =>
             SeqexecCircuit
               .dispatchCB(FlipBreakpointStep(oid, step))
-              .when_(step.canSetBreakpoint(index + 1, p.nextStepToRun)))
-        .getOrEmpty.when_(p.canSetBreakpoint)
+              .when_(step.canSetBreakpoint(index + 1, p.nextStepToRun))
+        )
+        .getOrEmpty
+        .when_(p.canSetBreakpoint)
     } else {
       onRowClick
         .filter(_ => e.clientX > ControlWidth)
@@ -906,8 +936,10 @@ object StepsTable extends Columns {
   // Scroll to pos on run requested
   private def scrollToCB(cur: Props, next: Props): Callback =
     scrollTo(next.nextStepToRun)
-      .when_(cur.tabOperations.runRequested =!= next.tabOperations.runRequested
-        && next.tabOperations.runRequested === RunOperation.RunInFlight)
+      .when_(
+        cur.tabOperations.runRequested =!= next.tabOperations.runRequested
+          && next.tabOperations.runRequested === RunOperation.RunInFlight
+      )
 
   private def selectStepCB(b: ReceiveProps): Callback = {
     val (cur: Props, next: Props) = (b.currentProps, b.nextProps)
@@ -978,7 +1010,7 @@ object StepsTable extends Columns {
       }.getOrEmpty
 
     scrollToCB(cur, next) *>
-    selectStepCB(b) *>
+      selectStepCB(b) *>
       selectedStepChangeCB(b) *>
       recalculateHeight
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceControl.scala
@@ -46,9 +46,6 @@ object SequenceControl {
     private val cancelPauseRequested: CancelPauseOperation =
       p.control.tabOperations.cancelPauseRequested
 
-    private val resourceInFlight: Boolean =
-      p.control.tabOperations.resourceInFlight
-
     private val syncIdle: Boolean =
       syncRequested === SyncOperation.SyncIdle
     private val runIdle: Boolean =
@@ -61,8 +58,8 @@ object SequenceControl {
     val canSync: Boolean =
       p.canOperate && syncIdle && runIdle
     val canRun: Boolean =
-      p.canOperate && runIdle && syncIdle && !resourceInFlight
-    val canPause: Boolean = p.canOperate && pauseIdle
+      p.canOperate && runIdle && syncIdle && !p.control.tabOperations.anyResourceInFlight
+    val canPause: Boolean       = p.canOperate && pauseIdle
     val canCancelPause: Boolean = p.canOperate && cancelPauseIdle
   }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SequenceTab.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/SequenceTab.scala
@@ -154,7 +154,8 @@ object SequenceTab {
             Label.Props(tabTitle,
                         color       = color.some,
                         icon        = icon.some,
-                        extraStyles = List(SeqexecStyles.labelPointer)))
+                        extraStyles = List(SeqexecStyles.labelPointer))
+          )
         )
 
       val resourceLabels =
@@ -163,19 +164,20 @@ object SequenceTab {
           resources.map {
             case (r, s) =>
               val color = s match {
-                case ResourceRunOperation.ResourceRunIdle      => "white"
-                case ResourceRunOperation.ResourceRunCompleted => "green"
-                case ResourceRunOperation.ResourceRunInFlight  => "yellow"
+                case ResourceRunOperation.ResourceRunIdle         => "white"
+                case ResourceRunOperation.ResourceRunCompleted(_) => "green"
+                case ResourceRunOperation.ResourceRunInFlight(_)  => "yellow"
+                case ResourceRunOperation.ResourceRunFailed(_)    => "red"
               }
               s match {
-                case ResourceRunOperation.ResourceRunInFlight =>
+                case ResourceRunOperation.ResourceRunInFlight(_) =>
                   Label(
                     Label.Props(r.show,
                                 color = color.some,
                                 size  = Size.Small,
                                 extraStyles = List(
                                   SeqexecStyles.activeResourceLabel))): VdomNode
-                case ResourceRunOperation.ResourceRunCompleted =>
+                case ResourceRunOperation.ResourceRunCompleted(_) =>
                   Label(Label.Props(r.show,
                                     color = color.some,
                                     size  = Size.Small)): VdomNode
@@ -193,7 +195,8 @@ object SequenceTab {
             Label.Props(tabTitle,
                         color       = color.some,
                         icon        = icon.some,
-                        extraStyles = List(SeqexecStyles.labelPointer)))
+                        extraStyles = List(SeqexecStyles.labelPointer))
+          )
         )
 
       val tabContent: VdomNode =
@@ -224,7 +227,9 @@ object SequenceTab {
         )
 
       linkTo(b.props, linkPage)(
-        if (isPreview) previewTabContent else tabContent)
+        if (isPreview) previewTabContent
+        else tabContent
+      )
     }
     .componentWillReceiveProps { f =>
       val preview = f.nextProps.tab.isPreview
@@ -235,7 +240,8 @@ object SequenceTab {
       val isLoading  = f.nextProps.tab.loading
       // Reset the loading state if the id changes
       Callback.when(preview && (id =!= newId || (wasLoading && !isLoading)))(
-        f.setState(State(false)))
+        f.setState(State(false))
+      )
     }
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -8,6 +8,9 @@ import cats.tests.CatsSuite
 import diode.data._
 import gem.arb.ArbEnumerated._
 import monocle.law.discipline.LensTests
+import monocle.law.discipline.PrismTests
+import monocle.law.discipline.OptionalTests
+import monocle.law.discipline.TraversalTests
 import org.scalajs.dom.WebSocket
 import seqexec.web.client.components.sequence.steps.StepConfigTable
 import seqexec.web.client.components.SessionQueueTable
@@ -42,11 +45,13 @@ final class ModelSpec extends CatsSuite with ArbitrariesWebClient {
            EqTests[AllObservationsProgressState].eqv)
   checkAll("Eq[SessionQueueFilter]", EqTests[SessionQueueFilter].eqv)
   checkAll("Eq[SectionVisibilityState]", EqTests[SectionVisibilityState].eqv)
-  checkAll("Eq[TableState[StepConfigTable.TableColumn]", EqTests[TableState[StepConfigTable.TableColumn]].eqv)
-  checkAll("Eq[TableState[SessionQueueTable.TableColumn]", EqTests[TableState[SessionQueueTable.TableColumn]].eqv)
+  checkAll("Eq[TableState[StepConfigTable.TableColumn]",
+           EqTests[TableState[StepConfigTable.TableColumn]].eqv)
+  checkAll("Eq[TableState[SessionQueueTable.TableColumn]",
+           EqTests[TableState[SessionQueueTable.TableColumn]].eqv)
   checkAll("Eq[SoundSelection]", EqTests[SoundSelection].eqv)
   checkAll("Eq[StepsTableTypeSelection]", EqTests[StepsTableTypeSelection].eqv)
-  // checkAll("Eq[SeqexecUIModel]", EqTests[SeqexecUIModel].eqv)
+  checkAll("Eq[SeqexecUIModel]", EqTests[SeqexecUIModel].eqv)
   checkAll("Eq[RunOperation]", EqTests[RunOperation].eqv)
   checkAll("Eq[SyncOperation]", EqTests[SyncOperation].eqv)
   checkAll("Eq[TabOperations]", EqTests[TabOperations].eqv)
@@ -54,10 +59,11 @@ final class ModelSpec extends CatsSuite with ArbitrariesWebClient {
   // lenses
   checkAll("Lens[SequenceTab, Option[Int]]", LensTests(SequenceTab.stepConfigL))
 
-  // Property generation errors
-  // checkAll("SeqexecTab.previewTab", PrismTests(SeqexecTab.previewTab))
-  // checkAll("SeqexecTab.instrumentTab", PrismTests(SeqexecTab.instrumentTab))
-  // checkAll("SeqexecTab.sequenceTab", PrismTests(SeqexecTab.sequenceTab))
-  // checkAll("SequencesOn.focusSequence", OptionalTests(SequencesOnDisplay.focusSequence))
-  // checkAll("SequencesOnDisplay.previewTab", TraversalTests(SequencesOnDisplay.previewTab))
+  checkAll("SeqexecTab.previewTab", PrismTests(SeqexecTab.previewTab))
+  checkAll("SeqexecTab.instrumentTab", PrismTests(SeqexecTab.instrumentTab))
+  checkAll("SeqexecTab.sequenceTab", PrismTests(SeqexecTab.sequenceTab))
+  checkAll("SequencesOn.focusSequence",
+           OptionalTests(SequencesOnDisplay.focusSequence))
+  checkAll("SequencesOnDisplay.previewTab",
+           TraversalTests(SequencesOnDisplay.previewTab))
 }


### PR DESCRIPTION
This is the first PR to properly show A&C. This is the minimum which is to display that we are running A&C but a next PR will show the steps while doing so

![Seqexec - GS-2018B-Q-0-116 2019-07-25 15-33-30](https://user-images.githubusercontent.com/3615303/61910126-bfd8df00-af01-11e9-8308-0a1c43741592.png)

While doing this PR I noted that subsystem failures were not properly displayed. That fix accounts for a big part of the size of this PR, but benefits all instruments

![Seqexec - GS-2018B-Q-0-116 2019-07-25 15-59-13](https://user-images.githubusercontent.com/3615303/61910168-dda64400-af01-11e9-902c-9c4afca49ecb.png)
