### PR TITLE
Engine support for Nod and shuffle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -515,6 +515,7 @@ lazy val seqexec_server = project
   .settings(
     addCompilerPlugin(Plugins.paradisePlugin),
     addCompilerPlugin(Plugins.kindProjectorPlugin),
+    addCompilerPlugin(Plugins.betterMonadicForPlugin),
     libraryDependencies ++=
       Seq(Http4sCirce,
           Squants.value,
@@ -526,7 +527,8 @@ lazy val seqexec_server = project
           Log4s.value,
           Http4sXml,
           Http4sBoopickle,
-          PrometheusClient
+          PrometheusClient,
+          Log4Cats.value
       ) ++ Http4s ++ Http4sClient ++ SeqexecOdb ++ Monocle.value ++ WDBAClient ++ TestLibs.value ++
         Circe.value
   )

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Action.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Action.scala
@@ -4,21 +4,27 @@
 package seqexec.engine
 
 import fs2.Stream
-import seqexec.engine.Result.{Error, PartialVal, PauseContext, RetVal}
+import seqexec.engine.Result.Error
+import seqexec.engine.Result.PartialVal
+import seqexec.engine.Result.PauseContext
+import seqexec.engine.Result.RetVal
 import seqexec.model.ActionType
 import seqexec.model.enum.ActionStatus
 import monocle.macros.Lenses
 
 @Lenses
 final case class Action[F[_]](
-  kind: ActionType,
-  gen: Stream[F, Result[F]],
+  kind:  ActionType,
+  gen:   Stream[F, Result[F]],
   state: Action.State[F]
 )
 
 object Action {
 
-  final case class State[F[_]](runState: ActionState[F], partials: List[PartialVal])
+  final case class State[F[_]](
+    runState: ActionState[F],
+    partials: List[PartialVal]
+  )
 
   sealed trait ActionState[+F[_]] {
     def isIdle: Boolean = false
@@ -45,9 +51,8 @@ object Action {
     }
 
     def active: Boolean = this match {
-      case ActionState.Paused(_) |
-           ActionState.Started => true
-      case _                   => false
+      case ActionState.Paused(_) | ActionState.Started => true
+      case _                                           => false
     }
 
     def started: Boolean = this match {
@@ -65,9 +70,9 @@ object Action {
       override val isIdle: Boolean = true
     }
     case object Started extends ActionState[Nothing]
-    final case class Paused[F[_]](ctx: PauseContext[F]) extends ActionState[F]
+    final case class Paused[F[_]](ctx:         PauseContext[F]) extends ActionState[F]
     final case class Completed[V <: RetVal](r: V) extends ActionState[Nothing]
-    final case class Failed(e: Error) extends ActionState[Nothing]
+    final case class Failed(e:                 Error) extends ActionState[Nothing]
 
     private def actionStateToStatus[F[_]](s: ActionState[F]): ActionStatus =
       s match {

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -229,7 +229,8 @@ class Engine[D, U](stateL: Engine.State[D]) {
       _.current.execution.forall(Action.completed).option(Handle.fromStream[D, EventType](Stream(executed(id))))
     ).getOrElse(unit))
 
-  private def partialResult[R <: PartialVal](id: Observation.Id, i: Int, p: Result.Partial[R]): HandleType[Unit] = modifyS(id)(_.mark(i)(p))
+  private def partialResult[R <: PartialVal](id: Observation.Id, i: Int, p: Result.Partial[R]): HandleType[Unit] =
+    modifyS(id)(_.mark(i)(p))
 
   def actionPause(id: Observation.Id, i: Int, p: Result.Paused[IO]): HandleType[Unit] = modifyS(id)(s => Sequence.State.internalStopSet(false)(s).mark(i)(p))
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
@@ -6,8 +6,12 @@ package seqexec.model
 import cats._
 import cats.implicits._
 import seqexec.model.enum._
+import monocle.Prism
+import monocle.Lens
+import monocle.macros.Lenses
+import monocle.macros.GenPrism
 
-sealed trait Step {
+sealed trait Step extends Product with Serializable {
   def id: StepId
   def config: StepConfig
   def status: StepState
@@ -17,40 +21,123 @@ sealed trait Step {
 }
 
 object Step {
-  val Zero: Step = StandardStep(id = -1, config = Map.empty, status = StepState.Pending, breakpoint = false, skip = false, fileId = None, configStatus = Nil, observeStatus = ActionStatus.Pending)
+  val Zero: Step = StandardStep(id = -1,
+                                config        = Map.empty,
+                                status        = StepState.Pending,
+                                breakpoint    = false,
+                                skip          = false,
+                                fileId        = None,
+                                configStatus  = Nil,
+                                observeStatus = ActionStatus.Pending)
+
+  val standardStepP: Prism[Step, StandardStep] =
+    GenPrism[Step, StandardStep]
+
+  val nsStepP: Prism[Step, NodAndShuffleStep] =
+    GenPrism[Step, NodAndShuffleStep]
+
+  val status: Lens[Step, StepState] =
+    Lens[Step, StepState] {
+      _.status
+    } { n => a =>
+      a match {
+        case s: StandardStep      => StandardStep.status.set(n)(s)
+        case s: NodAndShuffleStep => NodAndShuffleStep.status.set(n)(s)
+      }
+    }
+
+  val config: Lens[Step, StepConfig] =
+    Lens[Step, StepConfig] {
+      _.config
+    } { n => a =>
+      a match {
+        case s: StandardStep      => StandardStep.config.set(n)(s)
+        case s: NodAndShuffleStep => NodAndShuffleStep.config.set(n)(s)
+      }
+    }
+
+  val id: Lens[Step, StepId] =
+    Lens[Step, StepId] {
+      _.id
+    } { n => a =>
+      a match {
+        case s: StandardStep      => StandardStep.id.set(n)(s)
+        case s: NodAndShuffleStep => NodAndShuffleStep.id.set(n)(s)
+      }
+    }
+
+  val skip: Lens[Step, Boolean] =
+    Lens[Step, Boolean] {
+      _.skip
+    } { n => a =>
+      a match {
+        case s: StandardStep      => StandardStep.skip.set(n)(s)
+        case s: NodAndShuffleStep => NodAndShuffleStep.skip.set(n)(s)
+      }
+    }
+
+  val breakpoint: Lens[Step, Boolean] =
+    Lens[Step, Boolean] {
+      _.breakpoint
+    } { n => a =>
+      a match {
+        case s: StandardStep      => StandardStep.breakpoint.set(n)(s)
+        case s: NodAndShuffleStep => NodAndShuffleStep.breakpoint.set(n)(s)
+      }
+    }
+
+  val observeStatus: Lens[Step, ActionStatus] =
+    Lens[Step, ActionStatus] {
+      case s: StandardStep      => s.observeStatus
+      case s: NodAndShuffleStep => s.nsStatus.observing
+    } { n => a =>
+      a match {
+        case s: StandardStep => StandardStep.observeStatus.set(n)(s)
+        case s: NodAndShuffleStep =>
+          (NodAndShuffleStep.nsStatus ^|-> NodAndShuffleStatus.observing).set(n)(s)
+      }
+    }
+
+  val configStatus: Lens[Step, List[(Resource, ActionStatus)]] =
+    Lens[Step, List[(Resource, ActionStatus)]] {
+      case s: StandardStep      => s.configStatus
+      case s: NodAndShuffleStep => s.configStatus
+    } { n => a =>
+      a match {
+        case s: StandardStep      => StandardStep.configStatus.set(n)(s)
+        case s: NodAndShuffleStep => NodAndShuffleStep.configStatus.set(n)(s)
+      }
+    }
 
   implicit val equal: Eq[Step] =
     Eq.instance {
       case (x: StandardStep, y: StandardStep) =>
-        (x.id === y.id) &&
-        (x.config === y.config) &&
-        (x.status === y.status) &&
-        (x.breakpoint === y.breakpoint) &&
-        (x.skip === y.skip) &&
-        (x.fileId === y.fileId) &&
-        (x.configStatus === y.configStatus) &&
-        (x.observeStatus === y.observeStatus)
+        x === y
+      case (x: NodAndShuffleStep, y: NodAndShuffleStep) =>
+        x === y
       case _ =>
         false
     }
 
   implicit class StepOps(val s: Step) extends AnyVal {
     def flipBreakpoint: Step = s match {
-      case st: StandardStep => st.copy(breakpoint = !st.breakpoint)
-      case st               => st
+      case st: StandardStep      => StandardStep.breakpoint.modify(!_)(st)
+      case st: NodAndShuffleStep => NodAndShuffleStep.breakpoint.modify(!_)(st)
+      case st                    => st
     }
 
     def flipSkip: Step = s match {
-      case st: StandardStep => st.copy(skip = !st.skip)
-      case st               => st
+      case st: StandardStep      => StandardStep.skip.modify(!_)(st)
+      case st: NodAndShuffleStep => NodAndShuffleStep.skip.modify(!_)(st)
+      case st                    => st
     }
 
     def file: Option[String] = None
 
     def canSetBreakpoint(i: Int, firstRunnable: Int): Boolean = s.status match {
-      case StepState.Pending | StepState.Skipped
-        | StepState.Paused | StepState.Running => i > firstRunnable
-      case _                                   => false
+      case StepState.Pending | StepState.Skipped | StepState.Paused |
+          StepState.Running => i > firstRunnable
+      case _ => false
     }
 
     def canSetSkipmark: Boolean = s.status match {
@@ -70,8 +157,9 @@ object Step {
     }
 
     def isObserving: Boolean = s match {
-      case StandardStep(_, _, _, _, _, _, _, o) => o === ActionStatus.Running
-      case _                                    => false
+      case StandardStep(_, _, _, _, _, _, _, o)      => o === ActionStatus.Running
+      case NodAndShuffleStep(_, _, _, _, _, _, _, o) => o.observing === ActionStatus.Running
+      case _                                         => false
     }
 
     def isObservePaused: Boolean = s match {
@@ -80,29 +168,89 @@ object Step {
     }
 
     def isConfiguring: Boolean = s match {
-      case StandardStep(_, _, _, _, _, _, c, _) => c.map(_._2).contains(ActionStatus.Running)
-      case _                                    => false
+      case StandardStep(_, _, _, _, _, _, c, _) =>
+        c.count(_._2 === ActionStatus.Running) > 0
+      case NodAndShuffleStep(_, _, _, _, _, _, c, _) =>
+        c.count(_._2 === ActionStatus.Running) > 0
+      case _ => false
     }
 
-    def isFinished: Boolean = s.status === StepState.Completed || s.status === StepState.Skipped
+    def isFinished: Boolean =
+      s.status === StepState.Completed || s.status === StepState.Skipped
 
     def wasSkipped: Boolean = s.status === StepState.Skipped
+
+    def canRunFrom: Boolean = s.status match {
+      case StepState.Pending | StepState.Failed(_) => true
+      case _                                       => false
+    }
+
+    def canConfigure: Boolean = s.status match {
+      case StepState.Pending | StepState.Paused | StepState.Failed(_) => true
+      case _                                                          => false
+    }
 
   }
 }
 
+@Lenses
 final case class StandardStep(
-  override val id: StepId,
-  override val config: StepConfig,
-  override val status: StepState,
+  override val id:         StepId,
+  override val config:     StepConfig,
+  override val status:     StepState,
   override val breakpoint: Boolean,
-  override val skip: Boolean,
-  override val fileId: Option[dhs.ImageFileId],
-  configStatus: List[(Resource, ActionStatus)],
-  observeStatus: ActionStatus
+  override val skip:       Boolean,
+  override val fileId:     Option[dhs.ImageFileId],
+  configStatus:            List[(Resource, ActionStatus)],
+  observeStatus:           ActionStatus
 ) extends Step
 
 object StandardStep {
-  implicit val equal: Eq[StandardStep] = Eq.by(x => x: Step)
+  implicit val equalStandardStep: Eq[StandardStep] = Eq.by(
+    x =>
+      (x.id,
+       x.config,
+       x.status,
+       x.breakpoint,
+       x.skip,
+       x.fileId,
+       x.configStatus,
+       x.observeStatus)
+  )
 }
+
+@Lenses
+final case class NodAndShuffleStatus(observing: ActionStatus)
+
+object NodAndShuffleStatus {
+
+  implicit val equalNodAndShuffleStatus: Eq[NodAndShuffleStatus] =
+    Eq.by(x => (x.observing))
+}
+
 // Other kinds of Steps to be defined.
+@Lenses
+final case class NodAndShuffleStep(
+  override val id:         StepId,
+  override val config:     StepConfig,
+  override val status:     StepState,
+  override val breakpoint: Boolean,
+  override val skip:       Boolean,
+  override val fileId:     Option[dhs.ImageFileId],
+  configStatus:            List[(Resource, ActionStatus)],
+  nsStatus:                NodAndShuffleStatus
+) extends Step
+
+object NodAndShuffleStep {
+  implicit val equalNodAndShuffleStop: Eq[NodAndShuffleStep] = Eq.by(
+    x =>
+      (x.id,
+       x.config,
+       x.status,
+       x.breakpoint,
+       x.skip,
+       x.fileId,
+       x.configStatus,
+       x.nsStatus)
+  )
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ActionStatus.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ActionStatus.scala
@@ -11,12 +11,16 @@ object ActionStatus {
 
   /** Action is not yet run. */
   case object Pending extends ActionStatus
+
   /** Action run and completed. */
   case object Completed extends ActionStatus
+
   /** Action currently running. */
   case object Running extends ActionStatus
+
   /** Action run but paused. */
   case object Paused extends ActionStatus
+
   /** Action run but failed to complete. */
   case object Failed extends ActionStatus
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ObserveCommandResult.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ObserveCommandResult.scala
@@ -9,11 +9,12 @@ sealed trait ObserveCommandResult extends Product with Serializable
 
 object ObserveCommandResult {
   case object Success extends ObserveCommandResult
-  case object Paused extends ObserveCommandResult
+  case object Paused  extends ObserveCommandResult
   case object Stopped extends ObserveCommandResult
   case object Aborted extends ObserveCommandResult
+  case object Partial extends ObserveCommandResult // Used for N&S
 
   /** @group Typeclass Instances */
   implicit val ObserveCommandResultEnumerated: Enumerated[ObserveCommandResult] =
-    Enumerated.of(Success, Paused, Stopped, Aborted)
+    Enumerated.of(Success, Paused, Stopped, Aborted, Partial)
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/events.scala
@@ -26,14 +26,6 @@ object events {
     def clientId: ClientId
   }
 
-  // TODO: msg should be LogMsg but it does IO when getting a timestamp, it
-  // has to be embedded in a `Task`
-  final case class NewLogMessage(msg: String) extends SeqexecEvent
-
-  object NewLogMessage {
-    implicit lazy val equal: Eq[NewLogMessage] = Eq.fromUniversalEquals
-  }
-
   final case class ObservationProgressEvent(progress: ObservationProgress)
       extends SeqexecEvent
 
@@ -334,7 +326,6 @@ object events {
     Eq.instance {
       case (a: ConnectionOpenEvent,      b: ConnectionOpenEvent)      => a === b
       case (a: SeqexecModelUpdate,       b: SeqexecModelUpdate)       => a === b
-      case (a: NewLogMessage,            b: NewLogMessage)            => a === b
       case (a: ServerLogMessage,         b: ServerLogMessage)         => a === b
       case (a: UserNotification,         b: UserNotification)         => a === b
       case (a: GuideConfigUpdate,        b: GuideConfigUpdate)        => a === b

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ExecutionQueueViewSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ExecutionQueueViewSpec.scala
@@ -5,6 +5,7 @@ package seqexec.model
 
 import cats.tests.CatsSuite
 import gem.arb.ArbEnumerated._
+import gem.arb.ArbObservation._
 import monocle.law.discipline.LensTests
 import seqexec.model.SeqexecModelArbitraries._
 

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelLensesSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelLensesSpec.scala
@@ -95,7 +95,7 @@ final class ModelLensesSpec extends CatsSuite with ModelLenses {
   checkAll("Step.breakpoint",
            LensTests(Step.breakpoint))
   checkAll("Step.observeStatus",
-           LensTests(Step.observeStatus))
+           OptionalTests(Step.observeStatus))
   checkAll("Step.configStatus",
-           LensTests(Step.configStatus))
+           OptionalTests(Step.configStatus))
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelLensesSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelLensesSpec.scala
@@ -14,15 +14,18 @@ import gem.arb.ArbEnumerated._
 import seqexec.model.enum._
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.SequenceEventsArbitraries._
+import seqexec.model.arb.ArbStep._
+import seqexec.model.arb.ArbStepState._
+import seqexec.model.arb.ArbStandardStep._
+import seqexec.model.arb.ArbNodAndShuffleStep._
+import seqexec.model.arb.ArbStepConfig._
 
 final class ModelLensesSpec extends CatsSuite with ModelLenses {
   checkAll("event observer name lens", LensTests(obsNameL))
-  checkAll("standard step prism", PrismTests(standardStepP))
   checkAll("each step traversal", TraversalTests(eachStepT))
   checkAll("observation steps lens", LensTests(obsStepsL))
   checkAll("each view traversal", TraversalTests(eachViewT))
   checkAll("sequence queue lens", LensTests(sessionQueueL))
-  checkAll("standard step config lens", LensTests(stepConfigL))
   checkAll("events prism", PrismTests(sequenceEventsP))
   checkAll("param value lens", LensTests(paramValueL("object")))
   checkAll("system parameters lens",
@@ -77,4 +80,22 @@ final class ModelLensesSpec extends CatsSuite with ModelLenses {
            OptionalTests(instrumentReadModeO))
   checkAll("step class",
            OptionalTests(stepClassO))
+  checkAll("StandardStep",
+           PrismTests(Step.standardStepP))
+  checkAll("NodAndShuffleStep",
+           PrismTests(Step.nsStepP))
+  checkAll("Step.status",
+           LensTests(Step.status))
+  checkAll("Step.config",
+           LensTests(Step.config))
+  checkAll("Step.id",
+           LensTests(Step.id))
+  checkAll("Step.skip",
+           LensTests(Step.skip))
+  checkAll("Step.breakpoint",
+           LensTests(Step.breakpoint))
+  checkAll("Step.observeStatus",
+           LensTests(Step.observeStatus))
+  checkAll("Step.configStatus",
+           LensTests(Step.configStatus))
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -14,6 +14,11 @@ import seqexec.model.arb.ArbNotification._
 import seqexec.model.arb.ArbM2GuideConfig._
 import seqexec.model.arb.ArbM1GuideConfig._
 import seqexec.model.arb.ArbTelescopeGuideConfig._
+import seqexec.model.arb.ArbStep._
+import seqexec.model.arb.ArbStandardStep._
+import seqexec.model.arb.ArbNodAndShuffleStep._
+import seqexec.model.arb.ArbStepState._
+import seqexec.model.arb.ArbStepConfig._
 import squants.time.Time
 import squants.time.TimeUnit
 
@@ -34,6 +39,8 @@ final class ModelSpec extends CatsSuite {
   checkAll("Eq[ActionStatus]", EqTests[ActionStatus].eqv)
   checkAll("Eq[Step]", EqTests[Step].eqv)
   checkAll("Eq[StandardStep]", EqTests[StandardStep].eqv)
+  checkAll("Eq[NodAndShuffleStatus]", EqTests[NodAndShuffleStatus].eqv)
+  checkAll("Eq[NodAndShuffleStep]", EqTests[NodAndShuffleStep].eqv)
   checkAll("Eq[SequenceState]", EqTests[SequenceState].eqv)
   checkAll("Eq[ActionType]", EqTests[ActionType].eqv)
   checkAll("Eq[SequenceMetadata]", EqTests[SequenceMetadata].eqv)

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecEventSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SeqexecEventSpec.scala
@@ -31,7 +31,6 @@ final class SeqexecEventSpec extends CatsSuite with SequenceEventsArbitraries {
   checkAll("Eq[SequencePaused]", EqTests[SequencePaused].eqv)
   checkAll("Eq[ExposurePaused]", EqTests[ExposurePaused].eqv)
   checkAll("Eq[SequenceError]", EqTests[SequenceError].eqv)
-  checkAll("Eq[NewLogMessage]", EqTests[NewLogMessage].eqv)
   checkAll("Eq[UserNotification]", EqTests[UserNotification].eqv)
   checkAll("Eq[ObservationProgressEvent]", EqTests[ObservationProgressEvent].eqv)
   checkAll("Eq[SequenceStopped]", EqTests[SequenceStopped].eqv)

--- a/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/SequenceEventsArbitraries.scala
@@ -91,9 +91,6 @@ trait SequenceEventsArbitraries extends ArbTime with ArbNotification {
   implicit val asrArb = Arbitrary[ActionStopRequested] {
     arbitrary[SequencesQueue[SequenceView]].map(ActionStopRequested.apply)
   }
-  implicit val nlmArb = Arbitrary[NewLogMessage] {
-    arbitrary[String].map(NewLogMessage.apply)
-  }
   implicit val slmArb = Arbitrary[ServerLogMessage] {
     for {
       l <- arbitrary[ServerLogLevel]
@@ -222,7 +219,6 @@ trait SequenceEventsArbitraries extends ArbTime with ArbNotification {
     Gen.oneOf[SeqexecEvent](
       arbitrary[SeqexecModelUpdate],
       arbitrary[ConnectionOpenEvent],
-      arbitrary[NewLogMessage],
       arbitrary[ServerLogMessage],
       arbitrary[UserNotification],
       arbitrary[ObservationProgressEvent],
@@ -310,9 +306,6 @@ trait SequenceEventsArbitraries extends ArbTime with ArbNotification {
   implicit val slmCogen: Cogen[ServerLogMessage] =
     Cogen[(ServerLogLevel, Instant, String)]
       .contramap(x => (x.level, x.timestamp, x.msg))
-
-  implicit val nlmCogen: Cogen[NewLogMessage] =
-    Cogen[String].contramap(_.msg)
 
   implicit val unCogen: Cogen[UserNotification] =
     Cogen[(Notification, ClientId)].contramap(x => (x.memo, x.clientId))

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNodAndShuffleStep.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNodAndShuffleStep.scala
@@ -33,14 +33,14 @@ trait ArbNodAndShuffleStep {
       cs <- arbitrary[List[(Resource, ActionStatus)]]
       os <- arbitrary[NodAndShuffleStatus]
     } yield
-      new NodAndShuffleStep(id      = id,
-                       config       = c,
-                       status       = s,
-                       breakpoint   = b,
-                       skip         = k,
-                       fileId       = f,
-                       configStatus = cs,
-                       nsStatus     = os)
+      new NodAndShuffleStep(id           = id,
+                            config       = c,
+                            status       = s,
+                            breakpoint   = b,
+                            skip         = k,
+                            fileId       = f,
+                            configStatus = cs,
+                            nsStatus     = os)
   }
 
   implicit val nodShuffleStepCogen: Cogen[NodAndShuffleStep] =

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNodAndShuffleStep.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNodAndShuffleStep.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.arb
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import gem.arb.ArbEnumerated._
+import seqexec.model._
+import seqexec.model.enum._
+import seqexec.model.arb.ArbStepConfig._
+import seqexec.model.arb.ArbStepState._
+
+trait ArbNodAndShuffleStep {
+  implicit val nssArb = Arbitrary[NodAndShuffleStatus] {
+    arbitrary[ActionStatus].map(NodAndShuffleStatus.apply)
+  }
+
+  implicit val nodAndShuffleStatusCogen: Cogen[NodAndShuffleStatus] =
+    Cogen[ActionStatus].contramap {
+      _.observing
+    }
+
+  implicit val nodShuffleStepArb = Arbitrary[NodAndShuffleStep] {
+    for {
+      id <- arbitrary[StepId]
+      c  <- stepConfigGen
+      s  <- arbitrary[StepState]
+      b  <- arbitrary[Boolean]
+      k  <- arbitrary[Boolean]
+      f  <- arbitrary[Option[dhs.ImageFileId]]
+      cs <- arbitrary[List[(Resource, ActionStatus)]]
+      os <- arbitrary[NodAndShuffleStatus]
+    } yield
+      new NodAndShuffleStep(id      = id,
+                       config       = c,
+                       status       = s,
+                       breakpoint   = b,
+                       skip         = k,
+                       fileId       = f,
+                       configStatus = cs,
+                       nsStatus     = os)
+  }
+
+  implicit val nodShuffleStepCogen: Cogen[NodAndShuffleStep] =
+    Cogen[(
+      StepId,
+      Map[SystemName, Map[String, String]],
+      StepState,
+      Boolean,
+      Boolean,
+      Option[dhs.ImageFileId],
+      List[(Resource, ActionStatus)],
+      NodAndShuffleStatus
+    )].contramap(
+      s =>
+        (s.id,
+         s.config,
+         s.status,
+         s.breakpoint,
+         s.skip,
+         s.fileId,
+         s.configStatus,
+         s.nsStatus)
+    )
+
+}
+
+object ArbNodAndShuffleStep extends ArbNodAndShuffleStep

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbStandardStep.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbStandardStep.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.arb
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import gem.arb.ArbEnumerated._
+import seqexec.model._
+import seqexec.model.enum._
+import seqexec.model.arb.ArbStepConfig._
+import seqexec.model.arb.ArbStepState._
+
+trait ArbStandardStep {
+  implicit val stsArb = Arbitrary[StandardStep] {
+    for {
+      id <- arbitrary[StepId]
+      c  <- stepConfigGen
+      s  <- arbitrary[StepState]
+      b  <- arbitrary[Boolean]
+      k  <- arbitrary[Boolean]
+      f  <- arbitrary[Option[dhs.ImageFileId]]
+      cs <- arbitrary[List[(Resource, ActionStatus)]]
+      os <- arbitrary[ActionStatus]
+    } yield
+      new StandardStep(id            = id,
+                       config        = c,
+                       status        = s,
+                       breakpoint    = b,
+                       skip          = k,
+                       fileId        = f,
+                       configStatus  = cs,
+                       observeStatus = os)
+  }
+
+  implicit val standardStepCogen: Cogen[StandardStep] =
+    Cogen[(
+      StepId,
+      Map[SystemName, Map[String, String]],
+      StepState,
+      Boolean,
+      Boolean,
+      Option[dhs.ImageFileId],
+      List[(Resource, ActionStatus)],
+      ActionStatus
+    )].contramap(
+      s =>
+        (s.id,
+         s.config,
+         s.status,
+         s.breakpoint,
+         s.skip,
+         s.fileId,
+         s.configStatus,
+         s.observeStatus)
+    )
+
+}
+
+object ArbStandardStep extends ArbStandardStep

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbStep.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbStep.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.arb
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+import seqexec.model._
+import seqexec.model.arb.ArbStandardStep._
+import seqexec.model.arb.ArbNodAndShuffleStep._
+
+trait ArbStep {
+  implicit val steArb = Arbitrary[Step] {
+    for {
+      ss <- arbitrary[StandardStep]
+      ns <- arbitrary[NodAndShuffleStep]
+      s  <- Gen.oneOf(ss, ns)
+    } yield s
+  }
+
+  implicit val stepCogen: Cogen[Step] =
+    Cogen[Either[StandardStep, NodAndShuffleStep]].contramap {
+      case a: StandardStep => Left(a)
+      case a: NodAndShuffleStep => Right(a)
+    }
+}
+
+object ArbStep extends ArbStep

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbStepConfig.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbStepConfig.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.arb
+
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+import gem.arb.ArbEnumerated._
+import seqexec.model._
+import seqexec.model.enum._
+
+trait ArbStepConfig {
+  val asciiStr: Gen[String] =
+    Gen.listOf(Gen.alphaChar).map(_.mkString)
+
+  val stepItemG: Gen[(String, String)] =
+    for {
+      a <- asciiStr
+      b <- asciiStr
+    } yield (a, b)
+
+  val parametersGen: Gen[Parameters] =
+    Gen.chooseNum(0, 10).flatMap(s => Gen.mapOfN[String, String](s, stepItemG))
+
+  val stepConfigG: Gen[(SystemName, Parameters)] =
+    for {
+      a <- arbitrary[SystemName]
+      b <- parametersGen
+    } yield (a, b)
+
+  val stepConfigGen: Gen[StepConfig] = Gen
+    .chooseNum(0, 3)
+    .flatMap(s => Gen.mapOfN[SystemName, Parameters](s, stepConfigG))
+
+  implicit val stParams: Cogen[StepConfig] =
+    Cogen[String].contramap(_.mkString(","))
+
+}
+
+object ArbStepConfig extends ArbStepConfig

--- a/modules/seqexec/server/src/main/scala/seqexec/server/FileIdProvider.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/FileIdProvider.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.keywords._
+
+object FileIdProvider {
+
+  def fileId[F[_]](env: ObserveEnvironment[F]): F[ImageFileId] =
+    // All instruments ask the DHS for an ImageFileId
+    env.systems.dhs.createImage(
+      DhsClient.ImageParameters(DhsClient.Permanent,
+                                List(env.inst.contributorName, "dhs-http"))
+    )
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
@@ -1,0 +1,108 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import cats.MonadError
+import cats.data.NonEmptyList
+import cats.implicits._
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.ActionType
+import seqexec.model.dhs.ImageFileId
+import seqexec.engine.Action
+import seqexec.engine.Action.ActionState
+import seqexec.engine.ParallelActions
+import seqexec.engine.Result
+
+/**
+  * Algebra to generate actions for an observation.
+  * Most instruments behave the same but in some cases we need to customize
+  * behavior. The two prime examples are:
+  * GPI A&C
+  * GMOS N&S
+  * In both cases the InstrumentActions for the instrument can provide the correct behavior
+  */
+trait InstrumentActions[F[_]] {
+
+  /**
+    * Produce a progress stream for the given observe
+    * @param env Properties of the observation
+    */
+  def observationProgressStream(
+    env: ObserveEnvironment[F]
+  ): Stream[F, Result[F]]
+
+  /**
+    * Builds a list of actions to run while observing
+    * In most cases it is just a plain observe but could be skipped or made more complex
+    * if needed
+    * @param env Properties of the observation
+    * @param post Function to customize the output of the parallel actions
+    */
+  def observeActions(
+    env:  ObserveEnvironment[F],
+    post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+  ): List[ParallelActions[F]]
+
+  /**
+    * Indicates if we should run the initial observe actions
+    * e.g. requesting a file Id
+    */
+  def runInitialAction(stepType: StepType): Boolean
+}
+
+object InstrumentActions {
+
+  /**
+   * This is the default observe action, just a simple observe call
+   */
+  def defaultObserveActions[F[_]](
+    observeResults: Stream[F, Result[F]]
+  ): List[ParallelActions[F]] =
+    List(
+      NonEmptyList.one(
+        Action(ActionType.Observe,
+               observeResults,
+               Action.State(ActionState.Idle, Nil))
+      )
+    )
+
+  def safeObserve[F[_]: MonadError[?[_], Throwable]: Logger](
+    env: ObserveEnvironment[F], doObserve: (ImageFileId, ObserveEnvironment[F]) => F[Stream[F, Result[F]]]
+  ): Stream[F, Result[F]] = {
+    // We need to be careful about handling this particular error
+    Stream.eval(FileIdProvider.fileId(env).attempt).flatMap {
+      case Right(fileId) =>
+        val observationCommand =
+          Stream.eval(doObserve(fileId, env)).flatten
+
+        Stream.emit(Result.Partial(FileIdAllocated(fileId))) ++ observationCommand
+      case Left(e: SeqexecFailure) => Stream.emit(Result.Error(SeqexecFailure.explain(e)))
+      case Left(e: Throwable) => Stream.emit(Result.Error(SeqexecFailure.explain(SeqexecFailure.SeqexecException(e))))
+    }
+  }
+
+  /**
+    * Default Actions for most instruments it basically delegates to ObserveActions
+    */
+  def defaultInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger]
+    : InstrumentActions[F] =
+    new InstrumentActions[F] {
+      def observationProgressStream(
+        env: ObserveEnvironment[F]
+      ): Stream[F, Result[F]] =
+        ObserveActions.observationProgressStream(env)
+
+      override def observeActions(
+        env: ObserveEnvironment[F],
+        post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+      ): List[ParallelActions[F]] =
+        defaultObserveActions(
+          post(safeObserve(env, ObserveActions.stdObserve[F]), env)
+        )
+
+      def runInitialAction(stepType: StepType): Boolean = true
+    }
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
@@ -69,13 +69,13 @@ object InstrumentActions {
     )
 
   def safeObserve[F[_]: MonadError[?[_], Throwable]: Logger](
-    env: ObserveEnvironment[F], doObserve: (ImageFileId, ObserveEnvironment[F]) => F[Stream[F, Result[F]]]
+    env: ObserveEnvironment[F], doObserve: (ImageFileId, ObserveEnvironment[F]) => Stream[F, Result[F]]
   ): Stream[F, Result[F]] = {
     // We need to be careful about handling this particular error
     Stream.eval(FileIdProvider.fileId(env).attempt).flatMap {
       case Right(fileId) =>
         val observationCommand =
-          Stream.eval(doObserve(fileId, env)).flatten
+          doObserve(fileId, env)
 
         Stream.emit(Result.Partial(FileIdAllocated(fileId))) ++ observationCommand
       case Left(e: SeqexecFailure) => Stream.emit(Result.Error(SeqexecFailure.explain(e)))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentControllerSim.scala
@@ -21,6 +21,8 @@ import squants.time.Time
 import scala.concurrent.duration._
 
 sealed trait InstrumentControllerSim[F[_]] {
+  def log(msg: => String): F[Unit]
+
   def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult]
 
   def applyConfig[C: Show](config: C): F[Unit]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -20,15 +20,22 @@ trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
   val contributorName: String
   val observeControl: InstrumentSystem.ObserveControl[F]
 
-  def observe(
-      config: Config): Kleisli[F, ImageFileId, ObserveCommandResult]
+  def observe(config: Config): Kleisli[F, ImageFileId, ObserveCommandResult]
+
   //Expected total observe lapse, used to calculate timeout
   def calcObserveTime(config: Config): F[Time]
+
   def keywordsClient: KeywordsClient[F]
+
   def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress]
+
+  def instrumentActions(config: Config): InstrumentActions[F]
+
   def calcStepType(config: Config): Either[SeqexecFailure, StepType] =
     SequenceConfiguration.calcStepType(config)
+
   override val oiOffsetGuideThreshold: Option[Length] = None
+
   override def instrument: Instrument = resource
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -124,7 +124,7 @@ trait ObserveActions {
 
   /**
     * Preamble for observations. It tells the odb, the subsystems
-    * send the start headers and finall ysends an observe
+    * send the start headers and finally sends an observe
     */
   def observePreamble[F[_]: MonadError[?[_], Throwable]: Logger](
     fileId: ImageFileId,
@@ -193,11 +193,12 @@ trait ObserveActions {
   def stdObserve[F[_]: MonadError[?[_], Throwable]: Logger](
     fileId: ImageFileId,
     env:    ObserveEnvironment[F]
-  ): F[Stream[F, Result[F]]] =
+  ): Stream[F, Result[F]] =
+    Stream.eval(
     for {
       (fileId, result) <- observePreamble(fileId, env)
       ret              <- observeTail(fileId, fileId, env)(result)
-    } yield ret
+    } yield ret).flatten
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -4,128 +4,200 @@
 package seqexec.server
 
 import cats._
-import cats.effect.Sync
-import cats.effect.Concurrent
-import cats.data.Reader
 import cats.data.EitherT
 import cats.implicits._
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.obscomp.InstConstants._
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import fs2.Stream
 import gem.Observation
-import org.log4s._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.engine._
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.keywords._
 import seqexec.server.InstrumentSystem.ElapsedTime
 import squants.time.TimeConversions._
 
 /**
- * Methods usedd to generate observation related actions
- */
+  * Methods usedd to generate observation related actions
+  */
 trait ObserveActions {
-  private val Log = getLogger
 
-  // All instruments ask the DHS for an ImageFileId
-  private def dhsFileId[F[_]: ApplicativeError[?[_], Throwable]](systems: Systems[F], inst: InstrumentSystem[F]): F[ImageFileId] =
-    systems.dhs.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List(inst.contributorName, "dhs-http")))
+  private def info[F[_]: Logger](msg: => String): F[Unit] = Logger[F].info(msg)
 
-  private def info[F[_]: Sync](msg: => String): F[Unit] = Sync[F].delay(Log.info(msg))
+  /**
+    * Actions to perform when an observe is aborted
+    */
+  def abortTail[F[_]: MonadError[?[_], Throwable]](
+    systems:     Systems[F],
+    obsId:       Observation.Id,
+    imageFileId: ImageFileId
+  ): F[Result[F]] =
+    systems.odb
+      .obsAbort(obsId, imageFileId)
+      .ensure(
+        SeqexecFailure
+          .Unexpected("Unable to send ObservationAborted message to ODB.")
+      )(identity) *>
+      MonadError[F, Throwable].raiseError(
+        SeqexecFailure
+          .Execution(s"Observation ${obsId.format} aborted by user.")
+      )
 
-  private def abortTail[F[_]: MonadError[?[_], Throwable]](systems: Systems[F], obsId: Observation.Id, imageFileId: ImageFileId): F[Result[F]] =
-    systems.odb.obsAbort(obsId, imageFileId)
-      .ensure(SeqexecFailure.Unexpected("Unable to send ObservationAborted message to ODB."))(identity) *>
-    MonadError[F, Throwable].raiseError(SeqexecFailure.Execution(s"Observation ${obsId.format} aborted by user."))
-
-  private def sendDataStart[F[_]: MonadError[?[_], Throwable]](systems: Systems[F], obsId: Observation.Id, imageFileId: ImageFileId, dataId: String): F[Unit] =
-    systems.odb.datasetStart(obsId, dataId, imageFileId)
-      .ensure(SeqexecFailure.Unexpected("Unable to send DataStart message to ODB."))(identity)
+  /**
+    * Send the datasetStart command to the odb
+    */
+  private def sendDataStart[F[_]: MonadError[?[_], Throwable]](
+    systems:     Systems[F],
+    obsId:       Observation.Id,
+    imageFileId: ImageFileId,
+    dataId:      String
+  ): F[Unit] =
+    systems.odb
+      .datasetStart(obsId, dataId, imageFileId)
+      .ensure(
+        SeqexecFailure.Unexpected("Unable to send DataStart message to ODB.")
+      )(identity)
       .void
 
-  private def sendDataEnd[F[_]: MonadError[?[_], Throwable]](systems: Systems[F], obsId: Observation.Id, imageFileId: ImageFileId, dataId: String): F[Unit] =
-    systems.odb.datasetComplete(obsId, dataId, imageFileId)
-      .ensure(SeqexecFailure.Unexpected("Unable to send DataEnd message to ODB."))(identity)
+  /**
+    * Send the datasetEnd command to the odb
+    */
+  private def sendDataEnd[F[_]: MonadError[?[_], Throwable]](
+    systems:     Systems[F],
+    obsId:       Observation.Id,
+    imageFileId: ImageFileId,
+    dataId:      String
+  ): F[Unit] =
+    systems.odb
+      .datasetComplete(obsId, dataId, imageFileId)
+      .ensure(
+        SeqexecFailure.Unexpected("Unable to send DataEnd message to ODB.")
+      )(identity)
       .void
 
-  def observe[F[_]: Sync: Concurrent](
-    systems: Systems[F],
-    config: Config,
-    obsId: Observation.Id,
-    inst: InstrumentSystem[F],
-    otherSys: List[System[F]],
-    headers: Reader[HeaderExtraData, List[Header[F]]])(
-      ctx: HeaderExtraData): Stream[F, Result[F]]
-  = {
-    def dataId: F[String] =
-      EitherT.fromEither[F](
-        config.extractAs[String](OBSERVE_KEY / DATA_LABEL_PROP)
+  /**
+    * Standard progress stream for an observation
+    */
+  def observationProgressStream[F[_]](
+    env: ObserveEnvironment[F]
+  ): Stream[F, Result[F]] =
+    for {
+      ot <- Stream.eval(env.inst.calcObserveTime(env.config))
+      pr <- env.inst.observeProgress(ot, ElapsedTime(0.0.seconds))
+    } yield Result.Partial(pr)
+
+  /**
+    * Tell each subsystem that an observe will start
+    */
+  def notifyObserveStart[F[_]: Applicative](
+    env: ObserveEnvironment[F]
+  ): F[Unit] =
+    env.otherSys.map(_.notifyObserveStart).sequence.void
+
+  /**
+    * Tell each subsystem that an observe will end
+    * Unlike observe start we also tell the instrumetn about it
+    */
+  def notifyObserveEnd[F[_]: Applicative](env: ObserveEnvironment[F]): F[Unit] =
+    (env.inst +: env.otherSys).map(_.notifyObserveEnd).sequence.void
+
+  /**
+    * Close the image, telling either DHS or GDS as it correspond
+    */
+  def closeImage[F[_]](id: ImageFileId, env: ObserveEnvironment[F]): F[Unit] =
+    env.inst.keywordsClient.closeImage(id)
+
+  /**
+    * Read the data id value from the sequence
+    */
+  def dataId[F[_]: MonadError[?[_], Throwable]](
+    env: ObserveEnvironment[F]
+  ): F[String] =
+    EitherT
+      .fromEither[F](
+        env.config
+          .extractAs[String](OBSERVE_KEY / DATA_LABEL_PROP)
           .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
-      ).widenRethrowT
+      )
+      .widenRethrowT
 
-    def notifyObserveStart: F[Unit] =
-      otherSys.map(_.notifyObserveStart).sequence.void
+  /**
+    * Preamble for observations. It tells the odb, the subsystems
+    * send the start headers and finall ysends an observe
+    */
+  def observePreamble[F[_]: MonadError[?[_], Throwable]: Logger](
+    fileId: ImageFileId,
+    env:    ObserveEnvironment[F]
+  ): F[(String, ObserveCommandResult)] =
+    for {
+      d <- dataId(env)
+      _ <- sendDataStart(env.systems, env.obsId, fileId, d)
+      _ <- notifyObserveStart(env)
+      _ <- env.headers(env.ctx).map(_.sendBefore(env.obsId, fileId)).sequence
+      _ <- info(s"Start ${env.inst.resource.show} observation ${env.obsId.format} with label $fileId")
+      r <- env.inst.observe(env.config)(fileId)
+      _ <- info(s"Completed ${env.inst.resource.show} observation ${env.obsId.format} with label $fileId")
+    } yield (d, r)
 
-    // endObserve must be sent to the instrument too.
-    def notifyObserveEnd: F[Unit] =
-      (inst +: otherSys).map(_.notifyObserveEnd).sequence.void
+  /**
+    * End of an observation for a typical instrument
+    * It tells the odb and each subsystem and also sends the end
+    * observation keywords
+    */
+  def okTail[F[_]: MonadError[?[_], Throwable]](
+    fileId:  ImageFileId,
+    dataId:  String,
+    stopped: Boolean,
+    env:     ObserveEnvironment[F]
+  ): F[Result[F]] =
+    for {
+      _ <- notifyObserveEnd(env)
+      _ <- env.headers(env.ctx).reverseMap(_.sendAfter(fileId)).sequence.void
+      _ <- closeImage(fileId, env)
+      _ <- sendDataEnd[F](env.systems, env.obsId, fileId, dataId)
+    } yield
+      if (stopped) Result.OKStopped(Response.Observed(fileId))
+      else Result.OK(Response.Observed(fileId))
 
-    def closeImage(id: ImageFileId): F[Unit] =
-      inst.keywordsClient.closeImage(id)
-
-    def doObserve(fileId: ImageFileId): F[Result[F]] =
-      for {
-        d   <- dataId
-        _   <- sendDataStart(systems, obsId, fileId, d)
-        _   <- notifyObserveStart
-        _   <- headers(ctx).map(_.sendBefore(obsId, fileId)).sequence
-        _   <- info(s"Start ${inst.resource.show} observation ${obsId.format} with label $fileId")
-        r   <- inst.observe(config)(fileId)
-        _   <- info(s"Completed ${inst.resource.show} observation ${obsId.format} with label $fileId")
-        ret <- observeTail(fileId, d)(r)
-      } yield ret
-
-    def observeTail(id: ImageFileId, dataId: String)(r: ObserveCommandResult): F[Result[F]] = {
-      def okTail(stopped: Boolean): F[Result[F]] = for {
-        _ <- notifyObserveEnd
-        _ <- headers(ctx).reverseMap(_.sendAfter(id)).sequence.void
-        _ <- closeImage(id)
-        _ <- sendDataEnd[F](systems, obsId, id, dataId)
-      } yield if (stopped) Result.OKStopped(Response.Observed(id)) else Result.OK(Response.Observed(id))
-
-      val successTail: F[Result[F]] = okTail(stopped = false)
-
-      val stopTail: F[Result[F]] = okTail(stopped = true)
-
-      r match {
-        case ObserveCommandResult.Success => successTail
-        case ObserveCommandResult.Stopped => stopTail
-        case ObserveCommandResult.Aborted => abortTail(systems, obsId, id)
-        case ObserveCommandResult.Paused  =>
-          inst.calcObserveTime(config)
-            .map(e => Result.Paused(ObserveContext(observeTail(id, dataId), e)))
-      }
+  /**
+    * Method to process observe results and act accordingly to the response
+    */
+  private def observeTail[F[_]: MonadError[?[_], Throwable]](
+    fileId: ImageFileId,
+    dataId: String,
+    env:    ObserveEnvironment[F]
+  )(r:      ObserveCommandResult): F[Stream[F, Result[F]]] = {
+    val result: F[Result[F]] = r match {
+      case ObserveCommandResult.Success =>
+        okTail(fileId, dataId, stopped = false, env)
+      case ObserveCommandResult.Stopped =>
+        okTail(fileId, dataId, stopped = true, env)
+      case ObserveCommandResult.Aborted =>
+        abortTail(env.systems, env.obsId, fileId)
+      case ObserveCommandResult.Paused =>
+        env.inst
+          .calcObserveTime(env.config)
+          .map(e => Result.Paused(ObserveContext(observeTail(fileId, dataId, env), e)))
+      case ObserveCommandResult.Partial =>
+        // This shouldn't happen in normal observations. Raise an error
+        MonadError[F, Throwable]
+          .raiseError(SeqexecFailure.Execution("Unuspported Partial observation"))
     }
-
-    Stream.eval(dhsFileId(systems, inst).attempt).flatMap {
-      case Right(id) =>
-        val observationProgressStream =
-          for {
-            ot <- Stream.eval(inst.calcObserveTime(config))
-            pr <- inst.observeProgress(ot, ElapsedTime(0.0.seconds))
-          } yield Result.Partial(pr)
-
-        val observationCommand =
-          Stream.eval[F, Result[F]](doObserve(id))
-
-        Stream.emit(Result.Partial(FileIdAllocated(id))) ++
-          observationProgressStream.mergeHaltR(observationCommand)
-      case Left(e: SeqexecFailure)   => Stream.emit(Result.Error(SeqexecFailure.explain(e)))
-      case Left(e: Throwable)   => Stream.emit(Result.Error(SeqexecFailure.explain(SeqexecFailure.SeqexecException(e))))
-    }
+    result.map(Stream.emit[F, Result[F]])
   }
+
+  /**
+    * Observe for a typical instrument
+    */
+  def stdObserve[F[_]: MonadError[?[_], Throwable]: Logger](
+    fileId: ImageFileId,
+    env:    ObserveEnvironment[F]
+  ): F[Stream[F, Result[F]]] =
+    for {
+      (fileId, result) <- observePreamble(fileId, env)
+      ret              <- observeTail(fileId, fileId, env)(result)
+    } yield ret
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import cats.data.Reader
+import gem.Observation
+import edu.gemini.spModel.config2.Config
+import seqexec.server.keywords._
+
+/**
+  * Describes the parameters for an observation
+  */
+final case class ObserveEnvironment[F[_]](
+  systems:  Systems[F],
+  config:   Config,
+  stepType: StepType,
+  obsId:    Observation.Id,
+  inst:     InstrumentSystem[F],
+  otherSys: List[System[F]],
+  headers:  Reader[HeaderExtraData, List[Header[F]]],
+  ctx:      HeaderExtraData
+)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server
 
-import cats.data.Reader
 import gem.Observation
 import edu.gemini.spModel.config2.Config
 import seqexec.server.keywords._
@@ -18,6 +17,6 @@ final case class ObserveEnvironment[F[_]](
   obsId:    Observation.Id,
   inst:     InstrumentSystem[F],
   otherSys: List[System[F]],
-  headers:  Reader[HeaderExtraData, List[Header[F]]],
+  headers:  HeaderExtraData => List[Header[F]],
   ctx:      HeaderExtraData
 )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -5,7 +5,6 @@ package seqexec.server
 
 import cats._
 import cats.data.{Kleisli, StateT}
-import cats.data.NonEmptyList
 import cats.effect.{ConcurrentEffect, ContextShift, IO, Sync, Timer}
 import cats.implicits._
 import edu.gemini.seqexec.odb.SeqFailure
@@ -25,18 +24,16 @@ import monocle.Monocle._
 import monocle.Optional
 import org.http4s.client.Client
 import org.http4s.Uri
-import seqexec.engine
 import seqexec.engine.Result.Partial
 import seqexec.engine.EventResult._
 import seqexec.engine.{Step => _, _}
 import seqexec.engine.Handle
 import seqexec.engine.SystemEvent
 import seqexec.engine.UserEvent
-import seqexec.engine.Action.ActionState
 import seqexec.model._
 import seqexec.model.enum._
 import seqexec.model.events.{SequenceStart => ClientSequenceStart, _}
-import seqexec.model.{ActionType, StepId, UserDetails}
+import seqexec.model.{StepId, UserDetails}
 import seqexec.server.keywords._
 import seqexec.server.flamingos2.{Flamingos2ControllerEpics, Flamingos2ControllerSim, Flamingos2ControllerSimBad, Flamingos2Epics}
 import seqexec.server.gcal.{GcalControllerEpics, GcalControllerSim, GcalEpics}
@@ -52,15 +49,19 @@ import seqexec.server.gws.GwsEpics
 import seqexec.server.gems.{GemsControllerEpics, GemsControllerSim, GemsEpics}
 import seqexec.server.tcs.{GuideConfigDb, TcsEpics, TcsNorthControllerEpics, TcsNorthControllerSim, TcsSouthControllerEpics, TcsSouthControllerSim}
 import seqexec.server.SeqEvent._
-import seqexec.model.dhs.ImageFileId
 import seqexec.server.altair.{AltairControllerEpics, AltairControllerSim, AltairEpics}
 
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
 import shapeless.tag
 
-class SeqexecEngine(httpClient: Client[IO], gpi: GpiClient[IO], ghost: GhostClient[IO], guideConfigDb: GuideConfigDb[IO],
-                    settings: Settings, sm: SeqexecMetrics)(
+class SeqexecEngine(
+  httpClient: Client[IO],
+  gpi: GpiClient[IO],
+  ghost: GhostClient[IO],
+  guideConfigDb: GuideConfigDb[IO],
+  settings: Settings,
+  sm: SeqexecMetrics)(
   implicit ceio: ConcurrentEffect[IO], tio: Timer[IO]
 ) {
   import SeqexecEngine._
@@ -544,113 +545,13 @@ object SeqexecEngine extends SeqexecConfiguration {
   def splitWhere[A](l: List[A])(p: A => Boolean): (List[A], List[A]) =
     l.splitAt(l.indexWhere(p))
 
-  def splitAfter[A](l: List[A])(p: A => Boolean): (List[A], List[A]) =
-    l.splitAt(l.indexWhere(p) + 1)
-
-  private def kindToResource(kind: ActionType): List[Resource] = kind match {
-    case ActionType.Configure(r) => List(r)
-    case _                       => Nil
-  }
-
-  private[server] def separateActions[F[_]](ls: NonEmptyList[Action[F]]): (List[Action[F]], List[Action[F]]) =
-    ls.toList.partition(_.state.runState match {
-        case ActionState.Completed(_) => false
-        case ActionState.Failed(_)    => false
-        case _                        => true
-      }
-    )
-
-  private[server] def configStatus[F[_]](executions: List[ParallelActions[F]]): List[(Resource, ActionStatus)] = {
-    // Remove undefined actions
-    val ex = executions.filter { !separateActions(_)._2.exists(_.kind === ActionType.Undefined) }
-    // Split where at least one is running
-    val (current, pending) = splitAfter(ex)(separateActions(_)._1.nonEmpty)
-
-    // Calculate the state up to the current
-    val configStatus = current.foldLeft(Map.empty[Resource, ActionStatus]) {
-      case (s, e) =>
-        val (a, r) = separateActions(e).bimap(
-            _.flatMap(a => kindToResource(a.kind).tupleRight(ActionStatus.Running)).toMap,
-            _.flatMap(r => kindToResource(r.kind).tupleRight(ActionStatus.Completed)).toMap)
-        s ++ a ++ r
-    }
-
-    // Find out systems in the future
-    val presentSystems = configStatus.keys.toList
-    // Calculate status of pending items
-    val systemsPending = pending.map {
-      s => separateActions(s).bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
-    }.flatMap {
-      x => x._1.tupleRight(ActionStatus.Pending) ::: x._2.tupleRight(ActionStatus.Completed)
-    }.filter {
-      case (a, _) => !presentSystems.contains(a)
-    }.distinct
-
-    (configStatus ++ systemsPending).toList.sortBy(_._1)
-  }
-
-  /**
-   * Calculates the config status for pending steps
-   */
-  private[server] def pendingConfigStatus[F[_]](executions: List[ParallelActions[F]]): List[(Resource, ActionStatus)] =
-    executions.map {
-      s => separateActions(s).bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
-    }.flatMap {
-      x => x._1 ::: x._2
-    }.distinct.tupleRight(ActionStatus.Pending).sortBy(_._1)
-
-  /**
-   * Overall pending status for a step
-   */
-  private def stepConfigStatus[F[_]](step: engine.Step[F]): List[(Resource, ActionStatus)] =
-    engine.Step.status(step) match {
-      case StepState.Pending => pendingConfigStatus(step.executions)
-      case _                 => configStatus(step.executions)
-    }
-
-  private def observeAction[F[_]](executions: List[ParallelActions[F]]): Option[Action[F]] =
-    executions.flatMap(_.toList).find(_.kind === ActionType.Observe)
-
-  private[server] def observeStatus[F[_]](executions: List[ParallelActions[F]]): ActionStatus =
-    observeAction(executions).map(a => a.state.runState.actionStatus).getOrElse(
-      ActionStatus.Pending)
-
-  private def fileId[F[_]](executions: List[engine.ParallelActions[F]]): Option[ImageFileId] =
-    observeAction(executions).flatMap(_.state.partials.collectFirst{
-      case FileIdAllocated(fid) => fid
-    })
-
-  def viewStep[F[_]](stepg: SequenceGen.StepGen[F], step: engine.Step[F],
-               altCfgStatus: List[(Resource, ActionStatus)]): StandardStep = {
-    val status = engine.Step.status(step)
-    val configStatus =
-      if (status === StepState.Completed || status === StepState.Running) {
-        stepConfigStatus(step)
-      } else {
-        altCfgStatus
-      }
-
-    StandardStep(
-      id = step.id,
-      config = stepg.config,
-      status = status,
-      breakpoint = step.breakpoint.self,
-      skip = step.skipMark.self,
-      configStatus = configStatus,
-      observeStatus = observeStatus(step.executions),
-      fileId = fileId(step.executions).orElse(stepg.some.collect{
-        case SequenceGen.CompletedStepGen(_, _, fileId) => fileId
-      }.flatten)
-    )
-  }
-
   private def systemsBeingConfigured(st: EngineState): Set[Resource] =
     st.sequences.values.filter(d => d.seq.status.isError || d.seq.status.isIdle).toList
       .flatMap(s => s.seq.getSingleActionStates.filter(_._2.started).keys.toList
         .mapFilter(s.seqGen.resourceAtCoords)
       ).toSet
 
-  /*
+  /**
    * Resource in use = Resources used by running sequences, plus the systems that are being configured because a user
    * commanded a manual configuration apply.
    */
@@ -658,7 +559,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     st.sequences.values.toList.mapFilter(s => s.seq.status.isRunning.option(s.seqGen.resources)).foldK ++
       systemsBeingConfigured(st)
 
-  /*
+  /**
    * Resources reserved by running queues.
    */
   private def resourcesReserved(st: EngineState): Set[Resource] = {
@@ -897,7 +798,6 @@ object SeqexecEngine extends SeqexecConfiguration {
     case SequenceStart(sid, stepId)         => ClientSequenceStart(sid, stepId, svs)
     case Busy(id, cid)                      => UserNotification(ResourceConflict(id), cid)
     case ResourceBusy(id, sid, res, cid)    => UserNotification(SubsystemBusy(id, sid, res), cid)
-
   }
 
   private def executionQueueViews(st: EngineState): SortedMap[QueueId, ExecutionQueueView] = {
@@ -909,6 +809,7 @@ object SeqexecEngine extends SeqexecConfiguration {
   private def viewSequence[F[_]](obsSeq: SequenceData[F]): SequenceView = {
     val st = obsSeq.seq
     val seq = st.toSequence
+    val instrument = obsSeq.seqGen.instrument
 
     def resources(s: SequenceGen.StepGen[F]): List[Resource] = s match {
       case s: SequenceGen.PendingStepGen[F] => s.resources.toList
@@ -917,7 +818,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     def engineSteps(seq: Sequence[F]): List[Step] = {
 
       obsSeq.seqGen.steps.zip(seq.steps).map{
-        case (a, b) => viewStep(a, b, resources(a).mapFilter(x =>
+        case (a, b) => StepsView.stepsView(instrument).stepView(a, b, resources(a).mapFilter(x =>
           obsSeq.seqGen.configActionCoord(a.id, x)
             .map(i => (x, obsSeq.seq.getSingleState(i).actionStatus))
         ))
@@ -928,16 +829,16 @@ object SeqexecEngine extends SeqexecConfiguration {
         // Find first Pending Step when no Step is Running and mark it as Running
         case steps if Sequence.State.isRunning(st) && steps.forall(_.status =!= StepState.Running) =>
           val (xs, y :: ys) = splitWhere(steps)(_.status === StepState.Pending)
-          xs ++ (y.copy(status = StepState.Running) :: ys)
+          xs ++ (Step.status.set(StepState.Running)(y) :: ys)
         case steps if st.status === SequenceState.Idle && steps.exists(_.status === StepState.Running) =>
           val (xs, y :: ys) = splitWhere(steps)(_.status === StepState.Running)
-          xs ++ (y.copy(status = StepState.Paused) :: ys)
+          xs ++ (Step.status.set(StepState.Paused)(y) :: ys)
         case x => x
       }
     }
 
     // TODO: Implement willStopIn
-    SequenceView(seq.id, SequenceMetadata(obsSeq.seqGen.instrument, obsSeq.observer, obsSeq.seqGen.title), st.status, engineSteps(seq), None)
+    SequenceView(seq.id, SequenceMetadata(instrument, obsSeq.observer, obsSeq.seqGen.title), st.status, engineSteps(seq), None)
   }
 
   def toSeqexecEvent(ev: executeEngine.ResultType, qState: EngineState): SeqexecEvent = {
@@ -977,7 +878,8 @@ object SeqexecEngine extends SeqexecConfiguration {
           ObservationProgressEvent(ObservationProgress(i, s, t, r.self))
         case SystemEvent.PartialResult(_, _, _, Partial(FileIdAllocated(fileId))) =>
           FileIdStepExecuted(fileId, svs)
-        case SystemEvent.PartialResult(_, _, _, _)                                => SequenceUpdated(svs)
+        case SystemEvent.PartialResult(_, _, _, _)                                =>
+          SequenceUpdated(svs)
         case SystemEvent.Failed(id, _, _)                                         => SequenceError(id, svs)
         case SystemEvent.Busy(id, clientId)                                       =>
           UserNotification(ResourceConflict(id), clientId)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
@@ -9,7 +9,6 @@ import seqexec.model.enum.Instrument
 
 sealed trait StepType {
   def instrument: Instrument
-  def includesObserve: Boolean = true
 }
 
 object StepType {
@@ -22,7 +21,6 @@ object StepType {
   final case class DarkOrBias(override val instrument: Instrument) extends StepType
   case object AlignAndCalib extends StepType {
     override val instrument: Instrument = Instrument.Gpi
-    override val includesObserve: Boolean = false
   }
 
   implicit val eqStepType: Eq[StepType] = Eq.instance {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepsView.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepsView.scala
@@ -1,0 +1,182 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import cats.implicits._
+import cats.data.NonEmptyList
+import seqexec.model.ActionType
+import seqexec.model.Step
+import seqexec.model.StandardStep
+import seqexec.model.NodAndShuffleStep
+import seqexec.model.NodAndShuffleStatus
+import seqexec.model.dhs.ImageFileId
+import seqexec.model.enum.ActionStatus
+import seqexec.model.enum.Resource
+import seqexec.model.enum.Instrument
+import seqexec.model.enum.Instrument._
+import seqexec.model.enum.SystemName
+import seqexec.model.StepState
+import seqexec.engine
+import seqexec.engine.Action.ActionState
+import seqexec.engine.Action
+import seqexec.engine.ParallelActions
+import seqexec.server.gmos.Gmos
+
+sealed trait StepsView[F[_]] {
+  /**
+   * This method creates a view of the step for the client
+   * The Step returned maybe a StandardStep of be specialized e.g. for N&S
+   */
+  def stepView(
+    stepg: SequenceGen.StepGen[F],
+    step: engine.Step[F],
+    altCfgStatus: List[(Resource, ActionStatus)]
+  ): Step
+}
+
+object StepsView {
+  private def kindToResource(kind: ActionType): List[Resource] = kind match {
+    case ActionType.Configure(r) => List(r)
+    case _                       => Nil
+  }
+
+  def splitAfter[A](l: List[A])(p: A => Boolean): (List[A], List[A]) =
+    l.splitAt(l.indexWhere(p) + 1)
+
+  private[server] def separateActions[F[_]](ls: NonEmptyList[Action[F]]): (List[Action[F]], List[Action[F]]) =
+    ls.toList.partition(_.state.runState match {
+        case ActionState.Completed(_) => false
+        case ActionState.Failed(_)    => false
+        case _                        => true
+      }
+    )
+
+  private[server] def configStatus[F[_]](executions: List[ParallelActions[F]]): List[(Resource, ActionStatus)] = {
+    // Remove undefined actions
+    val ex = executions.filter { !separateActions(_)._2.exists(_.kind === ActionType.Undefined) }
+    // Split where at least one is running
+    val (current, pending) = splitAfter(ex)(separateActions(_)._1.nonEmpty)
+
+    // Calculate the state up to the current
+    val configStatus = current.foldLeft(Map.empty[Resource, ActionStatus]) {
+      case (s, e) =>
+        val (a, r) = separateActions(e).bimap(
+            _.flatMap(a => kindToResource(a.kind).tupleRight(ActionStatus.Running)).toMap,
+            _.flatMap(r => kindToResource(r.kind).tupleRight(ActionStatus.Completed)).toMap)
+        s ++ a ++ r
+    }
+
+    // Find out systems in the future
+    val presentSystems = configStatus.keys.toList
+    // Calculate status of pending items
+    val systemsPending = pending.map {
+      s => separateActions(s).bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
+    }.flatMap {
+      x => x._1.tupleRight(ActionStatus.Pending) ::: x._2.tupleRight(ActionStatus.Completed)
+    }.filter {
+      case (a, _) => !presentSystems.contains(a)
+    }.distinct
+
+    (configStatus ++ systemsPending).toList.sortBy(_._1)
+  }
+
+  /**
+   * Calculates the config status for pending steps
+   */
+  private[server] def pendingConfigStatus[F[_]](executions: List[ParallelActions[F]]): List[(Resource, ActionStatus)] =
+    executions.map {
+      s => separateActions(s).bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
+    }.flatMap {
+      x => x._1 ::: x._2
+    }.distinct.tupleRight(ActionStatus.Pending).sortBy(_._1)
+
+  /**
+   * Overall pending status for a step
+   */
+  private def stepConfigStatus[F[_]](step: engine.Step[F]): List[(Resource, ActionStatus)] =
+    engine.Step.status(step) match {
+      case StepState.Pending => pendingConfigStatus(step.executions)
+      case _                 => configStatus(step.executions)
+    }
+
+  private def observeAction[F[_]](executions: List[ParallelActions[F]]): Option[Action[F]] =
+    // FIXME This is too naive and doesn't work properly for N&S
+    executions.flatMap(_.toList).filter(_.kind === ActionType.Observe).headOption
+
+  private[server] def observeStatus[F[_]](executions: List[ParallelActions[F]]): ActionStatus =
+    observeAction(executions)
+      .map(_.state.runState.actionStatus)
+      .getOrElse(ActionStatus.Pending)
+
+  private def fileId[F[_]](executions: List[engine.ParallelActions[F]]): Option[ImageFileId] =
+    observeAction(executions).flatMap(_.state.partials.collectFirst{
+      case FileIdAllocated(fid) => fid
+    })
+
+  private def defaultStepsView[F[_]]: StepsView[F] = new StepsView[F] {
+    def stepView(
+      stepg: SequenceGen.StepGen[F],
+      step: engine.Step[F],
+      altCfgStatus: List[(Resource, ActionStatus)]
+    ): Step = {
+      val status = engine.Step.status(step)
+      val configStatus =
+        if (status === StepState.Completed || status === StepState.Running) {
+          stepConfigStatus(step)
+        } else {
+          altCfgStatus
+        }
+
+      StandardStep(
+        id = step.id,
+        config = stepg.config,
+        status = status,
+        breakpoint = step.breakpoint.self,
+        skip = step.skipMark.self,
+        configStatus = configStatus,
+        observeStatus = observeStatus(step.executions),
+        fileId = fileId(step.executions).orElse(stepg.some.collect{
+          case SequenceGen.CompletedStepGen(_, _, fileId) => fileId
+        }.flatten))
+    }
+
+  }
+
+  private def gmosStepsView[F[_]]: StepsView[F] = new StepsView[F] {
+    def stepView(
+      stepg: SequenceGen.StepGen[F],
+      step: engine.Step[F],
+      altCfgStatus: List[(Resource, ActionStatus)]
+    ): Step = {
+      // Not nice, At this stage we only have the raw config
+      if (stepg.config.get(SystemName.Instrument).exists(_.get(Gmos.NSKey.getPath).exists(_ === "true"))) {
+        val status = engine.Step.status(step)
+        val configStatus =
+          if (status === StepState.Completed || status === StepState.Running) {
+            stepConfigStatus(step)
+          } else {
+            altCfgStatus
+          }
+
+        NodAndShuffleStep(
+          id = step.id,
+          config = stepg.config,
+          status = status,
+          breakpoint = step.breakpoint.self,
+          skip = step.skipMark.self,
+          configStatus = configStatus,
+          nsStatus = NodAndShuffleStatus(observeStatus(step.executions)),
+          fileId = fileId(step.executions).orElse(stepg.some.collect{
+            case SequenceGen.CompletedStepGen(_, _, fileId) => fileId
+          }.flatten))
+      } else defaultStepsView.stepView(stepg, step, altCfgStatus)
+    }
+
+  }
+
+  def stepsView[F[_]](instrument: Instrument): StepsView[F] = instrument match {
+    case GmosN | GmosS => gmosStepsView[F]
+    case _ => defaultStepsView[F]
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -15,6 +15,7 @@ import edu.gemini.spModel.obscomp.InstConstants.{DARK_OBSERVE_TYPE, OBSERVE_TYPE
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import java.lang.{Double => JDouble}
 import gem.enum.LightSinkName
+import io.chrisdavenport.log4cats.Logger
 import scala.concurrent.duration.{Duration, SECONDS}
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import seqexec.model.enum.Instrument
@@ -30,7 +31,7 @@ import squants.time.{Seconds, Time}
 
 import scala.reflect.ClassTag
 
-final case class Flamingos2[F[_]: Sync: Timer](f2Controller: Flamingos2Controller[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
+final case class Flamingos2[F[_]: Sync: Timer: Logger](f2Controller: Flamingos2Controller[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
 
   import Flamingos2._
 
@@ -72,6 +73,9 @@ final case class Flamingos2[F[_]: Sync: Timer](f2Controller: Flamingos2Controlle
 
   override def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress] =
     f2Controller.observeProgress(total)
+
+  override def instrumentActions(config: Config): InstrumentActions[F] =
+    InstrumentActions.defaultInstrumentActions[F]
 
   // TODO Use different value if using electronic offsets
   override val oiOffsetGuideThreshold: Option[Length] =
@@ -146,7 +150,6 @@ object Flamingos2 {
       obsType <- config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
       // WINDOW_COVER_PROP is optional. It can be a WindowCover, an Option[WindowCover], or not be present. If no
       // value is given, then window cover position is inferred from observe type.
-      pItem = config.extract(INSTRUMENT_KEY / WINDOW_COVER_PROP)
       p <- extractEngineeringParam(config.extract(INSTRUMENT_KEY / WINDOW_COVER_PROP),
              windowCoverFromObserveType(obsType)
            )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -14,6 +14,7 @@ import edu.gemini.spModel.gemini.ghost.{ Ghost => SPGhost }
 import gem.enum.LightSinkName
 import gsp.math.{ Coordinates, Declination, RightAscension }
 import gsp.math.optics.Format
+import io.chrisdavenport.log4cats.Logger
 import scala.concurrent.duration._
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
@@ -27,7 +28,7 @@ import squants.time.Seconds
 import squants.time.Time
 import scala.reflect.ClassTag
 
-final case class Ghost[F[_]: Sync](controller: GhostController[F])
+final case class Ghost[F[_]: Sync: Logger](controller: GhostController[F])
     extends GdsInstrument[F]
     with InstrumentSystem[F] {
 
@@ -71,6 +72,10 @@ final case class Ghost[F[_]: Sync](controller: GhostController[F])
   override def observeProgress(
     total:   Time,
     elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress] = Stream.empty
+
+  override def instrumentActions(config: Config): InstrumentActions[F] =
+    InstrumentActions.defaultInstrumentActions[F]
+
 }
 
 object Ghost {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -3,11 +3,11 @@
 
 package seqexec.server.gmos
 
-import cats.Applicative
+import cats._
 import cats.data.Kleisli
 import cats.data.EitherT
+import cats.data.NonEmptyList
 import cats.implicits._
-import cats.effect.Sync
 import gem.enum.LightSinkName
 import gsp.math.Angle
 import gsp.math.Offset
@@ -20,13 +20,14 @@ import edu.gemini.spModel.guide.StandardGuideOptions
 import edu.gemini.spModel.obscomp.InstConstants.{EXPOSURE_TIME_PROP, _}
 import edu.gemini.spModel.seqcomp.SeqConfigNames.{INSTRUMENT_KEY, OBSERVE_KEY}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType
+import io.chrisdavenport.log4cats.Logger
 import java.lang.{Double => JDouble, Integer => JInt}
-import org.log4s.{Logger, getLogger}
 import scala.concurrent.duration._
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Guiding
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.model.enum.NodAndShuffleStage
+import seqexec.model.enum.NodAndShuffleStage._
 import seqexec.server.ConfigUtilOps.{ContentError, ConversionError, _}
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.Config._
@@ -38,7 +39,7 @@ import squants.space.Length
 import squants.{Seconds, Time}
 import squants.space.LengthConversions._
 
-abstract class Gmos[F[_]: Sync, T<:GmosController.SiteDependentTypes](controller: GmosController[F, T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends DhsInstrument[F] with InstrumentSystem[F] {
+abstract class Gmos[F[_]: MonadError[?[_], Throwable]: Logger, T <: GmosController.SiteDependentTypes](controller: GmosController[F, T], ss: SiteSpecifics[T])(configTypes: GmosController.Config[T]) extends DhsInstrument[F] with InstrumentSystem[F] {
   import Gmos._
   import InstrumentSystem._
 
@@ -59,8 +60,6 @@ abstract class Gmos[F[_]: Sync, T<:GmosController.SiteDependentTypes](controller
     StopPausedCmd(controller.stopPaused),
     AbortPausedCmd(controller.abortPaused)
   )
-
-  val Log: Logger = getLogger
 
   protected def fpuFromFPUnit(n: Option[T#FPU], m: Option[String])(fpu: FPUnitMode): GmosFPU = fpu match {
     case FPUnitMode.BUILTIN     => configTypes.BuiltInFPU(n.getOrElse(ss.fpuDefault))
@@ -122,6 +121,9 @@ abstract class Gmos[F[_]: Sync, T<:GmosController.SiteDependentTypes](controller
       }
     }
 
+  override def instrumentActions(config: Config): InstrumentActions[F] =
+    new GmosInstrumentActions(this, config)
+
   override def notifyObserveEnd: F[Unit] =
     controller.endObserve
 
@@ -133,9 +135,14 @@ abstract class Gmos[F[_]: Sync, T<:GmosController.SiteDependentTypes](controller
       .flatMap(controller.applyConfig)
       .as(ConfigResult(this))
 
+  def configureShuffle(rows: Int): F[ConfigResult[F]] =
+    controller.setRowsToShuffle(rows)
+      .as(ConfigResult(this))
+
   override def calcObserveTime(config: Config): F[Time] =
-    Sync[F].delay(config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP)
-      .map(v => Seconds(v.toDouble)).getOrElse(Seconds(10000)))
+    (Gmos.expTime[F](config), Gmos.nsConfigF[F](config)).mapN {(v, ns) =>
+      v / ns.exposureDivider.toDouble
+    }
 
   override def observeProgress(total: Time, elapsed: ElapsedTime): fs2.Stream[F, Progress] =
     controller
@@ -144,6 +151,12 @@ abstract class Gmos[F[_]: Sync, T<:GmosController.SiteDependentTypes](controller
 
 object Gmos {
   val name: String = INSTRUMENT_NAME_PROP
+
+  // The sequence of nod and shuffle is always BAAB,
+  // In principle we'd expect the OT to send the sequence but instead the
+  // sequence is hardcoded in the seqexec and we only read the positions from
+  // the OT
+  val NsSequence = NonEmptyList.of(StageB, StageA, StageA, StageB)
 
   trait SiteSpecifics[T<:SiteDependentTypes] {
     def extractFilter(config: Config): Either[ExtractFailure, T#Filter]
@@ -157,8 +170,10 @@ object Gmos {
     val fpuDefault: T#FPU
   }
 
+  val NSKey = INSTRUMENT_KEY / USE_NS_PROP
+
   def isNodAndShuffle(config: Config): Boolean =
-    config.extractAs[java.lang.Boolean](INSTRUMENT_KEY / USE_NS_PROP)
+    config.extractAs[java.lang.Boolean](NSKey)
       .map(_.booleanValue())
       .getOrElse(false)
 
@@ -200,6 +215,19 @@ object Gmos {
       ns               <- (if (useNS) nodAndShuffle(config) else NSConfig.NoNodAndShuffle.asRight)
     } yield ns).leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
+  def nsConfigF[F[_]: ApplicativeError[?[_], Throwable]](config: Config): F[NSConfig] =
+    ApplicativeError[F, Throwable]
+      .catchNonFatal(
+        nsConfig(config).getOrElse(NSConfig.NoNodAndShuffle)
+      )
+
+  def expTime[F[_]: ApplicativeError[?[_], Throwable]](config: Config): F[Time] =
+    ApplicativeError[F, Throwable]
+      .catchNonFatal(
+        config.extractObsAs[JDouble](EXPOSURE_TIME_PROP)
+          .map(v => Seconds(v.toDouble))
+          .getOrElse(Seconds(10000))
+      )
 
   // It seems this is unused but it shows up on the DC apply config
   private def biasTimeObserveType(observeType: String): BiasTime = observeType match {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -27,6 +27,8 @@ trait GmosController[F[_], T <: GmosController.SiteDependentTypes] {
 
   def applyConfig(config: GmosConfig[T]): F[Unit]
 
+  def setRowsToShuffle(rows: Int): F[Unit]
+
   def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult]
 
   // endObserve is to notify the completion of the observation, not to cause its end.
@@ -150,11 +152,13 @@ object GmosController {
     // Node and shuffle options
     sealed trait NSConfig extends Product with Serializable {
       def nsPairs: Int
+      def exposureDivider: Int
     }
 
     object NSConfig {
       case object NoNodAndShuffle extends NSConfig {
         val nsPairs = 0
+        val exposureDivider = 1
       }
 
       final case class NodAndShuffle(
@@ -162,6 +166,7 @@ object GmosController {
         rows: Int,
         positions: Vector[NSPosition]) extends NSConfig {
         val nsPairs = cycles
+        val exposureDivider = 2
       }
     }
 
@@ -236,6 +241,6 @@ object GmosController {
   type GmosNorthController[F[_]] = GmosController[F, NorthTypes]
 
   implicit def configShow[T<:SiteDependentTypes]: Show[GmosConfig[T]] =
-    Show.show { config => s"(${config.cc.filter}, ${config.cc.disperser}, ${config.cc.fpu}, ${config.cc.stage}, ${config.cc.stage}, ${config.cc.dtaX}, ${config.cc.adc}, ${config.cc.useElectronicOffset}, ${config.dc.t}, ${config.dc.b}, ${config.dc.s}, ${config.dc.bi}, ${config.dc.roi.rois})" }
+    Show.show { config => s"(${config.cc.filter}, ${config.cc.disperser}, ${config.cc.fpu}, ${config.cc.stage}, ${config.cc.stage}, ${config.cc.dtaX}, ${config.cc.adc}, ${config.cc.useElectronicOffset}, ${config.dc.t}, ${config.dc.b}, ${config.dc.s}, ${config.dc.bi}, ${config.dc.roi.rois} ${config.ns})" }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -364,6 +364,12 @@ object GmosControllerEpics extends GmosEncoders {
           IO(Log.info("Completed Gmos configuration"))
       }
 
+      override def setRowsToShuffle(rows: Int): IO[Unit] =
+        IO(Log.debug(s"Set rows to shuffle to $rows")) *>
+          DC.setNsRows(rows) *>
+          sys.configCmd.setTimeout[IO](ConfigTimeout) *>
+          sys.post.void
+
       override def observe(fileId: ImageFileId, expTime: Time): IO[ObserveCommandResult] =
         failOnDHSNotConected *>
           sys.observeCmd.setLabel(fileId) *>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
@@ -3,24 +3,89 @@
 
 package seqexec.server.gmos
 
+import cats._
+import cats.implicits._
 import cats.effect.Sync
 import cats.effect.Timer
+import cats.effect.concurrent.Ref
+import monocle.Optional
+import monocle.macros.Lenses
+import monocle.std.option.some
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.server.InstrumentSystem.ElapsedTime
-import seqexec.server.gmos.GmosController.{GmosConfig, NorthTypes, SiteDependentTypes, SouthTypes}
-import seqexec.server.{InstrumentControllerSim, Progress}
+import seqexec.server.gmos.GmosController.GmosConfig
+import seqexec.server.gmos.GmosController.NorthTypes
+import seqexec.server.gmos.GmosController.SiteDependentTypes
+import seqexec.server.gmos.GmosController.SouthTypes
+import seqexec.server.gmos.GmosController.Config.NSConfig
+import seqexec.server.InstrumentControllerSim
+import seqexec.server.Progress
 import squants.Time
+import scala.concurrent.duration._
+
+@Lenses
+final case class NSCurrent(
+  fileId:        ImageFileId,
+  exposureCount: Int,
+  expTime:       Time
+)
+
+/**
+ * Used to keep the internal state of NS
+ */
+@Lenses
+final case class NSObsState(config: NSConfig, current: Option[NSCurrent])
+
+object NSObsState {
+  def fromConfig(c: NSConfig): NSObsState =
+    NSObsState(c, None)
+
+  val Zero: NSObsState = NSObsState(NSConfig.NoNodAndShuffle, None)
+
+  val fileId: Optional[NSObsState, ImageFileId] =
+    NSObsState.current ^<-? some ^|-> NSCurrent.fileId
+
+  val exposureCount: Optional[NSObsState, Int] =
+    NSObsState.current ^<-? some ^|-> NSCurrent.exposureCount
+
+  val expTime: Optional[NSObsState, Time] =
+    NSObsState.current ^<-? some ^|-> NSCurrent.expTime
+}
 
 object GmosControllerSim {
-  def apply[F[_]: Sync: Timer, T <: SiteDependentTypes](name: String): GmosController[F, T] =
+  def apply[F[_]: FlatMap: Timer, T <: SiteDependentTypes](
+    sim:      InstrumentControllerSim[F],
+    nsConfig: Ref[F, NSObsState]
+  ): GmosController[F, T] =
     new GmosController[F, T] {
-      private val sim: InstrumentControllerSim[F] = InstrumentControllerSim[F](s"GMOS $name")
+      override def observe(
+        fileId:  ImageFileId,
+        expTime: Time
+      ): F[ObserveCommandResult] =
+        nsConfig.modify {
+          case s @ NSObsState(NSConfig.NoNodAndShuffle, _) =>
+            (s, s)
+          case s @ NSObsState(NSConfig.NodAndShuffle(_, _, _), _) =>
+            val update =
+              NSObsState.current.set(NSCurrent(fileId, 0, expTime).some)
+            (update(s), update(s))
+        } >>= {
+          case NSObsState(NSConfig.NoNodAndShuffle, _) =>
+            sim.observe(fileId, expTime) // Regular observation
+          case NSObsState(NSConfig.NodAndShuffle(_, _, _), _) =>
+            sim.log(s"Simulate Gmos N&S observation with label $fileId and $expTime") *>
+              // Initial N&S obs
+              sim.observe(fileId, expTime).as(ObserveCommandResult.Partial)
+        }
 
-      override def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult] =
-        sim.observe(fileId, expTime)
+      override def applyConfig(config: GmosConfig[T]): F[Unit] =
+        nsConfig.set(NSObsState.fromConfig(config.ns)) *> // Keep the state of NS Config
+          sim.applyConfig(config)
 
-      override def applyConfig(config: GmosConfig[T]): F[Unit] = sim.applyConfig(config)
+      override def setRowsToShuffle(rows: Int): F[Unit] =
+        sim.log(s"Set rows to shuffle to $rows") *>
+          Timer[F].sleep(new FiniteDuration(2, SECONDS))
 
       override def stopObserve: F[Unit] = sim.stopObserve
 
@@ -30,20 +95,50 @@ object GmosControllerSim {
 
       override def pauseObserve: F[Unit] = sim.pauseObserve
 
-      override def resumePaused(expTime: Time): F[ObserveCommandResult] = sim.resumePaused
+      override def resumePaused(expTime: Time): F[ObserveCommandResult] =
+        nsConfig.modify {
+          case s @ NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(NSCurrent(_, exposureCount, _)))
+              if exposureCount < Gmos.NsSequence.length =>
+              // We should keep track of where on a N&S Sequence are we
+            (NSObsState.exposureCount.modify(_ + 1)(s),
+             NSObsState.exposureCount.modify(_ + 1)(s))
+          case s =>
+            (s, s)
+        } >>= {
+          case NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(NSCurrent(fileId, exposureCount, expTime)))
+              if exposureCount < Gmos.NsSequence.length - 1 =>
+            sim.log(s"Next Nod ${exposureCount + 1}, stage: ${Gmos.NsSequence.toList.lift(exposureCount).getOrElse("Unknown")}") *>
+              sim.observe(fileId, expTime).as(ObserveCommandResult.Partial)
+          case NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(NSCurrent(fileId, exposureCount, expTime)))
+              if exposureCount === Gmos.NsSequence.length - 1 =>
+            sim.log(s"Final Nod ${exposureCount + 1}, stage: ${Gmos.NsSequence.toList.lift(exposureCount).getOrElse("Unknown")}") *>
+              sim.observe(fileId, expTime)
+          case _ =>
+            // Regular observation
+            sim.resumePaused
+        }
 
       override def stopPaused: F[ObserveCommandResult] = sim.stopPaused
 
       override def abortPaused: F[ObserveCommandResult] = sim.abortPaused
 
-      override def observeProgress(total: Time, elapsed: ElapsedTime): fs2.Stream[F, Progress] =
+      override def observeProgress(
+        total:   Time,
+        elapsed: ElapsedTime
+      ): fs2.Stream[F, Progress] =
         sim.observeCountdown(total, elapsed)
 
     }
 
-  def south[F[_]: Sync: Timer]: GmosController[F, SouthTypes] =
-    GmosControllerSim[F, SouthTypes]("South")
+  def south[F[_]: Sync: Timer]: GmosController[F, SouthTypes] = {
+    val nsConfig: Ref[F, NSObsState] = Ref.unsafe(NSObsState.Zero)
+    val sim: InstrumentControllerSim[F] = InstrumentControllerSim[F](s"GMOS South")
+    GmosControllerSim[F, SouthTypes](sim, nsConfig)
+  }
 
-  def north[F[_]: Sync: Timer]: GmosController[F, NorthTypes] =
-    GmosControllerSim[F, NorthTypes]("North")
+  def north[F[_]: Sync: Timer]: GmosController[F, NorthTypes] = {
+    val nsConfig: Ref[F, NSObsState] = Ref.unsafe(NSObsState.Zero)
+    val sim: InstrumentControllerSim[F] = InstrumentControllerSim[F](s"GMOS North")
+    GmosControllerSim[F, NorthTypes](sim, nsConfig)
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -1,0 +1,206 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.gmos
+
+import cats._
+import cats.implicits._
+import cats.data.NonEmptyList
+import edu.gemini.spModel.config2.Config
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.ActionType
+import seqexec.model.dhs.ImageFileId
+import seqexec.model.enum.NodAndShuffleStage._
+import seqexec.model.enum.ObserveCommandResult
+import seqexec.engine.Action
+import seqexec.engine.ParallelActions
+import seqexec.engine.Result
+import seqexec.server.Response
+import seqexec.server.SeqTranslate._
+import seqexec.server.StepType
+import seqexec.server.FileIdAllocated
+import seqexec.server.FileIdProvider
+import seqexec.server.InstrumentActions
+import seqexec.server.ObserveEnvironment
+import seqexec.server.ObserveActions
+import seqexec.server.ObserveContext
+import seqexec.server.SeqexecFailure
+import seqexec.server.ObserveActions._
+import seqexec.server.gmos.GmosController.Config._
+
+/**
+  * Gmos needs different actions for N&S
+  */
+class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger, A <: GmosController.SiteDependentTypes](
+  inst:   Gmos[F, A],
+  config: Config
+) extends InstrumentActions[F] {
+  override def observationProgressStream(
+    env: ObserveEnvironment[F]
+  ): Stream[F, Result[F]] =
+    ObserveActions.observationProgressStream(env)
+
+  // This tail is based on ObserveActions.observeTail
+  // But it can understand how to process Partial observations
+  // And can eventually return more than one result
+  private def observeTail(
+    fileId: ImageFileId,
+    dataId: String,
+    env:    ObserveEnvironment[F]
+  )(r:      ObserveCommandResult): F[Stream[F, Result[F]]] =
+    r match {
+      case ObserveCommandResult.Success =>
+        okTail(fileId, dataId, stopped = false, env).map(Stream.emit)
+      case ObserveCommandResult.Stopped =>
+        okTail(fileId, dataId, stopped = true, env).map(Stream.emit)
+      case ObserveCommandResult.Aborted =>
+        abortTail(env.systems, env.obsId, fileId).map(Stream.emit)
+      case ObserveCommandResult.Paused =>
+        env.inst
+          .calcObserveTime(env.config)
+          .map(
+            e =>
+              Stream.emit(
+                Result
+                  .Paused(ObserveContext(observeTail(fileId, dataId, env), e))
+              )
+          )
+      case ObserveCommandResult.Partial =>
+        Stream
+          .emits[F, Result[F]](
+            List(Result.Partial(NSStep), Result.OK(Response.Ignored))
+          )
+          .pure[F]
+    }
+
+  private def startObserve(
+    fileId: ImageFileId,
+    env:    ObserveEnvironment[F]
+  ): F[Stream[F, Result[F]]] =
+    // Essentially the same as default observation but with a custom tail
+    for {
+      (fileId, result) <- observePreamble(fileId, env)
+      ret              <- observeTail(fileId, fileId, env)(result)
+    } yield ret
+
+  private def completeObserve(
+    fileId: ImageFileId,
+    env:    ObserveEnvironment[F]
+  ): F[Stream[F, Result[F]]] =
+    for {
+      dataId  <- dataId(env)
+      timeout <- inst.calcObserveTime(env.config)
+      ret     <- inst.continueCommand(timeout)
+      r       <- observeTail(fileId, dataId, env)(ret)
+    } yield r
+
+  private def observe(i: Int, env: ObserveEnvironment[F])(fileId: ImageFileId): Stream[F, Result[F]] =
+    if (i === 0) {
+      // The first steps allocates a file and runs the firt observe
+      Stream.emit[F, Result[F]](Result.Partial(FileIdAllocated(fileId))) ++ Stream
+        .eval(startObserve(fileId, env))
+        .flatten
+    } else if (i === Gmos.NsSequence.length - 1) {
+      // the last step completes the observations with a complete and a tail
+      Stream.eval(completeObserve(fileId, env).map(_ ++
+        Stream.emit[F, Result[F]](Result.Partial(NSComplete))))
+        .flatten
+    } else {
+      // Steps in betweet do a continue
+      Stream
+        .eval(
+          inst
+            .calcObserveTime(env.config)
+            .flatMap(inst.continueCommand)
+        )
+        .as(Result.Partial(NSContinue)) ++
+        Stream.emit(Result.OK(Response.Ignored))
+    }
+
+  // TODO reduce duplication with respect to InstrumentActions.safeObserve
+  private def safeObserve(
+    i: Int,
+    env: ObserveEnvironment[F]
+  ): Stream[F, Result[F]] = {
+    Stream.eval(FileIdProvider.fileId(env).attempt).flatMap {
+      case Right(fileId) =>
+        observe(i, env)(fileId)
+      case Left(e: SeqexecFailure) => Stream.emit(Result.Error(SeqexecFailure.explain(e)))
+      case Left(e: Throwable) => Stream.emit(Result.Error(SeqexecFailure.explain(SeqexecFailure.SeqexecException(e))))
+    }
+  }
+
+  /**
+   * Calculate the actions for a N&S cycle
+   */
+  private def actionPositions(
+    env:       ObserveEnvironment[F],
+    rows:      Int,
+    post:      (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+  ): List[ParallelActions[F]] =
+    Gmos.NsSequence.zipWithIndex
+      .map {
+        case (stage, i) =>
+          val rowsToShuffle = if (stage === StageA) 0 else rows
+          List(
+            // Configure rows to shuffle
+            NonEmptyList.one(
+              inst
+                .configureShuffle(rowsToShuffle)
+                .as(Response.Configured(inst.resource))
+                .toAction(ActionType.Configure(inst.resource))
+              // TODO confgure the TCS
+            ),
+            // Do an obs observe/continue
+            NonEmptyList.one(
+              Action(
+                ActionType.Observe,
+                post( // post lets upstream to mix progress events
+                  safeObserve(i, env),
+                  env
+                ),
+                Action.State(Action.ActionState.Idle, Nil)
+              )
+            )
+          )
+      }
+      .toList
+      .flatten
+
+  override def observeActions(
+    env:  ObserveEnvironment[F],
+    post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+  ): List[ParallelActions[F]] =
+    env.stepType match {
+      case StepType.NodAndShuffle(i) if i === inst.resource =>
+        Gmos
+          .nsConfig(config)
+          .map {
+            case NSConfig.NoNodAndShuffle =>
+              // This shouldn't happen but we need to code it anyway
+              Nil
+            case NSConfig.NodAndShuffle(cycles, rows, _) =>
+              // Initial notification of N&S Starting
+              NonEmptyList.one(
+                Action(ActionType.Undefined,
+                       Stream.emits[F, Result[F]](
+                         List(Result.Partial(NSStart),
+                              Result.OK(Response.Ignored))
+                       ),
+                       Action.State(Action.ActionState.Idle, Nil))
+              ) ::
+                actionPositions(env, rows, post) // Add steps for each cycle
+                  .replicateA(cycles)
+                  .toList
+                  .flatten
+          }
+          .getOrElse(Nil)
+      case _ =>
+        // Regular GMOS obseravtions behave as any instrument
+        InstrumentActions.defaultInstrumentActions[F].observeActions(env, post)
+    }
+
+  def runInitialAction(stepType: StepType): Boolean = true
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -3,8 +3,9 @@
 
 package seqexec.server.gmos
 
-import cats.effect.Sync
+import cats.MonadError
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
@@ -21,7 +22,7 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosNorth[F[_]: Sync](c: GmosNorthController[F], dhsClient: DhsClient[F]) extends Gmos[F, NorthTypes](c,
+final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosNorthController[F], dhsClient: DhsClient[F]) extends Gmos[F, NorthTypes](c,
   new SiteSpecifics[NorthTypes] {
     override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
     override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
@@ -42,5 +43,5 @@ final case class GmosNorth[F[_]: Sync](c: GmosNorthController[F], dhsClient: Dhs
 object GmosNorth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: Sync](c: GmosController[F, NorthTypes], dhsClient: DhsClient[F]): GmosNorth[F] = new GmosNorth[F](c, dhsClient)
+  def apply[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosController[F, NorthTypes], dhsClient: DhsClient[F]): GmosNorth[F] = new GmosNorth[F](c, dhsClient)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -3,8 +3,9 @@
 
 package seqexec.server.gmos
 
-import cats.effect.Sync
+import cats.MonadError
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
@@ -21,7 +22,7 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosSouth[F[_]: Sync](c: GmosSouthController[F], dhsClient: DhsClient[F]) extends Gmos[F, SouthTypes](c,
+final case class GmosSouth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosSouthController[F], dhsClient: DhsClient[F]) extends Gmos[F, SouthTypes](c,
   new SiteSpecifics[SouthTypes] {
     override val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
     override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
@@ -43,5 +44,5 @@ final case class GmosSouth[F[_]: Sync](c: GmosSouthController[F], dhsClient: Dhs
 object GmosSouth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: Sync](c: GmosController[F, SouthTypes], dhsClient: DhsClient[F]): GmosSouth[F] = new GmosSouth[F](c, dhsClient)
+  def apply[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosController[F, SouthTypes], dhsClient: DhsClient[F]): GmosSouth[F] = new GmosSouth[F](c, dhsClient)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import seqexec.engine.Result.PartialVal
+
+package gmos {
+  // N&S Partials. TODO add more details about the current step
+  case object NSStart extends PartialVal
+  case object NSStep extends PartialVal
+  case object NSContinue extends PartialVal
+  case object NSComplete extends PartialVal
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -16,6 +16,7 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.{INSTRUMENT_KEY, OBSERVE_KEY}
 import java.lang.{Double => JDouble, Integer => JInt}
 import gem.enum.LightSinkName
 import gsp.math.syntax.string._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.model.enum.Instrument
 import seqexec.model.dhs.ImageFileId
@@ -27,7 +28,7 @@ import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
-final case class Gnirs[F[_]: Sync](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
+final case class Gnirs[F[_]: Sync: Logger](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
   override def sfName(config: Config): LightSinkName = LightSinkName.Gnirs
   override val contributorName: String = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"
@@ -66,6 +67,10 @@ final case class Gnirs[F[_]: Sync](controller: GnirsController[F], dhsClient: Dh
 
   override def observeProgress(total: Time, elapsed: ElapsedTime): fs2.Stream[F, Progress] =
     controller.observeProgress(total)
+
+  override def instrumentActions(config: Config): InstrumentActions[F] =
+    InstrumentActions.defaultInstrumentActions[F]
+
 }
 
 object Gnirs {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -3,9 +3,9 @@
 
 package seqexec.server.gpi
 
+import cats._
 import cats.data.EitherT
 import cats.data.Kleisli
-import cats.effect.Sync
 import cats.effect.Timer
 import cats.implicits._
 import edu.gemini.spModel.config2.Config
@@ -14,6 +14,7 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import edu.gemini.spModel.obscomp.InstConstants
 import edu.gemini.spModel.obsclass.ObsClass
 import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
 import java.lang.{ Boolean => JBoolean }
 import java.lang.{ Double => JDouble }
 import java.lang.{ Integer => JInt }
@@ -33,7 +34,7 @@ import squants.time.Milliseconds
 import squants.time.Seconds
 import squants.time.Time
 
-final case class Gpi[F[_]: Sync: Timer](controller: GpiController[F])
+final case class Gpi[F[_]: MonadError[?[_], Throwable]: Timer: Logger](controller: GpiController[F])
     extends GdsInstrument[F]
     with InstrumentSystem[F] {
 
@@ -87,9 +88,9 @@ final case class Gpi[F[_]: Sync: Timer](controller: GpiController[F])
   override def notifyObserveEnd: F[Unit] =
     controller.endObserve
 
-  override def notifyObserveStart: F[Unit] = Sync[F].unit
+  override def notifyObserveStart: F[Unit] = Applicative[F].unit
 
-  override def calcObserveTime(config: Config): F[Time] = Sync[F].delay {
+  override def calcObserveTime(config: Config): F[Time] = MonadError[F, Throwable].catchNonFatal {
     val obsTime =
       for {
         exp <- config.extractObsAs[JDouble](EXPOSURE_TIME_PROP)
@@ -104,6 +105,9 @@ final case class Gpi[F[_]: Sync: Timer](controller: GpiController[F])
     elapsed: InstrumentSystem.ElapsedTime
   ): Stream[F, Progress] =
     ProgressUtil.countdown[F](total, elapsed.self)
+
+  override def instrumentActions(config: Config): InstrumentActions[F] =
+    new GpiInstrumentActions[F]
 
 }
 
@@ -189,8 +193,8 @@ object Gpi {
           ConversionError(OBSERVE_KEY / DETECTOR_STARTX_PROP,
           "Cannot read readout area"))).flatten
 
-  private def regularSequenceConfig[F[_]: Sync](config: Config): F[GpiConfig] =
-    EitherT(Sync[F].delay(
+  private def regularSequenceConfig[F[_]: MonadError[?[_], Throwable]](config: Config): F[GpiConfig] =
+    EitherT(ApplicativeError[F, Throwable].catchNonFatal(
       (for {
         adc      <- config.extractInstAs[Adc](ADC_PROP)
         exp      <- config.extractObsAs[JDouble](EXPOSURE_TIME_PROP)
@@ -211,10 +215,12 @@ object Gpi {
         .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
     )).widenRethrowT.widen[GpiConfig]
 
-  private def alignAndCalibConfig[F[_]: Sync]: F[GpiConfig] =
+  private def alignAndCalibConfig[F[_]: Applicative]: F[GpiConfig] =
     AlignAndCalibConfig.pure[F].widen[GpiConfig]
 
-  def fromSequenceConfig[F[_]: Sync](config: Config): F[GpiConfig] =
-    Sync[F].delay(isAlignAndCalib(config)).ifM(alignAndCalibConfig, regularSequenceConfig(config))
+  def fromSequenceConfig[F[_]: MonadError[?[_], Throwable]](config: Config): F[GpiConfig] =
+    ApplicativeError[F, Throwable]
+      .catchNonFatal(isAlignAndCalib(config))
+      .ifM(alignAndCalibConfig[F], regularSequenceConfig[F](config))
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiInstrumentActions.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.gpi
+
+import cats._
+import cats.implicits._
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import seqexec.engine.ParallelActions
+import seqexec.engine.Result
+import seqexec.server.StepType
+import seqexec.server.InstrumentActions
+import seqexec.server.ObserveActions
+import seqexec.server.ObserveEnvironment
+
+/**
+  * Gpi needs different actions for A&C
+  */
+class GpiInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger]
+    extends InstrumentActions[F] {
+
+  override def observationProgressStream(
+    env: ObserveEnvironment[F]
+  ): Stream[F, Result[F]] =
+    ObserveActions.observationProgressStream(env)
+
+  override def observeActions(
+    env:  ObserveEnvironment[F],
+    post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+  ): List[ParallelActions[F]] =
+    if (env.stepType === StepType.AlignAndCalib) {
+      Nil
+    } else {
+      InstrumentActions.defaultInstrumentActions[F].observeActions(env, post)
+    }
+
+  override def runInitialAction(stepType: StepType): Boolean =
+    stepType =!= StepType.AlignAndCalib
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -13,6 +13,7 @@ import edu.gemini.spModel.obscomp.InstConstants.DARK_OBSERVE_TYPE
 import edu.gemini.spModel.obscomp.InstConstants.OBSERVE_TYPE_PROP
 import edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_KEY
 import gem.enum.LightSinkName
+import io.chrisdavenport.log4cats.Logger
 import java.lang.{Double => JDouble}
 import java.lang.{Integer => JInt}
 import shapeless.tag
@@ -31,13 +32,14 @@ import seqexec.server.keywords.DhsClient
 import seqexec.server.keywords.DhsInstrument
 import seqexec.server.keywords.KeywordsClient
 import seqexec.server.InstrumentSystem._
+import seqexec.server.InstrumentActions
 import seqexec.server.gsaoi.GsaoiController._
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Gsaoi[F[_]: Sync](
+final case class Gsaoi[F[_]: Sync: Logger](
   controller: GsaoiController[F],
   dhsClient:  DhsClient[F])
     extends DhsInstrument[F]
@@ -97,6 +99,9 @@ final case class Gsaoi[F[_]: Sync](
 
   override def notifyObserveEnd: F[Unit] =
     controller.endObserve
+
+  override def instrumentActions(config: Config): InstrumentActions[F] =
+    InstrumentActions.defaultInstrumentActions[F]
 }
 
 object Gsaoi {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -3,11 +3,8 @@
 
 package seqexec.server
 
-import cats.{Applicative, Eq, Monad, Monoid, Functor}
-import cats.MonadError
-import cats.ApplicativeError
+import cats._
 import cats.implicits._
-import cats.effect.Sync
 import gem.Observation
 import gem.enum.KeywordName
 import seqexec.model.dhs.ImageFileId
@@ -31,7 +28,7 @@ package keywords {
     def keywordsBundler: KeywordsBundler[F]
   }
 
-  abstract class DhsInstrument[F[_]: Sync] extends KeywordsClient[F] {
+  abstract class DhsInstrument[F[_]: Monad] extends KeywordsClient[F] {
     val dhsClient: DhsClient[F]
 
     val dhsInstrumentName: String
@@ -69,7 +66,7 @@ package keywords {
     ): F[KeywordBag] =
       ks.foldLeft(Applicative[F].pure(KeywordBag.empty)) { case (a, b) => a.flatMap(b) }
 
-    def kb[F[_]: Sync]: KeywordsBundler[F] = new KeywordsBundler[F] {
+    def kb[F[_]: Monad]: KeywordsBundler[F] = new KeywordsBundler[F] {
       def bundleKeywords(
         ks: List[KeywordBag => F[KeywordBag]]
       ): F[KeywordBag] =
@@ -77,7 +74,7 @@ package keywords {
     }
   }
 
-  abstract class GdsInstrument[F[_]: Sync] extends KeywordsClient[F] {
+  abstract class GdsInstrument[F[_]: Monad] extends KeywordsClient[F] {
     val gdsClient: GdsClient[F]
 
     def setKeywords(id: ImageFileId,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -16,6 +16,7 @@ import edu.gemini.spModel.obscomp.InstConstants.FLAT_OBSERVE_TYPE
 import edu.gemini.spModel.obscomp.InstConstants.OBSERVE_TYPE_PROP
 import edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_KEY
 import gem.enum.LightSinkName
+import io.chrisdavenport.log4cats.Logger
 import java.lang.{Double => JDouble}
 import java.lang.{Integer => JInt}
 import shapeless.tag
@@ -34,13 +35,14 @@ import seqexec.server.keywords.KeywordsClient
 import seqexec.server.InstrumentSystem.UnpausableControl
 import seqexec.server.InstrumentSystem.AbortObserveCmd
 import seqexec.server.InstrumentSystem.StopObserveCmd
+import seqexec.server.InstrumentActions
 import seqexec.server.nifs.NifsController._
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Nifs[F[_]: Sync](
+final case class Nifs[F[_]: Sync: Logger](
   controller: NifsController[F],
   dhsClient:  DhsClient[F])
     extends DhsInstrument[F]
@@ -97,6 +99,9 @@ final case class Nifs[F[_]: Sync](
 
   override def notifyObserveEnd: F[Unit] =
     controller.endObserve
+
+  override def instrumentActions(config: Config): InstrumentActions[F] =
+    InstrumentActions.defaultInstrumentActions[F]
 }
 
 object Nifs {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -15,6 +15,7 @@ import edu.gemini.spModel.gemini.niri.Niri.{Camera, WellDepth, ReadMode => OCSRe
 import edu.gemini.spModel.obscomp.InstConstants.{BIAS_OBSERVE_TYPE, DARK_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
 import edu.gemini.seqexec.server.niri.ReadMode
 import gem.enum.LightSinkName
+import io.chrisdavenport.log4cats.Logger
 import seqexec.server.ConfigUtilOps._
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.ObserveCommandResult
@@ -27,12 +28,13 @@ import java.lang.{Double => JDouble, Integer => JInt}
 import seqexec.server.InstrumentSystem.UnpausableControl
 import seqexec.server.InstrumentSystem.AbortObserveCmd
 import seqexec.server.InstrumentSystem.StopObserveCmd
+import seqexec.server.InstrumentActions
 import seqexec.server.niri.NiriController._
 import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Niri[F[_]: Sync: Timer](controller: NiriController[F], dhsClient: DhsClient[F])
+final case class Niri[F[_]: Sync: Timer: Logger](controller: NiriController[F], dhsClient: DhsClient[F])
   extends DhsInstrument[F] with InstrumentSystem[F] {
 
   import Niri._
@@ -85,6 +87,9 @@ final case class Niri[F[_]: Sync: Timer](controller: NiriController[F], dhsClien
 
   override def notifyObserveEnd: F[Unit] =
     controller.endObserve
+
+  override def instrumentActions(config: Config): InstrumentActions[F] =
+    InstrumentActions.defaultInstrumentActions[F]
 }
 
 object Niri {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -76,7 +76,7 @@ package server {
     val default: HeaderExtraData = HeaderExtraData(Conditions.Default, None, None)
   }
 
-  final case class ObserveContext[F[_]](t: ObserveCommandResult => F[Result[F]], expTime: Time) extends PauseContext[F]
+  final case class ObserveContext[F[_]](t: ObserveCommandResult => F[Stream[F, Result[F]]], expTime: Time) extends PauseContext[F]
 
 }
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/ExecutionQueueSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/ExecutionQueueSpec.scala
@@ -4,6 +4,7 @@
 package seqexec.server
 
 import cats.tests.CatsSuite
+import gem.arb.ArbObservation._
 import monocle.law.discipline.LensTests
 import seqexec.model.SeqexecModelArbitraries._
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -79,8 +79,8 @@ class SeqTranslateSpec extends FlatSpec {
     .modify(_.start(0).mark(0)(Result.Partial(FileIdAllocated(fileId))))(baseState)
   // Observe paused
   private val s4: EngineState = EngineState.sequenceStateIndex(seqId)
-    .modify(_.mark(0)(Result.Paused(ObserveContext[IO](_ => IO.pure(Result.OK(Observed
-    (fileId))), Seconds(1)))))(baseState)
+    .modify(_.mark(0)(Result.Paused(ObserveContext[IO](_ => IO.pure(Stream.emit(Result.OK(Observed
+    (fileId))).covary[IO]), Seconds(1)))))(baseState)
   // Observe failed
   private val s5: EngineState = EngineState.sequenceStateIndex(seqId)
     .modify(_.mark(0)(Result.Error("error")))(baseState)

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerArbitraries.scala
@@ -5,6 +5,7 @@ package seqexec.server
 
 import gem.arb.ArbEnumerated._
 import gem.Observation
+import gem.arb.ArbObservation._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{Arbitrary, Cogen}
 import seqexec.model.BatchCommandState

--- a/modules/seqexec/server/src/test/scala/seqexec/server/StepsViewNSSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/StepsViewNSSpec.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import cats.Id
+import cats.effect.IO
+import cats.data.NonEmptyList
+import org.scalatest.FunSuite
+import seqexec.server.TestCommon._
+import seqexec.engine._
+import seqexec.model.enum._
+
+class SeqexecEngineNSSpec extends FunSuite {
+
+  test("running after the first observe") {
+    val executions: List[ParallelActions[IO]] = List(
+      NonEmptyList.one(running(Resource.TCS)),
+      NonEmptyList.one(observePartial))
+    assert(StepsView.observeStatus(executions) === ActionStatus.Running)
+  }
+  test("running after the observe and configure") {
+    val executions: List[ParallelActions[Id]] = List(
+      NonEmptyList.one(running(Resource.TCS)),
+      NonEmptyList.one(observePartial),
+      NonEmptyList.one(done(Instrument.GmosN)))
+    assert(StepsView.observeStatus(executions) === ActionStatus.Running)
+  }
+  test("running after the observe/configure/continue/complete") {
+    val executions: List[ParallelActions[Id]] = List(
+      NonEmptyList.one(running(Resource.TCS)),
+      NonEmptyList.one(observePartial),
+      NonEmptyList.one(done(Instrument.GmosN)),
+      NonEmptyList.one(observed))
+    assert(StepsView.observeStatus(executions) === ActionStatus.Running)
+  }
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -194,8 +194,9 @@ object actions {
   // Used for UI debugging
   final case class MarkStepAsRunning(s: Observation.Id, step: Int) extends Action
 
-  private val standardStep: PartialFunction[Step, (StepId, StepState, List[(Resource, ActionStatus)])] = {
+  private val stepInfo: PartialFunction[Step, (StepId, StepState, List[(Resource, ActionStatus)])] = {
     case i: StandardStep => (i.id, i.status, i.configStatus)
+    case i: NodAndShuffleStep => (i.id, i.status, i.configStatus)
   }
 
   implicit val show: Show[Action] = Show.show {
@@ -210,9 +211,9 @@ object actions {
            s"steps: ${s.steps.length}",
            s"state: ${s.status}",
            s.steps
-             .filter(_.status === StepState.Running)
+             .filter(_.status === StepState.Pending)
              .slice(0, scala.math.min(s.steps.length, 20))
-             .collect(standardStep)))
+             .collect(stepInfo)))
       val dayCalQueue = view.queues.values.map(x => s"${x.execState} ${x.queue}").mkString(",")
       s"${s.getClass.getSimpleName}(${u.getClass.getSimpleName}, dayCal: '${dayCalQueue}', loaded: '${view.loaded.mkString(",")}', $someSteps)"
     case a                                              =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
@@ -183,7 +183,6 @@ object SeqexecCircuit
   private val defaultObserverHandler   = new DefaultObserverHandler(zoomTo(_.uiModel.defaultObserver))
   private val remoteRequestsHandler    = new RemoteRequestsHandler(zoomTo(_.clientId))
   private val queueRequestsHandler     = new QueueRequestsHandler(queueFocusRW)
-  private val debuggingHandler         = new DebuggingHandler(zoomTo(_.sequences))
   private val tableStateHandler        = new TableStateHandler(tableStateRW)
   private val loadSequencesHandler     = new LoadedSequencesHandler(sodLocationReaderRW)
   private val operationsStateHandler   = new OperationsStateHandler(sequencesOnDisplayRW)
@@ -221,7 +220,6 @@ object SeqexecCircuit
       foldHandlers(remoteRequestsHandler, operationsStateHandler),
       foldHandlers(queueOpsHandler, queueRequestsHandler),
       navigationHandler,
-      debuggingHandler,
       tableStateHandler,
       siteHandler,
       sessionFilterHandler,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
@@ -11,7 +11,6 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
 import react.common.implicits._
-import seqexec.model.Step
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages.SeqexecPages
 import seqexec.web.client.model.SectionVisibilityState.SectionClosed
@@ -67,13 +66,13 @@ object SequenceTabContent {
         p.stepsConnect { x =>
           val focus = x()
 
-          val steps =
-            focus.stepsTable.foldMap(_.steps).lift(i).getOrElse(Step.Zero)
-          val hs = focus.configTableState
-          <.div(
-            ^.height := "100%",
-            StepConfigTable(StepConfigTable.Props(steps, hs))
-          )
+          focus.stepsTable.foldMap(_.steps).lift(i).map { steps =>
+            val hs = focus.configTableState
+            <.div(
+              ^.height := "100%",
+              StepConfigTable(StepConfigTable.Props(steps, hs))
+            )
+          }.getOrElse(<.div())
         }
     }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -4,6 +4,7 @@
 package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
+import cats.data.Nested
 import gem.Observation
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -87,7 +88,8 @@ object StepProgressCell {
       ),
       <.div(
         SeqexecStyles.subsystems,
-        Step.configStatus.get(step)
+        Step.configStatus.getOption(step)
+          .orEmpty
           .sortBy(_._1)
           .map(Function.tupled(statusLabel))
           .toTagMod
@@ -183,7 +185,7 @@ object StepProgressCell {
           SubsystemControlCell
             .Props(props.obsId,
                    props.step.id,
-                   Step.configStatus.get(props.step).map(_._1),
+                   Nested(Step.configStatus.getOption(props.step)).map(_._1).value.orEmpty,
                    props.resourceRunRequested))
     )
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -315,7 +315,8 @@ object StepsTable extends Columns {
     def unapply(l: StepRow): Option[(Step)] =
       Some((l.step))
 
-    val Zero: StepRow = apply(Step.Zero)
+    val Zero: StepRow =
+      (new js.Object).asInstanceOf[StepRow]
   }
 
   final case class Props(

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ObservationsProgressStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ObservationsProgressStateHandler.scala
@@ -39,7 +39,7 @@ class ObservationsProgressStateHandler[M](
           curSIdx <- obs.runningStep.map(_.last)
           curStep <- sequenceStepT.find(_.id === curSIdx)(obs)
         } yield
-          if (Step.observeStatus.get(curStep) === ActionStatus.Completed && !curStep.isObservePaused) {
+          if (Step.observeStatus.getOption(curStep).exists(_ === ActionStatus.Completed) && !curStep.isObservePaused) {
             updatedL(
               AllObservationsProgressState
                 .progressByIdL(e.obsId, curSIdx)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ObservationsProgressStateHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ObservationsProgressStateHandler.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import diode.ActionHandler
 import diode.ActionResult
 import diode.ModelRW
+import seqexec.model.Step
 import seqexec.model.enum.ActionStatus
 import seqexec.model.events.ObservationProgressEvent
 import seqexec.model.events.StepExecuted
@@ -38,7 +39,7 @@ class ObservationsProgressStateHandler[M](
           curSIdx <- obs.runningStep.map(_.last)
           curStep <- sequenceStepT.find(_.id === curSIdx)(obs)
         } yield
-          if (curStep.observeStatus === ActionStatus.Completed && !curStep.isObservePaused) {
+          if (Step.observeStatus.get(curStep) === ActionStatus.Completed && !curStep.isObservePaused) {
             updatedL(
               AllObservationsProgressState
                 .progressByIdL(e.obsId, curSIdx)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
@@ -16,6 +16,7 @@ import seqexec.model.Observer
 import seqexec.model.SequencesQueue
 import seqexec.model.SequenceView
 import seqexec.model.StepState
+import seqexec.model.Step
 import seqexec.model.events._
 import seqexec.web.client.model.lenses.sequenceStepT
 import seqexec.web.client.model.lenses.sequenceViewT
@@ -84,11 +85,6 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
       effectOnly(soundEffect)
   }
 
-  val logMessage: PartialFunction[Any, ActionResult[M]] = {
-    case ServerMessage(l: ServerLogMessage) =>
-      effectOnly(Effect(Future(AppendToLog(l))))
-  }
-
   val connectionOpenMessage: PartialFunction[Any, ActionResult[M]] = {
     case ServerMessage(ConnectionOpenEvent(u, c, v)) =>
       // After connected to the Websocket request a refresh
@@ -121,8 +117,10 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
           obs     <- sequenceViewT.find(_.id === obsId)(e)
           curSIdx <- obs.runningStep.map(_.last)
           curStep <- sequenceStepT.find(_.id === curSIdx)(obs)
-          if curStep.observeStatus === ActionStatus.Pending && curStep.status === StepState.Running
-          if curStep.configStatus.map(_._2).forall(_ === ActionStatus.Pending)
+          observeStatus = Step.observeStatus.get(curStep)
+          configStatus = Step.configStatus.get(curStep)
+          if observeStatus === ActionStatus.Pending && curStep.status === StepState.Running
+          if configStatus.map(_._2).forall(_ === ActionStatus.Pending)
         } yield curStep
 
       val doneStep =
@@ -278,7 +276,6 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
   override def handle: PartialFunction[Any, ActionResult[M]] =
     List(
       soundCheck,
-      logMessage,
       stepCompletedMessage,
       connectionOpenMessage,
       sequenceCompletedMessage,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/ServerMessagesHandler.scala
@@ -114,11 +114,12 @@ class ServerMessagesHandler[M](modelRW: ModelRW[M, WebSocketsFocus])
     case ServerMessage(e @ StepExecuted(obsId, sv)) =>
       val curStep =
         for {
-          obs     <- sequenceViewT.find(_.id === obsId)(e)
-          curSIdx <- obs.runningStep.map(_.last)
-          curStep <- sequenceStepT.find(_.id === curSIdx)(obs)
-          observeStatus = Step.observeStatus.get(curStep)
-          configStatus = Step.configStatus.get(curStep)
+          obs           <- sequenceViewT.find(_.id === obsId)(e)
+          curSIdx       <- obs.runningStep.map(_.last)
+          curStep       <- sequenceStepT.find(_.id === curSIdx)(obs)
+          observeStatus <- Step.observeStatus.getOption(curStep)
+          configStatus  <- Step.configStatus.getOption(curStep)
+          d = configStatus // workaround
           if observeStatus === ActionStatus.Pending && curStep.status === StepState.Running
           if configStatus.map(_._2).forall(_ === ActionStatus.Pending)
         } yield curStep

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/WebSocketHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/WebSocketHandler.scala
@@ -60,7 +60,7 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection])
           val byteBuffer = TypedArrayBuffer.wrap(buffer)
           Either.catchNonFatal(Unpickle[SeqexecEvent].fromBytes(byteBuffer)) match {
             case Right(event: ServerLogMessage) =>
-              SeqexecCircuit.dispatch(ServerMessage(event))
+              SeqexecCircuit.dispatch(AppendToLog(event))
             case Right(event: ObservationProgressEvent) =>
               SeqexecCircuit.dispatch(ServerMessage(event))
             case Right(event)                   =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/handlers.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/handlers.scala
@@ -12,10 +12,7 @@ import diode.NoAction
 import gem.enum.Site
 import seqexec.model.Observer
 import seqexec.model.Operator
-import seqexec.model.SequencesQueue
-import seqexec.model.SequenceView
-import seqexec.web.client.model._
-import seqexec.web.client.model.ModelOps._
+import seqexec.web.client.model.GlobalLog
 import seqexec.web.client.actions._
 import seqexec.web.client.services.SeqexecWebClient
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
@@ -71,20 +68,5 @@ class DefaultObserverHandler[M](modelRW: ModelRW[M, Observer])
   override def handle: PartialFunction[Any, ActionResult[M]] = {
     case UpdateDefaultObserver(o) =>
       updated(o)
-  }
-}
-
-/**
-  * Handle for UI debugging events
-  */
-class DebuggingHandler[M](modelRW: ModelRW[M, SequencesQueue[SequenceView]])
-    extends ActionHandler(modelRW)
-    with Handlers[M, SequencesQueue[SequenceView]] {
-  override def handle: PartialFunction[Any, ActionResult[M]] = {
-    case MarkStepAsRunning(obsId, step) =>
-      updated(value.copy(sessionQueue = value.sessionQueue.collect {
-        case v: SequenceView if v.id === obsId => v.showAsRunning(step)
-        case v                                 => v
-      }))
   }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ModelOps.scala
@@ -7,13 +7,11 @@ import cats.Show
 import cats.implicits._
 import cats.data.NonEmptyList
 import gem.enum.Site
-import seqexec.model.enum.ActionStatus
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.Resource
 import seqexec.model.StepState
 import seqexec.model.SequenceState
 import seqexec.model.Step
-import seqexec.model.StandardStep
 import seqexec.model.SequenceView
 
 /**
@@ -60,15 +58,14 @@ object ModelOps {
 
     def flipSkipMarkAtStep(step: Step): SequenceView =
       s.copy(steps = s.steps.collect {
-        case st: StandardStep if st.id === step.id => st.copy(skip = !st.skip)
-        case st                                    => st
+        case st if st.id === step.id => Step.skip.modify(!_)(st)
+        case st                      => st
       })
 
     def flipBreakpointAtStep(step: Step): SequenceView =
       s.copy(steps = s.steps.collect {
-        case st: StandardStep if st.id === step.id =>
-          st.copy(breakpoint = !st.breakpoint)
-        case st => st
+        case st if st.id === step.id => Step.breakpoint.modify(!_)(st)
+        case st                      => st
       })
 
     def nextStepToRun: Option[Int] =
@@ -88,17 +85,6 @@ object ModelOps {
 
     def isPartiallyExecuted: Boolean = s.steps.exists(_.isFinished)
 
-    def showAsRunning(i: Int): SequenceView =
-      s.copy(steps = s.steps.collect {
-        case s: StandardStep if s.id === i =>
-          s.copy(
-            status = StepState.Running,
-            configStatus = List((Resource.TCS, ActionStatus.Pending),
-                                (Resource.Gcal, ActionStatus.Running),
-                                (Instrument.Gpi, ActionStatus.Completed))
-          )
-        case s => s
-      })
   }
 
   implicit class SiteOps(val s: Site) extends AnyVal {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -12,7 +12,6 @@ import seqexec.model.enum.FPUMode
 import seqexec.model.enum.Guiding
 import seqexec.model.enum.StepType
 import seqexec.model.Step
-import seqexec.model.StepState
 import seqexec.model.SequenceState
 import seqexec.model.enumerations
 import seqexec.model.OffsetAxis
@@ -37,11 +36,6 @@ object StepItems {
     GpiObservingMode.all.map(x => x.shortName -> x.longName).toMap
 
   implicit class StepOps(val s: Step) extends AnyVal {
-    def canRunFrom: Boolean = s.status match {
-      case StepState.Pending | StepState.Failed(_) => true
-      case _                                       => false
-    }
-
     def fpuNameMapper(i: Instrument): String => Option[String] = i match {
       case Instrument.GmosS => enumerations.fpu.GmosSFPU.get
       case Instrument.GmosN => enumerations.fpu.GmosNFPU.get

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -34,6 +34,7 @@ import seqexec.model.events.ServerLogMessage
 import seqexec.model.arb.ArbRunningStep._
 import seqexec.model.arb.ArbNotification._
 import seqexec.model.arb.ArbTelescopeGuideConfig._
+import seqexec.model.arb.ArbStep._
 import seqexec.model.SeqexecModelArbitraries._
 import seqexec.model.SequenceEventsArbitraries.slmArb
 import seqexec.model.SequenceEventsArbitraries.slmCogen

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -116,9 +116,12 @@ trait ModelBooPicklers extends GemModelBooPicklers {
     .addConcreteType[StepState.Paused.type]
 
   implicit val standardStepPickler = generatePickler[StandardStep]
+  implicit val nsStatusPickler = generatePickler[NodAndShuffleStatus]
+  implicit val nsStepPickler = generatePickler[NodAndShuffleStep]
 
   implicit val stepPickler = compositePickler[Step]
     .addConcreteType[StandardStep]
+    .addConcreteType[NodAndShuffleStep]
 
   implicit val sequenceMetadataPickler = generatePickler[SequenceMetadata]
 

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
@@ -17,6 +17,10 @@ import seqexec.model.SequenceEventsArbitraries._
 import seqexec.model.arb.ArbM1GuideConfig._
 import seqexec.model.arb.ArbM2GuideConfig._
 import seqexec.model.arb.ArbTelescopeGuideConfig._
+import seqexec.model.arb.ArbStep._
+import seqexec.model.arb.ArbStepState._
+import seqexec.model.arb.ArbStandardStep._
+import seqexec.model.arb.ArbNodAndShuffleStep._
 import squants.time.Time
 
 /**
@@ -82,6 +86,9 @@ final class BoopicklingSpec extends CatsSuite with ModelBooPicklers with ArbObse
   checkAll("Pickler[StepState]", PicklerTests[StepState].pickler)
   checkAll("Pickler[ActionStatus]", PicklerTests[ActionStatus].pickler)
   checkAll("Pickler[StandardStep]", PicklerTests[StandardStep].pickler)
+  checkAll("Pickler[NodAndShuffleStatus]", PicklerTests[NodAndShuffleStatus].pickler)
+  checkAll("Pickler[NodAndShuffleStep]", PicklerTests[NodAndShuffleStep].pickler)
+  checkAll("Pickler[Step]", PicklerTests[Step].pickler)
   checkAll("Pickler[QueueId]", PicklerTests[QueueId].pickler)
   checkAll("Pickler[Time]", PicklerTests[Time].pickler)
   checkAll("Pickler[ObservationProgress]",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -100,6 +100,7 @@ object Settings {
     val jwt                     = "2.1.0"
     val slf4j                   = "1.7.26"
     val log4s                   = "1.8.2"
+    val log4cats                = "0.2.0"
     val logback                 = "1.2.3"
     val janino                  = "3.1.0"
     val logstash                = "6.1"
@@ -172,6 +173,7 @@ object Settings {
     val Slf4j                  = "org.slf4j"                 %   "slf4j-api"                         % LibraryVersions.slf4j
     val JuliSlf4j              = "org.slf4j"                 %   "jul-to-slf4j"                      % LibraryVersions.slf4j
     val NopSlf4j               = "org.slf4j"                 %   "slf4j-nop"                         % LibraryVersions.slf4j
+    val Log4Cats               = Def.setting("io.chrisdavenport" %%% "log4cats-slf4j" % LibraryVersions.log4cats)
     val Logback                = Seq(
       "ch.qos.logback"       % "logback-core"             % LibraryVersions.logback,
       "ch.qos.logback"       % "logback-classic"          % LibraryVersions.logback,
@@ -279,13 +281,15 @@ object Settings {
 
   object PluginVersions {
     // Compiler plugins
-    val paradiseVersion    = "2.1.1"
-    val kpVersion          = "0.9.10"
+    val paradiseVersion  = "2.1.1"
+    val kpVersion        = "0.9.10"
+    val betterMonadicFor = "0.3.1"
   }
 
   object Plugins {
-    val paradisePlugin = "org.scalamacros" %% "paradise" % PluginVersions.paradiseVersion cross CrossVersion.patch
-    val kindProjectorPlugin = "org.spire-math" %% "kind-projector" % PluginVersions.kpVersion
+    val paradisePlugin = ("org.scalamacros" %% "paradise" % PluginVersions.paradiseVersion) .cross(CrossVersion.patch)
+    val kindProjectorPlugin    = "org.spire-math" %% "kind-projector" % PluginVersions.kpVersion
+    val betterMonadicForPlugin = "com.olegpy" %% "better-monadic-for" % PluginVersions.betterMonadicFor
   }
 
 }


### PR DESCRIPTION
This PR is a fairly large change to support running Nod And Shuffle steps. At the moment the engine has the notion of actions and usually an observe is one action. Moreover, now all observe actions are the same for each instrument making it easier to centralize. However Nod and Shuffle requires several actions inside a single observe and they are different depending on the instrument and step type.

N&S Support required an important change on the design where instead of a single place where observe actions are created we delegate to the instrument how to create the actions asking them to return an `InstrumentActions` instance. For most instruments the code won't change but for GPI and GMOS we create special `InstrumentAction` instances.

The methods in `ObserveActions` have been reorganized to let the different pieces be assembled differently between instruments.

This PR supports pushing updates to the client and a new Step type was added (Contributing greatly to the PR size as changes were required on the UI). Extra events are sent to indicate when NS begins and at each substage. This can be somewhat observed on the image below though it is far from being the final UI

![ezgif com-video-to-gif(2)](https://user-images.githubusercontent.com/3615303/64137458-57b1ce80-cdc6-11e9-926a-18ddbbf18041.gif)

You may notice that we do config/observe/config/observe in the same step

Finally in this PR I'm adding log4cats to reduce the pervasive use of `Sync` and `better-monadic-for`

While this is the core N&S PR we are far from over. The following needs to still be done:

* Add TCS offsets
* Support N&S Darks
* Fix some issues on the client state across observes
* Custom UI for N&S
* Support for the special pause/abort for N&S
* N&S keywords
* Testing