### PR TITLE
SEQNG-995B: Show the substeps of align and calib

### DIFF
--- a/modules/giapi/src/main/scala/giapi/client/GiapiStatusDb.scala
+++ b/modules/giapi/src/main/scala/giapi/client/GiapiStatusDb.scala
@@ -31,6 +31,8 @@ trait GiapiStatusDb[F[_]] {
   // Tries to read a value from the db and throws an exception in not found
   def value(i: String): F[StatusValue]
 
+  def discrete: Stream[F, Map[String, StatusValue]]
+
   private[giapi] def close: F[Unit]
 }
 
@@ -126,6 +128,9 @@ object GiapiStatusDb {
             new GiapiException("No values available in a simulated db")
           )
 
+      def discrete: Stream[F, Map[String, StatusValue]] =
+        Stream.empty
+
       def close: F[Unit] = Applicative[F].unit
     }
 
@@ -156,6 +161,9 @@ object GiapiStatusDb {
               _.isDefined
             )
             .map { _.orNull } // orNull lets us typecheck but it will never be used due to the `ensure` call above
+
+        def discrete: Stream[F, Map[String, StatusValue]] =
+          db.discrete
 
         def close: F[Unit] =
           for {

--- a/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
@@ -64,6 +64,11 @@ object Step {
       case _                  => false
     }
 
+    def isRunning: Boolean = s.status match {
+      case StepState.Running => true
+      case _                 => false
+    }
+
     def isObserving: Boolean = s match {
       case StandardStep(_, _, _, _, _, _, _, o) => o === ActionStatus.Running
       case _                                    => false

--- a/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
@@ -322,6 +322,14 @@ object events {
       Eq.by(_.telescope)
   }
 
+  final case class AlignAndCalibEvent(step: Int)
+      extends SeqexecEvent
+
+  object AlignAndCalibEvent {
+    implicit lazy val equal: Eq[AlignAndCalibEvent] =
+      Eq.by(_.step)
+  }
+
   implicit val equal: Eq[SeqexecEvent] =
     Eq.instance {
       case (a: ConnectionOpenEvent,      b: ConnectionOpenEvent)      => a === b
@@ -332,6 +340,7 @@ object events {
       case (a: GuideConfigUpdate,        b: GuideConfigUpdate)        => a === b
       case (a: ObservationProgressEvent, b: ObservationProgressEvent) => a === b
       case (a: SingleActionEvent,        b: SingleActionEvent)        => a === b
+      case (a: AlignAndCalibEvent,       b: AlignAndCalibEvent)       => a === b
       case (_: NullEvent.type,           _: NullEvent.type)           => true
       case _                                                          => false
     }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -211,6 +211,13 @@ trait SequenceEventsArbitraries extends ArbTime with ArbNotification {
       arbitrary[SequenceError]
     )
   }
+
+  implicit val acpArb = Arbitrary[AlignAndCalibEvent] {
+    for {
+      p <- Gen.posNum[Int]
+    } yield AlignAndCalibEvent(p)
+  }
+
   implicit val seArb = Arbitrary[SeqexecEvent] {
     Gen.oneOf[SeqexecEvent](
       arbitrary[SeqexecModelUpdate],
@@ -219,6 +226,7 @@ trait SequenceEventsArbitraries extends ArbTime with ArbNotification {
       arbitrary[ServerLogMessage],
       arbitrary[UserNotification],
       arbitrary[ObservationProgressEvent],
+      arbitrary[AlignAndCalibEvent],
       arbitrary[NullEvent.type]
     )
   }
@@ -311,6 +319,9 @@ trait SequenceEventsArbitraries extends ArbTime with ArbNotification {
 
   implicit val oprCogen: Cogen[ObservationProgressEvent] =
     Cogen[ObservationProgress].contramap(_.progress)
+
+  implicit val acpCogen: Cogen[AlignAndCalibEvent] =
+    Cogen[Int].contramap(_.step)
 
 }
 

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -429,6 +429,18 @@ body {
   margin-bottom: 1em;
 }
 
+.SeqexecStyles-acProgressRow {
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: @table_row_left_padding;
+  z-index: 100;
+  position: relative;
+  margin-left: 20px;
+}
+
 .SeqexecStyles-observationProgressBar {
   margin: 0 !important;
   width: 100%;
@@ -729,6 +741,7 @@ body {
   min-width: 21px;
   .borderRight();
   position: relative;
+  z-index: 0;
 }
 
 .SeqexecStyles-controlCell {
@@ -736,10 +749,12 @@ body {
   justify-content: space-around;
   align-items: center;
   min-width: 42.3px;
+  align-self: flex-start;
 }
 
 .breakPointHandle() {
   position: relative;
+  z-index: 200;
   left: 3.82px;
   top: -4px;
   height: 13px;
@@ -784,6 +799,7 @@ body {
   min-width: 24px;
   height: 100%;
   align-items: center;
+  align-self: flex-start;
   width: 100%;
   display: flex;
 }
@@ -793,6 +809,7 @@ body {
   min-width: 24px;
   height: 100%;
   align-items: center;
+  align-self: flex-start;
   width: 100%;
   display: flex;
 }
@@ -802,6 +819,7 @@ body {
   min-width: 24px;
   height: 100%;
   align-items: center;
+  align-self: flex-start;
   width: 100%;
   display: flex;
   padding-bottom: 8px;
@@ -812,6 +830,7 @@ body {
   min-width: 24px;
   height: 100%;
   align-items: center;
+  align-self: flex-start;
   width: 100%;
   display: flex;
   padding-right: 10px;
@@ -1119,6 +1138,20 @@ body {
   padding: 0px;
 }
 
+.SeqexecStyles-expandedRunningRow {
+  display: flex;
+  flex-direction: column;
+}
+.SeqexecStyles-expandedTopRow {
+  height: 50%;
+}
+.SeqexecStyles-expandedBottomRow {
+  height: 50%;
+  background: @secondaryBackground;
+  position: relative;
+  z-index: 100;
+  border-top: @border;
+}
 .SeqexecStyles-errorIcon {
   .queueText;
   margin-bottom: 6px !important;

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
@@ -116,6 +116,9 @@ object SeqexecCircuit
   val queueFocusRW: ModelRW[SeqexecAppRootModel, QueueRequestsFocus] =
     this.zoomRWL(QueueRequestsFocus.unsafeQueueRequestsFocusL)
 
+  val acProgressRW: ModelRW[SeqexecAppRootModel, AlignAndCalibStep] =
+    this.zoomRWL(SeqexecAppRootModel.alignAndCalib)
+
   def sequenceTab(
     id: Observation.Id
   ): ModelR[SeqexecAppRootModel, Option[SeqexecTabActive]] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/WebSocketFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/WebSocketFocus.scala
@@ -12,6 +12,7 @@ import seqexec.model._
 import seqexec.web.client.model.Pages
 import seqexec.web.client.model.SeqexecAppRootModel
 import seqexec.web.client.model.SoundSelection
+import seqexec.web.client.model.AlignAndCalibStep
 
 @Lenses
 final case class WebSocketsFocus(location:        Pages.SeqexecPages,
@@ -22,7 +23,8 @@ final case class WebSocketsFocus(location:        Pages.SeqexecPages,
                                  site:            Option[Site],
                                  sound:           SoundSelection,
                                  serverVersion:   Option[String],
-                                 guideConfig:     TelescopeGuideConfig)
+                                 guideConfig:     TelescopeGuideConfig,
+                                 alignAndCalib:   AlignAndCalibStep)
 
 object WebSocketsFocus {
   implicit val eq: Eq[WebSocketsFocus] =
@@ -35,7 +37,8 @@ object WebSocketsFocus {
          x.clientId,
          x.site,
          x.serverVersion,
-         x.guideConfig))
+         x.guideConfig,
+         x.alignAndCalib))
 
   val webSocketFocusL: Lens[SeqexecAppRootModel, WebSocketsFocus] =
     Lens[SeqexecAppRootModel, WebSocketsFocus](
@@ -48,7 +51,8 @@ object WebSocketsFocus {
                         m.site,
                         m.uiModel.sound,
                         m.serverVersion,
-                        m.guideConfig))(
+                        m.guideConfig,
+                        m.alignAndCalib))(
       v =>
         m =>
           m.copy(
@@ -59,6 +63,7 @@ object WebSocketsFocus {
             clientId      = v.clientId,
             site          = v.site,
             serverVersion = v.serverVersion,
-            guideConfig   = v.guideConfig
+            guideConfig   = v.guideConfig,
+            alignAndCalib = v.alignAndCalib
       ))
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -14,8 +14,21 @@ object SeqexecStyles {
   val rowHeight: Int           = 30
   val overscanRowCount: Int    = 10
   val runningRowHeight: Int    = 60
+  val runningBottomRowHeight: Int    = 60
   val TableBorderWidth: Double = 1.0
   val TableRightPadding: Int   = 13
+
+  val acProgressRow: Css =
+    Css("SeqexecStyles-acProgressRow")
+
+  val expandedRunningRow: Css =
+    Css("SeqexecStyles-expandedRunningRow")
+
+  val expandedTopRow: Css =
+    Css("SeqexecStyles-expandedTopRow")
+
+  val expandedBottomRow: Css =
+    Css("SeqexecStyles-expandedBottomRow")
 
   val activeGuide: Css =
     Css("SeqexecStyles-activeGuide")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/AlignAndCalibProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/AlignAndCalibProgress.scala
@@ -1,0 +1,130 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components.sequence.steps
+
+import cats.Show
+import cats.implicits._
+import gem.util.Enumerated
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.Reusability
+import japgolly.scalajs.react.MonocleReact._
+import monocle.macros.Lenses
+import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.circuit.SeqexecCircuit
+import seqexec.web.client.reusability._
+import seqexec.web.client.semanticui.elements.progress.Progress
+import seqexec.web.client.model.AlignAndCalibStep
+import seqexec.web.client.model.AlignAndCalibStep._
+import seqexec.web.client.model.StepItems.StepStateSnapshot
+import seqexec.web.client.reusability._
+import scala.math.max
+
+object ACProgressBar {
+  final case class Props(step: AlignAndCalibStep, state: StepStateSnapshot)
+
+  @Lenses
+  final case class State(counter: Int, msg: String)
+
+  object State {
+    def initialStateFromProps(p: Props): State = p.step match {
+      case Done => State(0, "Preparing...")
+      case x    => State(stepsOrdering.indexOf(x), x.show)
+    }
+  }
+
+  implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.never
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+  implicit val stateReuse: Reusability[State] = Reusability.derive[State]
+
+  val enum = Enumerated[AlignAndCalibStep]
+  implicit val showACS: Show[AlignAndCalibStep] = Show.show {
+    case NoAction           => ""
+    case StartGuiding       => "Start Guiding"
+    case StopGuiding        => "Stop Guiding"
+    case SuperContOff       => "SuperContinuum Off"
+    case OMSSEntShutterOff  => "Entrance shutter closed"
+    case CalExistShutterOff => "CAL Exit shutter closed"
+    case ArtSourceDeploy    => "Artificial Source deploy"
+    case AoDarks            => "Take AO Darks"
+    case SuperContOn        => "SuperContinumm On"
+    case CalFlags           => "Set CAL flags"
+    case Twt2Lens           => "TWT to Lens"
+    case CalExitShutterOn   => "CAL Exit shutten opened"
+    case ArtSourceExtract   => "Artificial Source extract"
+    case OMSSEntShutterOn   => "Entrance shutter opened"
+    case InputFoldTracking  => "Input fold tracking"
+    case Done               => "Done"
+  }
+
+  // The typical AC sequence is like this
+  // We use it to guestimate the location when the component is created
+  val stepsOrdering = List(
+    SuperContOff,
+    OMSSEntShutterOff,
+    CalExistShutterOff,
+    ArtSourceDeploy,
+    AoDarks,
+    SuperContOn,
+    CalFlags,
+    Twt2Lens,
+    StartGuiding,
+    StopGuiding,
+    SuperContOff,
+    ArtSourceExtract,
+    OMSSEntShutterOn,
+    InputFoldTracking,
+    Done
+  )
+
+  private val component = ScalaComponent
+    .builder[Props]("ACProgressBar")
+    .initialStateFromProps(State.initialStateFromProps)
+    .render_PS { (p, s) =>
+      val isInError = !p.state.isACRunning && p.state.isACInError
+      val msg = if (isInError) "Error" else s.msg
+      Progress(Progress.Props(
+        s"Align and Calib: $msg",
+        total       = enum.all.length.toLong - 1,
+        value       = max(0, s.counter.toLong),
+        color       = if (isInError) "red".some else "green".some,
+        progressCls = List(SeqexecStyles.observationProgressBar),
+        barCls      = List(SeqexecStyles.observationBar),
+        labelCls    = List(SeqexecStyles.observationLabel)
+      ))
+    }
+    .componentWillReceiveProps(x =>
+      x.modStateL(State.counter)(_ + 1) >> x.setStateL(State.msg)(x.nextProps.step.show))
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(p: Props): Unmounted[Props, State, Unit] = component(p)
+}
+
+/**
+  * Component to wrap the progress bar
+  */
+object AlignAndCalibProgress {
+  final case class Props(state: StepStateSnapshot) {
+    protected[steps] val connect =
+      SeqexecCircuit.connect(SeqexecCircuit.acProgressRW)
+  }
+
+  implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.never
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+
+  private val component = ScalaComponent
+    .builder[Props]("AlignAndCalibProgress")
+    .stateless
+    .render_P(p =>
+        p.connect{s =>
+          ACProgressBar(ACProgressBar.Props(s(), p.state))
+        }
+    )
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
@@ -70,7 +70,7 @@ object SmoothProgressBar {
   }
 
   private val component = ScalaComponent
-    .builder[Props]("ObservationProgressBar")
+    .builder[Props]("SmoothProgressBar")
     .initialStateFromProps(State.fromProps)
     .backend(x => new Backend(x))
     .render_PS { (p, s) =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
@@ -53,7 +53,7 @@ object StepBreakStopCell {
       SeqexecCircuit.dispatchCB(FlipSkipStep(p.obsId, p.step)))
 
   private val component = ScalaComponent
-    .builder[Props]("StepIconCell")
+    .builder[Props]("StepBreakStopCell")
     .stateless
     .render_P { p =>
       val canSetBreakpoint = p.clientStatus.canOperate && p.step

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
@@ -27,6 +27,7 @@ object StepToolsCell {
   final case class Props(clientStatus:       ClientStatus,
                          step:               Step,
                          rowHeight:          Int,
+                         secondRowHeight:    Int,
                          isPreview:          Boolean,
                          nextStepToRun:      Option[Int],
                          obsId:              Observation.Id,
@@ -60,7 +61,9 @@ object StepToolsCell {
         StepIconCell(
           StepIconCell.Props(p.step.status,
                              p.step.skip,
-                             p.nextStepToRun.forall(_ === p.step.id)))
+                             p.nextStepToRun.forall(_ === p.step.id),
+                             p.rowHeight - p.secondRowHeight
+                           ))
       )
     }
     .configure(Reusability.shouldComponentUpdate)
@@ -73,7 +76,7 @@ object StepToolsCell {
   * Component to display an icon for the state
   */
 object StepIconCell {
-  final case class Props(status: StepState, skip: Boolean, nextToRun: Boolean)
+  final case class Props(status: StepState, skip: Boolean, nextToRun: Boolean, height: Int)
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
@@ -108,6 +111,7 @@ object StepIconCell {
     .render_P(
       p =>
         <.div(
+          ^.height := p.height.px,
           stepStyle(p),
           stepIcon(p)
       ))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
@@ -21,6 +21,7 @@ import seqexec.web.client.model.lenses.sequenceStepT
 import seqexec.web.client.model.lenses.sequenceViewT
 import seqexec.web.client.model.ModelOps._
 import seqexec.web.client.model.SoundSelection
+import seqexec.web.client.model.AlignAndCalibStep
 import seqexec.web.client.actions._
 import seqexec.web.client.circuit._
 import seqexec.web.client.services.SeqexecWebClient
@@ -263,6 +264,11 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       updatedL(WebSocketsFocus.guideConfig.set(r.telescope))
   }
 
+  val acMessage: PartialFunction[Any, ActionResult[M]] = {
+    case ServerMessage(AlignAndCalibEvent(i)) =>
+      updatedL(WebSocketsFocus.alignAndCalib.set(AlignAndCalibStep.fromInt(i)))
+  }
+
   val defaultMessage: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(_) =>
       // Ignore unknown events
@@ -290,6 +296,7 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       modelUpdateMessage,
       singleRunCompleteMessage,
       guideConfigMessage,
+      acMessage,
       defaultMessage
     ).combineAll
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AlignAndCalibStep.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/AlignAndCalibStep.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.model
+
+import gem.util.Enumerated
+
+sealed trait AlignAndCalibStep extends Product with Serializable
+
+object AlignAndCalibStep {
+  case object NoAction extends AlignAndCalibStep
+  case object StartGuiding extends AlignAndCalibStep
+  case object StopGuiding extends AlignAndCalibStep
+  case object SuperContOff extends AlignAndCalibStep
+  case object OMSSEntShutterOff extends AlignAndCalibStep
+  case object CalExistShutterOff extends AlignAndCalibStep
+  case object ArtSourceDeploy extends AlignAndCalibStep
+  case object AoDarks extends AlignAndCalibStep
+  case object SuperContOn extends AlignAndCalibStep
+  case object CalFlags extends AlignAndCalibStep
+  case object Twt2Lens extends AlignAndCalibStep
+  case object CalExitShutterOn extends AlignAndCalibStep
+  case object ArtSourceExtract extends AlignAndCalibStep
+  case object OMSSEntShutterOn extends AlignAndCalibStep
+  case object InputFoldTracking extends AlignAndCalibStep
+  case object Done extends AlignAndCalibStep
+
+  /** @group Typeclass Instances */
+  implicit val AlignAndCalibStepEnumerated: Enumerated[AlignAndCalibStep] =
+    Enumerated.of(NoAction, StartGuiding, StopGuiding, SuperContOff, OMSSEntShutterOff, CalExistShutterOff, ArtSourceDeploy, AoDarks, SuperContOn, CalFlags, Twt2Lens, CalExitShutterOn, ArtSourceExtract, OMSSEntShutterOn, InputFoldTracking, Done)
+
+  def fromInt(i: Int): AlignAndCalibStep = i match {
+    case 0  => StartGuiding
+    case 1  => StopGuiding
+    case 2  => SuperContOff
+    case 3  => OMSSEntShutterOff
+    case 4  => CalExistShutterOff
+    case 5  => ArtSourceDeploy
+    case 6  => AoDarks
+    case 7  => SuperContOn
+    case 8  => CalFlags
+    case 9  => Twt2Lens
+    case 10 => CalExitShutterOn
+    case 11 => ArtSourceExtract
+    case 12 => OMSSEntShutterOn
+    case 13 => InputFoldTracking
+    case 14 => Done
+    case _  => NoAction
+  }
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -43,7 +43,8 @@ final case class SeqexecAppRootModel(
   clientId:      Option[ClientId],
   uiModel:       SeqexecUIModel,
   serverVersion: Option[String],
-  guideConfig:   TelescopeGuideConfig
+  guideConfig:   TelescopeGuideConfig,
+  alignAndCalib: AlignAndCalibStep
 )
 
 object SeqexecAppRootModel {
@@ -61,7 +62,8 @@ object SeqexecAppRootModel {
     none,
     SeqexecUIModel.Initial,
     none,
-    TelescopeGuideConfig(MountGuideOff, M1GuideOff, M2GuideOff)
+    TelescopeGuideConfig(MountGuideOff, M1GuideOff, M2GuideOff),
+    AlignAndCalibStep.NoAction
   )
 
   val logDisplayL: Lens[SeqexecAppRootModel, SectionVisibilityState] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -13,6 +13,7 @@ import seqexec.model.enum.Guiding
 import seqexec.model.enum.StepType
 import seqexec.model.Step
 import seqexec.model.StepState
+import seqexec.model.SequenceState
 import seqexec.model.enumerations
 import seqexec.model.OffsetAxis
 import seqexec.model.TelescopeOffset
@@ -218,6 +219,23 @@ object StepItems {
       val (p, q) = steps.sequenceOffsetWidths
       OffsetsDisplay.DisplayOffsets(scala.math.max(p, q))
     }
+  }
+
+  final case class StepStateSnapshot(step: Step, i: Instrument, t: TabOperations, state: SequenceState) {
+    val isAC: Boolean =
+      step.alignAndCalib(i).isDefined
+
+    val isACRunning: Boolean =
+      isAC && (t.resourceInFlight(step.id) || step.isRunning)
+
+    val anyError: Boolean =
+      t.resourceInError(step.id) || step.hasError
+
+    val isACInError: Boolean =
+      isAC && anyError
+
+    val displayDetails: Boolean =
+      isACRunning || isACInError
   }
 
 }

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -732,6 +732,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         sound       <- arbitrary[SoundSelection]
         serverVer   <- arbitrary[Option[String]]
         guideConf   <- arbitrary[TelescopeGuideConfig]
+        acStep      <- arbitrary[AlignAndCalibStep]
       } yield
         WebSocketsFocus(navLocation,
                         sequences,
@@ -741,7 +742,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
                         site,
                         sound,
                         serverVer,
-                        guideConf)
+                        guideConf,
+                        acStep)
     }
 
   implicit val wsfCogen: Cogen[WebSocketsFocus] =
@@ -753,7 +755,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
            Option[Site],
            SoundSelection,
            Option[String],
-           TelescopeGuideConfig)]
+           TelescopeGuideConfig,
+           AlignAndCalibStep)]
       .contramap(
         x =>
           (x.location,
@@ -764,7 +767,8 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
            x.site,
            x.sound,
            x.serverVersion,
-           x.guideConfig))
+           x.guideConfig,
+           x.alignAndCalib))
 
   implicit val arbInitialSyncFocus: Arbitrary[InitialSyncFocus] =
     Arbitrary {
@@ -789,7 +793,13 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         uiModel   <- arbitrary[SeqexecUIModel]
         version   <- arbitrary[Option[String]]
         guideConf <- arbitrary[TelescopeGuideConfig]
-      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel, version, guideConf)
+        acStep    <- arbitrary[AlignAndCalibStep]
+      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel, version, guideConf, acStep)
+    }
+
+  implicit val seqexecAppRootModelCogen: Cogen[SeqexecAppRootModel] =
+    Cogen[(SequencesQueue[SequenceView], WebSocketConnection, Option[Site], Option[ClientId], SeqexecUIModel, Option[String], TelescopeGuideConfig, AlignAndCalibStep)].contramap { x =>
+      (x.sequences, x.ws, x.site, x.clientId, x.uiModel, x.serverVersion, x.guideConfig, x.alignAndCalib)
     }
 
   implicit val arbAppTableStates: Arbitrary[AppTableStates] =

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ModelSpec.scala
@@ -52,9 +52,12 @@ final class ModelSpec extends CatsSuite with ArbitrariesWebClient {
   checkAll("Eq[SoundSelection]", EqTests[SoundSelection].eqv)
   checkAll("Eq[StepsTableTypeSelection]", EqTests[StepsTableTypeSelection].eqv)
   checkAll("Eq[SeqexecUIModel]", EqTests[SeqexecUIModel].eqv)
+  checkAll("Eq[SeqexecAppRootModel]", EqTests[SeqexecAppRootModel].eqv)
   checkAll("Eq[RunOperation]", EqTests[RunOperation].eqv)
   checkAll("Eq[SyncOperation]", EqTests[SyncOperation].eqv)
   checkAll("Eq[TabOperations]", EqTests[TabOperations].eqv)
+  checkAll("Eq[AlignAndCalibStep]", EqTests[AlignAndCalibStep].eqv)
+  checkAll("Eq[AppTableStates]", EqTests[AppTableStates].eqv)
 
   // lenses
   checkAll("Lens[SequenceTab, Option[Int]]", LensTests(SequenceTab.stepConfigL))

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -246,6 +246,7 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     transformPickler((t: Double) => t.milliseconds)(_.toMilliseconds)
   implicit val observationProgressPickler = generatePickler[ObservationProgress]
   implicit val obsProgressPickler         = generatePickler[ObservationProgressEvent]
+  implicit val acProgressPickler          = generatePickler[AlignAndCalibEvent]
   implicit val singleActionEventPickler   = generatePickler[SingleActionEvent]
   implicit val nullEventPickler           = generatePickler[NullEvent.type]
 
@@ -280,6 +281,7 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     .addConcreteType[QueueUpdated]
     .addConcreteType[ObservationProgressEvent]
     .addConcreteType[SingleActionEvent]
+    .addConcreteType[AlignAndCalibEvent]
     .addConcreteType[NullEvent.type]
 
   implicit val userLoginPickler = generatePickler[UserLoginRequest]

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
@@ -87,6 +87,7 @@ final class BoopicklingSpec extends CatsSuite with ModelBooPicklers with ArbObse
   checkAll("Pickler[ObservationProgress]",
            PicklerTests[ObservationProgress].pickler)
   checkAll("Pickler[SingleActionEvent]", PicklerTests[SingleActionEvent].pickler)
+  checkAll("Pickler[AlignAndCalibEvent]", PicklerTests[AlignAndCalibEvent].pickler)
   checkAll("Pickler[ComaOption]", PicklerTests[ComaOption].pickler)
   checkAll("Pickler[TipTiltSource]", PicklerTests[TipTiltSource].pickler)
   checkAll("Pickler[M1Source]", PicklerTests[M1Source].pickler)


### PR DESCRIPTION
Align and calib is a slow action but the instrument provides status as it progresses. This PR changes the UI to handle this case. It will expand a row with A&C and show the steps along a progress bar to provide feedback

The code is not too explanatory, so I'm attaching a video (It is recorded at 4x to make it more interesting). The video was recorded running with the actual hardware. There are a few minor cosmetic changes in the latest version but the core is the same. 

https://www.dropbox.com/s/vjh1q6buuv56vb9/acscreencast.mp4?dl=0

This same technique will be applied for Nod & Shuffle