### PR TITLE
Feature/seqng 1043

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -336,11 +336,11 @@ object EpicsUtil {
   // The return signature indicates this programs calculates if we maybe need an action
   // e.g. it checks that a value in epics compares to a reference and if so returns an optional
   // action
-  def smartSetParamF[F[_]: Monad, A: Eq](v: A, get: F[Option[A]], set: F[Unit]): F[Option[F[Unit]]] =
-    get.map(_ =!= v.some).map(_.option(set))
+  def smartSetParamF[F[_]: Monad, A: Eq](v: A, get: F[A], set: F[Unit]): F[Option[F[Unit]]] =
+    get.map(_ =!= v).map(_.option(set))
 
-  def smartSetDoubleParamF[F[_]: Functor](relTolerance: Double)(v: Double, get: F[Option[Double]], set: F[Unit]): F[Option[F[Unit]]] =
-    get.map(g => g.forall(areValuesDifferentEnough(relTolerance, _, v)).option(set))
+  def smartSetDoubleParamF[F[_]: Functor](relTolerance: Double)(v: Double, get: F[Double], set: F[Unit]): F[Option[F[Unit]]] =
+    get.map(areValuesDifferentEnough(relTolerance, _, v).option(set))
 
   def countdown[F[_]: Apply: cats.effect.Timer](total: Time, remT: F[Option[Time]],
                               obsState: F[Option[CarStateGeneric]]): Stream[F, Progress] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
@@ -45,7 +45,7 @@ object SeqexecFailure {
   final case class GdsXmlError(msg: String, url: Uri) extends SeqexecFailure
 
   /** Null epics read */
-  final case class NullEpicsError(name: String) extends SeqexecFailure
+  final case class NullEpicsError(channel: String) extends SeqexecFailure
 
   /** Failed simulation */
   case object FailedSimulation extends SeqexecFailure

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
@@ -28,7 +28,7 @@ trait Altair[F[_]] extends Gaos[F] {
 
   def usesOI(guide: AltairConfig): Boolean
 
-  def isFollowing: F[Option[Boolean]]
+  def isFollowing: F[Boolean]
 
   def hasTarget(guide: AltairConfig): Boolean
 
@@ -62,7 +62,7 @@ object Altair {
       case _            => false
     }
 
-    override def isFollowing: F[Option[Boolean]] = controller.isFollowing
+    override def isFollowing: F[Boolean] = controller.isFollowing
 
     override def hasTarget(guide: AltairConfig): Boolean = guide match {
       case Lgs(st, sf, _) => st || sf

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairController.scala
@@ -19,7 +19,7 @@ trait AltairController[F[_]] {
 
   def endObserve(cfg: AltairConfig): F[Unit]
 
-  def isFollowing: F[Option[Boolean]]
+  def isFollowing: F[Boolean]
 }
 
 object AltairController {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -271,22 +271,18 @@ object AltairControllerEpics extends AltairController[IO] {
 
   override def endObserve(cfg: AltairConfig): IO[Unit] = IO.unit
 
-  private def getStatusVal[A](get: IO[Option[A]], name: String, system: String): IO[A] = get.flatMap(
-    _.map(IO(_)).getOrElse(IO.raiseError(SeqexecFailure.Unexpected(s"Unable to read $name from $system.")))
-  )
-
   def retrieveConfig: IO[EpicsAltairConfig] = for {
-    cmtxx <- getStatusVal(epicsAltair.matrixStartX.map(_.map(Millimeters(_))), "current control matrix X", "Altair")
-    cmtxy <- getStatusVal(epicsAltair.matrixStartY.map(_.map(Millimeters(_))), "current control matrix Y", "Altair")
-    pmtxx <- getStatusVal(epicsTcs.aoPreparedCMX.map(_.map(Millimeters(_))), "Altair next control matrix X", "TCS")
-    pmtxy <- getStatusVal(epicsTcs.aoPreparedCMY.map(_.map(Millimeters(_))), "Altair next control matrix Y", "TCS")
-    strRT <- getStatusVal(epicsAltair.strapRTStatus, "strap RT control status", "Altair")
-    strTm <- getStatusVal(epicsAltair.strapTempStatus, "strap temperature control status", "Altair")
-    strHV <- getStatusVal(epicsAltair.strapHVStatus, "strap HVolt status", "Altair")
-    strap <- getStatusVal(epicsAltair.strapLoop, "strap loop state", "Altair")
-    sfo   <- getStatusVal(epicsAltair.sfoLoop, "SFO loop state", "Altair")
-    stGat <- getStatusVal(epicsAltair.strapGate, "strap gate state", "Altair")
-    aolp  <- getStatusVal(epicsAltair.aoLoop, "AO active", "Altair")
+    cmtxx <- epicsAltair.matrixStartX.map(Millimeters(_))
+    cmtxy <- epicsAltair.matrixStartY.map(Millimeters(_))
+    pmtxx <- epicsTcs.aoPreparedCMX.map(Millimeters(_))
+    pmtxy <- epicsTcs.aoPreparedCMY.map(Millimeters(_))
+    strRT <- epicsAltair.strapRTStatus
+    strTm <- epicsAltair.strapTempStatus
+    strHV <- epicsAltair.strapHVStatus
+    strap <- epicsAltair.strapLoop
+    sfo   <- epicsAltair.sfoLoop
+    stGat <- epicsAltair.strapGate
+    aolp  <- epicsAltair.aoLoop
   } yield EpicsAltairConfig(
     (cmtxx, cmtxy),
     (pmtxx, pmtxy),
@@ -313,5 +309,5 @@ object AltairControllerEpics extends AltairController[IO] {
   )
 
   // This is a bit convoluted. AO follow state is read from Altair, but set as part of TCS configuration
-  override def isFollowing: IO[Option[Boolean]] = AltairEpics.instance.aoFollow
+  override def isFollowing: IO[Boolean] = AltairEpics.instance.aoFollow
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerSim.scala
@@ -26,5 +26,5 @@ object AltairControllerSim extends AltairController[IO] {
     Log.info("Simulate endObserve notification for Altair")
   }
 
-  override def isFollowing: IO[Option[Boolean]] = IO(false.some)
+  override def isFollowing: IO[Boolean] = IO(false)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairEpics.scala
@@ -4,7 +4,6 @@
 package seqexec.server.altair
 
 import cats.effect.{IO, Async}
-import cats.data.Nested
 import mouse.boolean._
 import edu.gemini.epics.acm._
 import edu.gemini.seqexec.server.altair.LgsSfoControl
@@ -56,121 +55,121 @@ class AltairEpics[F[_]: Async](service: CaService, tops: Map[String, String]) {
 
   val status: CaStatusAcceptor = service.getStatusAcceptor("aostate")
 
-  def strapTempStatus: F[Option[Boolean]] =
-    Nested(safeAttributeSInt(status.getIntegerAttribute("strapTPStat"))).map(_ =!= 0).value
+  def strapTempStatus: F[Boolean] =
+    safeAttributeSIntF(status.getIntegerAttribute("strapTPStat")).map(_ =!= 0)
 
   private val strapGateAttr = status.getIntegerAttribute("strapgate")
-  def strapGate: F[Option[Int]] = safeAttributeSInt(strapGateAttr)
+  def strapGate: F[Int] = safeAttributeSIntF(strapGateAttr)
 
   def waitForStrapGate(v: Int, timeout: Time): F[Unit] =
     EpicsUtil.waitForValueF(strapGateAttr, v:Integer, timeout, "Altair strap gate")
 
   private val strapLoopAttr = status.getIntegerAttribute("straploop")
-  def strapLoop: F[Option[Boolean]] =
-    Nested(safeAttributeSInt(strapLoopAttr)).map(_ =!= 0).value
+  def strapLoop: F[Boolean] =
+    safeAttributeSIntF(strapLoopAttr).map(_ =!= 0)
 
   def waitForStrapLoop(v: Boolean, timeout: Time): F[Unit] =
     EpicsUtil.waitForValueF(strapLoopAttr, v.fold(1, 0):Integer, timeout, "Altair strap loop")
 
-  def strapRTStatus: F[Option[Boolean]] =
-    Nested(safeAttributeSInt(status.getIntegerAttribute("strapRTStat"))).map(_ =!= 0).value
+  def strapRTStatus: F[Boolean] =
+    safeAttributeSIntF(status.getIntegerAttribute("strapRTStat")).map(_ =!= 0)
 
-  def strapHVStatus: F[Option[Boolean]] =
-    Nested(safeAttributeSInt(status.getIntegerAttribute("strapHVStat"))).map(_ =!= 0).value
+  def strapHVStatus: F[Boolean] =
+    safeAttributeSIntF(status.getIntegerAttribute("strapHVStat")).map(_ =!= 0)
 
   private val sfoLoopAttr: CaAttribute[LgsSfoControl] = status.addEnum("sfoloop",
     s"${AltairTop}cc:lgszoomSfoLoop.VAL", classOf[LgsSfoControl])
-  def sfoLoop: F[Option[LgsSfoControl]] = safeAttribute(sfoLoopAttr)
+  def sfoLoop: F[LgsSfoControl] = safeAttributeF(sfoLoopAttr)
 
-  def aoexpt: F[Option[Float]] = safeAttributeSFloat(status.getFloatAttribute("aoexpt"))
+  def aoexpt: F[Float] = safeAttributeSFloatF(status.getFloatAttribute("aoexpt"))
 
-  def aocounts: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("aocounts"))
+  def aocounts: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("aocounts"))
 
-  def aoseeing: F[Option[Float]] = safeAttributeSFloat(status.getFloatAttribute("aoseeing"))
+  def aoseeing: F[Float] = safeAttributeSFloatF(status.getFloatAttribute("aoseeing"))
 
-  def aowfsx: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("aowfsx"))
+  def aowfsx: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("aowfsx"))
 
-  def aowfsy: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("aowfsy"))
+  def aowfsy: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("aowfsy"))
 
-  def aowfsz: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("aowfsz"))
+  def aowfsz: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("aowfsz"))
 
-  def aogain: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("aogain"))
+  def aogain: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("aogain"))
 
-  def aoncpa: F[Option[String]] = safeAttribute(status.getStringAttribute("aoncpa"))
+  def aoncpa: F[String] = safeAttributeF(status.getStringAttribute("aoncpa"))
 
-  def ngndfilt: F[Option[String]] = safeAttribute(status.getStringAttribute("ngndfilt"))
+  def ngndfilt: F[String] = safeAttributeF(status.getStringAttribute("ngndfilt"))
 
-  def astar: F[Option[String]] = safeAttribute(status.getStringAttribute("astar"))
+  def astar: F[String] = safeAttributeF(status.getStringAttribute("astar"))
 
-  def aoflex: F[Option[String]] = safeAttribute(status.getStringAttribute("aoflex"))
+  def aoflex: F[String] = safeAttributeF(status.getStringAttribute("aoflex"))
 
-  def lgustage: F[Option[String]] = safeAttribute(status.getStringAttribute("lgustage"))
+  def lgustage: F[String] = safeAttributeF(status.getStringAttribute("lgustage"))
 
-  def aobs: F[Option[String]] = safeAttribute(status.getStringAttribute("aobs"))
+  def aobs: F[String] = safeAttributeF(status.getStringAttribute("aobs"))
 
-  def aoLoop: F[Option[Boolean]] = safeAttributeSInt(status.getIntegerAttribute("aowfsOn"))
-    .map(_.map(_ =!= 0))
+  def aoLoop: F[Boolean] = safeAttributeSIntF(status.getIntegerAttribute("aowfsOn"))
+    .map(_ =!= 0)
 
   private val aoSettledAttr = status.getDoubleAttribute("aoSettled")
-  def aoSettled: F[Option[Boolean]] = safeAttributeSDouble(aoSettledAttr)
-    .map(_.map(_ =!= 0.0))
+  def aoSettled: F[Boolean] = safeAttributeSDoubleF(aoSettledAttr)
+    .map(_ =!= 0.0)
 
   def waitAoSettled(timeout: Time): F[Unit] =
     EpicsUtil.waitForValueF[java.lang.Double, F](aoSettledAttr, 1.0, timeout, "AO settled flag")
 
-  def matrixStartX: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("conmatx"))
+  def matrixStartX: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("conmatx"))
 
-  def matrixStartY: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("conmaty"))
+  def matrixStartY: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("conmaty"))
 
   private val controlMatrixCalcAttr = status.addEnum[CarStateGEM5]("cmPrepBusy", s"${AltairTop}prepareCm.BUSY", classOf[CarStateGEM5])
-  def controlMatrixCalc: F[Option[CarStateGEM5]] = safeAttribute(controlMatrixCalcAttr)
+  def controlMatrixCalc: F[CarStateGEM5] = safeAttributeF(controlMatrixCalcAttr)
 
   def waitMatrixCalc(v: CarStateGEM5, timeout: Time): F[Unit] =
     EpicsUtil.waitForValueF(controlMatrixCalcAttr, v, timeout, "Atair control matrix calculation")
 
-  def lgsP1: F[Option[Boolean]] = safeAttributeSInt(status.getIntegerAttribute("lgsp1On"))
-    .map(_.map(_ =!= 0))
+  def lgsP1: F[Boolean] = safeAttributeSIntF(status.getIntegerAttribute("lgsp1On"))
+    .map(_ =!= 0)
 
-  def lgsOi: F[Option[Boolean]] = safeAttributeSInt(status.getIntegerAttribute("lgsoiOn"))
-    .map(_.map(_ =!= 0))
+  def lgsOi: F[Boolean] = safeAttributeSIntF(status.getIntegerAttribute("lgsoiOn"))
+    .map(_ =!= 0)
 
-  def aoFollow: F[Option[Boolean]] = safeAttribute(status.getStringAttribute("aoFollowS"))
-    .map(_.map(_ === "On"))
+  def aoFollow: F[Boolean] = safeAttributeF(status.getStringAttribute("aoFollowS"))
+    .map(_ === "On")
 
   // Lgs channels
-  def lgdfocus: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("lgdfocus"))
+  def lgdfocus: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("lgdfocus"))
 
-  def apd1: F[Option[Float]] = safeAttributeSFloat(status.getFloatAttribute("apd1"))
+  def apd1: F[Float] = safeAttributeSFloatF(status.getFloatAttribute("apd1"))
 
-  def apd2: F[Option[Float]] = safeAttributeSFloat(status.getFloatAttribute("apd2"))
+  def apd2: F[Float] = safeAttributeSFloatF(status.getFloatAttribute("apd2"))
 
-  def apd3: F[Option[Float]] = safeAttributeSFloat(status.getFloatAttribute("apd3"))
+  def apd3: F[Float] = safeAttributeSFloatF(status.getFloatAttribute("apd3"))
 
-  def apd4: F[Option[Float]] = safeAttributeSFloat(status.getFloatAttribute("apd4"))
+  def apd4: F[Float] = safeAttributeSFloatF(status.getFloatAttribute("apd4"))
 
-  def lgttexp: F[Option[Int]] = safeAttributeSInt(status.getIntegerAttribute("lgttexp"))
+  def lgttexp: F[Int] = safeAttributeSIntF(status.getIntegerAttribute("lgttexp"))
 
-  def fsmtip: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("fsmtip"))
+  def fsmtip: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("fsmtip"))
 
-  def fsmtilt: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("fsmtilt"))
+  def fsmtilt: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("fsmtilt"))
 
-  def lgzmpos: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("lgzmpos"))
+  def lgzmpos: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("lgzmpos"))
 
-  def aozoom: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("aozoom"))
+  def aozoom: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("aozoom"))
 
-  def aoza: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("aoza"))
+  def aoza: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("aoza"))
 
-  def nathick: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("nathick"))
+  def nathick: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("nathick"))
 
-  def lgndfilt: F[Option[String]] = safeAttribute(status.getStringAttribute("lgndfilt"))
+  def lgndfilt: F[String] = safeAttributeF(status.getStringAttribute("lgndfilt"))
 
-  def lgttiris: F[Option[String]] = safeAttribute(status.getStringAttribute("lgttiris"))
+  def lgttiris: F[String] = safeAttributeF(status.getStringAttribute("lgttiris"))
 
   val sfoStatus: CaStatusAcceptor = service.getStatusAcceptor("sfostate")
 
-  def lgsfcnts: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("lgsfcnts"))
+  def lgsfcnts: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("lgsfcnts"))
 
-  def lgsfexp: F[Option[Double]] = safeAttributeSDouble(status.getDoubleAttribute("lgsfexp"))
+  def lgsfexp: F[Double] = safeAttributeSDoubleF(status.getDoubleAttribute("lgsfexp"))
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalKeywordReader.scala
@@ -5,9 +5,9 @@ package seqexec.server.gcal
 
 import cats.Applicative
 import cats.Eq
-import cats.data.Nested
 import cats.effect.Sync
 import cats.implicits._
+import mouse.boolean._
 import edu.gemini.seqexec.server.gcal.BinaryOnOff
 import seqexec.server.keywords._
 
@@ -41,25 +41,25 @@ object GcalKeywordsReaderEpics {
     def filter: F[String] = sys.filter.safeValOrDefault
 
     def lamp: F[String] = {
-      val noValue = none[String].pure[F]
-      val onCheck: BinaryOnOff => Boolean = _ === BinaryOnOff.ON
-      val ar   = sys.lampAr.delay.map(_.exists(onCheck)).ifM("Ar".some.pure[F], noValue)
-      val cuAr = sys.lampCuAr.delay.map(_.exists(onCheck)).ifM("CuAr".some.pure[F], noValue)
-      val ir   = Nested(sys.lampIr.delay).map{
-        case BinaryOnOff.ON => "IRhigh"
-        case _              => "IRlow"
-      }.value
-      val qh   = sys.lampQH.delay.map(_.exists(onCheck)).ifM("QH".some.pure[F], noValue)
-      val thAr = sys.lampThAr.delay.map(_.exists(onCheck)).ifM("ThAr".some.pure[F], noValue)
-      val xe   = sys.lampXe.delay.map(_.exists(onCheck)).ifM("Xe".some.pure[F], noValue)
+      def onCheck(v: BinaryOnOff): Boolean = v === BinaryOnOff.ON
 
-      ar.orElse(xe).orElse(cuAr).orElse(thAr).orElse(qh).orElse(ir).safeValOrDefault
-    }
+      for {
+        ar <- sys.lampAr.map(onCheck(_).option("Ar"))
+        cuAr <- sys.lampCuAr.map(onCheck(_).option("CuAr"))
+        ir <- sys.lampIr.map {
+          case BinaryOnOff.ON => "IRhigh".some
+          case _ => "IRlow".some
+        }
+        qh <- sys.lampQH.map(onCheck(_).option("QH"))
+        thAr <- sys.lampThAr.map(onCheck(_).option("ThAr"))
+        xe <- sys.lampXe.map(onCheck(_).option("Xe"))
+      } yield ar.orElse(xe).orElse(cuAr).orElse(thAr).orElse(qh).orElse(ir)
+    }.safeValOrDefault
 
-    def shutter: F[String] = Nested(sys.shutter).map {
-      case "OPEN"  => "OPEN"
+    def shutter: F[String] = sys.shutter.map {
+      case "OPEN" => "OPEN"
       case "CLOSE" => "CLOSED"
-      case _       => "INDEF"
-    }.value.safeValOrDefault
+      case _ => "INDEF"
+    }.safeValOrDefault
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiHeader.scala
@@ -25,10 +25,7 @@ object GpiHeader {
                               id: ImageFileId): F[Unit] = {
         val ks = GdsInstrument.bundleKeywords(
           List(
-            buildDouble(Nested(tcsKeywordsReader.parallacticAngle)
-                          .map(_.toDegrees)
-                          .value
-                          .orDefault,
+            buildDouble(tcsKeywordsReader.parallacticAngle.map(_.toDegrees),
                         KeywordName.PAR_ANG),
             buildInt32(tcsKeywordsReader.gpiInstPort,
                        KeywordName.INPORT),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsEpics.scala
@@ -11,13 +11,12 @@ import edu.gemini.seqexec.server.nifs.ReadMode
 import edu.gemini.seqexec.server.nifs.TimeMode
 import java.lang.{Double => JDouble}
 import org.log4s.{Logger, getLogger}
-import seqexec.server.ObserveCommand
 import seqexec.server.EpicsSystem
 import seqexec.server.EpicsCommand
 import seqexec.server.ObserveCommand
-import seqexec.server.EpicsUtil.safeAttribute
-import seqexec.server.EpicsUtil.safeAttributeSDouble
-import seqexec.server.EpicsUtil.safeAttributeSInt
+import seqexec.server.EpicsUtil.safeAttributeF
+import seqexec.server.EpicsUtil.safeAttributeSDoubleF
+import seqexec.server.EpicsUtil.safeAttributeSIntF
 import seqexec.server.EpicsCommand.setParameter
 
 class NifsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String]) {
@@ -128,82 +127,82 @@ class NifsEpics[F[_]: Sync](epicsService: CaService, tops: Map[String, String]) 
 
   private val dcStatus: CaStatusAcceptor = epicsService.getStatusAcceptor("nifs::dcstatus")
 
-  def exposureTime: F[Option[Double]] =
-    safeAttributeSDouble(dcStatus.getDoubleAttribute("exposureTime"))
+  def exposureTime: F[Double] =
+    safeAttributeSDoubleF(dcStatus.getDoubleAttribute("exposureTime"))
 
-  def exposedTime: F[Option[Double]] =
-    safeAttributeSDouble(dcStatus.getDoubleAttribute("exposedTime"))
+  def exposedTime: F[Double] =
+    safeAttributeSDoubleF(dcStatus.getDoubleAttribute("exposedTime"))
 
-  def numberOfResets: F[Option[Int]] =
-    safeAttributeSInt(dcStatus.getIntegerAttribute("numberOfResets"))
+  def numberOfResets: F[Int] =
+    safeAttributeSIntF(dcStatus.getIntegerAttribute("numberOfResets"))
 
-  def readMode: F[Option[String]] =
-    safeAttribute(dcStatus.getStringAttribute("readMode"))
+  def readMode: F[String] =
+    safeAttributeF(dcStatus.getStringAttribute("readMode"))
 
-  def numberOfFowSamples: F[Option[Int]] =
-    safeAttributeSInt(dcStatus.getIntegerAttribute("numberOfFowSamples"))
+  def numberOfFowSamples: F[Int] =
+    safeAttributeSIntF(dcStatus.getIntegerAttribute("numberOfFowSamples"))
 
-  def coadds: F[Option[Int]] =
-    safeAttributeSInt(dcStatus.getIntegerAttribute("coadds"))
+  def coadds: F[Int] =
+    safeAttributeSIntF(dcStatus.getIntegerAttribute("coadds"))
 
-  def period: F[Option[Double]] =
-    safeAttributeSDouble(dcStatus.getDoubleAttribute("period"))
+  def period: F[Double] =
+    safeAttributeSDoubleF(dcStatus.getDoubleAttribute("period"))
 
-  def countDown: F[Option[Double]] =
-    safeAttributeSDouble(dcStatus.getDoubleAttribute("countdown"))
+  def countDown: F[Double] =
+    safeAttributeSDoubleF(dcStatus.getDoubleAttribute("countdown"))
 
-  def numberOfPeriods: F[Option[Int]] =
-    safeAttributeSInt(dcStatus.getIntegerAttribute("numberOfPeriods"))
+  def numberOfPeriods: F[Int] =
+    safeAttributeSIntF(dcStatus.getIntegerAttribute("numberOfPeriods"))
 
-  def timeMode: F[Option[String]] =
-    safeAttribute(dcStatus.getStringAttribute("timeMode"))
+  def timeMode: F[String] =
+    safeAttributeF(dcStatus.getStringAttribute("timeMode"))
 
   private val dhsConnectedAttr: CaAttribute[DhsConnected] =
     dcStatus.addEnum[DhsConnected]("dhsConnected", s"${NifsTop}sad:dc:dhsConnO", classOf[DhsConnected])
 
-  def dhsConnected: F[Option[DhsConnected]] =
-    safeAttribute(dhsConnectedAttr)
+  def dhsConnected: F[DhsConnected] =
+    safeAttributeF(dhsConnectedAttr)
 
-  def dcName: F[Option[String]] =
-    safeAttribute(dcStatus.getStringAttribute("name"))
+  def dcName: F[String] =
+    safeAttributeF(dcStatus.getStringAttribute("name"))
 
-  def exposureMode: F[Option[String]] =
-    safeAttribute(dcStatus.getStringAttribute("expMode"))
+  def exposureMode: F[String] =
+    safeAttributeF(dcStatus.getStringAttribute("expMode"))
 
-  def readTime: F[Option[Double]] =
-    safeAttributeSDouble(dcStatus.getDoubleAttribute("readTime"))
+  def readTime: F[Double] =
+    safeAttributeSDoubleF(dcStatus.getDoubleAttribute("readTime"))
 
-  def biasPwr: F[Option[Double]] =
-    safeAttributeSDouble(dcStatus.getDoubleAttribute("biasPwr"))
+  def biasPwr: F[Double] =
+    safeAttributeSDoubleF(dcStatus.getDoubleAttribute("biasPwr"))
 
   private val ccStatus: CaStatusAcceptor = epicsService.getStatusAcceptor("nifs::status")
 
-  def centralWavelength: F[Option[Double]] =
-    safeAttributeSDouble(ccStatus.getDoubleAttribute("centralWavelength"))
+  def centralWavelength: F[Double] =
+    safeAttributeSDoubleF(ccStatus.getDoubleAttribute("centralWavelength"))
 
-  def disperser: F[Option[String]] =
-    safeAttribute(ccStatus.getStringAttribute("disperser"))
+  def disperser: F[String] =
+    safeAttributeF(ccStatus.getStringAttribute("disperser"))
 
-  def imagingMirror: F[Option[String]] =
-    safeAttribute(ccStatus.getStringAttribute("imagingMirror"))
+  def imagingMirror: F[String] =
+    safeAttributeF(ccStatus.getStringAttribute("imagingMirror"))
 
-  def mask: F[Option[String]] =
-    safeAttribute(ccStatus.getStringAttribute("mask"))
+  def mask: F[String] =
+    safeAttributeF(ccStatus.getStringAttribute("mask"))
 
-  def lastSelectedDisperser: F[Option[String]] =
-    safeAttribute(ccStatus.getStringAttribute("lastSelDisp"))
+  def lastSelectedDisperser: F[String] =
+    safeAttributeF(ccStatus.getStringAttribute("lastSelDisp"))
 
-  def lastSelectedMask: F[Option[String]] =
-    safeAttribute(ccStatus.getStringAttribute("lastSelMask"))
+  def lastSelectedMask: F[String] =
+    safeAttributeF(ccStatus.getStringAttribute("lastSelMask"))
 
-  def maskOffset: F[Option[Double]] =
-    safeAttributeSDouble(ccStatus.getDoubleAttribute("maskOffset"))
+  def maskOffset: F[Double] =
+    safeAttributeSDoubleF(ccStatus.getDoubleAttribute("maskOffset"))
 
-  def filter: F[Option[String]] =
-    safeAttribute(ccStatus.getStringAttribute("filter"))
+  def filter: F[String] =
+    safeAttributeF(ccStatus.getStringAttribute("filter"))
 
-  def windowCover: F[Option[String]] =
-    safeAttribute(ccStatus.getStringAttribute("windowCover"))
+  def windowCover: F[String] =
+    safeAttributeF(ccStatus.getStringAttribute("windowCover"))
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsKeywordReader.scala
@@ -49,7 +49,7 @@ object NifsKeywordReaderDummy {
 }
 
 trait NifsKeywordReaderLUT {
-  val Invalid: Option[String] = "INVALID".some
+  val Invalid: String = "INVALID"
 
   val DisperserKeywordLUT: Map[String, String] =
     Map(
@@ -94,7 +94,7 @@ object NifsKeywordReaderEpics extends NifsKeywordReaderLUT {
       sys.mask
         .map(_ === Invalid)
         .ifM(sys.lastSelectedMask, sys.mask)
-        .map(_.flatMap(MaskKeywordLUT.get))
+        .map(MaskKeywordLUT.get)
         .safeValOrDefault
 
     override def biasPwr: F[Double] = sys.biasPwr.safeValOrDefault
@@ -111,13 +111,13 @@ object NifsKeywordReaderEpics extends NifsKeywordReaderLUT {
     override def exposureMode: F[String] = sys.exposureMode.safeValOrDefault
 
     override def filter: F[String] =
-      sys.filter.map(_.flatMap(FilterKeywordLUT.get)).safeValOrDefault
+      sys.filter.map(FilterKeywordLUT.get).safeValOrDefault
 
     override def grating: F[String] =
       sys.disperser
         .map(_ === Invalid)
         .ifM(sys.lastSelectedDisperser, sys.disperser)
-        .map(_.flatMap(DisperserKeywordLUT.get))
+        .map(DisperserKeywordLUT.get)
         .safeValOrDefault
 
     override def imagingMirror: F[String] = sys.imagingMirror.safeValOrDefault

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriKeywordReader.scala
@@ -4,7 +4,6 @@
 package seqexec.server.niri
 
 import cats.Applicative
-import cats.data.Nested
 import cats.effect.Sync
 import cats.implicits._
 import seqexec.server.keywords._
@@ -90,7 +89,7 @@ object NiriKeywordReaderEpics {
       (for {
         it <- sys.integrationTime
         mi <- sys.minIntegration
-      } yield (it, mi).mapN(_ + _)).safeValOrDefault
+      } yield it + mi).safeValOrDefault
     override def filter1: F[String] = sys.filter1.safeValOrDefault
     override def filter2: F[String] = sys.filter2.safeValOrDefault
     override def filter3: F[String] = sys.filter3.safeValOrDefault
@@ -100,33 +99,33 @@ object NiriKeywordReaderEpics {
     override def beamSplitter: F[String] = sys.beamSplitter.safeValOrDefault
     override def windowCover: F[String] = sys.windowCover.safeValOrDefault
     override def framesPerCycle: F[Int] = sys.framesPerCycle.safeValOrDefault
-    override def headerTiming: F[String] = Nested(sys.hdrTiming).map {
+    override def headerTiming: F[String] = sys.hdrTiming.map {
       case 1 => "BEFORE"
       case 2 => "AFTER"
       case 3 => "BOTH"
       case _ => "INDEF"
-    }.value.safeValOrDefault
+    }.safeValOrDefault
     override def lnrs: F[Int] = sys.lnrs.safeValOrDefault
-    override def mode: F[String] = Nested(sys.mode).map {
+    override def mode: F[String] = sys.mode.map {
       case 0 => "STARE"
       case 1 => "SEP"
       case 2 => "CHOP"
       case 3 => "CHOP2"
       case 4 => "TEST"
       case _ => "INDEF"
-    }.value.safeValOrDefault
+    }.safeValOrDefault
     override def numberDigitalAverage: F[Int] = sys.digitalAverageCount.safeValOrDefault
     override def pupilViewer: F[String] = sys.pupilViewer.safeValOrDefault
     override def detectorTemperature: F[Double] = sys.detectorTemp.safeValOrDefault
     override def mountTemperature: F[Double] = sys.mountTemp.safeValOrDefault
     override def µcodeName: F[String] = sys.µcodeName.safeValOrDefault
-    override def µcodeType: F[String] = Nested(sys.µcodeType).map {
+    override def µcodeType: F[String] = sys.µcodeType.map {
       case 1 => "RRD"
       case 2 => "RDD"
       case 3 => "RD"
       case 4 => "SRB"
       case _ => "INDEF"
-    }.value.safeValOrDefault
+    }.safeValOrDefault
     override def cl1VoltageDD: F[Double] = sys.vddCl1.safeValOrDefault
     override def cl2VoltageDD: F[Double] = sys.vddCl2.safeValOrDefault
     override def ucVoltage: F[Double] = sys.vddUc.safeValOrDefault

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
@@ -3,8 +3,8 @@
 
 package seqexec.server.tcs
 
-import cats.{Eq, MonadError}
-import cats.data.{Nested, OneAnd, OptionT}
+import cats.Eq
+import cats.data.OneAnd
 import cats.effect.IO
 import cats.implicits._
 import mouse.boolean._
@@ -20,7 +20,8 @@ import seqexec.model.TelescopeGuideConfig
 import seqexec.server.EpicsCodex.{DecodeEpicsValue, decode}
 import seqexec.server.tcs.TcsController.FollowOption.{FollowOff, FollowOn}
 import seqexec.server.SeqexecFailure
-import seqexec.server.gems.Gems.{DetectorStateOps, GemsWfsState, Cwfs1DetectorState, Cwfs2DetectorState, Cwfs3DetectorState, Odgw1DetectorState, Odgw2DetectorState, Odgw3DetectorState, Odgw4DetectorState}
+import seqexec.server.SeqexecFailure.NullEpicsError
+import seqexec.server.gems.Gems.{Cwfs1DetectorState, Cwfs2DetectorState, Cwfs3DetectorState, DetectorStateOps, GemsWfsState, Odgw1DetectorState, Odgw2DetectorState, Odgw3DetectorState, Odgw4DetectorState}
 import seqexec.server.gems.Gems.Cwfs1DetectorState.{Off => _, On => _, _}
 import seqexec.server.gems.Gems.Cwfs2DetectorState.{Off => _, On => _, _}
 import seqexec.server.gems.Gems.Cwfs3DetectorState.{Off => _, On => _, _}
@@ -28,7 +29,7 @@ import seqexec.server.gems.Gems.Odgw1DetectorState.{Off => _, On => _, _}
 import seqexec.server.gems.Gems.Odgw2DetectorState.{Off => _, On => _, _}
 import seqexec.server.gems.Gems.Odgw3DetectorState.{Off => _, On => _, _}
 import seqexec.server.gems.Gems.Odgw4DetectorState.{Off => _, On => _, _}
-import seqexec.server.tcs.GemsSource.{Odgw1, Odgw2, Odgw3, Odgw4, Cwfs1, Cwfs2, Cwfs3}
+import seqexec.server.tcs.GemsSource.{Cwfs1, Cwfs2, Cwfs3, Odgw1, Odgw2, Odgw3, Odgw4}
 import seqexec.server.tcs.TcsController._
 import seqexec.server.tcs.TcsControllerEpicsCommon.{AoFold, InstrumentPorts, InvalidPort, ScienceFold}
 import seqexec.server.tcs.TcsEpics.VirtualGemsTelescope
@@ -71,58 +72,52 @@ object TcsConfigRetriever {
 
   private def getGuideConfig: IO[TelescopeGuideConfig] = {
     for {
-      mountGuide <-  OptionT(TcsEpics.instance.absorbTipTilt).map(decode[Int, MountGuideOption])
-      m1Source   <-  OptionT(TcsEpics.instance.m1GuideSource).map(decode[String, M1Source])
-      m1Guide    <-  OptionT(TcsEpics.instance.m1Guide).map(decodeM1Guide(_, m1Source))
-      m2p1Guide  <-  OptionT(TcsEpics.instance.m2p1Guide).map(decodeGuideSourceOption)
-      m2p2Guide  <-  OptionT(TcsEpics.instance.m2p2Guide).map(decodeGuideSourceOption)
-      m2oiGuide  <-  OptionT(TcsEpics.instance.m2oiGuide).map(decodeGuideSourceOption)
-      m2aoGuide  <-  OptionT(TcsEpics.instance.m2aoGuide).map(decodeGuideSourceOption)
-      m2Coma     <-  OptionT(TcsEpics.instance.comaCorrect).map(decode[String, ComaOption])
-      m2Guide    <- OptionT(Nested(TcsEpics.instance.m2GuideState).map(decodeM2Guide(_, m2Coma, List((m2p1Guide, TipTiltSource.PWFS1),
+      mountGuide <-  TcsEpics.instance.absorbTipTilt.map(decode[Int, MountGuideOption])
+      m1Source   <-  TcsEpics.instance.m1GuideSource.map(decode[String, M1Source])
+      m1Guide    <-  TcsEpics.instance.m1Guide.map(decodeM1Guide(_, m1Source))
+      m2p1Guide  <-  TcsEpics.instance.m2p1Guide.map(decodeGuideSourceOption)
+      m2p2Guide  <-  TcsEpics.instance.m2p2Guide.map(decodeGuideSourceOption)
+      m2oiGuide  <-  TcsEpics.instance.m2oiGuide.map(decodeGuideSourceOption)
+      m2aoGuide  <-  TcsEpics.instance.m2aoGuide.map(decodeGuideSourceOption)
+      m2Coma     <-  TcsEpics.instance.comaCorrect.map(decode[String, ComaOption])
+      m2Guide    <-  TcsEpics.instance.m2GuideState.map(decodeM2Guide(_, m2Coma, List((m2p1Guide, TipTiltSource.PWFS1),
         (m2p2Guide, TipTiltSource.PWFS2), (m2oiGuide, TipTiltSource.OIWFS),
-        (m2aoGuide, TipTiltSource.GAOS)).foldLeft(Set.empty[TipTiltSource])((s: Set[TipTiltSource], v: (Boolean, TipTiltSource)) => if (v._1) s + v._2 else s))).value)
+        (m2aoGuide, TipTiltSource.GAOS)).foldLeft(Set.empty[TipTiltSource])((s: Set[TipTiltSource], v: (Boolean, TipTiltSource)) => if (v._1) s + v._2 else s)))
     } yield TelescopeGuideConfig(mountGuide, m1Guide, m2Guide)
-  }.getOrElseF(IO.raiseError(SeqexecFailure.Unexpected("Unable to read guide configuration from TCS.")))
+  }.adaptError{ case e => SeqexecFailure.Unexpected(s"Unable to read guide configuration from TCS: $e")}
 
-  private def getAoFold: IO[AoFold] =
-    getStatusVal(Nested(TcsEpics.instance.aoFoldPosition).map(decode[String, AoFold]).value, "AO Fold")
+  private def getAoFold: IO[AoFold] = TcsEpics.instance.aoFoldPosition.map(decode[String, AoFold])
 
   private def decodeNodChopOption(s: String): Boolean = s.trim === "On"
 
-  private def getNodChopTrackingConfig(g: TcsEpics.ProbeGuideConfig[IO]): IO[Option[NodChopTrackingConfig]] = (
+  private def getNodChopTrackingConfig(g: TcsEpics.ProbeGuideConfig[IO]): IO[NodChopTrackingConfig] =
     for {
-      aa <-  OptionT(g.nodachopa).map(decodeNodChopOption)
-      ab <-  OptionT(g.nodachopb).map(decodeNodChopOption)
-      ac <-  OptionT(g.nodachopc).map(decodeNodChopOption)
-      ba <-  OptionT(g.nodbchopa).map(decodeNodChopOption)
-      bb <-  OptionT(g.nodbchopb).map(decodeNodChopOption)
-      bc <-  OptionT(g.nodbchopc).map(decodeNodChopOption)
-      ca <-  OptionT(g.nodcchopa).map(decodeNodChopOption)
-      cb <-  OptionT(g.nodcchopb).map(decodeNodChopOption)
-      cc <-  OptionT(g.nodcchopc).map(decodeNodChopOption)
-
-      // This last product is slightly tricky.
-      o  <- OptionT(IO{
-        if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).contains(true)) {
-          if (List(aa, bb).forall(_ === true) && List(ab, ac, ba, bc, ca, cb, cc).forall(_ === false)) {
-            Some(NodChopTrackingConfig.Normal)
-          } else {
-            List(
-              (aa, NodChop(Beam.A, Beam.A)), (ab, NodChop(Beam.A, Beam.B)), (ac, NodChop(Beam.A, Beam.C)),
-              (ba, NodChop(Beam.B, Beam.A)), (bb, NodChop(Beam.B, Beam.B)), (bc, NodChop(Beam.B, Beam.C)),
-              (ca, NodChop(Beam.C, Beam.A)), (cb, NodChop(Beam.C, Beam.B)), (cc, NodChop(Beam.C, Beam.C))
-            ) collect {
-              case (true, a) => a
-            } match {
-              case h :: t => Some(NodChopTrackingConfig.Special(OneAnd(h, t)))
-              case Nil    => None // the list is empty
-            }
+      aa <- g.nodachopa.map(decodeNodChopOption)
+      ab <- g.nodachopb.map(decodeNodChopOption)
+      ac <- g.nodachopc.map(decodeNodChopOption)
+      ba <- g.nodbchopa.map(decodeNodChopOption)
+      bb <- g.nodbchopb.map(decodeNodChopOption)
+      bc <- g.nodbchopc.map(decodeNodChopOption)
+      ca <- g.nodcchopa.map(decodeNodChopOption)
+      cb <- g.nodcchopb.map(decodeNodChopOption)
+      cc <- g.nodcchopc.map(decodeNodChopOption)
+    } yield
+      if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).contains(true)) {
+        if (List(aa, bb).forall(_ === true) && List(ab, ac, ba, bc, ca, cb, cc).forall(_ === false)) {
+          NodChopTrackingConfig.Normal
+        } else {
+          List(
+            (aa, NodChop(Beam.A, Beam.A)), (ab, NodChop(Beam.A, Beam.B)), (ac, NodChop(Beam.A, Beam.C)),
+            (ba, NodChop(Beam.B, Beam.A)), (bb, NodChop(Beam.B, Beam.B)), (bc, NodChop(Beam.B, Beam.C)),
+            (ca, NodChop(Beam.C, Beam.A)), (cb, NodChop(Beam.C, Beam.B)), (cc, NodChop(Beam.C, Beam.C))
+          ) collect {
+            case (true, a) => a
+          } match {
+            case h :: t => NodChopTrackingConfig.Special(OneAnd(h, t))
+            case Nil    => NodChopTrackingConfig.AllOff
           }
-        } else Some(NodChopTrackingConfig.AllOff)
-      })
-    } yield o
-  ).value
+        }
+      } else NodChopTrackingConfig.AllOff
 
   private def calcProbeTrackingConfig(f: FollowOption, t: NodChopTrackingConfig): ProbeTrackingConfig = (f, t) match {
     case (FollowOff, _)                            => ProbeTrackingConfig.Off
@@ -137,42 +132,42 @@ object TcsConfigRetriever {
     DecodeEpicsValue((s: BinaryYesNo) => if (s === BinaryYesNo.No) GuiderSensorOff else GuiderSensorOn)
 
   private def getPwfs1: IO[GuiderConfig] = for {
-    prk <- getStatusVal(TcsEpics.instance.p1Parked, "PWFS1 parked state")
-    trk <- getStatusVal(getNodChopTrackingConfig(TcsEpics.instance.pwfs1ProbeGuideConfig), "PWFS1 tracking configuration")
-    fol <- getStatusVal(Nested(TcsEpics.instance.p1FollowS).map(decode[String, FollowOption]).value, "PWFS1 follow state")
-    wfs <- getStatusVal(Nested(TcsEpics.instance.pwfs1On).map(decode[BinaryYesNo, GuiderSensorOption]).value, "PWFS1 detector")
+    prk <- TcsEpics.instance.p1Parked
+    trk <- getNodChopTrackingConfig(TcsEpics.instance.pwfs1ProbeGuideConfig)
+    fol <- TcsEpics.instance.p1FollowS.map(decode[String, FollowOption])
+    wfs <- TcsEpics.instance.pwfs1On.map(decode[BinaryYesNo, GuiderSensorOption])
   } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
 
   private def getPwfs2: IO[GuiderConfig] = for {
-    prk   <- getStatusVal(TcsEpics.instance.p2Parked, "PWFS2 parked state")
-    trk   <- getStatusVal(getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig), "PWFS2 tracking configuration")
-    fol   <- getStatusVal(Nested(TcsEpics.instance.p2FollowS).map(decode[String, FollowOption]).value, "PWFS2 follow state")
-    wfs   <- getStatusVal(Nested(TcsEpics.instance.pwfs2On).map(decode[BinaryYesNo, GuiderSensorOption]).value, "PWFS2 detector")
+    prk   <- TcsEpics.instance.p2Parked
+    trk   <- getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig)
+    fol   <- TcsEpics.instance.p2FollowS.map(decode[String, FollowOption])
+    wfs   <- TcsEpics.instance.pwfs2On.map(decode[BinaryYesNo, GuiderSensorOption])
     useAo <- getUseAo
   } yield if(useAo) GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, NodChopTrackingConfig.AllOff)), wfs)
           else GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
 
-  private def getUseAo: IO[Boolean] = getStatusVal(TcsEpics.instance.useAo, "use AO flag").map(_ === BinaryYesNo.Yes)
+  private def getUseAo: IO[Boolean] = TcsEpics.instance.useAo.map(_ === BinaryYesNo.Yes)
 
-  private def getAowfs(getAoFollow: IO[Option[Boolean]]): IO[ProbeTrackingConfig] = for {
-    aoFol <- getStatusVal(getAoFollow, "AO follow state").map(_.fold(FollowOn, FollowOff))
-    trk   <- getStatusVal(getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig), "AOWFS tracking configuration")
+  private def getAowfs(getAoFollow: IO[Boolean]): IO[ProbeTrackingConfig] = for {
+    aoFol <- getAoFollow.map(if(_) FollowOn else FollowOff)
+    trk   <- getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig)
     useAo <- getUseAo
   } yield if(useAo) calcProbeTrackingConfig(aoFol, trk)
           else calcProbeTrackingConfig(aoFol, NodChopTrackingConfig.AllOff)
 
   private def getOiwfs: IO[GuiderConfig] = for {
-    prk <- getStatusVal(TcsEpics.instance.oiParked, "OIWFS parked state")
-    trk <- getStatusVal(getNodChopTrackingConfig(TcsEpics.instance.oiwfsProbeGuideConfig), "OIWFS tracking configuration")
-    fol <- getStatusVal(Nested(TcsEpics.instance.oiFollowS).map(decode[String, FollowOption]).value, "OIWFS follow state")
-    wfs <- getStatusVal(Nested(TcsEpics.instance.oiwfsOn).map(decode[BinaryYesNo, GuiderSensorOption]).value, "OIWFS detector")
+    prk <- TcsEpics.instance.oiParked
+    trk <- getNodChopTrackingConfig(TcsEpics.instance.oiwfsProbeGuideConfig)
+    fol <- TcsEpics.instance.oiFollowS.map(decode[String, FollowOption])
+    wfs <- TcsEpics.instance.oiwfsOn.map(decode[BinaryYesNo, GuiderSensorOption])
   } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
 
   import ScienceFoldPositionCodex._
 
   private def getScienceFoldPosition: IO[Option[ScienceFold]] = for {
-    sfPos    <- getStatusVal(TcsEpics.instance.sfName,"SF position")
-    sfParked <- getStatusVal(Nested(TcsEpics.instance.sfParked).map(_ =!= 0).value, "SF park")
+    sfPos    <- TcsEpics.instance.sfName
+    sfParked <- TcsEpics.instance.sfParked.map(_ =!= 0)
   } yield if (sfParked) ScienceFold.Parked.some
           else decode[String, Option[ScienceFold]](sfPos)
 
@@ -181,26 +176,18 @@ object TcsConfigRetriever {
     else HrwfsPickupPosition.OUT)
 
   private def getHrwfsPickupPosition: IO[HrwfsPickupPosition] = for {
-    hwPos    <- getStatusVal(Nested(TcsEpics.instance.agHwName).map(decode[String, HrwfsPickupPosition]).value,
-      "Pickup position")
-    hwParked <- getStatusVal(Nested(TcsEpics.instance.agHwParked).map(_ =!= 0).value, "Pickup park")
+    hwPos    <- TcsEpics.instance.agHwName.map(decode[String, HrwfsPickupPosition])
+    hwParked <- TcsEpics.instance.agHwParked.map(_ =!= 0)
   } yield if (hwParked) HrwfsPickupPosition.Parked
           else hwPos
 
-  private def getStatusVal[F[_]: MonadError[?[_], Throwable], A](get: F[Option[A]], name: String): F[A] =
-    OptionT(get).getOrElseF(SeqexecFailure.Unexpected(s"Unable to read $name from TCS.").raiseError[F, A])
+  private def getIAA: IO[Angle] = TcsEpics.instance.instrAA.map(Degrees(_))
 
-  private def getIAA: IO[Angle] = getStatusVal(Nested(TcsEpics.instance.instrAA).map(Degrees(_)).value, "IAA")
+  private def getOffsetX: IO[Length] = TcsEpics.instance.xoffsetPoA1.map(Millimeters(_))
 
-  private def getOffsetX: IO[Length] = getStatusVal(Nested(TcsEpics.instance.xoffsetPoA1).map(Millimeters(_)).value,
-    "X offset")
+  private def getOffsetY: IO[Length] = TcsEpics.instance.yoffsetPoA1.map(Millimeters(_))
 
-  private def getOffsetY: IO[Length] = getStatusVal(Nested(TcsEpics.instance.yoffsetPoA1).map(Millimeters(_)).value,
-    "Y offset")
-
-  private def getWavelength: IO[Wavelength] =
-    getStatusVal(Nested(TcsEpics.instance.sourceAWavelength).map(v => Wavelength(Angstroms(v))).value,
-      "central wavelength")
+  private def getWavelength: IO[Wavelength] = TcsEpics.instance.sourceAWavelength.map(v => Wavelength(Angstroms(v)))
 
   private def getGemsMap: IO[Map[GemsSource, VirtualGemsTelescope]] = for {
     v1 <- TcsEpics.instance.g1MapName
@@ -214,55 +201,53 @@ object TcsConfigRetriever {
     v4 -> VirtualGemsTelescope.G4
   ).mapFilter{ case (s, v) => s.map((_, v))}.toMap
 
-  private def getCwfs[T: DetectorStateOps: Eq](getFollow: IO[Option[Boolean]], name: String)
+  private def getCwfs[T: DetectorStateOps: Eq](getFollow: IO[Boolean])
                                              (g: VirtualGemsTelescope, active: IO[T])
   : IO[GuiderConfig] = for {
-    trk <- getStatusVal(getNodChopTrackingConfig(TcsEpics.instance.gemsGuideConfig(g)), s"$name tracking configuration")
-    fol <- getStatusVal(Nested(getFollow).map{if(_) FollowOption.FollowOn else FollowOption.FollowOff}.value,
-      s"$name follow state")
+    trk <- getNodChopTrackingConfig(TcsEpics.instance.gemsGuideConfig(g))
+    fol <- getFollow.map{if(_) FollowOption.FollowOn else FollowOption.FollowOff}
     wfs <- active.map{x => if(DetectorStateOps.isActive(x)) GuiderSensorOn else GuiderSensorOff}
   } yield GuiderConfig(calcProbeTrackingConfig(fol, trk), wfs)
 
   private val getCwfs1: (VirtualGemsTelescope, IO[Cwfs1DetectorState]) => IO[GuiderConfig] =
-    getCwfs(TcsEpics.instance.cwfs1Follow, "NGS1")
+    getCwfs(TcsEpics.instance.cwfs1Follow)
 
   private val getCwfs2: (VirtualGemsTelescope, IO[Cwfs2DetectorState]) => IO[GuiderConfig] =
-    getCwfs(TcsEpics.instance.cwfs1Follow, "NGS2")
+    getCwfs(TcsEpics.instance.cwfs1Follow)
 
   private val getCwfs3: (VirtualGemsTelescope, IO[Cwfs3DetectorState]) => IO[GuiderConfig] =
-    getCwfs(TcsEpics.instance.cwfs1Follow, "NGS3")
+    getCwfs(TcsEpics.instance.cwfs1Follow)
 
-  private def getOdgw[T: DetectorStateOps: Eq](getParked: IO[Option[Boolean]], getFollow: IO[Option[Boolean]], name: String)
+  private def getOdgw[T: DetectorStateOps: Eq](getParked: IO[Boolean], getFollow: IO[Boolean])
                                           (g: VirtualGemsTelescope, active: IO[T])
   : IO[GuiderConfig] = for {
-    prk <- getStatusVal(getParked, s"$name parked state")
-    trk <- getStatusVal(getNodChopTrackingConfig(TcsEpics.instance.gemsGuideConfig(g)), s"$name tracking configuration")
-    fol <- getStatusVal(Nested(getFollow)
-      .map{ if(_) FollowOption.FollowOn else FollowOption.FollowOff}.value, s"$name follow state")
+    prk <- getParked
+    trk <- getNodChopTrackingConfig(TcsEpics.instance.gemsGuideConfig(g))
+    fol <- getFollow.map{ if(_) FollowOption.FollowOn else FollowOption.FollowOff}
     wfs <- active.map{x => if(DetectorStateOps.isActive[T](x)) GuiderSensorOn else GuiderSensorOff}
   } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
 
   private val getOdgw1: (VirtualGemsTelescope, IO[Odgw1DetectorState]) => IO[GuiderConfig] =
-    getOdgw(TcsEpics.instance.odgw1Parked, TcsEpics.instance.odgw1Follow, "ODGW1")
+    getOdgw(TcsEpics.instance.odgw1Parked, TcsEpics.instance.odgw1Follow)
 
   private val getOdgw2: (VirtualGemsTelescope, IO[Odgw2DetectorState]) => IO[GuiderConfig] =
-    getOdgw(TcsEpics.instance.odgw2Parked, TcsEpics.instance.odgw2Follow, "ODGW2")
+    getOdgw(TcsEpics.instance.odgw2Parked, TcsEpics.instance.odgw2Follow)
 
   private val getOdgw3: (VirtualGemsTelescope, IO[Odgw3DetectorState]) => IO[GuiderConfig] =
-    getOdgw(TcsEpics.instance.odgw3Parked, TcsEpics.instance.odgw3Follow, "ODGW3")
+    getOdgw(TcsEpics.instance.odgw3Parked, TcsEpics.instance.odgw3Follow)
 
   private val getOdgw4: (VirtualGemsTelescope, IO[Odgw4DetectorState]) => IO[GuiderConfig] =
-    getOdgw(TcsEpics.instance.odgw4Parked, TcsEpics.instance.odgw4Follow, "ODGW4")
+    getOdgw(TcsEpics.instance.odgw4Parked, TcsEpics.instance.odgw4Follow)
 
   private def getInstrumentPorts: IO[InstrumentPorts] = for {
-    f2    <- TcsEpics.instance.f2Port.map(_.getOrElse(InvalidPort))
-    ghost <- TcsEpics.instance.ghostPort.map(_.getOrElse(InvalidPort))
-    gmos  <- TcsEpics.instance.gmosPort.map(_.getOrElse(InvalidPort))
-    gnirs <- TcsEpics.instance.gnirsPort.map(_.getOrElse(InvalidPort))
-    gpi   <- TcsEpics.instance.gpiPort.map(_.getOrElse(InvalidPort))
-    gsaoi <- TcsEpics.instance.gsaoiPort.map(_.getOrElse(InvalidPort))
-    nifs  <- TcsEpics.instance.nifsPort.map(_.getOrElse(InvalidPort))
-    niri  <- TcsEpics.instance.niriPort.map(_.getOrElse(InvalidPort))
+    f2    <- TcsEpics.instance.f2Port.recover{case NullEpicsError(_) => InvalidPort}
+    ghost <- TcsEpics.instance.ghostPort.recover{case NullEpicsError(_) => InvalidPort}
+    gmos  <- TcsEpics.instance.gmosPort.recover{case NullEpicsError(_) => InvalidPort}
+    gnirs <- TcsEpics.instance.gnirsPort.recover{case NullEpicsError(_) => InvalidPort}
+    gpi   <- TcsEpics.instance.gpiPort.recover{case NullEpicsError(_) => InvalidPort}
+    gsaoi <- TcsEpics.instance.gsaoiPort.recover{case NullEpicsError(_) => InvalidPort}
+    nifs  <- TcsEpics.instance.nifsPort.recover{case NullEpicsError(_) => InvalidPort}
+    niri  <- TcsEpics.instance.niriPort.recover{case NullEpicsError(_) => InvalidPort}
   } yield InstrumentPorts(
     f2,
     ghost,
@@ -274,7 +259,7 @@ object TcsConfigRetriever {
     niri
   )
 
-  def retrieveConfigurationNorth(getAoFollow: IO[Option[Boolean]]): IO[TcsNorthControllerEpicsAo.EpicsTcsAoConfig] =
+  def retrieveConfigurationNorth(getAoFollow: IO[Boolean]): IO[TcsNorthControllerEpicsAo.EpicsTcsAoConfig] =
     for {
       base <- retrieveBaseConfiguration
       ao   <- getAowfs(getAoFollow)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.tcs
 
-import cats.data.Nested
 import cats.effect.{Async, IO, LiftIO, Sync}
 import cats.implicits._
 import squants.Angle
@@ -13,12 +12,11 @@ import org.log4s.{Logger, getLogger}
 import seqexec.model.enum.ApplyCommandResult
 import seqexec.server.EpicsCommand._
 import seqexec.server.EpicsUtil._
+import seqexec.server.SeqexecFailure.SeqexecException
 import seqexec.server.{EpicsCommand, EpicsSystem}
 import squants.Time
 import squants.space.Degrees
 import squants.time.TimeConversions._
-
-import scala.util.Try
 
 /**
  * TcsEpics wraps the non-functional parts of the EPICS ACM library to interact with TCS. It has all the objects used
@@ -287,95 +285,95 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
 
   private val tcsState = epicsService.getStatusAcceptor("tcsstate")
 
-  def absorbTipTilt: F[Option[Int]] = safeAttributeSInt(tcsState.getIntegerAttribute("absorbTipTilt"))
+  def absorbTipTilt: F[Int] = safeAttributeSIntF(tcsState.getIntegerAttribute("absorbTipTilt"))
 
-  def m1GuideSource: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("m1GuideSource"))
+  def m1GuideSource: F[String] = safeAttributeF(tcsState.getStringAttribute("m1GuideSource"))
 
   private val m1GuideAttr: CaAttribute[BinaryOnOff] = tcsState.addEnum("m1Guide",
     s"${TcsTop}im:m1GuideOn", classOf[BinaryOnOff], "M1 guide")
-  def m1Guide: F[Option[BinaryOnOff]] = safeAttribute(m1GuideAttr)
+  def m1Guide: F[BinaryOnOff] = safeAttributeF(m1GuideAttr)
 
-  def m2p1Guide: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("m2p1Guide"))
+  def m2p1Guide: F[String] = safeAttributeF(tcsState.getStringAttribute("m2p1Guide"))
 
-  def m2p2Guide: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("m2p2Guide"))
+  def m2p2Guide: F[String] = safeAttributeF(tcsState.getStringAttribute("m2p2Guide"))
 
-  def m2oiGuide: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("m2oiGuide"))
+  def m2oiGuide: F[String] = safeAttributeF(tcsState.getStringAttribute("m2oiGuide"))
 
-  def m2aoGuide: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("m2aoGuide"))
+  def m2aoGuide: F[String] = safeAttributeF(tcsState.getStringAttribute("m2aoGuide"))
 
-  def comaCorrect: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("comaCorrect"))
+  def comaCorrect: F[String] = safeAttributeF(tcsState.getStringAttribute("comaCorrect"))
 
   private val m2GuideStateAttr: CaAttribute[BinaryOnOff] = tcsState.addEnum("m2GuideState",
     s"${TcsTop}om:m2GuideState", classOf[BinaryOnOff], "M2 guiding state")
-  def m2GuideState: F[Option[BinaryOnOff]] = safeAttribute(m2GuideStateAttr)
+  def m2GuideState: F[BinaryOnOff] = safeAttributeF(m2GuideStateAttr)
 
-  def xoffsetPoA1: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("xoffsetPoA1"))
+  def xoffsetPoA1: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("xoffsetPoA1"))
 
-  def yoffsetPoA1: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("yoffsetPoA1"))
+  def yoffsetPoA1: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("yoffsetPoA1"))
 
-  def xoffsetPoB1: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("xoffsetPoB1"))
+  def xoffsetPoB1: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("xoffsetPoB1"))
 
-  def yoffsetPoB1: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("yoffsetPoB1"))
+  def yoffsetPoB1: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("yoffsetPoB1"))
 
-  def xoffsetPoC1: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("xoffsetPoC1"))
+  def xoffsetPoC1: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("xoffsetPoC1"))
 
-  def yoffsetPoC1: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("yoffsetPoC1"))
+  def yoffsetPoC1: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("yoffsetPoC1"))
 
-  def sourceAWavelength: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("sourceAWavelength"))
+  def sourceAWavelength: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("sourceAWavelength"))
 
-  def sourceBWavelength: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("sourceBWavelength"))
+  def sourceBWavelength: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("sourceBWavelength"))
 
-  def sourceCWavelength: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("sourceCWavelength"))
+  def sourceCWavelength: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("sourceCWavelength"))
 
-  def chopBeam: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("chopBeam"))
+  def chopBeam: F[String] = safeAttributeF(tcsState.getStringAttribute("chopBeam"))
 
-  def p1FollowS: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("p1FollowS"))
+  def p1FollowS: F[String] = safeAttributeF(tcsState.getStringAttribute("p1FollowS"))
 
-  def p2FollowS: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("p2FollowS"))
+  def p2FollowS: F[String] = safeAttributeF(tcsState.getStringAttribute("p2FollowS"))
 
-  def oiFollowS: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("oiFollowS"))
+  def oiFollowS: F[String] = safeAttributeF(tcsState.getStringAttribute("oiFollowS"))
 
-  def aoFollowS: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("aoFollowS"))
+  def aoFollowS: F[String] = safeAttributeF(tcsState.getStringAttribute("aoFollowS"))
 
-  def p1Parked: F[Option[Boolean]] = safeAttributeSInt(tcsState.getIntegerAttribute("p1Parked"))
-    .map(_.map(_ =!= 0))
+  def p1Parked: F[Boolean] = safeAttributeSIntF(tcsState.getIntegerAttribute("p1Parked"))
+    .map(_ =!= 0)
 
-  def p2Parked: F[Option[Boolean]] = safeAttributeSInt(tcsState.getIntegerAttribute("p2Parked"))
-    .map(_.map(_ =!= 0))
+  def p2Parked: F[Boolean] = safeAttributeSIntF(tcsState.getIntegerAttribute("p2Parked"))
+    .map(_ =!= 0)
 
-  def oiParked: F[Option[Boolean]] = safeAttributeSInt(tcsState.getIntegerAttribute("oiParked"))
-    .map(_.map(_ =!= 0))
+  def oiParked: F[Boolean] = safeAttributeSIntF(tcsState.getIntegerAttribute("oiParked"))
+    .map(_ =!= 0)
 
   private val pwfs1OnAttr: CaAttribute[BinaryYesNo] = tcsState.addEnum("pwfs1On",
     s"${TcsTop}drives:p1Integrating", classOf[BinaryYesNo], "P1 integrating")
-  def pwfs1On: F[Option[BinaryYesNo]] = safeAttribute(pwfs1OnAttr)
+  def pwfs1On: F[BinaryYesNo] = safeAttributeF(pwfs1OnAttr)
 
   private val pwfs2OnAttr: CaAttribute[BinaryYesNo] = tcsState.addEnum("pwfs2On",
     s"${TcsTop}drives:p2Integrating", classOf[BinaryYesNo], "P2 integrating")
 
-  def pwfs2On:F[Option[BinaryYesNo]] = safeAttribute(pwfs2OnAttr)
+  def pwfs2On:F[BinaryYesNo] = safeAttributeF(pwfs2OnAttr)
 
   private val oiwfsOnAttr: CaAttribute[BinaryYesNo] = tcsState.addEnum("oiwfsOn",
     s"${TcsTop}drives:oiIntegrating", classOf[BinaryYesNo], "P2 integrating")
 
-  def oiwfsOn: F[Option[BinaryYesNo]] = safeAttribute(oiwfsOnAttr)
+  def oiwfsOn: F[BinaryYesNo] = safeAttributeF(oiwfsOnAttr)
 
-  def sfName: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("sfName"))
+  def sfName: F[String] = safeAttributeF(tcsState.getStringAttribute("sfName"))
 
-  def sfParked: F[Option[Int]] = safeAttributeSInt(tcsState.getIntegerAttribute("sfParked"))
+  def sfParked: F[Int] = safeAttributeSIntF(tcsState.getIntegerAttribute("sfParked"))
 
-  def agHwName: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("agHwName"))
+  def agHwName: F[String] = safeAttributeF(tcsState.getStringAttribute("agHwName"))
 
-  def agHwParked: F[Option[Int]] = safeAttributeSInt(tcsState.getIntegerAttribute("agHwParked"))
+  def agHwParked: F[Int] = safeAttributeSIntF(tcsState.getIntegerAttribute("agHwParked"))
 
-  def instrAA: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("instrAA"))
+  def instrAA: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("instrAA"))
 
   private val inPositionAttr: CaAttribute[String] = tcsState.getStringAttribute("inPosition")
 
-  def inPosition:F[Option[String]] = safeAttribute(inPositionAttr)
+  def inPosition:F[String] = safeAttributeF(inPositionAttr)
 
   private val agInPositionAttr: CaAttribute[java.lang.Double] = tcsState.getDoubleAttribute("agInPosition")
-  def agInPosition:F[Option[Double]] = safeAttributeSDouble(agInPositionAttr)
+  def agInPosition:F[Double] = safeAttributeSDoubleF(agInPositionAttr)
 
   val pwfs1ProbeGuideConfig: ProbeGuideConfig[F] = new ProbeGuideConfig("p1", tcsState)
 
@@ -386,7 +384,7 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
   private val tcsStabilizeTime = 1.seconds
 
   private val filteredInPositionAttr: CaWindowStabilizer[String] = new CaWindowStabilizer[String](inPositionAttr, java.time.Duration.ofMillis(tcsStabilizeTime.toMillis))
-  def filteredInPosition:F[Option[String]] = safeAttribute(filteredInPositionAttr)
+  def filteredInPosition:F[String] = safeAttributeF(filteredInPositionAttr)
 
   // This functions returns a SeqAction that, when run, will wait up to `timeout`
   // seconds for the TCS in-position flag to set to TRUE
@@ -396,7 +394,7 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
   private val agStabilizeTime = 1.seconds
 
   private val filteredAGInPositionAttr: CaWindowStabilizer[java.lang.Double] = new CaWindowStabilizer[java.lang.Double](agInPositionAttr, java.time.Duration.ofMillis(agStabilizeTime.toMillis))
-  def filteredAGInPosition: F[Option[Double]] = safeAttributeSDouble(filteredAGInPositionAttr)
+  def filteredAGInPosition: F[Double] = safeAttributeSDoubleF(filteredAGInPositionAttr)
 
   // `waitAGInPosition` works like `waitInPosition`, but for the AG in-position flag.
   /* TODO: AG inposition can take up to 1[s] to react to a TCS command. If the value is read before that, it may induce
@@ -407,102 +405,102 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
     Sync[F].delay(filteredAGInPositionAttr.reset).flatMap(
       waitForValueF[java.lang.Double, F](_, 1.0, timeout, "AG inposition flag"))
 
-  def hourAngle: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("ha"))
+  def hourAngle: F[String] = safeAttributeF(tcsState.getStringAttribute("ha"))
 
-  def localTime: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("lt"))
+  def localTime: F[String] = safeAttributeF(tcsState.getStringAttribute("lt"))
 
-  def trackingFrame: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("trkframe"))
+  def trackingFrame: F[String] = safeAttributeF(tcsState.getStringAttribute("trkframe"))
 
-  def trackingEpoch: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("trkepoch"))
+  def trackingEpoch: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("trkepoch"))
 
-  def equinox: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("sourceAEquinox"))
+  def equinox: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("sourceAEquinox"))
 
-  def trackingEquinox: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("sourceATrackEq"))
+  def trackingEquinox: F[String] = safeAttributeF(tcsState.getStringAttribute("sourceATrackEq"))
 
-  def trackingDec: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("dectrack"))
+  def trackingDec: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("dectrack"))
 
-  def trackingRA: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("ratrack"))
+  def trackingRA: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("ratrack"))
 
-  def elevation: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("elevatio"))
+  def elevation: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("elevatio"))
 
-  def azimuth: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("azimuth"))
+  def azimuth: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("azimuth"))
 
-  def crPositionAngle: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("crpa"))
+  def crPositionAngle: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("crpa"))
 
-  def ut: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("ut"))
+  def ut: F[String] = safeAttributeF(tcsState.getStringAttribute("ut"))
 
-  def date: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("date"))
+  def date: F[String] = safeAttributeF(tcsState.getStringAttribute("date"))
 
-  def m2Baffle: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("m2baffle"))
+  def m2Baffle: F[String] = safeAttributeF(tcsState.getStringAttribute("m2baffle"))
 
-  def m2CentralBaffle: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("m2cenbaff"))
+  def m2CentralBaffle: F[String] = safeAttributeF(tcsState.getStringAttribute("m2cenbaff"))
 
-  def st: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("st"))
+  def st: F[String] = safeAttributeF(tcsState.getStringAttribute("st"))
 
-  def sfRotation: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("sfrt2"))
+  def sfRotation: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("sfrt2"))
 
-  def sfTilt: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("sftilt"))
+  def sfTilt: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("sftilt"))
 
-  def sfLinear: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("sflinear"))
+  def sfLinear: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("sflinear"))
 
-  def instrPA: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("instrPA"))
+  def instrPA: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("instrPA"))
 
-  def targetA: F[Option[List[Double]]] = safeAttributeSListSDouble(tcsState.getDoubleAttribute("targetA"))
+  def targetA: F[List[Double]] = safeAttributeSListSDoubleF(tcsState.getDoubleAttribute("targetA"))
 
-  def aoFoldPosition: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("aoName"))
+  def aoFoldPosition: F[String] = safeAttributeF(tcsState.getStringAttribute("aoName"))
 
   private val useAoAttr: CaAttribute[BinaryYesNo] = tcsState.addEnum("useAo",
     s"${TcsTop}im:AOConfigFlag.VAL", classOf[BinaryYesNo], "Using AO flag")
-  def useAo: F[Option[BinaryYesNo]] = safeAttribute(useAoAttr)
+  def useAo: F[BinaryYesNo] = safeAttributeF(useAoAttr)
 
-  def airmass: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("airmass"))
+  def airmass: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("airmass"))
 
-  def airmassStart: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("amstart"))
+  def airmassStart: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("amstart"))
 
-  def airmassEnd: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("amend"))
+  def airmassEnd: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("amend"))
 
-  def carouselMode: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("cguidmod"))
+  def carouselMode: F[String] = safeAttributeF(tcsState.getStringAttribute("cguidmod"))
 
-  def crFollow: F[Option[Int]]  = safeAttributeSInt(tcsState.getIntegerAttribute("crfollow"))
+  def crFollow: F[Int]  = safeAttributeSIntF(tcsState.getIntegerAttribute("crfollow"))
 
   def sourceATarget: Target[F] = new Target[F] {
-    override def epoch: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("sourceAEpoch"))
+    override def epoch: F[String] = safeAttributeF(tcsState.getStringAttribute("sourceAEpoch"))
 
-    override def equinox: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("sourceAEquinox"))
+    override def equinox: F[String] = safeAttributeF(tcsState.getStringAttribute("sourceAEquinox"))
 
-    override def radialVelocity: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("radvel"))
+    override def radialVelocity: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("radvel"))
 
-    override def frame: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("frame"))
+    override def frame: F[String] = safeAttributeF(tcsState.getStringAttribute("frame"))
 
-    override def centralWavelenght: F[Option[Double]] = sourceAWavelength
+    override def centralWavelenght: F[Double] = sourceAWavelength
 
-    override def ra: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("ra"))
+    override def ra: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("ra"))
 
-    override def objectName: F[Option[String]] = safeAttribute(tcsState.getStringAttribute("sourceAObjectName"))
+    override def objectName: F[String] = safeAttributeF(tcsState.getStringAttribute("sourceAObjectName"))
 
-    override def dec: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("dec"))
+    override def dec: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("dec"))
 
-    override def parallax: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("parallax"))
+    override def parallax: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("parallax"))
 
-    override def properMotionRA: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("pmra"))
+    override def properMotionRA: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("pmra"))
 
-    override def properMotionDec: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("pmdec"))
+    override def properMotionDec: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("pmdec"))
   }
 
   private def target(base: String): Target[F] = new Target[F] {
-      override def epoch: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(base + "aepoch"))
-      override def equinox: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(base + "aequin"))
-      override def radialVelocity:F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute(base + "arv"))
-      override def frame: F[Option[String]]  = safeAttribute(tcsState.getStringAttribute(base + "aframe"))
-      override def centralWavelenght:F[Option[Double]] =
-        safeAttributeSDouble(tcsState.getDoubleAttribute(base + "awavel"))
-      override def ra:F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute(base + "ara"))
-      override def objectName: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(base + "aobjec"))
-      override def dec:F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute(base + "adec"))
-      override def parallax:F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute(base + "aparal"))
-      override def properMotionRA:F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute(base + "apmra"))
-      override def properMotionDec:F[Option[Double]] =
-        safeAttributeSDouble(tcsState.getDoubleAttribute(base + "apmdec"))
+      override def epoch: F[String] = safeAttributeF(tcsState.getStringAttribute(base + "aepoch"))
+      override def equinox: F[String] = safeAttributeF(tcsState.getStringAttribute(base + "aequin"))
+      override def radialVelocity:F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute(base + "arv"))
+      override def frame: F[String]  = safeAttributeF(tcsState.getStringAttribute(base + "aframe"))
+      override def centralWavelenght:F[Double] =
+        safeAttributeSDoubleF(tcsState.getDoubleAttribute(base + "awavel"))
+      override def ra:F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute(base + "ara"))
+      override def objectName: F[String] = safeAttributeF(tcsState.getStringAttribute(base + "aobjec"))
+      override def dec:F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute(base + "adec"))
+      override def parallax:F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute(base + "aparal"))
+      override def properMotionRA:F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute(base + "apmra"))
+      override def properMotionDec:F[Double] =
+        safeAttributeSDoubleF(tcsState.getDoubleAttribute(base + "apmdec"))
     }
 
   val pwfs1Target: Target[F] = target("p1")
@@ -511,46 +509,48 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
 
   val oiwfsTarget: Target[F] = target("oi")
 
-  def parallacticAngle: F[Option[Angle]] =
-    safeAttributeSDouble(tcsState.getDoubleAttribute("parangle")).map(_.map(Degrees(_)))
+  def parallacticAngle: F[Angle] =
+    safeAttributeSDoubleF(tcsState.getDoubleAttribute("parangle")).map(Degrees(_))
 
-  def m2UserFocusOffset: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("m2ZUserOffset"))
+  def m2UserFocusOffset: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("m2ZUserOffset"))
 
   private val pwfs1Status = epicsService.getStatusAcceptor("pwfs1state")
 
-  def pwfs1IntegrationTime: F[Option[Double]] = safeAttributeSDouble(pwfs1Status.getDoubleAttribute("intTime"))
+  def pwfs1IntegrationTime: F[Double] = safeAttributeSDoubleF(pwfs1Status.getDoubleAttribute("intTime"))
 
   private val pwfs2Status = epicsService.getStatusAcceptor("pwfs2state")
 
-  def pwfs2IntegrationTime: F[Option[Double]] = safeAttributeSDouble(pwfs2Status.getDoubleAttribute("intTime"))
+  def pwfs2IntegrationTime: F[Double] = safeAttributeSDoubleF(pwfs2Status.getDoubleAttribute("intTime"))
 
   private val oiwfsStatus = epicsService.getStatusAcceptor("oiwfsstate")
 
   // Attribute must be changed back to Double after EPICS channel is fixed.
-  def oiwfsIntegrationTime:F[Option[Double]]  = safeAttributeSDouble(oiwfsStatus.getDoubleAttribute("intTime"))
+  def oiwfsIntegrationTime:F[Double]  = safeAttributeSDoubleF(oiwfsStatus.getDoubleAttribute("intTime"))
 
 
-  private def instPort(name: String): F[Option[Int]] =
-    safeAttributeSInt(tcsState.getIntegerAttribute(s"${name}Port"))
+  private def instPort(name: String): F[Int] =
+    safeAttributeSIntF(tcsState.getIntegerAttribute(s"${name}Port"))
 
-  def gsaoiPort: F[Option[Int]] = instPort("gsaoi")
-  def gpiPort: F[Option[Int]]= instPort("gpi")
-  def f2Port: F[Option[Int]] = instPort("f2")
-  def niriPort: F[Option[Int]] = instPort("niri")
-  def gnirsPort: F[Option[Int]] = instPort("nirs")
-  def nifsPort: F[Option[Int]] = instPort("nifs")
-  def gmosPort: F[Option[Int]] = instPort("gmos")
-  def ghostPort: F[Option[Int]] = instPort("ghost")
+  def gsaoiPort: F[Int] = instPort("gsaoi")
+  def gpiPort: F[Int]= instPort("gpi")
+  def f2Port: F[Int] = instPort("f2")
+  def niriPort: F[Int] = instPort("niri")
+  def gnirsPort: F[Int] = instPort("nirs")
+  def nifsPort: F[Int] = instPort("nifs")
+  def gmosPort: F[Int] = instPort("gmos")
+  def ghostPort: F[Int] = instPort("ghost")
 
-  def aoGuideStarX: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("aogsx"))
+  def aoGuideStarX: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("aogsx"))
 
-  def aoGuideStarY: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("aogsy"))
+  def aoGuideStarY: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("aogsy"))
 
-  def aoPreparedCMX: F[Option[Double]] = safeAttribute(tcsState.getStringAttribute("cmprepx"))
-    .map(_.flatMap(v => Try(v.toDouble).toOption))
+  def aoPreparedCMX: F[Double] = safeAttributeF(tcsState.getStringAttribute("cmprepx"))
+    .map(_.toDouble)
+    .adaptError{case e => SeqexecException(e)}
 
-  def aoPreparedCMY: F[Option[Double]] = safeAttribute(tcsState.getStringAttribute("cmprepy"))
-    .map(_.flatMap(v => Try(v.toDouble).toOption))
+  def aoPreparedCMY: F[Double] = safeAttributeF(tcsState.getStringAttribute("cmprepy"))
+    .map(_.toDouble)
+    .adaptError{case e => SeqexecException(e)}
 
   // GeMS Commands
   import VirtualGemsTelescope._
@@ -634,78 +634,78 @@ final class TcsEpics[F[_]: Async](epicsService: CaService, tops: Map[String, Str
 
   val cwfs1FollowAttr: CaAttribute[BinaryEnabledDisabled] = tcsState.addEnum("ngs1Follow",
     s"${TcsTop}ngsPr1FollowStat.VAL", classOf[BinaryEnabledDisabled])
-  def cwfs1Follow: F[Option[Boolean]] =
-    Nested(safeAttribute(cwfs1FollowAttr)).map(_ === BinaryEnabledDisabled.Enabled).value
+  def cwfs1Follow: F[Boolean] =
+    safeAttributeF(cwfs1FollowAttr).map(_ === BinaryEnabledDisabled.Enabled)
 
   val cwfs2FollowAttr: CaAttribute[BinaryEnabledDisabled] = tcsState.addEnum("ngs2Follow",
     s"${TcsTop}ngsPr2FollowStat.VAL", classOf[BinaryEnabledDisabled])
-  def cwfs2Follow: F[Option[Boolean]] =
-    Nested(safeAttribute(cwfs2FollowAttr)).map(_ === BinaryEnabledDisabled.Enabled).value
+  def cwfs2Follow: F[Boolean] =
+    safeAttributeF(cwfs2FollowAttr).map(_ === BinaryEnabledDisabled.Enabled)
 
   val cwfs3FollowAttr: CaAttribute[BinaryEnabledDisabled] = tcsState.addEnum("ngs3Follow",
     s"${TcsTop}ngsPr3FollowStat.VAL", classOf[BinaryEnabledDisabled])
-  def cwfs3Follow: F[Option[Boolean]] =
-    Nested(safeAttribute(cwfs3FollowAttr)).map(_ === BinaryEnabledDisabled.Enabled).value
+  def cwfs3Follow: F[Boolean] =
+    safeAttributeF(cwfs3FollowAttr).map(_ === BinaryEnabledDisabled.Enabled)
 
   val odgw1FollowAttr: CaAttribute[BinaryEnabledDisabled] = tcsState.addEnum("odgw1Follow",
     s"${TcsTop}odgw1FollowStat.VAL", classOf[BinaryEnabledDisabled])
-  def odgw1Follow: F[Option[Boolean]] =
-    Nested(safeAttribute(odgw1FollowAttr)).map(_ === BinaryEnabledDisabled.Enabled).value
+  def odgw1Follow: F[Boolean] =
+    safeAttributeF(odgw1FollowAttr).map(_ === BinaryEnabledDisabled.Enabled)
 
   val odgw2FollowAttr: CaAttribute[BinaryEnabledDisabled] = tcsState.addEnum("odgw2Follow",
     s"${TcsTop}odgw2FollowStat.VAL", classOf[BinaryEnabledDisabled])
-  def odgw2Follow: F[Option[Boolean]] =
-    Nested(safeAttribute(odgw2FollowAttr)).map(_ === BinaryEnabledDisabled.Enabled).value
+  def odgw2Follow: F[Boolean] =
+    safeAttributeF(odgw2FollowAttr).map(_ === BinaryEnabledDisabled.Enabled)
 
   val odgw3FollowAttr: CaAttribute[BinaryEnabledDisabled] = tcsState.addEnum("odgw3Follow",
     s"${TcsTop}odgw3FollowStat.VAL", classOf[BinaryEnabledDisabled])
-  def odgw3Follow: F[Option[Boolean]] =
-    Nested(safeAttribute(odgw3FollowAttr)).map(_ === BinaryEnabledDisabled.Enabled).value
+  def odgw3Follow: F[Boolean] =
+    safeAttributeF(odgw3FollowAttr).map(_ === BinaryEnabledDisabled.Enabled)
 
   val odgw4FollowAttr: CaAttribute[BinaryEnabledDisabled] = tcsState.addEnum("odgw4Follow",
     s"${TcsTop}odgw4FollowStat.VAL", classOf[BinaryEnabledDisabled])
-  def odgw4Follow: F[Option[Boolean]] =
-    Nested(safeAttribute(odgw4FollowAttr)).map(_ === BinaryEnabledDisabled.Enabled).value
+  def odgw4Follow: F[Boolean] =
+    safeAttributeF(odgw4FollowAttr).map(_ === BinaryEnabledDisabled.Enabled)
 
   val OdgwParkedState: String = "Parked"
 
-  def odgw1Parked: F[Option[Boolean]] =
-    Nested(safeAttribute(tcsState.getStringAttribute("odgw1Parked"))).map(_ === OdgwParkedState).value
+  def odgw1Parked: F[Boolean] =
+    safeAttributeF(tcsState.getStringAttribute("odgw1Parked")).map(_ === OdgwParkedState)
 
-  def odgw2Parked: F[Option[Boolean]] =
-    Nested(safeAttribute(tcsState.getStringAttribute("odgw2Parked"))).map(_ === OdgwParkedState).value
+  def odgw2Parked: F[Boolean] =
+    safeAttributeF(tcsState.getStringAttribute("odgw2Parked")).map(_ === OdgwParkedState)
 
-  def odgw3Parked: F[Option[Boolean]] =
-    Nested(safeAttribute(tcsState.getStringAttribute("odgw3Parked"))).map(_ === OdgwParkedState).value
+  def odgw3Parked: F[Boolean] =
+    safeAttributeF(tcsState.getStringAttribute("odgw3Parked")).map(_ === OdgwParkedState)
 
-  def odgw4Parked: F[Option[Boolean]] =
-    Nested(safeAttribute(tcsState.getStringAttribute("odgw4Parked"))).map(_ === OdgwParkedState).value
+  def odgw4Parked: F[Boolean] =
+    safeAttributeF(tcsState.getStringAttribute("odgw4Parked")).map(_ === OdgwParkedState)
 
   def g1MapName: F[Option[GemsSource]] =
-    safeAttribute(tcsState.getStringAttribute("g1MapName"))
-      .map(_.flatMap{x:String => GemsSource.all.find(_.epicsVal === x)})
+    safeAttributeF(tcsState.getStringAttribute("g1MapName"))
+      .map(x => GemsSource.all.find(_.epicsVal === x))
 
   def g2MapName: F[Option[GemsSource]] =
-    safeAttribute(tcsState.getStringAttribute("g2MapName"))
-      .map(_.flatMap{x:String => GemsSource.all.find(_.epicsVal === x)})
+    safeAttributeF(tcsState.getStringAttribute("g2MapName"))
+      .map(x => GemsSource.all.find(_.epicsVal === x))
 
   def g3MapName: F[Option[GemsSource]] =
-    safeAttribute(tcsState.getStringAttribute("g3MapName"))
-      .map(_.flatMap{x:String => GemsSource.all.find(_.epicsVal === x)})
+    safeAttributeF(tcsState.getStringAttribute("g3MapName"))
+      .map(x => GemsSource.all.find(_.epicsVal === x))
 
   def g4MapName: F[Option[GemsSource]] =
-    safeAttribute(tcsState.getStringAttribute("g4MapName"))
-      .map(_.flatMap{x:String => GemsSource.all.find(_.epicsVal === x)})
+    safeAttributeF(tcsState.getStringAttribute("g4MapName"))
+      .map(x => GemsSource.all.find(_.epicsVal === x))
 
-  def g1Wavelength: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("g1Wavelength"))
+  def g1Wavelength: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("g1Wavelength"))
 
-  def g2Wavelength: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("g2Wavelength"))
+  def g2Wavelength: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("g2Wavelength"))
 
-  def g3Wavelength: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("g3Wavelength"))
+  def g3Wavelength: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("g3Wavelength"))
 
-  def g4Wavelength: F[Option[Double]] = safeAttributeSDouble(tcsState.getDoubleAttribute("g4Wavelength"))
+  def g4Wavelength: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("g4Wavelength"))
 
-  def gemsWavelength(g: VirtualGemsTelescope): F[Option[Double]] = g match {
+  def gemsWavelength(g: VirtualGemsTelescope): F[Double] = g match {
     case G1 => g1Wavelength
     case G2 => g2Wavelength
     case G3 => g3Wavelength
@@ -809,45 +809,45 @@ object TcsEpics extends EpicsSystem[TcsEpics[IO]] {
   }
 
   class ProbeGuideConfig[F[_]: Sync](protected val prefix: String, protected val tcsState: CaStatusAcceptor) {
-    def nodachopa: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodachopa"))
-    def nodachopb: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodachopb"))
-    def nodachopc: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodachopc"))
-    def nodbchopa: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodbchopa"))
-    def nodbchopb: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodbchopb"))
-    def nodbchopc: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodbchopc"))
-    def nodcchopa: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodcchopa"))
-    def nodcchopb: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodcchopb"))
-    def nodcchopc: F[Option[String]] = safeAttribute(tcsState.getStringAttribute(prefix + "nodcchopc"))
+    def nodachopa: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodachopa"))
+    def nodachopb: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodachopb"))
+    def nodachopc: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodachopc"))
+    def nodbchopa: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodbchopa"))
+    def nodbchopb: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodbchopb"))
+    def nodbchopc: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodbchopc"))
+    def nodcchopa: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodcchopa"))
+    def nodcchopb: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodcchopb"))
+    def nodcchopc: F[String] = safeAttributeF(tcsState.getStringAttribute(prefix + "nodcchopc"))
   }
 
   sealed trait Target[F[_]] {
-    def objectName: F[Option[String]]
-    def ra: F[Option[Double]]
-    def dec: F[Option[Double]]
-    def frame: F[Option[String]]
-    def equinox: F[Option[String]]
-    def epoch: F[Option[String]]
-    def properMotionRA: F[Option[Double]]
-    def properMotionDec: F[Option[Double]]
-    def centralWavelenght: F[Option[Double]]
-    def parallax: F[Option[Double]]
-    def radialVelocity: F[Option[Double]]
+    def objectName: F[String]
+    def ra: F[Double]
+    def dec: F[Double]
+    def frame: F[String]
+    def equinox: F[String]
+    def epoch: F[String]
+    def properMotionRA: F[Double]
+    def properMotionDec: F[Double]
+    def centralWavelenght: F[Double]
+    def parallax: F[Double]
+    def radialVelocity: F[Double]
   }
 
   // TODO: Delete me after fully moved to tagless
   implicit class TargetIOOps(val tio: Target[IO]) extends AnyVal{
     def to[F[_]: LiftIO]: Target[F] = new Target[F] {
-      def objectName: F[Option[String]] = tio.objectName.to[F]
-      def ra: F[Option[Double]] = tio.ra.to[F]
-      def dec: F[Option[Double]] = tio.dec.to[F]
-      def frame: F[Option[String]] = tio.frame.to[F]
-      def equinox: F[Option[String]] = tio.equinox.to[F]
-      def epoch: F[Option[String]] = tio.epoch.to[F]
-      def properMotionRA: F[Option[Double]] = tio.properMotionRA.to[F]
-      def properMotionDec: F[Option[Double]] = tio.properMotionDec.to[F]
-      def centralWavelenght: F[Option[Double]] = tio.centralWavelenght.to[F]
-      def parallax: F[Option[Double]] = tio.parallax.to[F]
-      def radialVelocity: F[Option[Double]] = tio.radialVelocity.to[F]
+      def objectName: F[String] = tio.objectName.to[F]
+      def ra: F[Double] = tio.ra.to[F]
+      def dec: F[Double] = tio.dec.to[F]
+      def frame: F[String] = tio.frame.to[F]
+      def equinox: F[String] = tio.equinox.to[F]
+      def epoch: F[String] = tio.epoch.to[F]
+      def properMotionRA: F[Double] = tio.properMotionRA.to[F]
+      def properMotionDec: F[Double] = tio.properMotionDec.to[F]
+      def centralWavelenght: F[Double] = tio.centralWavelenght.to[F]
+      def parallax: F[Double] = tio.parallax.to[F]
+      def radialVelocity: F[Double] = tio.radialVelocity.to[F]
     }
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsKeywordReader.scala
@@ -158,7 +158,7 @@ trait TcsKeywordsReader[F[_]] {
 
   def m2UserFocusOffset: F[Double]
 
-  def parallacticAngle: F[Option[Angle]]
+  def parallacticAngle: F[Angle]
 
   def pwfs1Freq: F[Double]
 
@@ -274,7 +274,7 @@ object DummyTcsKeywordsReader {
 
     override def endAirMass: F[Double] = 1.0.pure[F]
 
-    override def parallacticAngle: F[Option[Angle]] = Arcseconds(0.0).some.pure[F]
+    override def parallacticAngle: F[Angle] = Arcseconds(0.0).pure[F]
 
     override def trackingRAOffset: F[Double] = 0.0.pure[F]
 
@@ -346,8 +346,7 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
 
     override def trackingEpoch: F[Double] = sys.trackingEpoch.safeValOrDefault
 
-    private def translateEpoch(v: Option[String]): Option[Double] =
-      v.filter(_.nonEmpty).flatMap(_.drop(1).parseDoubleOption)
+    private def translateEpoch(v: String): Option[Double] = v.drop(1).parseDoubleOption
 
     override def trackingEquinox: F[Double] = sys.trackingEquinox.map(translateEpoch).safeValOrDefault
 
@@ -381,12 +380,12 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
 
     override def gmosInstPort: F[Int] = sys.gmosPort.safeValOrDefault
 
-    private val xoffIndex = 6
-    private val yoffIndex = 7
+    private val xoffIndex = 6L
+    private val yoffIndex = 7L
 
     private def xOffsetOption: F[Option[Angle]] =
       sys.targetA
-        .map(_.flatMap(v => v.lift(xoffIndex).map(x => Millimeters(x) * FOCAL_PLANE_SCALE)))
+        .map(v => v.get(xoffIndex).map(x => Millimeters(x) * FOCAL_PLANE_SCALE))
         .handleError(_ => none)
 
     override def xOffset: F[Double] =
@@ -394,14 +393,14 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
 
     private def yOffsetOption: F[Option[Angle]] =
       sys.targetA
-        .map(_.flatMap(v => v.lift(yoffIndex).map(x => Millimeters(x) * FOCAL_PLANE_SCALE)))
+        .map(v => v.get(yoffIndex).map(x => Millimeters(x) * FOCAL_PLANE_SCALE))
         .handleError(_ => none)
 
     override def yOffset: F[Double] =
       Nested(yOffsetOption).map(_.toArcseconds).value.safeValOrDefault
 
-    private val raoffIndex = 2
-    private val decoffIndex = 3
+    private val raoffIndex = 2L
+    private val decoffIndex = 3L
 
     private def normalizeSignedAngle(v: Angle): Angle = {
       val r = v.value % 360.0
@@ -415,15 +414,15 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
     override def trackingRAOffset: F[Double] = {
       def raOffset(off: Angle, dec: Angle): Angle = normalizeSignedAngle(off) * dec.cos
 
-      sys.targetA.map(_.flatMap(v =>
-        Apply[Option].ap2(Option(raOffset _))(v.lift(raoffIndex).map(Radians(_)),v.lift(decoffIndex).map(Radians(_)))))
-        .map(_.map(_.toArcseconds))
-        .safeValOrDefault
+      sys.targetA.map(v =>
+        Apply[Option].ap2(Option(raOffset(_, _)))(v.get(raoffIndex).map(Radians(_)), v.get(decoffIndex).map(Radians(_)))
+          .map(_.toArcseconds)
+      ).safeValOrDefault
     }
 
     override def trackingDecOffset: F[Double] =
       sys.targetA
-        .map(_.flatMap(v => v.lift(decoffIndex).map(Radians(_).toArcseconds)))
+        .map(v => v.get(decoffIndex).map(Radians(_).toArcseconds))
         .safeValOrDefault
 
     override def instrumentAA: F[Double] = sys.instrAA.safeValOrDefault
@@ -463,11 +462,7 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
 
     override def endAirMass: F[Double] = sys.airmassEnd.safeValOrDefault
 
-    override def parallacticAngle: F[Option[Angle]] =
-      Nested(sys.parallacticAngle)
-        .map(normalizeSignedAngle).value
-        .handleError(_ => none)
-
+    override def parallacticAngle: F[Angle] = sys.parallacticAngle.map(normalizeSignedAngle).safeValOrDefault
 
     override def pwfs1Target: TargetKeywordsReader[F] = target(sys.pwfs1Target)
 
@@ -503,14 +498,11 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
 
     private def calcFrequency(t: Double): Double = if (t > 0.0) 1.0 / t else DefaultHeaderValue[Double].default
 
-    override def pwfs1Freq: F[Double] =
-      Nested(sys.pwfs1IntegrationTime).map(calcFrequency).value.safeValOrDefault
+    override def pwfs1Freq: F[Double] = sys.pwfs1IntegrationTime.map(calcFrequency).safeValOrDefault
 
-    override def pwfs2Freq: F[Double] =
-      Nested(sys.pwfs2IntegrationTime).map(calcFrequency).value.safeValOrDefault
+    override def pwfs2Freq: F[Double] = sys.pwfs2IntegrationTime.map(calcFrequency).safeValOrDefault
 
-    override def oiwfsFreq: F[Double] =
-      Nested(sys.oiwfsIntegrationTime).map(calcFrequency).value.safeValOrDefault
+    override def oiwfsFreq: F[Double] = sys.oiwfsIntegrationTime.map(calcFrequency).safeValOrDefault
 
     override def carouselMode: F[String] = sys.carouselMode.safeValOrDefault
 
@@ -527,14 +519,14 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
     override def f2InstPort: F[Int] = sys.f2Port.safeValOrDefault
 
     override def crFollow: F[Option[CRFollow]] =
-      sys.crFollow.map(_.flatMap(CRFollow.fromInt.getOption))
+      sys.crFollow.map(CRFollow.fromInt.getOption)
       .handleError(_ => none)
 
     private def pOffsetOption: F[Option[Angle]] = (
       for {
         xoff <- OptionT(xOffsetOption)
         yoff <- OptionT(yOffsetOption)
-        iaa  <- OptionT(sys.instrAA).map(Degrees(_))
+        iaa  <- OptionT.liftF(sys.instrAA.map(Degrees(_)))
       } yield  -xoff * iaa.cos + yoff * iaa.sin
     ).value
      .handleError(_ => none)
@@ -545,7 +537,7 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
       for {
         xoff <- OptionT(xOffsetOption)
         yoff <- OptionT(yOffsetOption)
-        iaa  <- OptionT(sys.instrAA).map(Degrees(_))
+        iaa  <- OptionT.liftF(sys.instrAA.map(Degrees(_)))
       } yield  -xoff * iaa.sin - yoff * iaa.cos
     ).value
      .handleError(_ => none)
@@ -554,17 +546,17 @@ object TcsKeywordsReaderEpics extends TcsKeywordDefaults {
 
     override def raOffset: F[Double] = (
       for {
-        p <- OptionT(pOffsetOption)
-        q <- OptionT(qOffsetOption)
-        ipa <- OptionT(sys.instrPA).map(Degrees(_))
+        p   <- OptionT(pOffsetOption)
+        q   <- OptionT(qOffsetOption)
+        ipa <- OptionT.liftF(sys.instrPA.map(Degrees(_)))
       } yield p * ipa.cos + q * ipa.sin
     ).map(_.toArcseconds).value.safeValOrDefault
 
     override def decOffset: F[Double] = (
       for {
-        p <- OptionT(pOffsetOption)
-        q <- OptionT(qOffsetOption)
-        ipa <- OptionT(sys.instrPA).map(Degrees(_))
+        p   <- OptionT(pOffsetOption)
+        q   <- OptionT(qOffsetOption)
+        ipa <- OptionT.liftF(sys.instrPA.map(Degrees(_)))
       } yield -p * ipa.sin + q * ipa.cos
     ).map(_.toArcseconds).value.safeValOrDefault
   }


### PR DESCRIPTION
All systems' EPICS statuses are now read as `F[A]` instead of `F[Option[A]]`, leaving to `F` the task of dealing with null values.