### PR TITLE
SEQNG-1034: GPI Wrong Sample mode

### DIFF
--- a/modules/core/shared/src/main/scala/gem/enum/GiapiStatusApply.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GiapiStatusApply.scala
@@ -49,10 +49,11 @@ object GiapiStatusApply {
   /** @group Constructors */ case object GpiFPM extends GiapiStatusApply("GpiFPM", Instrument.Gpi, GiapiType.String, "gpi:fpmMask", "gpi:selectFocalPlaneMask.maskStr")
   /** @group Constructors */ case object GpiLyot extends GiapiStatusApply("GpiLyot", Instrument.Gpi, GiapiType.String, "gpi:lyotMask", "gpi:selectLyotMask.maskStr")
   /** @group Constructors */ case object GpiAlignAndCalib extends GiapiStatusApply("GpiAlignAndCalib", Instrument.Gpi, GiapiType.Int, "gpi:alignAndCalib.part1", "gpi:alignAndCalib.part1")
+  /** @group Constructors */ case object GpiIFSReadMode extends GiapiStatusApply("GpiIFSReadMode", Instrument.Gpi, GiapiType.Int, "gpi:currentReadMode", "gpi:configIfs.readoutMode")
 
   /** All members of GiapiStatusApply, in canonical order. */
   val all: List[GiapiStatusApply] =
-    List(GpiAdc, GpiUseAo, GpiAoOptimize, GpiUseCal, GpiFpmPinholeBias, GpiIntegrationTime, GpiNumCoadds, GpiMagI, GpiMagH, GpiCalEntranceShutter, GpiCalReferenceShutter, GpiCalScienceShutter, GpiEntranceShutter, GpiCalExitShutter, GpiPupilCamera, GpiSCPower, GpiSCAttenuation, GpiSrcVis, GpiSrcIR, GpiPolarizerDeplay, GpiPolarizerAngle, GpiObservationMode, GpiIFSFilter, GpiPPM, GpiFPM, GpiLyot, GpiAlignAndCalib)
+    List(GpiAdc, GpiUseAo, GpiAoOptimize, GpiUseCal, GpiFpmPinholeBias, GpiIntegrationTime, GpiNumCoadds, GpiMagI, GpiMagH, GpiCalEntranceShutter, GpiCalReferenceShutter, GpiCalScienceShutter, GpiEntranceShutter, GpiCalExitShutter, GpiPupilCamera, GpiSCPower, GpiSCAttenuation, GpiSrcVis, GpiSrcIR, GpiPolarizerDeplay, GpiPolarizerAngle, GpiObservationMode, GpiIFSFilter, GpiPPM, GpiFPM, GpiLyot, GpiAlignAndCalib, GpiIFSReadMode)
 
   /** Select the member of GiapiStatusApply with the given tag, if any. */
   def fromTag(s: String): Option[GiapiStatusApply] =

--- a/modules/core/shared/src/main/scala/gem/enum/GiapiStatusApply.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GiapiStatusApply.scala
@@ -50,10 +50,14 @@ object GiapiStatusApply {
   /** @group Constructors */ case object GpiLyot extends GiapiStatusApply("GpiLyot", Instrument.Gpi, GiapiType.String, "gpi:lyotMask", "gpi:selectLyotMask.maskStr")
   /** @group Constructors */ case object GpiAlignAndCalib extends GiapiStatusApply("GpiAlignAndCalib", Instrument.Gpi, GiapiType.Int, "gpi:alignAndCalib.part1", "gpi:alignAndCalib.part1")
   /** @group Constructors */ case object GpiIFSReadMode extends GiapiStatusApply("GpiIFSReadMode", Instrument.Gpi, GiapiType.Int, "gpi:currentReadMode", "gpi:configIfs.readoutMode")
+  /** @group Constructors */ case object GpiIFSStartX extends GiapiStatusApply("GpiIFSStartX", Instrument.Gpi, GiapiType.Int, "gpi:currentStartX", "gpi:gpi:configIfs.startx")
+  /** @group Constructors */ case object GpiIFSStartY extends GiapiStatusApply("GpiIFSStartY", Instrument.Gpi, GiapiType.Int, "gpi:currentStartY", "gpi:gpi:configIfs.starty")
+  /** @group Constructors */ case object GpiIFSEndX extends GiapiStatusApply("GpiIFSEndX", Instrument.Gpi, GiapiType.Int, "gpi:currentEndX", "gpi:gpi:configIfs.endx")
+  /** @group Constructors */ case object GpiIFSEndY extends GiapiStatusApply("GpiIFSEndY", Instrument.Gpi, GiapiType.Int, "gpi:currentEndY", "gpi:gpi:configIfs.endy")
 
   /** All members of GiapiStatusApply, in canonical order. */
   val all: List[GiapiStatusApply] =
-    List(GpiAdc, GpiUseAo, GpiAoOptimize, GpiUseCal, GpiFpmPinholeBias, GpiIntegrationTime, GpiNumCoadds, GpiMagI, GpiMagH, GpiCalEntranceShutter, GpiCalReferenceShutter, GpiCalScienceShutter, GpiEntranceShutter, GpiCalExitShutter, GpiPupilCamera, GpiSCPower, GpiSCAttenuation, GpiSrcVis, GpiSrcIR, GpiPolarizerDeplay, GpiPolarizerAngle, GpiObservationMode, GpiIFSFilter, GpiPPM, GpiFPM, GpiLyot, GpiAlignAndCalib, GpiIFSReadMode)
+    List(GpiAdc, GpiUseAo, GpiAoOptimize, GpiUseCal, GpiFpmPinholeBias, GpiIntegrationTime, GpiNumCoadds, GpiMagI, GpiMagH, GpiCalEntranceShutter, GpiCalReferenceShutter, GpiCalScienceShutter, GpiEntranceShutter, GpiCalExitShutter, GpiPupilCamera, GpiSCPower, GpiSCAttenuation, GpiSrcVis, GpiSrcIR, GpiPolarizerDeplay, GpiPolarizerAngle, GpiObservationMode, GpiIFSFilter, GpiPPM, GpiFPM, GpiLyot, GpiAlignAndCalib, GpiIFSReadMode, GpiIFSStartX, GpiIFSStartY, GpiIFSEndX, GpiIFSEndY)
 
   /** Select the member of GiapiStatusApply with the given tag, if any. */
   def fromTag(s: String): Option[GiapiStatusApply] =

--- a/modules/core/shared/src/main/scala/gem/enum/GpiReadMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiReadMode.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for GPI ReadMode.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GpiReadMode(
+  val tag: String,
+  val shortName: String,
+  val value: Int
+) extends Product with Serializable
+
+object GpiReadMode {
+
+  /** @group Constructors */ case object Single extends GpiReadMode("Single", "Single", 1)
+  /** @group Constructors */ case object CDS extends GpiReadMode("CDS", "CDS", 2)
+  /** @group Constructors */ case object MCDS extends GpiReadMode("MCDS", "MCDS", 3)
+  /** @group Constructors */ case object UTR extends GpiReadMode("UTR", "UTR", 4)
+
+  /** All members of GpiReadMode, in canonical order. */
+  val all: List[GpiReadMode] =
+    List(Single, CDS, MCDS, UTR)
+
+  /** Select the member of GpiReadMode with the given tag, if any. */
+  def fromTag(s: String): Option[GpiReadMode] =
+    all.find(_.tag === s)
+
+  /** Select the member of GpiReadMode with the given tag, throwing if absent. */
+  def unsafeFromTag(s: String): GpiReadMode =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s"GpiReadMode: Invalid tag: '$s'"))
+
+  /** @group Typeclass Instances */
+  implicit val GpiReadModeEnumerated: Enumerated[GpiReadMode] =
+    new Enumerated[GpiReadMode] {
+      def all = GpiReadMode.all
+      def tag(a: GpiReadMode) = a.tag
+      override def unsafeFromTag(s: String): GpiReadMode =
+        GpiReadMode.unsafeFromTag(s)
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/GpiReadMode.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GpiReadMode.scala
@@ -14,15 +14,15 @@ import gem.util.Enumerated
  */
 sealed abstract class GpiReadMode(
   val tag: String,
-  val shortName: String,
+  val longName: String,
   val value: Int
 ) extends Product with Serializable
 
 object GpiReadMode {
 
-  /** @group Constructors */ case object Single extends GpiReadMode("Single", "Single", 1)
-  /** @group Constructors */ case object CDS extends GpiReadMode("CDS", "CDS", 2)
-  /** @group Constructors */ case object MCDS extends GpiReadMode("MCDS", "MCDS", 3)
+  /** @group Constructors */ case object Single extends GpiReadMode("Single", "Fast", 1)
+  /** @group Constructors */ case object CDS extends GpiReadMode("CDS", "Single CDS", 2)
+  /** @group Constructors */ case object MCDS extends GpiReadMode("MCDS", "Multiple CDS", 3)
   /** @group Constructors */ case object UTR extends GpiReadMode("UTR", "UTR", 4)
 
   /** All members of GpiReadMode, in canonical order. */

--- a/modules/core/shared/src/main/scala/gem/enum/package.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/package.scala
@@ -194,8 +194,8 @@ package object enum extends ToPrismOps {
    */
   implicit class GpiReadModeOps(val value: GpiReadMode.type) extends AnyVal {
     /** Select the member of GpiReadMode with the given value, if any. */
-    def fromValue(v: Int): Option[GpiReadMode] =
-      GpiReadMode.all.find(_.value === v)
+    def fromLongName(v: String): Option[GpiReadMode] =
+      GpiReadMode.all.find(_.longName === v)
 
   }
 

--- a/modules/core/shared/src/main/scala/gem/enum/package.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/package.scala
@@ -188,4 +188,15 @@ package object enum extends ToPrismOps {
 
   }
 
+  /**
+   * Enrichment methods for [[GpiReadMode]].
+   * @group Enrichment
+   */
+  implicit class GpiReadModeOps(val value: GpiReadMode.type) extends AnyVal {
+    /** Select the member of GpiReadMode with the given value, if any. */
+    def fromValue(v: Int): Option[GpiReadMode] =
+      GpiReadMode.all.find(_.value === v)
+
+  }
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
@@ -98,7 +98,17 @@ object ConfigUtilOps {
       new Extracted(c, INSTRUMENT_KEY / key).as[A]
 
     // config syntax: cfg.extractInstAs[Type](key)
+    def extractInstAs[A](key: String)(
+      implicit clazz:         ClassTag[A]): Either[ExtractFailure, A] =
+      new Extracted(c, INSTRUMENT_KEY / key).as[A]
+
+    // config syntax: cfg.extractInstAs[Type](key)
     def extractObsAs[A](key: PropertyDescriptor)(
+      implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
+      new Extracted(c, OBSERVE_KEY / key).as[A]
+
+    // config syntax: cfg.extractInstAs[Type](key)
+    def extractObsAs[A](key: String)(
       implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, OBSERVE_KEY / key).as[A]
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
@@ -19,6 +19,7 @@ import edu.gemini.spModel.gemini.gpi.Gpi.{ PupilCamera => LegacyPupilCamera }
 import edu.gemini.spModel.gemini.gpi.Gpi.{ Shutter => LegacyShutter }
 import edu.gemini.aspen.giapi.commands.HandlerResponse.Response
 import gem.enum.GiapiStatusApply._
+import gem.enum.GpiReadMode
 import giapi.client.commands.Configuration
 import giapi.client.commands.CommandResultException
 import giapi.client.gpi.GpiClient
@@ -85,6 +86,7 @@ final case class RegularGpiConfig(
   adc:            LegacyAdc,
   expTime:        Duration,
   coAdds:         Int,
+  readMode:       GpiReadMode,
   mode:           Either[LegacyObservingMode, NonStandardModeParams],
   disperser:      LegacyDisperser,
   disperserAngle: Double,
@@ -98,6 +100,7 @@ object RegularGpiConfig extends GpiConfigEq {
     x =>
       (x.adc,
        x.expTime,
+       x.readMode,
        x.coAdds,
        x.mode,
        x.disperser,
@@ -192,6 +195,7 @@ object GpiController extends GpiLookupTables with GpiConfigEq {
       Configuration.single(GpiIntegrationTime.applyItem,
         config.expTime.toMillis / 1000.0) |+|
       Configuration.single(GpiNumCoadds.applyItem, config.coAdds) |+|
+      Configuration.single(GpiIFSReadMode.applyItem, config.readMode.value) |+|
       Configuration.single(GpiMagI.applyItem, config.aoFlags.magI) |+|
       Configuration.single(GpiMagH.applyItem, config.aoFlags.magH) |+|
       Configuration.single(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
@@ -4,6 +4,7 @@
 package seqexec.server.gpi
 
 import cats.Applicative
+import cats.data.Nested
 import cats.effect.Sync
 import cats.implicits._
 import gem.Observation
@@ -24,16 +25,19 @@ object GpiHeader {
                               id: ImageFileId): F[Unit] = {
         val ks = GdsInstrument.bundleKeywords(
           List(
-            buildDouble(tcsKeywordsReader.parallacticAngle
-                          .map(_.map(_.toDegrees))
+            buildDouble(Nested(tcsKeywordsReader.parallacticAngle)
+                          .map(_.toDegrees)
+                          .value
                           .orDefault,
                         KeywordName.PAR_ANG),
             buildInt32(tcsKeywordsReader.gpiInstPort,
                        KeywordName.INPORT),
             buildBoolean(obsKeywordsReader.astrometicField,
                          KeywordName.ASTROMTC, DefaultHeaderValue.FalseDefaultValue),
-            buildString(tcsKeywordsReader.crFollow.map(
-                          _.map(CRFollow.keywordValue).getOrElse("INDEF")),
+            buildString(Nested(tcsKeywordsReader.crFollow)
+                          .map(CRFollow.keywordValue)
+                          .value
+                          .orDefault,
                         KeywordName.CRFOLLOW)
           )
         )

--- a/modules/sql/src/main/resources/db/migration/V073__Gpi_ReadMode.sql
+++ b/modules/sql/src/main/resources/db/migration/V073__Gpi_ReadMode.sql
@@ -1,0 +1,30 @@
+---------------------------
+-- Gpi read mode
+---------------------------
+
+INSERT INTO e_giapi_status_apply(id, instrument_id, type, status_item, apply_item)
+VALUES
+	('IFSReadMode', 'Gpi', 'Int', 'gpi:currentReadMode', 'gpi:configIfs.readoutMode');
+
+--
+-- Name: e_gpi_read_mode; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE e_gpi_read_mode (
+  id          identifier  PRIMARY KEY,
+  short_name  text        NOT NULL,
+  value       smallint    NOT NULL
+);
+
+ALTER TABLE e_gpi_read_mode OWNER TO postgres;
+
+--
+-- Data for Name: e_gpi_read_mode; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY e_gpi_read_mode(id, short_name, value) FROM stdin;
+Single	Single	1
+CDS	CDS	2
+MCDS	MCDS	3
+UTR	UTR	4
+\.

--- a/modules/sql/src/main/resources/db/migration/V073__Gpi_ReadMode.sql
+++ b/modules/sql/src/main/resources/db/migration/V073__Gpi_ReadMode.sql
@@ -4,7 +4,11 @@
 
 INSERT INTO e_giapi_status_apply(id, instrument_id, type, status_item, apply_item)
 VALUES
-	('IFSReadMode', 'Gpi', 'Int', 'gpi:currentReadMode', 'gpi:configIfs.readoutMode');
+	('IFSReadMode', 'Gpi', 'Int', 'gpi:currentReadMode', 'gpi:configIfs.readoutMode'),
+	('IFSStartX', 'Gpi', 'Int', 'gpi:currentStartX', 'gpi:gpi:configIfs.startx'),
+	('IFSStartY', 'Gpi', 'Int', 'gpi:currentStartY', 'gpi:gpi:configIfs.starty'),
+	('IFSEndX', 'Gpi', 'Int', 'gpi:currentEndX', 'gpi:gpi:configIfs.endx'),
+	('IFSEndY', 'Gpi', 'Int', 'gpi:currentEndY', 'gpi:gpi:configIfs.endy');
 
 --
 -- Name: e_gpi_read_mode; Type: TABLE; Schema: public; Owner: postgres
@@ -12,7 +16,7 @@ VALUES
 
 CREATE TABLE e_gpi_read_mode (
   id          identifier  PRIMARY KEY,
-  short_name  text        NOT NULL,
+  long_name   text        NOT NULL,
   value       smallint    NOT NULL
 );
 
@@ -22,9 +26,9 @@ ALTER TABLE e_gpi_read_mode OWNER TO postgres;
 -- Data for Name: e_gpi_read_mode; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY e_gpi_read_mode(id, short_name, value) FROM stdin;
-Single	Single	1
-CDS	CDS	2
-MCDS	MCDS	3
+COPY e_gpi_read_mode(id, long_name, value) FROM stdin;
+Single	Fast	1
+CDS	Single CDS	2
+MCDS	Multiple CDS	3
 UTR	UTR	4
 \.

--- a/modules/sql/src/main/scala/gem/sql/enum/GpiEnums.scala
+++ b/modules/sql/src/main/scala/gem/sql/enum/GpiEnums.scala
@@ -100,8 +100,8 @@ object GpiEnums {
       },
 
       EnumDef.fromQuery("GpiReadMode", "GPI ReadMode") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'value -> Int`.T
-        sql"""SELECT id, id tag, short_name, value FROM e_gpi_read_mode""".query[(String, E)]
+        type E = Record.`'tag -> String, 'longName -> String, 'value -> Int`.T
+        sql"""SELECT id, id tag, long_name, value FROM e_gpi_read_mode""".query[(String, E)]
       }
 
     )

--- a/modules/sql/src/main/scala/gem/sql/enum/GpiEnums.scala
+++ b/modules/sql/src/main/scala/gem/sql/enum/GpiEnums.scala
@@ -97,6 +97,11 @@ object GpiEnums {
         type F = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'filter -> Option[EnumRef[A]], 'filterIterable -> Boolean, 'apodizer -> Option[EnumRef[B]], 'fpm -> Option[EnumRef[C]], 'lyot -> Option[EnumRef[D]], 'brightLimitPrism -> Option[MagnitudeValue], 'brightLimitWollaston -> Option[MagnitudeValue], 'correspondingHMode -> LazyEnumRef[E], 'obsolete  -> Boolean`.T
         val ret = sql"""SELECT id, id tag, short_name, long_name, filter, filter_iterable, apodizer, fpm, lyot, bright_limit_prism, bright_limit_wollaston, corresponding_h_mode, obsolete FROM e_gpi_observing_mode""".query[(String, F)]
         (ret, a.value: A, b.value: B, c.value: C, d.value: D, e.value: E)._1 // suppress unused warnigs
+      },
+
+      EnumDef.fromQuery("GpiReadMode", "GPI ReadMode") {
+        type E = Record.`'tag -> String, 'shortName -> String, 'value -> Int`.T
+        sql"""SELECT id, id tag, short_name, value FROM e_gpi_read_mode""".query[(String, E)]
       }
 
     )


### PR DESCRIPTION
The sample mode for GPI is a parameter on the odb that cannot be edited and or all intents it is always UTR. However, it is still possible using the engineering to set it to some of the other values. Normally the value would be set automatically when doing an observation but in a rare case, doing a calibration may not set it and if combined with manual changes could produce FR-40693 where the readout mode was set to Single.

This PR will read the value from the ODB, compare it to the actual value and set it on the instrument if needed

Another set of parameters in the same category are the readout area. While there hasn't been a case of using a subarray ever, it is still possible to be set using the engineering level tools. Thus the readout area params receive the same treatment

This PR still needs some real field testing with the instrument
