### PR TITLE
SEQNG-331 Further refactorings

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -7,6 +7,11 @@ import cats._
 import cats.data.StateT
 import cats.effect.{Concurrent, IO}
 import cats.implicits._
+import fs2.Stream
+import gem.Observation
+import monocle.Optional
+import mouse.boolean._
+import org.log4s.getLogger
 import seqexec.engine.Event._
 import seqexec.engine.EventResult.UserCommandResponse
 import seqexec.engine.EventResult.SystemUpdate
@@ -15,11 +20,6 @@ import seqexec.engine.Result.{PartialVal, RetVal}
 import seqexec.engine.SystemEvent._
 import seqexec.engine.UserEvent._
 import seqexec.model.{ClientId, SequenceState, StepId}
-import fs2.Stream
-import gem.Observation
-import monocle.Optional
-import mouse.boolean._
-import org.log4s.getLogger
 
 class Engine[D, U](stateL: Engine.State[D]) {
 
@@ -54,7 +54,7 @@ class Engine[D, U](stateL: Engine.State[D]) {
       case None      => unit
     }
 
-  /*
+  /**
    * startFrom starts a sequence from an arbitrary step. It does it by marking all previous steps to be skipped and then
    * modifying the state sequence as if it was run.
    * If the requested step is already run or marked to be skipped, the sequence will start from the next runnable step
@@ -95,11 +95,13 @@ class Engine[D, U](stateL: Engine.State[D]) {
     x.map(p =>
       modifyS(c.sid)(_.startSingle(c.actCoords)) *>
       Handle.fromStream[D, EventType](
-        p.map{
-          case r@Result.OK(_)    => singleRunCompleted(c, r)
-          case e@Result.Error(_) => singleRunFailed(c, e)
-          case r                 =>
+        p.attempt.collect {
+          case Right(r@Result.OK(_))    => singleRunCompleted(c, r)
+          case Right(e@Result.Error(_)) => singleRunFailed(c, e)
+          case Right(r)                 =>
             singleRunFailed(c, Result.Error(s"Unhandled result for single run action: $r"))
+          case Left(r: Exception)       =>
+            singleRunFailed(c, Result.Error(s"Unhandled error for single run action: ${r.getMessage}"))
         }
       ).as[Outcome](Outcome.Ok)
     ).getOrElse(pure[Outcome](Outcome.Failure))
@@ -175,12 +177,13 @@ class Engine[D, U](stateL: Engine.State[D]) {
   private def act(id: Observation.Id, stepId: StepId, t: (Stream[IO, Result[IO]], Int))
   : Stream[IO, EventType] = t match {
     case (gen, i) =>
-      gen.map {
-        case r@Result.OK(_)        => completed(id, stepId, i, r)
-        case r@Result.OKStopped(_) => stopCompleted(id, stepId, i, r)
-        case r@Result.Partial(_)   => partial(id, stepId, i, r)
-        case e@Result.Error(_)     => failed(id, i, e)
-        case r@Result.Paused(_)    => paused[IO](id, i, r)
+      gen.attempt.collect {
+        case Right(r@Result.OK(_))        => completed(id, stepId, i, r)
+        case Right(r@Result.OKStopped(_)) => stopCompleted(id, stepId, i, r)
+        case Right(r@Result.Partial(_))   => partial(id, stepId, i, r)
+        case Right(e@Result.Error(_))     => failed(id, i, e)
+        case Right(r@Result.Paused(_))    => paused[IO](id, i, r)
+        case Left(t: Exception)           => failed(id, i, Result.Error(t.getMessage))
       }
   }
 

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Step.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Step.scala
@@ -53,7 +53,7 @@ object Step {
       // Find an error in the Step
       step.executions.flatten.find(Action.errored).flatMap { x => x.state.runState match {
         case ActionState.Failed(Result.Error(msg)) => msg.some
-        case _                                => None
+        case _                                     => None
         // Return error or continue with the rest of the checks
       }}.map[StepState](StepState.Failed).getOrElse(
         // All actions in this Step were completed successfully, or the Step is empty.

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
@@ -204,6 +204,30 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
     assert(result.isDefined)
   }
 
+  "engine" should "not capture runtime exceptions." in {
+    def s0(e: Throwable): TestState = TestState(
+      Map((seqId, Sequence.State.init(Sequence(
+        id = Observation.Id.unsafeFromString("GS-2018B-Q-0-4"),
+        steps = List(
+          Step.init(
+            id = 1,
+            executions = List(
+              List(fromF[IO](ActionType.Undefined,
+                IO.apply {
+                  throw e
+                }
+              ) )
+            )
+          )
+        )
+      ) ) ) )
+    )
+
+    assertThrows[java.lang.RuntimeException](
+      runToCompletion(s0(new java.lang.RuntimeException))
+    )
+  }
+
   it should "skip steps marked to be skipped at the beginning of the sequence." in {
     val s0: TestState = TestState(
       Map((seqId, Sequence.State.init(Sequence(

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
@@ -204,30 +204,6 @@ class packageSpec extends FlatSpec with NonImplicitAssertions {
     assert(result.isDefined)
   }
 
-  "engine" should "not capture runtime exceptions." in {
-    def s0(e: Throwable): TestState = TestState(
-      Map((seqId, Sequence.State.init(Sequence(
-        id = Observation.Id.unsafeFromString("GS-2018B-Q-0-4"),
-        steps = List(
-          Step.init(
-            id = 1,
-            executions = List(
-              List(fromF[IO](ActionType.Undefined,
-                IO.apply {
-                  throw e
-                }
-              ) )
-            )
-          )
-        )
-      ) ) ) )
-    )
-
-    assertThrows[java.lang.RuntimeException](
-      runToCompletion(s0(new java.lang.RuntimeException))
-    )
-  }
-
   it should "skip steps marked to be skipped at the beginning of the sequence." in {
     val s0: TestState = TestState(
       Map((seqId, Sequence.State.init(Sequence(

--- a/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
@@ -61,7 +61,7 @@ object Step {
 
     def hasError: Boolean = s.status match {
       case StepState.Failed(_) => true
-      case _                  => false
+      case _                   => false
     }
 
     def isRunning: Boolean = s.status match {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -4,7 +4,6 @@
 package seqexec.server
 
 import cats._
-import cats.data.EitherT
 import cats.data.Nested
 import cats.effect.Sync
 import cats.effect.Async
@@ -164,10 +163,6 @@ object EpicsCodex {
 }
 
 object EpicsUtil {
-  def safe[A](a: SeqAction[A]): SeqAction[A] = EitherT(a.value.attempt.map {
-    case Left(e)  => SeqexecException(e).asLeft
-    case Right(r) => r
-  })
 
   //`locked` gets a piece of code and runs it protected by `lock`
   private def locked[A](lock: ReentrantLock)(f: => A): A = {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
@@ -27,13 +27,13 @@ object StepType {
 
   implicit val eqStepType: Eq[StepType] = Eq.instance {
     case (CelestialObject(i), CelestialObject(j)) => i === j
-    case (Dark(i), Dark(j)) => i === j
-    case (NodAndShuffle(i), NodAndShuffle(j)) => i === j
-    case (Gems(i), Gems(j)) => i === j
-    case (AltairObs(i), AltairObs(j)) => i === j
-    case (FlatOrArc(i), FlatOrArc(j)) => i === j
-    case (DarkOrBias(i), DarkOrBias(j)) => i === j
-    case (AlignAndCalib, AlignAndCalib) => true
-    case _ => false
+    case (Dark(i), Dark(j))                       => i === j
+    case (NodAndShuffle(i), NodAndShuffle(j))     => i === j
+    case (Gems(i), Gems(j))                       => i === j
+    case (AltairObs(i), AltairObs(j))             => i === j
+    case (FlatOrArc(i), FlatOrArc(j))             => i === j
+    case (DarkOrBias(i), DarkOrBias(j))           => i === j
+    case (AlignAndCalib, AlignAndCalib)           => true
+    case _                                        => false
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/System.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/System.scala
@@ -12,11 +12,11 @@ trait System[F[_]] {
   /**
     * Called to configure a system
     */
-  def configure(config: Config): SeqActionF[F, ConfigResult[F]]
+  def configure(config: Config): F[ConfigResult[F]]
 
-  def notifyObserveStart: SeqActionF[F, Unit]
+  def notifyObserveStart: F[Unit]
 
-  def notifyObserveEnd: SeqActionF[F, Unit]
+  def notifyObserveEnd: F[Unit]
 }
 
 //Placeholder for config response

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorth.scala
@@ -18,7 +18,7 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.TELESCOPE_KEY
 import monocle.macros.Lenses
 import org.log4s.getLogger
 import seqexec.model.enum.Resource
-import seqexec.server.{ConfigResult, InstrumentSystem, SeqActionF, SeqexecFailure, System}
+import seqexec.server.{ConfigResult, InstrumentSystem, SeqexecFailure, System}
 import seqexec.server.altair.Altair
 import seqexec.server.altair.AltairController.AltairConfig
 import seqexec.server.tcs.TcsController._
@@ -54,16 +54,15 @@ class TcsNorth[F[_]: Sync: MonadError[?[_], Throwable]] private (tcsController: 
     }
   }
 
-  override def configure(config: Config): SeqActionF[F, ConfigResult[F]] = SeqActionF.embedF(
+  override def configure(config: Config): F[ConfigResult[F]] =
     buildTcsConfig.flatMap{ cfg =>
       Log.debug(s"Applying TCS configuration: ${subsystems.toList.flatMap(subsystemConfig(cfg, _))}").pure[F] *>
         tcsController.applyConfig(subsystems, gaos, cfg).as(ConfigResult(this))
     }
-  )
 
-  override def notifyObserveStart: SeqActionF[F, Unit] = SeqActionF.embedF(tcsController.notifyObserveStart)
+  override def notifyObserveStart: F[Unit] = tcsController.notifyObserveStart
 
-  override def notifyObserveEnd: SeqActionF[F, Unit] = SeqActionF.embedF(tcsController.notifyObserveEnd)
+  override def notifyObserveEnd: F[Unit] = tcsController.notifyObserveEnd
 
   val defaultGuiderConf = GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff)
   def calcGuiderConfig(inUse: Boolean, guideWith: Option[StandardGuideOptions.Value]): GuiderConfig =

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -75,7 +75,7 @@ class SeqTranslateSpec extends FlatSpec {
     .modify(_.start(0).mark(0)(Result.Partial(FileIdAllocated(fileId))))(baseState)
   // Observe paused
   private val s4: EngineState = EngineState.sequenceStateIndex(seqId)
-    .modify(_.mark(0)(Result.Paused(ObserveContext[IO](_ => SeqActionF(Result.OK(Observed
+    .modify(_.mark(0)(Result.Paused(ObserveContext[IO](_ => IO.pure(Result.OK(Observed
     (fileId))), Seconds(1)))))(baseState)
   // Observe failed
   private val s5: EngineState = EngineState.sequenceStateIndex(seqId)


### PR DESCRIPTION
This is a last refactoring to remove the usage of monad transformers preferring `F[A]` over `EitherT[F, Throwable, A]`

This seems to simplify the code quite a bit at the expense of requiring care to handle all errors at the appropriate places

This was tested on instrument (GPI) and in simulation in several scenarios. The change is very transparent for regular operations but it is bigger to handle exceptional cases