### PR TITLE
SEQNG-1028 Apply GeMS guiders tracking configuration.

### DIFF
--- a/modules/seqexec/server/src/main/resources/Tcs.xml
+++ b/modules/seqexec/server/src/main/resources/Tcs.xml
@@ -209,11 +209,6 @@
         </command>
         <command name="odgw3Park">
             <description>ODGW 3 park</description>
-            <parameter name="command">
-                <channel>odgw3Park.A</channel>
-                <type>STRING</type>
-                <description>Park command</description>
-            </parameter>
         </command>
         <command name="ngsPr1Park">
             <record>ngsPr1Park</record>
@@ -328,11 +323,6 @@
         </command>
         <command name="odgw1Park">
             <description>ODGW 1 park</description>
-            <parameter name="command">
-                <channel>odgw1Park.A</channel>
-                <type>STRING</type>
-                <description>Park command</description>
-            </parameter>
         </command>
         <command name="pwfs2Park">
             <record>pwfs2Park</record>
@@ -465,11 +455,6 @@
         </command>
         <command name="odgw4Park">
             <description>ODGW 4 park</description>
-            <parameter name="command">
-                <channel>odgw4Park.A</channel>
-                <type>STRING</type>
-                <description>Park command</description>
-            </parameter>
         </command>
         <command name="pwfs1StopObserve">
             <record>pwfs1StopObserve</record>
@@ -947,11 +932,6 @@
         </command>
         <command name="odgw2Park">
             <description>ODGW 2 park</description>
-            <parameter name="command">
-                <channel>odgw2Park.A</channel>
-                <type>STRING</type>
-                <description>Park command</description>
-            </parameter>
         </command>
         <command name="hrwfsPark">
             <record>hrwfsPark</record>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
@@ -14,13 +14,13 @@ import seqexec.model.enum.Resource
 import seqexec.server.TrySeq
 import seqexec.server.altair.AltairController._
 import seqexec.server.gems.GemsController.GemsConfig
-import seqexec.server.tcs.Gaos.{PauseResume, ResumeCondition}
+import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
 import seqexec.server.tcs.Gaos
 import squants.Time
 
 trait Altair[F[_]] extends Gaos[F] {
-  def pauseResume(config: AltairConfig, pauseReasons: Set[Gaos.PauseCondition],
-                  resumeReasons: Set[ResumeCondition]): F[PauseResume[F]]
+  def pauseResume(config: AltairConfig, pauseReasons: PauseConditionSet,
+                  resumeReasons: ResumeConditionSet): F[PauseResume[F]]
 
   val resource: Resource
 
@@ -39,8 +39,8 @@ object Altair {
   private class AltairImpl[F[_]: Sync] (controller: AltairController[F],
                                         fieldLens: FieldLens
                                        ) extends Altair[F] {
-    override def pauseResume(config: AltairConfig, pauseReasons: Set[Gaos.PauseCondition],
-                             resumeReasons: Set[ResumeCondition]): F[PauseResume[F]] =
+    override def pauseResume(config: AltairConfig, pauseReasons: PauseConditionSet,
+                             resumeReasons: ResumeConditionSet): F[PauseResume[F]] =
       controller.pauseResume(pauseReasons, resumeReasons, fieldLens)(config)
 
     override def observe(config: Either[AltairConfig, GemsConfig], expTime: Time): F[Unit] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairController.scala
@@ -5,14 +5,14 @@ package seqexec.server.altair
 
 import cats.Eq
 import cats.implicits._
-import seqexec.server.tcs.Gaos.{PauseCondition, PauseResume, ResumeCondition}
+import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
 import squants.Time
 import squants.space.Length
 
 trait AltairController[F[_]] {
   import AltairController._
 
-  def pauseResume(pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition], fieldLens: FieldLens)(
+  def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet, fieldLens: FieldLens)(
     cfg: AltairConfig): F[PauseResume[F]]
 
   def observe(expTime: Time)(cfg: AltairConfig): F[Unit]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -17,7 +17,7 @@ import edu.gemini.spModel.gemini.altair.AltairParams.FieldLens
 import monocle.macros.Lenses
 import seqexec.server.{SeqexecFailure, TrySeq}
 import seqexec.server.altair.AltairController._
-import seqexec.server.tcs.{FOCAL_PLANE_SCALE, Gaos, TcsEpics}
+import seqexec.server.tcs.{FOCAL_PLANE_SCALE, TcsEpics}
 import seqexec.server.tcs.Gaos._
 import seqexec.server.tcs.TcsController.FocalPlaneOffset
 import squants.{Length, Time}
@@ -73,14 +73,14 @@ object AltairControllerEpics extends AltairController[IO] {
   implicit val fieldLensEq: Eq[FieldLens] = Eq.by(_.ordinal)
 
   private def pauseNgsOrLgsMode(starPos: (Length, Length), fieldLens: FieldLens, currCfg: EpicsAltairConfig)(
-    reasons: Set[Gaos.PauseCondition])
+    reasons: Set[PauseCondition])
   : Option[(EpicsAltairConfig, IO[Unit])] = {
-    val offsets = reasons.collectFirst { case OffsetMove(p, n) => (p, n) }
+    val offsets = reasons.collectFirst { case PauseCondition.OffsetMove(p, n) => (p, n) }
     val newPos = offsets.map(u => newPosition(starPos)(u._2))
     val newPosOk = newPos.forall(newPosInRange)
     val matrixOk = newPos.forall(validateCurrentControlMatrix(currCfg, _)) || fieldLens === FieldLens.IN
     val prepMatrixOk = newPos.forall(validatePreparedControlMatrix(currCfg, _)) || fieldLens === FieldLens.IN
-    val guideOk = !reasons.contains(GaosGuideOff) //It can follow the guide star on this step
+    val guideOk = !reasons.contains(PauseCondition.GaosGuideOff) //It can follow the guide star on this step
 
     val needsToStop = !(newPosOk && matrixOk && guideOk)
 
@@ -103,7 +103,7 @@ object AltairControllerEpics extends AltairController[IO] {
   }
 
   private def pauseResumeNgsMode(starPos: (Length, Length), fieldLens: FieldLens, currCfg: EpicsAltairConfig)(
-    pauseReasons: Set[Gaos.PauseCondition], resumeReasons: Set[Gaos.ResumeCondition])
+    pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition])
   : PauseResume[IO] = {
     val pause = pauseNgsOrLgsMode(starPos, fieldLens, currCfg)(pauseReasons)
     val resume = resumeNgsOrLgsMode(starPos, pause.map(_._1).getOrElse(currCfg))(resumeReasons)
@@ -115,10 +115,10 @@ object AltairControllerEpics extends AltairController[IO] {
   val matrixPrepTimeout: Time = 10.seconds
 
   private def resumeNgsOrLgsMode(starPos: (Length, Length), currCfg: EpicsAltairConfig)(
-    reasons: Set[Gaos.ResumeCondition]): Option[IO[Unit]] = {
-    val offsets = reasons.collectFirst { case OffsetReached(o) => o }
+    reasons: Set[ResumeCondition]): Option[IO[Unit]] = {
+    val offsets = reasons.collectFirst { case ResumeCondition.OffsetReached(o) => o }
     val newPosOk = offsets.forall(v => newPosInRange(newPosition(starPos)(v)))
-    val guideOk = reasons.contains(GaosGuideOn)
+    val guideOk = reasons.contains(ResumeCondition.GaosGuideOn)
 
     (newPosOk && guideOk).option(
       (epicsAltair.waitMatrixCalc(CarStateGEM5.IDLE, matrixPrepTimeout) *>
@@ -196,7 +196,7 @@ object AltairControllerEpics extends AltairController[IO] {
 
   private def pauseResumeLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length), fieldLens: FieldLens,
                            currCfg: EpicsAltairConfig)(
-    pauseReasons: Set[Gaos.PauseCondition], resumeReasons: Set[Gaos.ResumeCondition]): PauseResume[IO] = {
+    pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition]): PauseResume[IO] = {
     val pause = pauseLgsMode(strap, sfo, starPos, fieldLens, currCfg)(pauseReasons)
     val resume = resumeLgsMode(strap, sfo, starPos)(pause.map(_._1).getOrElse(currCfg))(resumeReasons)
 
@@ -204,28 +204,28 @@ object AltairControllerEpics extends AltairController[IO] {
   }
 
   private def pauseLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length), fieldLens: FieldLens,
-                           currCfg: EpicsAltairConfig)(reasons: Set[Gaos.PauseCondition])
+                           currCfg: EpicsAltairConfig)(reasons: Set[PauseCondition])
   : Option[(EpicsAltairConfig, IO[Unit])] =
     pauseNgsOrLgsMode(starPos, fieldLens, currCfg)(reasons).filter(_ => strap || sfo)
       .map(_.bimap(ttgsOffEndo, ttgsOff(currCfg) *> _))
 
   private def resumeLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length))(currCfg: EpicsAltairConfig)(
-    reasons: Set[Gaos.ResumeCondition]): Option[IO[Unit]] =
+    reasons: Set[ResumeCondition]): Option[IO[Unit]] =
     resumeNgsOrLgsMode(starPos, currCfg)(reasons).filter(_ => strap || sfo).map(_ *> ttgsOn(strap, sfo, currCfg))
 
   /**
    * Modes LgsWithP1 and LgsWithOi don't use an Altair target. The only action required is to start or stop corrections
    */
   private def pauseResumeLgsWithXX(currCfg: EpicsAltairConfig)(
-      pauseReasons: Set[Gaos.PauseCondition], resumeReasons: Set[Gaos.ResumeCondition])
+      pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition])
   : PauseResume[IO] = {
-    val pause: Option[IO[Unit]] = (pauseReasons.contains(Gaos.GaosGuideOff) && currCfg.aoLoop).option{
+    val pause: Option[IO[Unit]] = (pauseReasons.contains(PauseCondition.GaosGuideOff) && currCfg.aoLoop).option{
       epicsTcs.aoCorrect.setCorrections(CorrectionsOff) *>
         epicsTcs.targetFilter.setShortCircuit(TargetFilterClosed) *>
         epicsTcs.targetFilter.post[IO].void
     }
-    val resume: Option[IO[Unit]] = (resumeReasons.contains(Gaos.GaosGuideOn) &&
-      (pauseReasons.contains(Gaos.GaosGuideOff) || !currCfg.aoLoop)
+    val resume: Option[IO[Unit]] = (resumeReasons.contains(ResumeCondition.GaosGuideOn) &&
+      (pauseReasons.contains(PauseCondition.GaosGuideOff) || !currCfg.aoLoop)
     ).option{
       epicsTcs.aoCorrect.setCorrections(CorrectionsOn) *>
         epicsTcs.aoFlatten.mark[IO] *>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -73,10 +73,10 @@ object AltairControllerEpics extends AltairController[IO] {
   implicit val fieldLensEq: Eq[FieldLens] = Eq.by(_.ordinal)
 
   private def pauseNgsOrLgsMode(starPos: (Length, Length), fieldLens: FieldLens, currCfg: EpicsAltairConfig)(
-    reasons: Set[PauseCondition])
+    reasons: PauseConditionSet)
   : Option[(EpicsAltairConfig, IO[Unit])] = {
-    val offsets = reasons.collectFirst { case PauseCondition.OffsetMove(p, n) => (p, n) }
-    val newPos = offsets.map(u => newPosition(starPos)(u._2))
+    val newOffset = reasons.offsetO.map(_.newOffset)
+    val newPos = newOffset.map(newPosition(starPos))
     val newPosOk = newPos.forall(newPosInRange)
     val matrixOk = newPos.forall(validateCurrentControlMatrix(currCfg, _)) || fieldLens === FieldLens.IN
     val prepMatrixOk = newPos.forall(validatePreparedControlMatrix(currCfg, _)) || fieldLens === FieldLens.IN
@@ -103,7 +103,7 @@ object AltairControllerEpics extends AltairController[IO] {
   }
 
   private def pauseResumeNgsMode(starPos: (Length, Length), fieldLens: FieldLens, currCfg: EpicsAltairConfig)(
-    pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition])
+    pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
   : PauseResume[IO] = {
     val pause = pauseNgsOrLgsMode(starPos, fieldLens, currCfg)(pauseReasons)
     val resume = resumeNgsOrLgsMode(starPos, pause.map(_._1).getOrElse(currCfg))(resumeReasons)
@@ -115,8 +115,8 @@ object AltairControllerEpics extends AltairController[IO] {
   val matrixPrepTimeout: Time = 10.seconds
 
   private def resumeNgsOrLgsMode(starPos: (Length, Length), currCfg: EpicsAltairConfig)(
-    reasons: Set[ResumeCondition]): Option[IO[Unit]] = {
-    val offsets = reasons.collectFirst { case ResumeCondition.OffsetReached(o) => o }
+    reasons: ResumeConditionSet): Option[IO[Unit]] = {
+    val offsets = reasons.offsetO.map(_.newOffset)
     val newPosOk = offsets.forall(v => newPosInRange(newPosition(starPos)(v)))
     val guideOk = reasons.contains(ResumeCondition.GaosGuideOn)
 
@@ -196,7 +196,7 @@ object AltairControllerEpics extends AltairController[IO] {
 
   private def pauseResumeLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length), fieldLens: FieldLens,
                            currCfg: EpicsAltairConfig)(
-    pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition]): PauseResume[IO] = {
+    pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet): PauseResume[IO] = {
     val pause = pauseLgsMode(strap, sfo, starPos, fieldLens, currCfg)(pauseReasons)
     val resume = resumeLgsMode(strap, sfo, starPos)(pause.map(_._1).getOrElse(currCfg))(resumeReasons)
 
@@ -204,20 +204,20 @@ object AltairControllerEpics extends AltairController[IO] {
   }
 
   private def pauseLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length), fieldLens: FieldLens,
-                           currCfg: EpicsAltairConfig)(reasons: Set[PauseCondition])
+                           currCfg: EpicsAltairConfig)(reasons: PauseConditionSet)
   : Option[(EpicsAltairConfig, IO[Unit])] =
     pauseNgsOrLgsMode(starPos, fieldLens, currCfg)(reasons).filter(_ => strap || sfo)
       .map(_.bimap(ttgsOffEndo, ttgsOff(currCfg) *> _))
 
   private def resumeLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length))(currCfg: EpicsAltairConfig)(
-    reasons: Set[ResumeCondition]): Option[IO[Unit]] =
+    reasons: ResumeConditionSet): Option[IO[Unit]] =
     resumeNgsOrLgsMode(starPos, currCfg)(reasons).filter(_ => strap || sfo).map(_ *> ttgsOn(strap, sfo, currCfg))
 
   /**
    * Modes LgsWithP1 and LgsWithOi don't use an Altair target. The only action required is to start or stop corrections
    */
   private def pauseResumeLgsWithXX(currCfg: EpicsAltairConfig)(
-      pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition])
+      pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
   : PauseResume[IO] = {
     val pause: Option[IO[Unit]] = (pauseReasons.contains(PauseCondition.GaosGuideOff) && currCfg.aoLoop).option{
       epicsTcs.aoCorrect.setCorrections(CorrectionsOff) *>
@@ -247,7 +247,7 @@ object AltairControllerEpics extends AltairController[IO] {
     None
   )
 
-  override def pauseResume(pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition],
+  override def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet,
                            fieldLens: FieldLens)(cfg: AltairConfig): IO[PauseResume[IO]] =
     retrieveConfig.map{ currCfg =>
       cfg match {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerSim.scala
@@ -6,13 +6,13 @@ import cats.effect.IO
 import cats.implicits._
 import org.log4s.getLogger
 import seqexec.server.altair.AltairController.FieldLens
-import seqexec.server.tcs.Gaos.{PauseCondition, PauseResume, ResumeCondition}
+import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
 import squants.Time
 
 object AltairControllerSim extends AltairController[IO] {
   private val Log = getLogger
 
-  override def pauseResume(pauseReasons: Set[PauseCondition], resumeReasons: Set[ResumeCondition], fieldLens: FieldLens)(cfg: AltairController.AltairConfig)
+  override def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet, fieldLens: FieldLens)(cfg: AltairController.AltairConfig)
   : IO[PauseResume[IO]] = IO{ PauseResume(
     IO(Log.info(s"Simulate pausing Altair loops because of $pauseReasons")).some,
     IO(Log.info(s"Simulatet restoring Altair configuration $cfg because of $resumeReasons")).some

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
@@ -8,14 +8,14 @@ import seqexec.server.altair.AltairController.AltairConfig
 import seqexec.server.gems.Gems.GemsGuiderStatus
 import seqexec.server.gems.GemsController.{GemsConfig, GemsOff}
 import seqexec.server.tcs.Gaos
-import seqexec.server.tcs.Gaos.{PauseResume, ResumeCondition}
+import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
 import squants.Time
 
 trait Gems[F[_]] extends Gaos[F] {
   val cfg: GemsConfig
 
-  def pauseResume(config: GemsConfig, pauseReasons: Set[Gaos.PauseCondition],
-                  resumeReasons: Set[ResumeCondition]): F[PauseResume[F]]
+  def pauseResume(config: GemsConfig, pauseReasons: PauseConditionSet,
+                  resumeReasons: ResumeConditionSet): F[PauseResume[F]]
 
   val stateGetter: GemsGuiderStatus[F]
 
@@ -32,8 +32,8 @@ object Gems {
     override def endObserve(config: Either[AltairConfig, GemsConfig]): F[Unit] = controller.endObserve
 
     override def pauseResume(config: GemsConfig,
-                             pauseReasons: Set[Gaos.PauseCondition],
-                             resumeReasons: Set[ResumeCondition]): F[PauseResume[F]] = {
+                             pauseReasons: PauseConditionSet,
+                             resumeReasons: ResumeConditionSet): F[PauseResume[F]] = {
       controller.pauseResume(cfg, pauseReasons, resumeReasons)
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
@@ -5,7 +5,7 @@ package seqexec.server.gems
 
 import cats.Applicative
 import seqexec.server.altair.AltairController.AltairConfig
-import seqexec.server.gems.Gems.GemsGuiderStatus
+import seqexec.server.gems.Gems.GemsWfsStatus
 import seqexec.server.gems.GemsController.{GemsConfig, GemsOff}
 import seqexec.server.tcs.Gaos
 import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
@@ -17,7 +17,7 @@ trait Gems[F[_]] extends Gaos[F] {
   def pauseResume(config: GemsConfig, pauseReasons: PauseConditionSet,
                   resumeReasons: ResumeConditionSet): F[PauseResume[F]]
 
-  val stateGetter: GemsGuiderStatus[F]
+  val stateGetter: GemsWfsStatus[F]
 
 }
 
@@ -37,13 +37,13 @@ object Gems {
       controller.pauseResume(cfg, pauseReasons, resumeReasons)
     }
 
-    override val stateGetter: GemsGuiderStatus[F] = controller.stateGetter
+    override val stateGetter: GemsWfsStatus[F] = controller.stateGetter
   }
 
   def fromConfig[F[_]: Applicative](controller: GemsController[F])/*(config: Config)*/: F[Gems[F]] =
     Applicative[F].pure(new GemsImpl[F](controller, GemsOff))
 
-  final case class GemsGuiderStatus[F[_]](
+  final case class GemsWfsStatus[F[_]](
     ngs1: F[Option[Boolean]],
     ngs2: F[Option[Boolean]],
     ngs3: F[Option[Boolean]],

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
@@ -5,7 +5,8 @@ package seqexec.server.gems
 
 import cats.Applicative
 import seqexec.server.altair.AltairController.AltairConfig
-import seqexec.server.gems.GemsController.{GemsConfig, GemsOff}
+import seqexec.server.gems.Gems.GemsGuiderStatus
+import seqexec.server.gems.GemsController.{GemsConfig, GemsOff, GemsOn}
 import seqexec.server.tcs.Gaos
 import seqexec.server.tcs.Gaos.{PauseResume, ResumeCondition}
 import squants.Time
@@ -15,8 +16,14 @@ trait Gems[F[_]] extends Gaos[F] {
 
   def pauseResume(config: GemsConfig, pauseReasons: Set[Gaos.PauseCondition],
                   resumeReasons: Set[ResumeCondition]): F[PauseResume[F]]
-}
 
+  def usesP1(guide: GemsConfig): Boolean
+
+  def usesOI(guide: GemsConfig): Boolean
+
+  val stateGetter: GemsGuiderStatus[F]
+
+}
 
 object Gems {
 
@@ -31,12 +38,35 @@ object Gems {
     override def pauseResume(config: GemsConfig,
                              pauseReasons: Set[Gaos.PauseCondition],
                              resumeReasons: Set[ResumeCondition]): F[PauseResume[F]] = {
-      Applicative[F].pure(PauseResume(None, None))
+      controller.pauseResume(cfg, pauseReasons, resumeReasons)
     }
+
+    override def usesP1(guide: GemsConfig): Boolean = guide match {
+      case GemsOn(_, _, _, _, _, _, _, _, useP1) => useP1
+      case _                                     => false
+    }
+
+    override def usesOI(guide: GemsConfig): Boolean = guide match {
+      case GemsOn(_, _, _, _, _, _, _, useOI, _) => useOI
+      case _                                     => false
+    }
+
+    override val stateGetter: GemsGuiderStatus[F] = controller.stateGetter
   }
 
   def fromConfig[F[_]: Applicative](controller: GemsController[F])/*(config: Config)*/: F[Gems[F]] =
     Applicative[F].pure(new GemsImpl[F](controller, GemsOff))
+
+  final case class GemsGuiderStatus[F[_]](
+    ngs1: F[Option[Boolean]],
+    ngs2: F[Option[Boolean]],
+    ngs3: F[Option[Boolean]],
+    odgw1: F[Option[Boolean]],
+    odgw2: F[Option[Boolean]],
+    odgw3: F[Option[Boolean]],
+    odgw4: F[Option[Boolean]]
+  )
+
 }
 
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
@@ -6,7 +6,7 @@ package seqexec.server.gems
 import cats.Applicative
 import seqexec.server.altair.AltairController.AltairConfig
 import seqexec.server.gems.Gems.GemsGuiderStatus
-import seqexec.server.gems.GemsController.{GemsConfig, GemsOff, GemsOn}
+import seqexec.server.gems.GemsController.{GemsConfig, GemsOff}
 import seqexec.server.tcs.Gaos
 import seqexec.server.tcs.Gaos.{PauseResume, ResumeCondition}
 import squants.Time
@@ -16,10 +16,6 @@ trait Gems[F[_]] extends Gaos[F] {
 
   def pauseResume(config: GemsConfig, pauseReasons: Set[Gaos.PauseCondition],
                   resumeReasons: Set[ResumeCondition]): F[PauseResume[F]]
-
-  def usesP1(guide: GemsConfig): Boolean
-
-  def usesOI(guide: GemsConfig): Boolean
 
   val stateGetter: GemsGuiderStatus[F]
 
@@ -39,16 +35,6 @@ object Gems {
                              pauseReasons: Set[Gaos.PauseCondition],
                              resumeReasons: Set[ResumeCondition]): F[PauseResume[F]] = {
       controller.pauseResume(cfg, pauseReasons, resumeReasons)
-    }
-
-    override def usesP1(guide: GemsConfig): Boolean = guide match {
-      case GemsOn(_, _, _, _, _, _, _, _, useP1) => useP1
-      case _                                     => false
-    }
-
-    override def usesOI(guide: GemsConfig): Boolean = guide match {
-      case GemsOn(_, _, _, _, _, _, _, useOI, _) => useOI
-      case _                                     => false
     }
 
     override val stateGetter: GemsGuiderStatus[F] = controller.stateGetter

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
@@ -3,9 +3,10 @@
 
 package seqexec.server.gems
 
-import cats.Applicative
+import cats.{Applicative, Eq}
+import cats.implicits._
 import seqexec.server.altair.AltairController.AltairConfig
-import seqexec.server.gems.Gems.GemsWfsStatus
+import seqexec.server.gems.Gems.GemsWfsState
 import seqexec.server.gems.GemsController.{GemsConfig, GemsOff}
 import seqexec.server.tcs.Gaos
 import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
@@ -17,7 +18,7 @@ trait Gems[F[_]] extends Gaos[F] {
   def pauseResume(config: GemsConfig, pauseReasons: PauseConditionSet,
                   resumeReasons: ResumeConditionSet): F[PauseResume[F]]
 
-  val stateGetter: GemsWfsStatus[F]
+  val stateGetter: GemsWfsState[F]
 
 }
 
@@ -37,20 +38,109 @@ object Gems {
       controller.pauseResume(cfg, pauseReasons, resumeReasons)
     }
 
-    override val stateGetter: GemsWfsStatus[F] = controller.stateGetter
+    override val stateGetter: GemsWfsState[F] = controller.stateGetter
   }
 
   def fromConfig[F[_]: Applicative](controller: GemsController[F])/*(config: Config)*/: F[Gems[F]] =
     Applicative[F].pure(new GemsImpl[F](controller, GemsOff))
 
-  final case class GemsWfsStatus[F[_]](
-    ngs1: F[Option[Boolean]],
-    ngs2: F[Option[Boolean]],
-    ngs3: F[Option[Boolean]],
-    odgw1: F[Option[Boolean]],
-    odgw2: F[Option[Boolean]],
-    odgw3: F[Option[Boolean]],
-    odgw4: F[Option[Boolean]]
+  trait DetectorStateOps[T] {
+    val trueVal: T
+    val falseVal: T
+  }
+
+  object DetectorStateOps {
+    def apply[T](implicit b: DetectorStateOps[T]): DetectorStateOps[T] = b
+
+    def build[T](t: T, f: T): DetectorStateOps[T] = new DetectorStateOps[T] {
+      override val trueVal: T = t
+      override val falseVal: T = f
+    }
+
+    def fromBoolean[T: DetectorStateOps](b: Boolean): T =
+      if(b) DetectorStateOps[T].trueVal else DetectorStateOps[T].falseVal
+
+    def isActive[T: DetectorStateOps: Eq](v: T): Boolean = v === DetectorStateOps[T].trueVal
+  }
+
+  sealed trait Ngs1DetectorState extends Product with Serializable
+  object Ngs1DetectorState {
+    case object On extends Ngs1DetectorState
+    case object Off extends Ngs1DetectorState
+
+    implicit val ngs1DetectorStateEq: Eq[Ngs1DetectorState] = Eq.fromUniversalEquals
+    implicit val ngs1DetectorStateDetectorStateOps: DetectorStateOps[Ngs1DetectorState] =
+      DetectorStateOps.build(On, Off)
+  }
+
+  sealed trait Ngs2DetectorState extends Product with Serializable
+  object Ngs2DetectorState {
+    case object On extends Ngs2DetectorState
+    case object Off extends Ngs2DetectorState
+
+    implicit val ngs2DetectorStateEq: Eq[Ngs2DetectorState] = Eq.fromUniversalEquals
+    implicit val ngs2DetectorStateDetectorStateOps: DetectorStateOps[Ngs2DetectorState] =
+      DetectorStateOps.build(On, Off)
+  }
+
+  sealed trait Ngs3DetectorState extends Product with Serializable
+  object Ngs3DetectorState {
+    case object On extends Ngs3DetectorState
+    case object Off extends Ngs3DetectorState
+
+    implicit val ngs3DetectorStateEq: Eq[Ngs3DetectorState] = Eq.fromUniversalEquals
+    implicit val ngs3DetectorStateDetectorStateOps: DetectorStateOps[Ngs3DetectorState] =
+      DetectorStateOps.build(On, Off)
+  }
+
+  sealed trait Odgw1DetectorState extends Product with Serializable
+  object Odgw1DetectorState {
+    case object On extends Odgw1DetectorState
+    case object Off extends Odgw1DetectorState
+
+    implicit val odgw1DetectorStateEq: Eq[Odgw1DetectorState] = Eq.fromUniversalEquals
+    implicit val odgw1DetectorStateDetectorStateOps: DetectorStateOps[Odgw1DetectorState] =
+      DetectorStateOps.build(On, Off)
+  }
+
+  sealed trait Odgw2DetectorState extends Product with Serializable
+  object Odgw2DetectorState {
+    case object On extends Odgw2DetectorState
+    case object Off extends Odgw2DetectorState
+
+    implicit val odgw2DetectorStateEq: Eq[Odgw2DetectorState] = Eq.fromUniversalEquals
+    implicit val odgw2DetectorStateDetectorStateOps: DetectorStateOps[Odgw2DetectorState] =
+      DetectorStateOps.build(On, Off)
+  }
+
+  sealed trait Odgw3DetectorState extends Product with Serializable
+  object Odgw3DetectorState {
+    case object On extends Odgw3DetectorState
+    case object Off extends Odgw3DetectorState
+
+    implicit val odgw3DetectorStateEq: Eq[Odgw3DetectorState] = Eq.fromUniversalEquals
+    implicit val odgw3DetectorStateDetectorStateOps: DetectorStateOps[Odgw3DetectorState] =
+      DetectorStateOps.build(On, Off)
+  }
+
+  sealed trait Odgw4DetectorState extends Product with Serializable
+  object Odgw4DetectorState {
+    case object On extends Odgw4DetectorState
+    case object Off extends Odgw4DetectorState
+
+    implicit val odgw4DetectorStateEq: Eq[Odgw4DetectorState] = Eq.fromUniversalEquals
+    implicit val odgw4DetectorStateDetectorStateOps: DetectorStateOps[Odgw4DetectorState] =
+      DetectorStateOps.build(On, Off)
+  }
+
+  final case class GemsWfsState[F[_]](
+    ngs1: F[Option[Ngs1DetectorState]],
+    ngs2: F[Option[Ngs2DetectorState]],
+    ngs3: F[Option[Ngs3DetectorState]],
+    odgw1: F[Option[Odgw1DetectorState]],
+    odgw2: F[Option[Odgw2DetectorState]],
+    odgw3: F[Option[Odgw3DetectorState]],
+    odgw4: F[Option[Odgw4DetectorState]]
   )
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
@@ -5,7 +5,7 @@ package seqexec.server.gems
 
 import cats.Eq
 import cats.implicits._
-import seqexec.server.gems.Gems.GemsWfsStatus
+import seqexec.server.gems.Gems.GemsWfsState
 import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
 import squants.Time
 
@@ -17,7 +17,7 @@ trait GemsController[F[_]] {
   def observe(expTime: Time): F[Unit]
   def endObserve: F[Unit]
 
-  val stateGetter: GemsWfsStatus[F]
+  val stateGetter: GemsWfsState[F]
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
@@ -5,7 +5,7 @@ package seqexec.server.gems
 
 import cats.Eq
 import cats.implicits._
-import seqexec.server.gems.Gems.GemsGuiderStatus
+import seqexec.server.gems.Gems.GemsWfsStatus
 import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
 import squants.Time
 
@@ -17,104 +17,129 @@ trait GemsController[F[_]] {
   def observe(expTime: Time): F[Unit]
   def endObserve: F[Unit]
 
-  val stateGetter: GemsGuiderStatus[F]
+  val stateGetter: GemsWfsStatus[F]
 
 }
 
 object GemsController {
 
-  sealed trait P1Usage
+  sealed trait P1Usage extends Product with Serializable
   object P1Usage {
-    case object UsesP1 extends P1Usage
-    case object DoesNotUseP1 extends P1Usage
+    case object UseP1 extends P1Usage
+    case object DontUseP1 extends P1Usage
 
-    implicit val p1UsageEq: Eq[P1Usage] = Eq.instance{
-      case (UsesP1, UsesP1)             => true
-      case (DoesNotUseP1, DoesNotUseP1) => true
-      case _                            => false
-    }
+    implicit val p1UsageEq: Eq[P1Usage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): P1Usage = if(b) UseP1 else DontUseP1
   }
 
-  sealed trait OIUsage
+  sealed trait OIUsage extends Product with Serializable
   object OIUsage {
-    case object UsesOI extends OIUsage
-    case object DoesNotUseOI extends OIUsage
+    case object UseOI extends OIUsage
+    case object DontUseOI extends OIUsage
 
-    implicit val oiUsageEq: Eq[OIUsage] = Eq.instance{
-      case (UsesOI, UsesOI)             => true
-      case (DoesNotUseOI, DoesNotUseOI) => true
-      case _                            => false
-    }
+    implicit val oiUsageEq: Eq[OIUsage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): OIUsage = if(b) UseOI else DontUseOI
   }
 
-  sealed trait GemsConfig {
-    val usesP1: Boolean
-    val usesOI: Boolean
+  sealed trait GemsConfig extends Product with Serializable {
+    val isP1Used: Boolean
+    val isOIUsed: Boolean
   }
 
   case object GemsOff extends GemsConfig {
-    override val usesP1: Boolean = false
-    override val usesOI: Boolean = false
+    override val isP1Used: Boolean = false
+    override val isOIUsed: Boolean = false
   }
 
-  sealed trait Ttgs1Active
-  object Ttgs1Active {
-    case object Ttgs1On extends Ttgs1Active
-    case object Ttgs1Off extends Ttgs1Active
+  sealed trait Ttgs1Usage extends Product with Serializable
+  object Ttgs1Usage {
+    case object UseTtgs1 extends Ttgs1Usage
+    case object DontUseTtgs1 extends Ttgs1Usage
+
+    implicit val ttgs1UsageEq: Eq[Ttgs1Usage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): Ttgs1Usage = if(b) UseTtgs1 else DontUseTtgs1
   }
 
-  sealed trait Ttgs2Active
-  object Ttgs2Active {
-    case object Ttgs2On extends Ttgs2Active
-    case object Ttgs2Off extends Ttgs2Active
+  sealed trait Ttgs2Usage extends Product with Serializable
+  object Ttgs2Usage {
+    case object UseTtgs2 extends Ttgs2Usage
+    case object DontUseTtgs2 extends Ttgs2Usage
+
+    implicit val ttgs2UsageEq: Eq[Ttgs2Usage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): Ttgs2Usage = if(b) UseTtgs2 else DontUseTtgs2
   }
 
-  sealed trait Ttgs3Active
-  object Ttgs3Active {
-    case object Ttgs3On extends Ttgs3Active
-    case object Ttgs3Off extends Ttgs3Active
+  sealed trait Ttgs3Usage extends Product with Serializable
+  object Ttgs3Usage {
+    case object UseTtgs3 extends Ttgs3Usage
+    case object DontUseTtgs3 extends Ttgs3Usage
+
+    implicit val ttgs3UsageEq: Eq[Ttgs3Usage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): Ttgs3Usage = if(b) UseTtgs3 else DontUseTtgs3
   }
 
-  sealed trait Odgw1Active
-  object Odgw1Active {
-    case object Odgw1On extends Odgw1Active
-    case object Odgw1Off extends Odgw1Active
+  sealed trait Odgw1Usage extends Product with Serializable
+  object Odgw1Usage {
+    case object UseOdgw1 extends Odgw1Usage
+    case object DontUseOdgw1 extends Odgw1Usage
+
+    implicit val odgw1UsageEq: Eq[Odgw1Usage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): Odgw1Usage = if(b) UseOdgw1 else DontUseOdgw1
   }
 
-  sealed trait Odgw2Active
-  object Odgw2Active {
-    case object Odgw2On extends Odgw2Active
-    case object Odgw2Off extends Odgw2Active
+  sealed trait Odgw2Usage extends Product with Serializable
+  object Odgw2Usage {
+    case object UseOdgw2 extends Odgw2Usage
+    case object DontUseOdgw2 extends Odgw2Usage
+
+    implicit val odgw2UsageEq: Eq[Odgw2Usage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): Odgw2Usage = if(b) UseOdgw2 else DontUseOdgw2
   }
 
-  sealed trait Odgw3Active
-  object Odgw3Active {
-    case object Odgw3On extends Odgw3Active
-    case object Odgw3Off extends Odgw3Active
+  sealed trait Odgw3Usage extends Product with Serializable
+  object Odgw3Usage {
+    case object UseOdgw3 extends Odgw3Usage
+    case object DontUseOdgw3 extends Odgw3Usage
+
+    implicit val odgw3UsageEq: Eq[Odgw3Usage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): Odgw3Usage = if(b) UseOdgw3 else DontUseOdgw3
   }
 
-  sealed trait Odgw4Active
-  object Odgw4Active {
-    case object Odgw4On extends Odgw4Active
-    case object Odgw4Off extends Odgw4Active
-  }
+  sealed trait Odgw4Usage extends Product with Serializable
+  object Odgw4Usage {
+    case object UseOdgw4 extends Odgw4Usage
+    case object DontUseOdgw4 extends Odgw4Usage
 
-  import P1Usage._
-  import OIUsage._
+    implicit val odgw4UsageEq: Eq[Odgw4Usage] = Eq.fromUniversalEquals
+
+    def fromBoolean(b: Boolean): Odgw4Usage = if(b) UseOdgw4 else DontUseOdgw4
+  }
 
   final case class GemsOn(
-    ttgs1: Ttgs1Active,
-    ttgs2: Ttgs2Active,
-    ttgs3: Ttgs3Active,
-    odgw1: Odgw1Active,
-    odgw2: Odgw2Active,
-    odgw3: Odgw3Active,
-    odgw4: Odgw4Active,
-    useP1: P1Usage,
-    useOI: OIUsage
+                           ttgs1: Ttgs1Usage,
+                           ttgs2: Ttgs2Usage,
+                           ttgs3: Ttgs3Usage,
+                           odgw1: Odgw1Usage,
+                           odgw2: Odgw2Usage,
+                           odgw3: Odgw3Usage,
+                           odgw4: Odgw4Usage,
+                           useP1: P1Usage,
+                           useOI: OIUsage
   ) extends GemsConfig {
-    override val usesP1: Boolean = useP1 === UsesP1
-    override val usesOI: Boolean = useOI === UsesOI
+
+    import P1Usage._
+    override val isP1Used: Boolean = useP1 === UseP1
+
+    import OIUsage._
+    override val isOIUsed: Boolean = useOI === UseOI
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
@@ -3,16 +3,19 @@
 
 package seqexec.server.gems
 
-import seqexec.server.tcs.Gaos.{PauseCondition, ResumeCondition}
+import seqexec.server.gems.Gems.GemsGuiderStatus
+import seqexec.server.tcs.Gaos.{PauseCondition, PauseResume, ResumeCondition}
 import squants.Time
 
 trait GemsController[F[_]] {
   import GemsController._
 
-  def pause(reasons: Set[PauseCondition]): F[Unit]
-  def resume(reasons: Set[ResumeCondition], config: GemsConfig): F[Unit]
+  def pauseResume(config: GemsConfig, pauseReasons: Set[PauseCondition],
+                  resumeReasons: Set[ResumeCondition]): F[PauseResume[F]]
   def observe(expTime: Time): F[Unit]
   def endObserve: F[Unit]
+
+  val stateGetter: GemsGuiderStatus[F]
 
 }
 
@@ -29,8 +32,9 @@ object GemsController {
     odgw1: Boolean,
     odgw2: Boolean,
     odgw3: Boolean,
-    odgw4: Boolean
+    odgw4: Boolean,
+    useOI: Boolean,
+    useP1: Boolean
   ) extends GemsConfig
 
 }
-

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
@@ -3,6 +3,8 @@
 
 package seqexec.server.gems
 
+import cats.Eq
+import cats.implicits._
 import seqexec.server.gems.Gems.GemsGuiderStatus
 import seqexec.server.tcs.Gaos.{PauseCondition, PauseResume, ResumeCondition}
 import squants.Time
@@ -21,20 +23,98 @@ trait GemsController[F[_]] {
 
 object GemsController {
 
-  sealed trait GemsConfig
+  sealed trait P1Usage
+  object P1Usage {
+    case object UsesP1 extends P1Usage
+    case object DoesNotUseP1 extends P1Usage
 
-  case object GemsOff extends GemsConfig
+    implicit val p1UsageEq: Eq[P1Usage] = Eq.instance{
+      case (UsesP1, UsesP1)             => true
+      case (DoesNotUseP1, DoesNotUseP1) => true
+      case _                            => false
+    }
+  }
+
+  sealed trait OIUsage
+  object OIUsage {
+    case object UsesOI extends OIUsage
+    case object DoesNotUseOI extends OIUsage
+
+    implicit val oiUsageEq: Eq[OIUsage] = Eq.instance{
+      case (UsesOI, UsesOI)             => true
+      case (DoesNotUseOI, DoesNotUseOI) => true
+      case _                            => false
+    }
+  }
+
+  sealed trait GemsConfig {
+    val usesP1: Boolean
+    val usesOI: Boolean
+  }
+
+  case object GemsOff extends GemsConfig {
+    override val usesP1: Boolean = false
+    override val usesOI: Boolean = false
+  }
+
+  sealed trait Ttgs1Active
+  object Ttgs1Active {
+    case object Ttgs1On extends Ttgs1Active
+    case object Ttgs1Off extends Ttgs1Active
+  }
+
+  sealed trait Ttgs2Active
+  object Ttgs2Active {
+    case object Ttgs2On extends Ttgs2Active
+    case object Ttgs2Off extends Ttgs2Active
+  }
+
+  sealed trait Ttgs3Active
+  object Ttgs3Active {
+    case object Ttgs3On extends Ttgs3Active
+    case object Ttgs3Off extends Ttgs3Active
+  }
+
+  sealed trait Odgw1Active
+  object Odgw1Active {
+    case object Odgw1On extends Odgw1Active
+    case object Odgw1Off extends Odgw1Active
+  }
+
+  sealed trait Odgw2Active
+  object Odgw2Active {
+    case object Odgw2On extends Odgw2Active
+    case object Odgw2Off extends Odgw2Active
+  }
+
+  sealed trait Odgw3Active
+  object Odgw3Active {
+    case object Odgw3On extends Odgw3Active
+    case object Odgw3Off extends Odgw3Active
+  }
+
+  sealed trait Odgw4Active
+  object Odgw4Active {
+    case object Odgw4On extends Odgw4Active
+    case object Odgw4Off extends Odgw4Active
+  }
+
+  import P1Usage._
+  import OIUsage._
 
   final case class GemsOn(
-    ttgs1: Boolean,
-    ttgs2: Boolean,
-    ttgs3: Boolean,
-    odgw1: Boolean,
-    odgw2: Boolean,
-    odgw3: Boolean,
-    odgw4: Boolean,
-    useOI: Boolean,
-    useP1: Boolean
-  ) extends GemsConfig
+    ttgs1: Ttgs1Active,
+    ttgs2: Ttgs2Active,
+    ttgs3: Ttgs3Active,
+    odgw1: Odgw1Active,
+    odgw2: Odgw2Active,
+    odgw3: Odgw3Active,
+    odgw4: Odgw4Active,
+    useP1: P1Usage,
+    useOI: OIUsage
+  ) extends GemsConfig {
+    override val usesP1: Boolean = useP1 === UsesP1
+    override val usesOI: Boolean = useOI === UsesOI
+  }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsController.scala
@@ -6,14 +6,14 @@ package seqexec.server.gems
 import cats.Eq
 import cats.implicits._
 import seqexec.server.gems.Gems.GemsGuiderStatus
-import seqexec.server.tcs.Gaos.{PauseCondition, PauseResume, ResumeCondition}
+import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
 import squants.Time
 
 trait GemsController[F[_]] {
   import GemsController._
 
-  def pauseResume(config: GemsConfig, pauseReasons: Set[PauseCondition],
-                  resumeReasons: Set[ResumeCondition]): F[PauseResume[F]]
+  def pauseResume(config: GemsConfig, pauseReasons: PauseConditionSet,
+                  resumeReasons: ResumeConditionSet): F[PauseResume[F]]
   def observe(expTime: Time): F[Unit]
   def endObserve: F[Unit]
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Gaos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Gaos.scala
@@ -28,7 +28,7 @@ trait Gaos[F[_]] {
 }
 
 object Gaos {
-  sealed trait PauseCondition
+  sealed trait PauseCondition extends Product with Serializable
 
   object PauseCondition {
     // Telescope offset will be changed
@@ -42,7 +42,7 @@ object Gaos {
     // Instrument config (affects ODGW)
     case object InstConfigMove extends PauseCondition
 
-    implicit val becauseOffsetMoveEq: Eq[OffsetMove] = Eq.by(x => (x.previousOffset, x.newOffset))
+    implicit val offsetMoveEq: Eq[OffsetMove] = Eq.by(x => (x.previousOffset, x.newOffset))
 
     implicit val pauseReasonEq: Eq[PauseCondition] = Eq.instance {
       case (a: OffsetMove, b: OffsetMove) => a === b
@@ -53,7 +53,8 @@ object Gaos {
       case _ => false
     }
   }
-  sealed trait ResumeCondition
+
+  sealed trait ResumeCondition extends Product with Serializable
 
   object ResumeCondition {
     // Telescope offset will be changed
@@ -67,7 +68,7 @@ object Gaos {
     // Instrument config (affects ODGW)
     case object InstConfigCompleted extends ResumeCondition
 
-    implicit val becauseOffsetReachedEq: Eq[OffsetReached] = Eq.by(_.newOffset)
+    implicit val offsetReachedEq: Eq[OffsetReached] = Eq.by(_.newOffset)
 
     implicit val resumeReasonEq: Eq[ResumeCondition] = Eq.instance {
       case (a: OffsetReached, b: OffsetReached) => a === b

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Gaos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Gaos.scala
@@ -30,43 +30,53 @@ trait Gaos[F[_]] {
 object Gaos {
   sealed trait PauseCondition
 
-  // Telescope offset will be changed
-  final case class OffsetMove(previousOffset: FocalPlaneOffset, newOffset: FocalPlaneOffset) extends PauseCondition
-  // OI will be turn off
-  case object OiOff extends PauseCondition
-  // PI will be turn off
-  case object P1Off extends PauseCondition
-  // Unguided step
-  case object GaosGuideOff extends PauseCondition
+  object PauseCondition {
+    // Telescope offset will be changed
+    final case class OffsetMove(previousOffset: FocalPlaneOffset, newOffset: FocalPlaneOffset) extends PauseCondition
+    // OI will be turn off
+    case object OiOff extends PauseCondition
+    // PI will be turn off
+    case object P1Off extends PauseCondition
+    // Unguided step
+    case object GaosGuideOff extends PauseCondition
+    // Instrument config (affects ODGW)
+    case object InstConfigMove extends PauseCondition
 
-  sealed trait ResumeCondition
-  // Telescope offset will be changed
-  final case class OffsetReached(newOffset: FocalPlaneOffset) extends ResumeCondition
-  // OI will be turn off
-  case object OiOn extends ResumeCondition
-  // PI will be turn off
-  case object P1On extends ResumeCondition
-  // Guided step
-  case object GaosGuideOn extends ResumeCondition
+    implicit val becauseOffsetMoveEq: Eq[OffsetMove] = Eq.by(x => (x.previousOffset, x.newOffset))
 
-  implicit val becauseOffsetMoveEq: Eq[OffsetMove] = Eq.by(x => (x.previousOffset, x.newOffset))
-
-  implicit val pauseReasonEq: Eq[PauseCondition] = Eq.instance{
-    case (a: OffsetMove, b: OffsetMove) => a === b
-    case (OiOff, OiOff)                 => true
-    case (P1Off, P1Off)                 => true
-    case (GaosGuideOff, GaosGuideOff)   => true
-    case _                              => false
+    implicit val pauseReasonEq: Eq[PauseCondition] = Eq.instance {
+      case (a: OffsetMove, b: OffsetMove) => a === b
+      case (OiOff, OiOff) => true
+      case (P1Off, P1Off) => true
+      case (GaosGuideOff, GaosGuideOff) => true
+      case (InstConfigMove, InstConfigMove) => true
+      case _ => false
+    }
   }
+  sealed trait ResumeCondition
 
-  implicit val becauseOffsetReachedEq: Eq[OffsetReached] = Eq.by(_.newOffset)
+  object ResumeCondition {
+    // Telescope offset will be changed
+    final case class OffsetReached(newOffset: FocalPlaneOffset) extends ResumeCondition
+    // OI will be turn off
+    case object OiOn extends ResumeCondition
+    // PI will be turn off
+    case object P1On extends ResumeCondition
+    // Guided step
+    case object GaosGuideOn extends ResumeCondition
+    // Instrument config (affects ODGW)
+    case object InstConfigCompleted extends ResumeCondition
 
-  implicit val resumeReasonEq: Eq[ResumeCondition] = Eq.instance{
-    case (a: OffsetReached, b: OffsetReached) => a === b
-    case (OiOn, OiOn)                         => true
-    case (P1On, P1On)                         => true
-    case (GaosGuideOn, GaosGuideOn)           => true
-    case _                                    => false
+    implicit val becauseOffsetReachedEq: Eq[OffsetReached] = Eq.by(_.newOffset)
+
+    implicit val resumeReasonEq: Eq[ResumeCondition] = Eq.instance {
+      case (a: OffsetReached, b: OffsetReached) => a === b
+      case (OiOn, OiOn) => true
+      case (P1On, P1On) => true
+      case (GaosGuideOn, GaosGuideOn) => true
+      case (InstConfigCompleted, InstConfigCompleted) => true
+      case _ => false
+    }
   }
 
   sealed case class PauseResume[F[_]](

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Gaos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Gaos.scala
@@ -3,10 +3,12 @@
 
 package seqexec.server.tcs
 
-import cats.Eq
+import cats.{Eq, Show}
 import cats.implicits._
 import seqexec.server.altair.AltairController.AltairConfig
 import seqexec.server.gems.GemsController.GemsConfig
+import seqexec.server.tcs.Gaos.PauseCondition.{FixedPauseCondition, OffsetMove}
+import seqexec.server.tcs.Gaos.ResumeCondition.{FixedResumeCondition, OffsetReached}
 import seqexec.server.tcs.TcsController.FocalPlaneOffset
 import squants.Time
 
@@ -32,26 +34,61 @@ object Gaos {
 
   object PauseCondition {
     // Telescope offset will be changed
-    final case class OffsetMove(previousOffset: FocalPlaneOffset, newOffset: FocalPlaneOffset) extends PauseCondition
+    final case class OffsetMove(newOffset: FocalPlaneOffset) extends PauseCondition
+
+    sealed trait FixedPauseCondition extends PauseCondition
+
     // OI will be turn off
-    case object OiOff extends PauseCondition
+    case object OiOff extends FixedPauseCondition
     // PI will be turn off
-    case object P1Off extends PauseCondition
+    case object P1Off extends FixedPauseCondition
     // Unguided step
-    case object GaosGuideOff extends PauseCondition
+    case object GaosGuideOff extends FixedPauseCondition
     // Instrument config (affects ODGW)
-    case object InstConfigMove extends PauseCondition
+    case object InstConfigMove extends FixedPauseCondition
 
-    implicit val offsetMoveEq: Eq[OffsetMove] = Eq.by(x => (x.previousOffset, x.newOffset))
+    implicit val offsetMoveEq: Eq[OffsetMove] = Eq.by(_.newOffset)
 
-    implicit val pauseReasonEq: Eq[PauseCondition] = Eq.instance {
-      case (a: OffsetMove, b: OffsetMove) => a === b
-      case (OiOff, OiOff) => true
-      case (P1Off, P1Off) => true
-      case (GaosGuideOff, GaosGuideOff) => true
+    implicit val fixedPauseReasonEq: Eq[FixedPauseCondition] = Eq.instance {
+      case (OiOff, OiOff)                   => true
+      case (P1Off, P1Off)                   => true
+      case (GaosGuideOff, GaosGuideOff)     => true
       case (InstConfigMove, InstConfigMove) => true
-      case _ => false
+      case _                                => false
     }
+
+    implicit val pauseReasonEq: Eq[PauseCondition] = Eq.instance{
+      case (a: OffsetMove, b: OffsetMove)                   => a === b
+      case (a: FixedPauseCondition, b: FixedPauseCondition) => a === b
+      case _                                                => false
+    }
+
+  }
+
+  // Non-repeatable collection of PauseCondition that admits only one OffsetMove
+  final case class PauseConditionSet private (offsetO: Option[OffsetMove], fixed: Set[FixedPauseCondition]){
+
+    def +(v: PauseCondition): PauseConditionSet = v match {
+      case a:OffsetMove           => PauseConditionSet(a.some, fixed)
+      case b: FixedPauseCondition => PauseConditionSet(offsetO, fixed + b)
+    }
+
+    def contains(v: FixedPauseCondition): Boolean = fixed.contains(v)
+
+  }
+
+  object PauseConditionSet{
+
+    def fromList(ss: List[PauseCondition]): PauseConditionSet = ss.foldLeft(empty){case (xx, e) => xx + e}
+
+    val empty: PauseConditionSet = PauseConditionSet(None, Set.empty)
+
+    implicit val pauseConditionSetEq: Eq[PauseConditionSet] = Eq.by{x => (x.offsetO, x.fixed)}
+
+    implicit val pauseConditionSetShow: Show[PauseConditionSet] = Show.show(
+      x => (x.offsetO.toList ++ x.fixed.toList).mkString
+    )
+
   }
 
   sealed trait ResumeCondition extends Product with Serializable
@@ -59,25 +96,59 @@ object Gaos {
   object ResumeCondition {
     // Telescope offset will be changed
     final case class OffsetReached(newOffset: FocalPlaneOffset) extends ResumeCondition
+
+    sealed trait FixedResumeCondition extends ResumeCondition
+
     // OI will be turn off
-    case object OiOn extends ResumeCondition
+    case object OiOn extends FixedResumeCondition
     // PI will be turn off
-    case object P1On extends ResumeCondition
+    case object P1On extends FixedResumeCondition
     // Guided step
-    case object GaosGuideOn extends ResumeCondition
+    case object GaosGuideOn extends FixedResumeCondition
     // Instrument config (affects ODGW)
-    case object InstConfigCompleted extends ResumeCondition
+    case object InstConfigCompleted extends FixedResumeCondition
 
     implicit val offsetReachedEq: Eq[OffsetReached] = Eq.by(_.newOffset)
 
-    implicit val resumeReasonEq: Eq[ResumeCondition] = Eq.instance {
-      case (a: OffsetReached, b: OffsetReached) => a === b
-      case (OiOn, OiOn) => true
-      case (P1On, P1On) => true
-      case (GaosGuideOn, GaosGuideOn) => true
+    implicit val fixedResumeReasonEq: Eq[FixedResumeCondition] = Eq.instance {
+      case (OiOn, OiOn)                               => true
+      case (P1On, P1On)                               => true
+      case (GaosGuideOn, GaosGuideOn)                 => true
       case (InstConfigCompleted, InstConfigCompleted) => true
-      case _ => false
+      case _                                          => false
     }
+
+    implicit val resumeReasonEq: Eq[ResumeCondition] = Eq.instance {
+      case (a: OffsetReached, b: OffsetReached)               => a === b
+      case (a: FixedResumeCondition, b: FixedResumeCondition) => a === b
+      case _                                                  => false
+    }
+  }
+
+  // Non-repeatable collection of ResumeCondition that admits only one OffsetMove
+  final case class ResumeConditionSet private (offsetO: Option[OffsetReached], fixed: Set[FixedResumeCondition]){
+
+    def +(v: ResumeCondition): ResumeConditionSet = v match {
+      case a: OffsetReached        => ResumeConditionSet(a.some, fixed)
+      case b: FixedResumeCondition => ResumeConditionSet(offsetO, fixed + b)
+    }
+
+    def contains(v: FixedResumeCondition): Boolean = fixed.contains(v)
+
+  }
+
+  object ResumeConditionSet{
+
+    def fromList(ss: List[ResumeCondition]): ResumeConditionSet = ss.foldLeft(empty){case (xx, e) => xx + e}
+
+    val empty: ResumeConditionSet = ResumeConditionSet(None, Set.empty)
+
+    implicit val resumeConditionSetEq: Eq[ResumeConditionSet] = Eq.by{x => (x.offsetO, x.fixed)}
+
+    implicit val resumeConditionSetShow: Show[ResumeConditionSet] = Show.show(
+      x => (x.offsetO.toList ++ x.fixed.toList).mkString
+    )
+
   }
 
   sealed case class PauseResume[F[_]](

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Gaos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/Gaos.scala
@@ -30,6 +30,7 @@ trait Gaos[F[_]] {
 }
 
 object Gaos {
+
   sealed trait PauseCondition extends Product with Serializable
 
   object PauseCondition {
@@ -49,13 +50,7 @@ object Gaos {
 
     implicit val offsetMoveEq: Eq[OffsetMove] = Eq.by(_.newOffset)
 
-    implicit val fixedPauseReasonEq: Eq[FixedPauseCondition] = Eq.instance {
-      case (OiOff, OiOff)                   => true
-      case (P1Off, P1Off)                   => true
-      case (GaosGuideOff, GaosGuideOff)     => true
-      case (InstConfigMove, InstConfigMove) => true
-      case _                                => false
-    }
+    implicit val fixedPauseReasonEq: Eq[FixedPauseCondition] = Eq.fromUniversalEquals
 
     implicit val pauseReasonEq: Eq[PauseCondition] = Eq.instance{
       case (a: OffsetMove, b: OffsetMove)                   => a === b
@@ -69,7 +64,7 @@ object Gaos {
   final case class PauseConditionSet private (offsetO: Option[OffsetMove], fixed: Set[FixedPauseCondition]){
 
     def +(v: PauseCondition): PauseConditionSet = v match {
-      case a:OffsetMove           => PauseConditionSet(a.some, fixed)
+      case a: OffsetMove          => PauseConditionSet(a.some, fixed)
       case b: FixedPauseCondition => PauseConditionSet(offsetO, fixed + b)
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideConfigDb.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideConfigDb.scala
@@ -20,7 +20,7 @@ import seqexec.model.M2GuideConfig
 import seqexec.model.M2GuideConfig._
 import seqexec.model.TelescopeGuideConfig
 import seqexec.server.altair.AltairController._
-import seqexec.server.gems.GemsController.{GemsConfig, GemsOff, GemsOn}
+import seqexec.server.gems.GemsController.{GemsConfig, GemsOff, GemsOn, OIUsage, Odgw1Active, Odgw2Active, Odgw3Active, Odgw4Active, P1Usage, Ttgs1Active, Ttgs2Active, Ttgs3Active}
 import io.circe.{Decoder, DecodingFailure}
 import squants.space.Millimeters
 
@@ -94,9 +94,19 @@ object GuideConfigDb {
             odgw2 <- c.downField("odgw2On").as[Boolean]
             odgw3 <- c.downField("odgw3On").as[Boolean]
             odgw4 <- c.downField("odgw4On").as[Boolean]
-            useOI <- c.downField("useOI").as[Boolean].recover{case _ => false}
             useP1 <- c.downField("useP1").as[Boolean].recover{case _ => false}
-          } yield GemsOn(ttgs1, ttgs2, ttgs3, odgw1, odgw2, odgw3, odgw4, useOI, useP1)
+            useOI <- c.downField("useOI").as[Boolean].recover{case _ => false}
+          } yield GemsOn(
+            if(ttgs1) Ttgs1Active.Ttgs1On else Ttgs1Active.Ttgs1Off,
+            if(ttgs2) Ttgs2Active.Ttgs2On else Ttgs2Active.Ttgs2Off,
+            if(ttgs3) Ttgs3Active.Ttgs3On else Ttgs3Active.Ttgs3Off,
+            if(odgw1) Odgw1Active.Odgw1On else Odgw1Active.Odgw1Off,
+            if(odgw2) Odgw2Active.Odgw2On else Odgw2Active.Odgw2Off,
+            if(odgw3) Odgw3Active.Odgw3On else Odgw3Active.Odgw3Off,
+            if(odgw4) Odgw4Active.Odgw4On else Odgw4Active.Odgw4Off,
+            if(useP1) P1Usage.UsesP1 else P1Usage.DoesNotUseP1,
+            if(useOI) OIUsage.UsesOI else OIUsage.DoesNotUseOI
+          )
         }
         else Right(GemsOff)
       }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideConfigDb.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideConfigDb.scala
@@ -20,7 +20,7 @@ import seqexec.model.M2GuideConfig
 import seqexec.model.M2GuideConfig._
 import seqexec.model.TelescopeGuideConfig
 import seqexec.server.altair.AltairController._
-import seqexec.server.gems.GemsController.{GemsConfig, GemsOff, GemsOn, OIUsage, Odgw1Active, Odgw2Active, Odgw3Active, Odgw4Active, P1Usage, Ttgs1Active, Ttgs2Active, Ttgs3Active}
+import seqexec.server.gems.GemsController.{GemsConfig, GemsOff, GemsOn, OIUsage, Odgw1Usage, Odgw2Usage, Odgw3Usage, Odgw4Usage, P1Usage, Ttgs1Usage, Ttgs2Usage, Ttgs3Usage}
 import io.circe.{Decoder, DecodingFailure}
 import squants.space.Millimeters
 
@@ -97,15 +97,15 @@ object GuideConfigDb {
             useP1 <- c.downField("useP1").as[Boolean].recover{case _ => false}
             useOI <- c.downField("useOI").as[Boolean].recover{case _ => false}
           } yield GemsOn(
-            if(ttgs1) Ttgs1Active.Ttgs1On else Ttgs1Active.Ttgs1Off,
-            if(ttgs2) Ttgs2Active.Ttgs2On else Ttgs2Active.Ttgs2Off,
-            if(ttgs3) Ttgs3Active.Ttgs3On else Ttgs3Active.Ttgs3Off,
-            if(odgw1) Odgw1Active.Odgw1On else Odgw1Active.Odgw1Off,
-            if(odgw2) Odgw2Active.Odgw2On else Odgw2Active.Odgw2Off,
-            if(odgw3) Odgw3Active.Odgw3On else Odgw3Active.Odgw3Off,
-            if(odgw4) Odgw4Active.Odgw4On else Odgw4Active.Odgw4Off,
-            if(useP1) P1Usage.UsesP1 else P1Usage.DoesNotUseP1,
-            if(useOI) OIUsage.UsesOI else OIUsage.DoesNotUseOI
+            Ttgs1Usage.fromBoolean(ttgs1),
+            Ttgs2Usage.fromBoolean(ttgs2),
+            Ttgs3Usage.fromBoolean(ttgs3),
+            Odgw1Usage.fromBoolean(odgw1),
+            Odgw2Usage.fromBoolean(odgw2),
+            Odgw3Usage.fromBoolean(odgw3),
+            Odgw4Usage.fromBoolean(odgw4),
+            P1Usage.fromBoolean(useP1),
+            OIUsage.fromBoolean(useOI)
           )
         }
         else Right(GemsOff)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideConfigDb.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideConfigDb.scala
@@ -94,7 +94,9 @@ object GuideConfigDb {
             odgw2 <- c.downField("odgw2On").as[Boolean]
             odgw3 <- c.downField("odgw3On").as[Boolean]
             odgw4 <- c.downField("odgw4On").as[Boolean]
-          } yield GemsOn(ttgs1, ttgs2, ttgs3, odgw1, odgw2, odgw3, odgw4)
+            useOI <- c.downField("useOI").as[Boolean].recover{case _ => false}
+            useP1 <- c.downField("useP1").as[Boolean].recover{case _ => false}
+          } yield GemsOn(ttgs1, ttgs2, ttgs3, odgw1, odgw2, odgw3, odgw4, useOI, useP1)
         }
         else Right(GemsOff)
       }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
@@ -20,7 +20,7 @@ import seqexec.model.TelescopeGuideConfig
 import seqexec.server.EpicsCodex.{DecodeEpicsValue, decode}
 import seqexec.server.tcs.TcsController.FollowOption.{FollowOff, FollowOn}
 import seqexec.server.SeqexecFailure
-import seqexec.server.gems.Gems.GemsGuiderStatus
+import seqexec.server.gems.Gems.GemsWfsStatus
 import seqexec.server.tcs.GemsSource.{Odgw1, Odgw2, Odgw3, Odgw4, Ttgs1, Ttgs2, Ttgs3}
 import seqexec.server.tcs.TcsController._
 import seqexec.server.tcs.TcsControllerEpicsCommon.{AoFold, InstrumentPorts, InvalidPort, ScienceFold}
@@ -276,7 +276,7 @@ object TcsConfigRetriever {
                                  getGuide: VirtualGemsTelescope => IO[GuiderConfig]): IO[GuiderConfig] =
     mapping.get(gemsSource).map(getGuide).getOrElse(IO(GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)))
 
-  def retrieveConfigurationSouth(gemsSt: GemsGuiderStatus[IO]): IO[TcsSouthControllerEpicsAo.EpicsTcsAoConfig] =
+  def retrieveConfigurationSouth(gemsSt: GemsWfsStatus[IO]): IO[TcsSouthControllerEpicsAo.EpicsTcsAoConfig] =
     for {
       base    <- retrieveBaseConfiguration
       mapping <- getGemsMap

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpicsCommon.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpicsCommon.scala
@@ -218,10 +218,10 @@ object TcsControllerEpicsCommon {
       s.setNodcchopb(encode(c.get(NodChop(Beam.C, Beam.B)))) *>
       s.setNodcchopc(encode(c.get(NodChop(Beam.C, Beam.C))))
 
-  private def setGuideProbe[F[_] : Async, C](guideControl: GuideControl[F],
-                                          trkSet: ProbeTrackingConfig => C => C)(
-                                           subsystems: NonEmptySet[Subsystem], c: ProbeTrackingConfig, d: ProbeTrackingConfig
-                                         ): Option[C => F[C]] =
+  def setGuideProbe[F[_] : Async, C](guideControl: GuideControl[F],
+                                     trkSet: ProbeTrackingConfig => C => C)(
+                                      subsystems: NonEmptySet[Subsystem], c: ProbeTrackingConfig, d: ProbeTrackingConfig
+                                    ): Option[C => F[C]] =
     if (subsystems.contains(guideControl.subs)) {
       val actions = List(
         (c.getNodChop =!= d.getNodChop)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpicsCommon.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpicsCommon.scala
@@ -233,7 +233,7 @@ object TcsControllerEpicsCommon {
                ProbeTrackingConfig.Frozen => (c.follow =!= d.follow)
             .option(guideControl.followCmd.setFollowState(encode(d.follow)))
         }
-      ).mapFilter(identity)
+      ).flattenOption
 
       actions.nonEmpty.option { x =>
         actions.sequence *>
@@ -458,7 +458,7 @@ object TcsControllerEpicsCommon {
     )),
     setScienceFold(Lens.id)(subsystems, current, tcs.agc.sfPos),
     setHrPickup(Lens.id)(subsystems, current, tcs.agc)
-  ).mapFilter(identity)
+  ).flattenOption
 
   def applyParam[F[_] : Applicative, T: Eq, C](used: Boolean,
                                             current: T,
@@ -476,7 +476,7 @@ object TcsControllerEpicsCommon {
     setPwfs1(Lens.id)(subsystems, current.pwfs1.detector, demand.gds.pwfs1.detector),
     setPwfs2(Lens.id)(subsystems, current.pwfs2.detector, demand.gds.pwfs2.detector),
     setOiwfs(Lens.id)(subsystems, current.oiwfs.detector, demand.gds.oiwfs.detector)
-  ).mapFilter(identity)
+  ).flattenOption
 
   // Disable M1 guiding if source is off
   private def normalizeM1Guiding(gaosEnabled: Boolean): Endo[BasicTcsConfig] = cfg =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
@@ -127,29 +127,11 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
     def setY(v: Double): F[Unit] = setParameter[F, java.lang.Double](y, v)
   }
 
-  object wavelSourceA extends EpicsCommand {
-    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelSourceA"))
+  val wavelSourceA: TargetWavelengthCmd[F] = new TargetWavelengthCmd[F]("wavelSourceA", epicsService)
 
-    private val wavel = cs.map(_.getDouble("wavel"))
+  val wavelSourceB: TargetWavelengthCmd[F] = new TargetWavelengthCmd[F]("wavelSourceB", epicsService)
 
-    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
-  }
-
-  object wavelSourceB extends EpicsCommand {
-    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelSourceB"))
-
-    private val wavel = cs.map(_.getDouble("wavel"))
-
-    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
-  }
-
-  object wavelSourceC extends EpicsCommand {
-    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelSourceC"))
-
-    private val wavel = cs.map(_.getDouble("wavel"))
-
-    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
-  }
+  val wavelSourceC: TargetWavelengthCmd[F] = new TargetWavelengthCmd[F]("wavelSourceC", epicsService)
 
   object m2Beam extends EpicsCommand {
     override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("m2Beam"))
@@ -164,14 +146,6 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
   val pwfs2ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("pwfs2Guide", epicsService)
 
   val oiwfsProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("oiwfsGuide", epicsService)
-
-  val g1ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("g1Guide", epicsService)
-
-  val g2ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("g2Guide", epicsService)
-
-  val g3ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("g3Guide", epicsService)
-
-  val g4ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("g4Guide", epicsService)
 
   val pwfs1ProbeFollowCmd: ProbeFollowCmd[F] = new ProbeFollowCmd("p1Follow", epicsService)
 
@@ -579,36 +553,36 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
     .map(_.flatMap(v => Try(v.toDouble).toOption))
 
   // GeMS Commands
-  object wavelG1 extends EpicsCommand {
-    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelG1"))
+  import VirtualGemsTelescope._
 
-    private val wavel = cs.map(_.getDouble("wavel"))
+  val g1ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("g1Guide", epicsService)
 
-    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
+  val g2ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("g2Guide", epicsService)
+
+  val g3ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("g3Guide", epicsService)
+
+  val g4ProbeGuideCmd: ProbeGuideCmd[F] = new ProbeGuideCmd("g4Guide", epicsService)
+
+  def gemsProbeGuideCmd(g: VirtualGemsTelescope): ProbeGuideCmd[F] = g match {
+    case G1 => g1ProbeGuideCmd
+    case G2 => g2ProbeGuideCmd
+    case G3 => g3ProbeGuideCmd
+    case G4 => g4ProbeGuideCmd
   }
 
-  object wavelG2 extends EpicsCommand {
-    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelG2"))
+  val wavelG1: TargetWavelengthCmd[F] = new TargetWavelengthCmd[F]("wavelG1", epicsService)
 
-    private val wavel = cs.map(_.getDouble("wavel"))
+  val wavelG2: TargetWavelengthCmd[F] = new TargetWavelengthCmd[F]("wavelG2", epicsService)
 
-    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
-  }
+  val wavelG3: TargetWavelengthCmd[F] = new TargetWavelengthCmd[F]("wavelG3", epicsService)
 
-  object wavelG3 extends EpicsCommand {
-    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelG3"))
+  val wavelG4: TargetWavelengthCmd[F] = new TargetWavelengthCmd[F]("wavelG4", epicsService)
 
-    private val wavel = cs.map(_.getDouble("wavel"))
-
-    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
-  }
-
-  object wavelG4 extends EpicsCommand {
-    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("wavelG4"))
-
-    private val wavel = cs.map(_.getDouble("wavel"))
-
-    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
+  def gemsWavelengthCmd(g: VirtualGemsTelescope): TargetWavelengthCmd[F] = g match {
+    case G1 => wavelG1
+    case G2 => wavelG2
+    case G3 => wavelG3
+    case G4 => wavelG4
   }
 
   def gwfs1Target: Target[F] = target("g1")
@@ -618,6 +592,13 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
   def gwfs3Target: Target[F] = target("g3")
 
   def gwfs4Target: Target[F] = target("g4")
+
+  def gemsTarget(g: VirtualGemsTelescope): Target[F] = g match {
+    case G1 => gwfs1Target
+    case G2 => gwfs2Target
+    case G3 => gwfs3Target
+    case G4 => gwfs4Target
+  }
 
   val ngs1ProbeFollowCmd: ProbeFollowCmd[F] = new ProbeFollowCmd("ngsPr1Follow", epicsService)
 
@@ -632,6 +613,22 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
   val odgw3FollowCmd: ProbeFollowCmd[F] = new ProbeFollowCmd("odgw3Follow", epicsService)
 
   val odgw4FollowCmd: ProbeFollowCmd[F] = new ProbeFollowCmd("odgw4Follow", epicsService)
+
+  object odgw1ParkCmd extends EpicsCommand {
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("odgw1Parked"))
+  }
+
+  object odgw2ParkCmd extends EpicsCommand {
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("odgw2Parked"))
+  }
+
+  object odgw3ParkCmd extends EpicsCommand {
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("odgw3Parked"))
+  }
+
+  object odgw4ParkCmd extends EpicsCommand {
+    override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("odgw4Parked"))
+  }
 
   // GeMS statuses
 
@@ -708,6 +705,13 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
 
   def g4Wavelength: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("g4Wavelength"))
 
+  def gemsWavelength(g: VirtualGemsTelescope): F[Option[Double]] = g match {
+    case G1 => g1Wavelength
+    case G2 => g2Wavelength
+    case G3 => g3Wavelength
+    case G4 => g4Wavelength
+  }
+
   val g1GuideConfig: ProbeGuideConfig[F] = new ProbeGuideConfig("g1", tcsState)
 
   val g2GuideConfig: ProbeGuideConfig[F] = new ProbeGuideConfig("g2", tcsState)
@@ -715,6 +719,13 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
   val g3GuideConfig: ProbeGuideConfig[F] = new ProbeGuideConfig("g3", tcsState)
 
   val g4GuideConfig: ProbeGuideConfig[F] = new ProbeGuideConfig("g4", tcsState)
+
+  def gemsGuideConfig(g: VirtualGemsTelescope): ProbeGuideConfig[F] = g match {
+    case G1 => g1GuideConfig
+    case G2 => g2GuideConfig
+    case G3 => g3GuideConfig
+    case G4 => g4GuideConfig
+  }
 
 }
 
@@ -789,6 +800,14 @@ object TcsEpics extends EpicsSystem[TcsEpics[IO]] {
     def setFollowState(v: String): F[Unit] = setParameter(follow, v)
   }
 
+  final class TargetWavelengthCmd[F[_]: Async](csName: String, epicsService: CaService) extends EpicsCommand {
+    override val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender(csName))
+
+    private val wavel = cs.map(_.getDouble("wavel"))
+
+    def setWavel(v: Double): F[Unit] = setParameter[F, java.lang.Double](wavel, v)
+  }
+
   class ProbeGuideConfig[F[_]: Sync](protected val prefix: String, protected val tcsState: CaStatusAcceptor) {
     def nodachopa: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodachopa"))
     def nodachopb: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodachopb"))
@@ -830,6 +849,14 @@ object TcsEpics extends EpicsSystem[TcsEpics[IO]] {
       def parallax: F[Option[Double]] = tio.parallax.to[F]
       def radialVelocity: F[Option[Double]] = tio.radialVelocity.to[F]
     }
+  }
+
+  sealed trait VirtualGemsTelescope
+  object VirtualGemsTelescope {
+    case object G1 extends VirtualGemsTelescope
+    case object G2 extends VirtualGemsTelescope
+    case object G3 extends VirtualGemsTelescope
+    case object G4 extends VirtualGemsTelescope
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
@@ -92,7 +92,7 @@ object TcsNorthControllerEpicsAo {
       )),
       setScienceFold(EpicsTcsAoConfig.base)(subsystems, current, tcs.agc.sfPos),
       setHrPickup(EpicsTcsAoConfig.base)(subsystems, current, tcs.agc)
-    ).mapFilter(identity)
+    ).flattenOption
 
     def sysConfig(current: EpicsTcsAoConfig): IO[EpicsTcsAoConfig] = {
       val params = configParams(current)
@@ -132,7 +132,7 @@ object TcsNorthControllerEpicsAo {
     setM2Guide(EpicsTcsAoConfig.base)(subsystems, current.base.telescopeGuideConfig.m2Guide, demand.gc.m2Guide),
     setPwfs1(EpicsTcsAoConfig.base)(subsystems, current.base.pwfs1.detector, demand.gds.pwfs1.detector),
     setOiwfs(EpicsTcsAoConfig.base)(subsystems, current.base.oiwfs.detector, demand.gds.oiwfs.detector)
-  ).mapFilter(identity)
+  ).flattenOption
 
   def tagIso[B, T]: Iso[B@@T, B] = Iso.apply[B@@T, B](x => x)(tag[T](_))
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouth.scala
@@ -99,7 +99,7 @@ case class TcsSouth [F[_]: Sync] private (tcsController: TcsSouthController[F],
         TelescopeConfig(config.offsetA, config.wavelA),
         AoGuidersConfig[GemsGuiders](
           tag[P1Config](calcGuiderConfig(
-            calcGuiderInUse(gc.tcsGuide, TipTiltSource.PWFS1, M1Source.PWFS1) | aog.usesP1,
+            calcGuiderInUse(gc.tcsGuide, TipTiltSource.PWFS1, M1Source.PWFS1) | aog.isP1Used,
             config.guideWithP1)
           ),
           GemsGuiders(
@@ -112,7 +112,7 @@ case class TcsSouth [F[_]: Sync] private (tcsController: TcsSouthController[F],
             tag[ODGW4Config](calcGuiderConfig(calcGuiderInUse(gc.tcsGuide, TipTiltSource.GAOS, M1Source.GAOS), config.guideWithODGW4))
           ),
           tag[OIConfig](calcGuiderConfig(
-            calcGuiderInUse(gc.tcsGuide, TipTiltSource.OIWFS, M1Source.OIWFS) | aog.usesOI,
+            calcGuiderInUse(gc.tcsGuide, TipTiltSource.OIWFS, M1Source.OIWFS) | aog.isOIUsed,
             config.guideWithOI)
           )
         ),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthController.scala
@@ -5,7 +5,9 @@ package seqexec.server.tcs
 
 import cats.data.NonEmptySet
 import seqexec.server.gems.Gems
-import seqexec.server.tcs.TcsController.{Subsystem, TcsConfig}
+import seqexec.server.gems.GemsController.GemsConfig
+import seqexec.server.tcs.TcsController.{AoTcsConfig, GuiderConfig, Subsystem, TcsConfig}
+import shapeless.tag.@@
 
 trait TcsSouthController[F[_]] {
   import TcsSouthController._
@@ -21,6 +23,25 @@ trait TcsSouthController[F[_]] {
 
 object TcsSouthController {
 
-  type TcsSouthConfig = TcsConfig[Nothing, Nothing]
+  trait NGS1Config
+  trait NGS2Config
+  trait NGS3Config
+  trait ODGW1Config
+  trait ODGW2Config
+  trait ODGW3Config
+  trait ODGW4Config
+
+  final case class GemsGuiders(
+    ngs1: GuiderConfig@@NGS1Config,
+    ngs2: GuiderConfig@@NGS2Config,
+    ngs3: GuiderConfig@@NGS3Config,
+    odgw1: GuiderConfig@@ODGW1Config,
+    odgw2: GuiderConfig@@ODGW2Config,
+    odgw3: GuiderConfig@@ODGW3Config,
+    odgw4: GuiderConfig@@ODGW4Config
+  )
+
+  type TcsSouthConfig = TcsConfig[GemsGuiders, GemsConfig]
+  type TcsSouthAoConfig = AoTcsConfig[GemsGuiders, GemsConfig]
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpics.scala
@@ -16,8 +16,9 @@ class TcsSouthControllerEpics private extends TcsSouthController[IO] {
                            gaos: Option[Gems[IO]],
                            tcs: TcsSouthConfig): IO[Unit] = {
     tcs match {
-      case c: BasicTcsConfig => TcsControllerEpicsCommon.applyBasicConfig(subsystems, c)
-      case _ => SeqexecFailure.Execution("GeMS steps not yet supported").raiseError[IO, Unit]
+      case c: BasicTcsConfig   => TcsControllerEpicsCommon.applyBasicConfig(subsystems, c)
+      case d: TcsSouthAoConfig => gaos.map(TcsSouthControllerEpicsAo.applyAoConfig(subsystems, _, d))
+        .getOrElse(SeqexecFailure.Execution("No GeMS object defined for GeMS step").raiseError[IO, Unit])
     }
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -1,0 +1,182 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import cats.implicits._
+import cats.data.NonEmptySet
+import cats.effect.IO
+import mouse.boolean._
+import monocle.macros.Lenses
+import org.log4s.{Logger, getLogger}
+import seqexec.server.EpicsCodex.encode
+import seqexec.server.SeqexecFailure
+import seqexec.server.gems.Gems
+import seqexec.server.tcs.GemsSource._
+import seqexec.server.tcs.TcsController.{GuiderConfig, ProbeTrackingConfig, Subsystem, wavelengthEq}
+import seqexec.server.tcs.TcsControllerEpicsCommon.{BaseEpicsTcsConfig, GuideControl, agTimeout, applyParam, encodeFollowOption, setGuideProbe, setHrPickup, setNodChopProbeTrackingConfig, setOiwfsProbe, setPwfs1Probe, setScienceFold, setTelescopeOffset, setWavelength, tcsTimeout}
+import seqexec.server.tcs.TcsEpics.VirtualGemsTelescope
+import seqexec.server.tcs.TcsSouthController.{GemsGuiders, TcsSouthAoConfig}
+
+object TcsSouthControllerEpicsAo {
+
+  val Log: Logger = getLogger
+
+  def setNgs1Guide(g: VirtualGemsTelescope,
+                   subsystems: NonEmptySet[Subsystem],
+                   current: ProbeTrackingConfig,
+                   demand: ProbeTrackingConfig
+                  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
+    if (subsystems.contains(Subsystem.Gaos)) {
+      val actions = List(
+        (current.getNodChop =!= demand.getNodChop)
+          .option(setNodChopProbeTrackingConfig(TcsEpics.instance.gemsProbeGuideCmd(g))(demand.getNodChop)),
+        (current.follow =!= demand.follow).option(TcsEpics.instance.ngs1ProbeFollowCmd.setFollowState(encode(demand.follow)))
+      ).mapFilter(identity)
+
+      actions.nonEmpty.option { x =>
+        actions.sequence *>
+          IO((EpicsTcsAoConfig.cwfs1 ^|-> GuiderConfig.tracking).set(demand)(x))
+      }
+    }
+    else none
+
+  def setNgs2Guide(g: VirtualGemsTelescope,
+                   subsystems: NonEmptySet[Subsystem],
+                   current: ProbeTrackingConfig,
+                   demand: ProbeTrackingConfig
+                  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
+    if (subsystems.contains(Subsystem.Gaos)) {
+      val actions = List(
+        (current.getNodChop =!= demand.getNodChop)
+          .option(setNodChopProbeTrackingConfig(TcsEpics.instance.gemsProbeGuideCmd(g))(demand.getNodChop)),
+        (current.follow =!= demand.follow).option(TcsEpics.instance.ngs2ProbeFollowCmd.setFollowState(encode(demand.follow)))
+      ).mapFilter(identity)
+
+      actions.nonEmpty.option { x =>
+        actions.sequence *>
+          IO((EpicsTcsAoConfig.cwfs2 ^|-> GuiderConfig.tracking).set(demand)(x))
+      }
+    }
+    else none
+
+  def setNgs3Guide(g: VirtualGemsTelescope,
+                   subsystems: NonEmptySet[Subsystem],
+                   current: ProbeTrackingConfig,
+                   demand: ProbeTrackingConfig
+                  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
+    if (subsystems.contains(Subsystem.Gaos)) {
+      val actions = List(
+        (current.getNodChop =!= demand.getNodChop)
+          .option(setNodChopProbeTrackingConfig(TcsEpics.instance.gemsProbeGuideCmd(g))(demand.getNodChop)),
+        (current.follow =!= demand.follow).option(TcsEpics.instance.ngs3ProbeFollowCmd.setFollowState(encode(demand.follow)))
+      ).mapFilter(identity)
+
+      actions.nonEmpty.option { x =>
+        actions.sequence *>
+          IO((EpicsTcsAoConfig.cwfs3 ^|-> GuiderConfig.tracking).set(demand)(x))
+      }
+    }
+    else none
+
+  private def odgw1GuiderControl(g: VirtualGemsTelescope): GuideControl[IO] = GuideControl(Subsystem.Gaos, TcsEpics.instance.odgw1ParkCmd,
+    TcsEpics.instance.gemsProbeGuideCmd(g), TcsEpics.instance.odgw1FollowCmd)
+
+  def setOdgw1Probe(g: VirtualGemsTelescope)(
+    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
+    setGuideProbe(odgw1GuiderControl(g), (EpicsTcsAoConfig.odgw1 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+  private def odgw2GuiderControl(g: VirtualGemsTelescope): GuideControl[IO] = GuideControl(Subsystem.Gaos, TcsEpics.instance.odgw2ParkCmd,
+    TcsEpics.instance.gemsProbeGuideCmd(g), TcsEpics.instance.odgw2FollowCmd)
+
+  def setOdgw2Probe(g: VirtualGemsTelescope)(
+    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
+    setGuideProbe(odgw2GuiderControl(g), (EpicsTcsAoConfig.odgw2 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+  private def odgw3GuiderControl(g: VirtualGemsTelescope): GuideControl[IO] = GuideControl(Subsystem.Gaos, TcsEpics.instance.odgw3ParkCmd,
+    TcsEpics.instance.gemsProbeGuideCmd(g), TcsEpics.instance.odgw3FollowCmd)
+
+  def setOdgw3Probe(g: VirtualGemsTelescope)(
+    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
+    setGuideProbe(odgw3GuiderControl(g), (EpicsTcsAoConfig.odgw3 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+  private def odgw4GuiderControl(g: VirtualGemsTelescope): GuideControl[IO] = GuideControl(Subsystem.Gaos, TcsEpics.instance.odgw4ParkCmd,
+    TcsEpics.instance.gemsProbeGuideCmd(g), TcsEpics.instance.odgw4FollowCmd)
+
+  def setOdgw4Probe(g: VirtualGemsTelescope)(
+    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
+    setGuideProbe(odgw4GuiderControl(g), (EpicsTcsAoConfig.odgw4 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+  def setGemsProbes(subsystems: NonEmptySet[Subsystem], current: EpicsTcsAoConfig, demand: GemsGuiders)
+  : List[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] = List(
+      current.mapping.get(Ttgs1).flatMap(setNgs1Guide(_, subsystems, current.cwfs1.tracking, demand.ngs1.tracking)),
+      current.mapping.get(Ttgs2).flatMap(setNgs1Guide(_, subsystems, current.cwfs2.tracking, demand.ngs2.tracking)),
+      current.mapping.get(Ttgs3).flatMap(setNgs1Guide(_, subsystems, current.cwfs3.tracking, demand.ngs3.tracking)),
+      current.mapping.get(Odgw1).flatMap(setOdgw1Probe(_)(subsystems, current.odgw1.tracking, demand.odgw1.tracking)),
+      current.mapping.get(Odgw2).flatMap(setOdgw1Probe(_)(subsystems, current.odgw2.tracking, demand.odgw2.tracking)),
+      current.mapping.get(Odgw3).flatMap(setOdgw1Probe(_)(subsystems, current.odgw3.tracking, demand.odgw3.tracking)),
+      current.mapping.get(Odgw4).flatMap(setOdgw1Probe(_)(subsystems, current.odgw4.tracking, demand.odgw4.tracking))
+    ).mapFilter(identity)
+
+  def applyAoConfig(subsystems: NonEmptySet[Subsystem],
+                  gaos: Gems[IO],
+                  tcs: TcsSouthAoConfig): IO[Unit] = {
+    def configParams(current: EpicsTcsAoConfig): List[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
+      List(
+        setPwfs1Probe(EpicsTcsAoConfig.base)(subsystems, current.base.pwfs1.tracking, tcs.gds.pwfs1.tracking),
+        setOiwfsProbe(EpicsTcsAoConfig.base)(subsystems, current.base.oiwfs.tracking, tcs.gds.oiwfs.tracking),
+        tcs.tc.offsetA.flatMap(o => applyParam(subsystems.contains(Subsystem.Mount), current.base.offset,
+          o.toFocalPlaneOffset(current.base.iaa), setTelescopeOffset, EpicsTcsAoConfig.base ^|-> BaseEpicsTcsConfig.offset
+        )),
+        tcs.tc.wavelA.flatMap(applyParam(subsystems.contains(Subsystem.Mount), current.base.wavelA, _, setWavelength,
+          EpicsTcsAoConfig.base ^|-> BaseEpicsTcsConfig.wavelA
+        )),
+        setScienceFold(EpicsTcsAoConfig.base)(subsystems, current, tcs.agc.sfPos),
+        setHrPickup(EpicsTcsAoConfig.base)(subsystems, current, tcs.agc)
+      ).mapFilter(identity) ++ setGemsProbes(subsystems, current, tcs.gds.aoguide)
+
+    def sysConfig(current: EpicsTcsAoConfig): IO[EpicsTcsAoConfig] = {
+      val params = configParams(current)
+
+      if(params.nonEmpty)
+        for {
+          s <- params.foldLeft(IO(current)){ case (c, p) => c.flatMap(p) }
+          _ <- TcsEpics.instance.post
+          _ <- IO(Log.debug("TCS configuration command post"))
+          _ <- if(subsystems.contains(Subsystem.Mount))
+            TcsEpics.instance.waitInPosition(tcsTimeout) *> IO.apply(Log.info("TCS inposition"))
+          else if(Set(Subsystem.PWFS1, Subsystem.PWFS2, Subsystem.AGUnit).exists(subsystems.contains))
+            TcsEpics.instance.waitAGInPosition(agTimeout) *> IO.apply(Log.debug("AG inposition"))
+          else IO.unit
+        } yield s
+      else
+        IO(Log.debug("Skipping TCS configuration")) *> IO(current)
+    }
+
+    //TODO add guideOff/guideOn
+    //TODO add GeMS pause/resume
+    for {
+      s0 <- TcsConfigRetriever.retrieveConfigurationSouth(gaos.stateGetter)
+      _  <- if(s0.base.useAo) IO.unit
+            else SeqexecFailure.Execution("Found useAo not set for AO step.").raiseError[IO, Unit]
+      _  <- sysConfig(s0)
+    } yield ()
+  }
+
+  @Lenses
+  final case class EpicsTcsAoConfig(
+    base: BaseEpicsTcsConfig,
+    mapping: Map[GemsSource, VirtualGemsTelescope],
+    cwfs1: GuiderConfig,
+    cwfs2: GuiderConfig,
+    cwfs3: GuiderConfig,
+    odgw1: GuiderConfig,
+    odgw2: GuiderConfig,
+    odgw3: GuiderConfig,
+    odgw4: GuiderConfig
+  )
+}

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSpec.scala
@@ -117,7 +117,7 @@ final class GuideConfigDbSpec extends FlatSpec {
       M1GuideConfig.M1GuideOn(M1Source.GAOS),
       M2GuideConfig.M2GuideOn(ComaOption.ComaOn, Set(TipTiltSource.GAOS))
     ),
-    Some(Right(GemsOn(true, false, false, true, false, true, true)))
+    Some(Right(GemsOn(true, false, false, true, false, true, true, false, false)))
   )
 
   "GuideConfigDb" should "provide decoders" in {

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSpec.scala
@@ -15,15 +15,15 @@ import seqexec.model.M2GuideConfig
 import seqexec.model.TelescopeGuideConfig
 import seqexec.server.altair.AltairController.Lgs
 import seqexec.server.gems.GemsController.GemsOn
-import seqexec.server.gems.GemsController.OIUsage.DoesNotUseOI
-import seqexec.server.gems.GemsController.Odgw1Active.Odgw1On
-import seqexec.server.gems.GemsController.Odgw2Active.Odgw2Off
-import seqexec.server.gems.GemsController.Odgw3Active.Odgw3On
-import seqexec.server.gems.GemsController.Odgw4Active.Odgw4On
-import seqexec.server.gems.GemsController.P1Usage.DoesNotUseP1
-import seqexec.server.gems.GemsController.Ttgs1Active.Ttgs1On
-import seqexec.server.gems.GemsController.Ttgs2Active.Ttgs2Off
-import seqexec.server.gems.GemsController.Ttgs3Active.Ttgs3Off
+import seqexec.server.gems.GemsController.OIUsage.DontUseOI
+import seqexec.server.gems.GemsController.Odgw1Usage.UseOdgw1
+import seqexec.server.gems.GemsController.Odgw2Usage.DontUseOdgw2
+import seqexec.server.gems.GemsController.Odgw3Usage.UseOdgw3
+import seqexec.server.gems.GemsController.Odgw4Usage.UseOdgw4
+import seqexec.server.gems.GemsController.P1Usage.DontUseP1
+import seqexec.server.gems.GemsController.Ttgs1Usage.UseTtgs1
+import seqexec.server.gems.GemsController.Ttgs2Usage.DontUseTtgs2
+import seqexec.server.gems.GemsController.Ttgs3Usage.DontUseTtgs3
 import squants.space.Millimeters
 
 final class GuideConfigDbSpec extends FlatSpec {
@@ -127,15 +127,15 @@ final class GuideConfigDbSpec extends FlatSpec {
       M2GuideConfig.M2GuideOn(ComaOption.ComaOn, Set(TipTiltSource.GAOS))
     ),
     Some(Right(GemsOn(
-      Ttgs1On,
-      Ttgs2Off,
-      Ttgs3Off,
-      Odgw1On,
-      Odgw2Off,
-      Odgw3On,
-      Odgw4On,
-      DoesNotUseP1,
-      DoesNotUseOI
+      UseTtgs1,
+      DontUseTtgs2,
+      DontUseTtgs3,
+      UseOdgw1,
+      DontUseOdgw2,
+      UseOdgw3,
+      UseOdgw4,
+      DontUseP1,
+      DontUseOI
     )))
   )
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSpec.scala
@@ -15,6 +15,15 @@ import seqexec.model.M2GuideConfig
 import seqexec.model.TelescopeGuideConfig
 import seqexec.server.altair.AltairController.Lgs
 import seqexec.server.gems.GemsController.GemsOn
+import seqexec.server.gems.GemsController.OIUsage.DoesNotUseOI
+import seqexec.server.gems.GemsController.Odgw1Active.Odgw1On
+import seqexec.server.gems.GemsController.Odgw2Active.Odgw2Off
+import seqexec.server.gems.GemsController.Odgw3Active.Odgw3On
+import seqexec.server.gems.GemsController.Odgw4Active.Odgw4On
+import seqexec.server.gems.GemsController.P1Usage.DoesNotUseP1
+import seqexec.server.gems.GemsController.Ttgs1Active.Ttgs1On
+import seqexec.server.gems.GemsController.Ttgs2Active.Ttgs2Off
+import seqexec.server.gems.GemsController.Ttgs3Active.Ttgs3Off
 import squants.space.Millimeters
 
 final class GuideConfigDbSpec extends FlatSpec {
@@ -117,7 +126,17 @@ final class GuideConfigDbSpec extends FlatSpec {
       M1GuideConfig.M1GuideOn(M1Source.GAOS),
       M2GuideConfig.M2GuideOn(ComaOption.ComaOn, Set(TipTiltSource.GAOS))
     ),
-    Some(Right(GemsOn(true, false, false, true, false, true, true, false, false)))
+    Some(Right(GemsOn(
+      Ttgs1On,
+      Ttgs2Off,
+      Ttgs3Off,
+      Odgw1On,
+      Odgw2Off,
+      Odgw3On,
+      Odgw4On,
+      DoesNotUseP1,
+      DoesNotUseOI
+    )))
   )
 
   "GuideConfigDb" should "provide decoders" in {


### PR DESCRIPTION
This PR is limited to applying the tracking configuration of GeMS guiders (nod/chop and follow state). There is a lot left to do, like the notifications to GeMS of guide changes, and starting/stopping the guiders.
One small complication is that all the settings go through TCS. But in most cases it does not have a dedicated CAR for every possible GeMS guider. Instead, because only 4 can be used at a time, TCS defines 4 virtual telescopes for GeMS (G1 to G4), and a mapping to the actual guiders.