### PR TITLE
SEQNG-1052 Transform N&S biases, flats and arcs into normal ones.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/CleanConfig.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/CleanConfig.scala
@@ -1,0 +1,71 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import cats.implicits._
+import edu.gemini.spModel.config2.{Config, ItemEntry, ItemKey}
+import seqexec.server.ConfigUtilOps._
+import edu.gemini.spModel.gemini.gmos.InstGmosCommon.USE_NS_PROP
+import edu.gemini.spModel.obscomp.InstConstants.{ARC_OBSERVE_TYPE, FLAT_OBSERVE_TYPE, OBSERVE_TYPE_PROP, BIAS_OBSERVE_TYPE}
+import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+import seqexec.model.StepConfig
+import seqexec.model.enum.SystemName
+
+import scala.collection.breakOut
+
+/*
+ * CleanConfig is a wrapper over Config that allows to override some of the Config parameters. It allows to change some
+ * of the Config parameters without mutation.
+ * It is used to correct some inconsistencies in the sequences coming from the ODB. It has only one of those corrections
+ * now, but it allows for more to be added in the future.
+ */
+class CleanConfig(config: Config, overrides: Map[ItemKey, AnyRef]) {
+  def itemValue(k: ItemKey): Option[AnyRef] = overrides.get(k).orElse(Option(config.getItemValue(k)))
+
+  private def sanitizeValue(s: Any): String = s match {
+    case x: edu.gemini.shared.util.immutable.Some[_] => s"${x.getValue}"
+    case _: edu.gemini.shared.util.immutable.None[_] => "None"
+    case _ => s"$s"
+  }
+
+  def itemEntries: List[ItemEntry] = config.itemEntries.filter(x => !overrides.contains(x.getKey)).toList ++
+    overrides.map{ case (k, v) => new ItemEntry(k, v) }
+
+  // config syntax: cfg.toStepConfig
+  def toStepConfig: StepConfig =
+    itemEntries.groupBy(_.getKey.getRoot).map {
+      case (subsystem, entries) =>
+        SystemName.unsafeFromString(subsystem.getName) ->
+          (entries.toList.map { e =>
+            (e.getKey.getPath, sanitizeValue(e.getItemValue))
+          }(breakOut): Map[String, String])
+    }
+
+}
+
+object CleanConfig {
+
+  implicit val extractItem: ExtractItem[CleanConfig] = (a: CleanConfig, key: ItemKey) => a.itemValue(key)
+
+  type ConfigWiper = Config => Map[ItemKey, AnyRef]
+
+  // The only check right now. GMOS arcs, flats and biases in a N&S sequence have shuffle parameters, even if that is
+  // not supported. The shuffling is automatically disabled by setting the useNS flag to false.
+  val nsWiper: ConfigWiper = cfg => (
+    for {
+      useNS <- cfg.extractInstAs[java.lang.Boolean](USE_NS_PROP)
+      obsType <- cfg.extractObsAs[String](OBSERVE_TYPE_PROP)
+    } yield
+      if (useNS && (obsType === ARC_OBSERVE_TYPE || obsType === FLAT_OBSERVE_TYPE || obsType === BIAS_OBSERVE_TYPE))
+        Map(INSTRUMENT_KEY / USE_NS_PROP -> (java.lang.Boolean.FALSE:AnyRef))
+      else
+        Map.empty[ItemKey, AnyRef]
+  ).getOrElse(Map.empty[ItemKey, AnyRef])
+
+  def createCleanConfig(config: Config, l: List[ConfigWiper]): CleanConfig =
+    new CleanConfig(config, l.map(_(config)).reduce(_ ++ _))
+
+  // New ConfigWiper must be added to the List
+  def apply(config: Config): CleanConfig = createCleanConfig(config, List(nsWiper))
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
@@ -85,59 +85,76 @@ object ConfigUtilOps {
       } yield b
   }
 
-  implicit class ConfigOps(val c: Config) extends AnyVal {
+  implicit class ExtractOps[C: ExtractItem](val c: C) {
     // config syntax: cfg.extract(key).as[Type]
-    def extract(key: ItemKey): Extracted[Config] = new Extracted(c, key)
+    def extract(key: ItemKey): Extracted[C] = new Extracted(c, key)
 
     // config syntax: cfg.extractAs[Type](key)
     def extractAs[A](key: ItemKey)(
-      implicit clazz:     ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, key).as[A]
 
     // config syntax: cfg.extractInstAs[Type](key)
     def extractInstAs[A](key: PropertyDescriptor)(
-      implicit clazz:         ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, INSTRUMENT_KEY / key).as[A]
 
     // config syntax: cfg.extractInstAs[Type](key)
     def extractInstAs[A](key: String)(
-      implicit clazz:         ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, INSTRUMENT_KEY / key).as[A]
 
     // config syntax: cfg.extractInstAs[Type](key)
     def extractObsAs[A](key: PropertyDescriptor)(
-      implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, OBSERVE_KEY / key).as[A]
 
     // config syntax: cfg.extractInstAs[Type](key)
     def extractObsAs[A](key: String)(
-      implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, OBSERVE_KEY / key).as[A]
 
     // config syntax: cfg.extractTelescopeAs[Type](key)
     def extractTelescopeAs[A](key: PropertyDescriptor)(
-      implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, TELESCOPE_KEY / key).as[A]
 
     // config syntax: cfg.extractTelescopeAs[Type](key)
     def extractTelescopeAs[A](key: String)(
-      implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, TELESCOPE_KEY / key).as[A]
 
     // config syntax: cfg.extractCalibrationAs[Type](key)
     def extractCalibrationAs[A](key: PropertyDescriptor)(
-      implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, CALIBRATION_KEY / key).as[A]
 
     // config syntax: cfg.extractCalibrationAs[Type](key)
     def extractCalibrationAs[A](key: String)(
-      implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, CALIBRATION_KEY / key).as[A]
 
-    // config syntax: cfg.extractInstAs[Type](key)
+    // config syntax: cfg.extractAOAs[Type](key)
     def extractAOAs[A](key: PropertyDescriptor)(
-      implicit clazz:        ClassTag[A]): Either[ExtractFailure, A] =
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
       new Extracted(c, AO_SYSTEM_KEY / key).as[A]
+
+    // config syntax: cfg.extractAOAs[Type](key)
+    def extractAOAs[A](key: String)(
+      implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
+      new Extracted(c, AO_SYSTEM_KEY / key).as[A]
+
+    def extractInstInt[A](
+      property: PropertyDescriptor
+    ): Either[ExtractFailure, Option[Int @@ A]] =
+      c.extractInstAs[JInt](property)
+        .map(_.toInt.some)
+        .map(_.map(tag[A][Int]))
+        .recoverOption
+
+  }
+
+  implicit class ConfigOps(val c: Config) extends AnyVal {
 
     private def sanitizeValue(s: Any): String = s match {
       case x: edu.gemini.shared.util.immutable.Some[_] => s"${x.getValue}"
@@ -155,24 +172,6 @@ object ConfigUtilOps {
             }(breakOut): Map[String, String])
       }
 
-    def extractInstInt[A](
-      property: PropertyDescriptor
-    ): Either[ExtractFailure, Option[Int @@ A]] =
-      c
-        .extractInstAs[JInt](property)
-        .map(_.toInt.some)
-        .map(_.map(tag[A][Int]))
-        .recoverOption
-
   }
 
-  implicit class ConfigSequenceOps(val c: ConfigSequence) extends AnyVal {
-    // config syntax: cfgSequence.extract(key).as[Type]
-    def extract(key: ItemKey): Extracted[ConfigSequence] = new Extracted(c, key)
-
-    // config syntax: cfgSequence.extractAs[Type](key)
-    def extractAs[A](key: ItemKey)(
-      implicit clazz:     ClassTag[A]): Either[ExtractFailure, A] =
-      new Extracted(c, key).as[A]
-  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
@@ -15,9 +15,6 @@ import edu.gemini.spModel.ao.AOConstants.AO_SYSTEM_KEY
 import java.beans.PropertyDescriptor
 import java.lang.{Integer => JInt}
 import scala.reflect.ClassTag
-import scala.collection.breakOut
-import seqexec.model.enum.SystemName
-import seqexec.model.StepConfig
 import shapeless.tag
 import shapeless.tag.@@
 
@@ -151,26 +148,6 @@ object ConfigUtilOps {
         .map(_.toInt.some)
         .map(_.map(tag[A][Int]))
         .recoverOption
-
-  }
-
-  implicit class ConfigOps(val c: Config) extends AnyVal {
-
-    private def sanitizeValue(s: Any): String = s match {
-      case x: edu.gemini.shared.util.immutable.Some[_] => s"${x.getValue}"
-      case _: edu.gemini.shared.util.immutable.None[_] => "None"
-      case _ => s"$s"
-    }
-
-    // config syntax: cfg.toStepConfig
-    def toStepConfig: StepConfig =
-      c.itemEntries().groupBy(_.getKey.getRoot).map {
-        case (subsystem, entries) =>
-          SystemName.unsafeFromString(subsystem.getName) ->
-            (entries.toList.map { e =>
-              (e.getKey.getPath, sanitizeValue(e.getItemValue))
-            }(breakOut): Map[String, String])
-      }
 
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -4,7 +4,6 @@
 package seqexec.server
 
 import cats.data.Kleisli
-import edu.gemini.spModel.config2.Config
 import fs2.Stream
 import gem.enum.LightSinkName
 import seqexec.model.dhs.ImageFileId
@@ -16,22 +15,22 @@ import squants.{Length, Time}
 trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
   override val resource: Instrument
   // The name used for this instrument in the science fold configuration
-  def sfName(config: Config): LightSinkName
+  def sfName(config: CleanConfig): LightSinkName
   val contributorName: String
   val observeControl: InstrumentSystem.ObserveControl[F]
 
-  def observe(config: Config): Kleisli[F, ImageFileId, ObserveCommandResult]
+  def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult]
 
   //Expected total observe lapse, used to calculate timeout
-  def calcObserveTime(config: Config): F[Time]
+  def calcObserveTime(config: CleanConfig): F[Time]
 
   def keywordsClient: KeywordsClient[F]
 
   def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress]
 
-  def instrumentActions(config: Config): InstrumentActions[F]
+  def instrumentActions(config: CleanConfig): InstrumentActions[F]
 
-  def calcStepType(config: Config): Either[SeqexecFailure, StepType] =
+  def calcStepType(config: CleanConfig): Either[SeqexecFailure, StepType] =
     SequenceConfiguration.calcStepType(config)
 
   override val oiOffsetGuideThreshold: Option[Length] = None

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
@@ -4,7 +4,6 @@
 package seqexec.server
 
 import gem.Observation
-import edu.gemini.spModel.config2.Config
 import seqexec.server.keywords._
 import seqexec.server.tcs.Tcs
 
@@ -13,7 +12,7 @@ import seqexec.server.tcs.Tcs
   */
 final case class ObserveEnvironment[F[_]](
   systems:  Systems[F],
-  config:   Config,
+  config:   CleanConfig,
   stepType: StepType,
   obsId:    Observation.Id,
   inst:     InstrumentSystem[F],

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
@@ -4,8 +4,6 @@
 package seqexec.server
 
 import cats.implicits._
-import edu.gemini.spModel.config2.Config
-import edu.gemini.spModel.config2.ItemKey
 import edu.gemini.spModel.obscomp.InstConstants._
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import edu.gemini.spModel.gemini.altair.AltairConstants
@@ -25,9 +23,10 @@ import seqexec.server.nifs._
 import seqexec.server.gnirs._
 import seqexec.server.SeqexecFailure.UnrecognizedInstrument
 import seqexec.server.SeqexecFailure.Unexpected
+import seqexec.server.CleanConfig.extractItem
 
 trait SequenceConfiguration {
-  def extractInstrument(config: Config): Either[SeqexecFailure, Instrument] =
+  def extractInstrument(config: CleanConfig): Either[SeqexecFailure, Instrument] =
     config
       .extractAs[String](INSTRUMENT_KEY / INSTRUMENT_NAME_PROP)
       .asTrySeq
@@ -44,18 +43,18 @@ trait SequenceConfiguration {
         case ins             => UnrecognizedInstrument(s"inst $ins").asLeft
       }
 
-  def extractStatus(config: Config): StepState =
-    config.getItemValue(new ItemKey("observe:status")).toString match {
+  def extractStatus(config: CleanConfig): StepState =
+    config.extractObsAs[String](STATUS_PROP).map {
       case "ready"    => StepState.Pending
       case "complete" => StepState.Completed
       case "skipped"  => StepState.Skipped
       case kw         => StepState.Failed("Unexpected status keyword: " ++ kw)
-    }
+    }.getOrElse(StepState.Failed("Logical error reading step status"))
 
-  def extractWavelength(config: Config): Option[Wavelength] =
+  def extractWavelength(config: CleanConfig): Option[Wavelength] =
     config.extractAs[Wavelength](OBSERVING_WAVELENGTH_KEY).toOption
 
-  def calcStepType(config: Config): TrySeq[StepType] = {
+  def calcStepType(config: CleanConfig): TrySeq[StepType] = {
     def extractGaos(inst: Instrument): TrySeq[StepType] =
       config.extractAs[String](AO_SYSTEM_KEY) match {
         case Left(ConfigUtilOps.ConversionError(_, _)) =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/System.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/System.scala
@@ -4,7 +4,6 @@
 package seqexec.server
 
 import seqexec.model.enum.Resource
-import edu.gemini.spModel.config2.Config
 
 trait System[F[_]] {
   val resource: Resource
@@ -12,7 +11,7 @@ trait System[F[_]] {
   /**
     * Called to configure a system
     */
-  def configure(config: Config): F[ConfigResult[F]]
+  def configure(config: CleanConfig): F[ConfigResult[F]]
 
   def notifyObserveStart: F[Unit]
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
@@ -4,14 +4,12 @@
 package seqexec.server.altair
 
 import cats.effect.Sync
-import edu.gemini.spModel.ao.AOConstants.AO_CONFIG_NAME
-import edu.gemini.spModel.config2.{Config, ItemKey}
 import edu.gemini.spModel.gemini.altair.AltairConstants.FIELD_LENSE_PROP
 import edu.gemini.spModel.gemini.altair.AltairConstants.GUIDESTAR_TYPE_PROP
 import edu.gemini.spModel.gemini.altair.AltairParams.GuideStarType
 import seqexec.server.ConfigUtilOps._
 import seqexec.model.enum.Resource
-import seqexec.server.TrySeq
+import seqexec.server.{CleanConfig, TrySeq}
 import seqexec.server.altair.AltairController._
 import seqexec.server.gems.GemsController.GemsConfig
 import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
@@ -74,12 +72,12 @@ object Altair {
 
   }
 
-  def fromConfig[F[_]: Sync](config: Config, controller: AltairController[F]): TrySeq[Altair[F]] =
-    config.extractAs[FieldLens](new ItemKey(AO_CONFIG_NAME) / FIELD_LENSE_PROP).map { fieldLens =>
+  def fromConfig[F[_]: Sync](config: CleanConfig, controller: AltairController[F]): TrySeq[Altair[F]] =
+    config.extractAOAs[FieldLens](FIELD_LENSE_PROP).map { fieldLens =>
       new AltairImpl[F](controller, fieldLens)
     }.asTrySeq
 
-  def guideStarType(config: Config): TrySeq[GuideStarType] =
-    config.extractAs[GuideStarType](new ItemKey(AO_CONFIG_NAME) / GUIDESTAR_TYPE_PROP).asTrySeq
+  def guideStarType(config: CleanConfig): TrySeq[GuideStarType] =
+    config.extractAOAs[GuideStarType](GUIDESTAR_TYPE_PROP).asTrySeq
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -9,7 +9,6 @@ import cats.effect.Sync
 import cats.effect.Timer
 import cats.implicits._
 import fs2.Stream
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.{Reads, _}
 import edu.gemini.spModel.obscomp.InstConstants.{DARK_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
@@ -39,7 +38,7 @@ final case class Flamingos2[F[_]: Sync: Timer: Logger](f2Controller: Flamingos2C
 
   override val resource: Instrument = Instrument.F2
 
-  override def sfName(config: Config): LightSinkName = LightSinkName.F2
+  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.F2
 
   override val contributorName: String = "flamingos2"
 
@@ -50,14 +49,14 @@ final case class Flamingos2[F[_]: Sync: Timer: Logger](f2Controller: Flamingos2C
   override val observeControl: InstrumentSystem.ObserveControl[F] = InstrumentSystem.Uncontrollable
 
   // FLAMINGOS-2 does not support abort or stop.
-  override def observe(config: Config): Kleisli[F, ImageFileId, ObserveCommandResult] =
+  override def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult] =
     Kleisli { fileId =>
       calcObserveTime(config).flatMap { x =>
         f2Controller.observe(fileId, x)
       }
   }
 
-  override def configure(config: Config): F[ConfigResult[F]] =
+  override def configure(config: CleanConfig): F[ConfigResult[F]] =
     EitherT.fromEither[F](fromSequenceConfig(config))
       .widenRethrowT
       .flatMap(f2Controller.applyConfig)
@@ -68,7 +67,7 @@ final case class Flamingos2[F[_]: Sync: Timer: Logger](f2Controller: Flamingos2C
 
   override def notifyObserveStart: F[Unit] = Sync[F].unit
 
-  override def calcObserveTime(config: Config): F[Time] =
+  override def calcObserveTime(config: CleanConfig): F[Time] =
     Sync[F].delay(
       config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP)
         .map(x => Seconds(x.toDouble)).getOrElse(Seconds(360)))
@@ -76,7 +75,7 @@ final case class Flamingos2[F[_]: Sync: Timer: Logger](f2Controller: Flamingos2C
   override def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress] =
     f2Controller.observeProgress(total)
 
-  override def instrumentActions(config: Config): InstrumentActions[F] =
+  override def instrumentActions(config: CleanConfig): InstrumentActions[F] =
     InstrumentActions.defaultInstrumentActions[F]
 
   // TODO Use different value if using electronic offsets
@@ -112,7 +111,7 @@ object Flamingos2 {
     case Decker.MOS       => BiasMode.MOS
   }
 
-  def fpuConfig(config: Config): Either[ConfigUtilOps.ExtractFailure, FocalPlaneUnit] = {
+  def fpuConfig(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, FocalPlaneUnit] = {
     val a = INSTRUMENT_KEY / FPU_PROP
     val b = INSTRUMENT_KEY / FPU_MASK_PROP
 
@@ -140,14 +139,14 @@ object Flamingos2 {
   }
 
   // This method deals with engineering parameters that can come as a T or an Option[T]
-  private def extractEngineeringParam[T](item: Extracted[Config], default: T)(
+  private def extractEngineeringParam[T](item: Extracted[CleanConfig], default: T)(
     implicit clazz: ClassTag[T]): Either[ExtractFailure, T] = item.as[T].recoverWith {
       case _:ConfigUtilOps.KeyNotFound     => Right(default)
       case _:ConfigUtilOps.ConversionError => item.as[edu.gemini.shared.util.immutable.Option[T]]
                                                 .map(_.getOrElse(default))
     }
 
-  def ccConfigFromSequenceConfig(config: Config): TrySeq[CCConfig] =
+  def ccConfigFromSequenceConfig(config: CleanConfig): TrySeq[CCConfig] =
     (for {
       obsType <- config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
       // WINDOW_COVER_PROP is optional. It can be a WindowCover, an Option[WindowCover], or not be present. If no
@@ -165,7 +164,7 @@ object Flamingos2 {
     } yield CCConfig(p, q, r, s, t, u)).leftMap(e => SeqexecFailure.Unexpected
     (ConfigUtilOps.explain(e)))
 
-  def dcConfigFromSequenceConfig(config: Config): TrySeq[DCConfig] =
+  def dcConfigFromSequenceConfig(config: CleanConfig): TrySeq[DCConfig] =
     (for {
       p <- config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP).map(x => Duration(x, SECONDS))
       // Reads is usually inferred from the read mode, but it can be explicit.
@@ -176,7 +175,7 @@ object Flamingos2 {
       s <- config.extractAs[Decker](INSTRUMENT_KEY / DECKER_PROP)
     } yield DCConfig(p, q, r, s)).leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
-  def fromSequenceConfig[F[_]: Sync](config: Config): Either[SeqexecFailure, Flamingos2Config] = ( for {
+  def fromSequenceConfig[F[_]: Sync](config: CleanConfig): Either[SeqexecFailure, Flamingos2Config] = ( for {
       p <- ccConfigFromSequenceConfig(config)
       q <- dcConfigFromSequenceConfig(config)
     } yield Flamingos2Config(p, q)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -11,26 +11,16 @@ import gem.Observation
 import gem.enum.KeywordName
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import edu.gemini.spModel.config2.Config
-import edu.gemini.spModel.data.YesNoType
-import edu.gemini.spModel.gemini.flamingos2.Flamingos2.MOS_PREIMAGING_PROP
-import edu.gemini.spModel.gemini.flamingos2.Flamingos2.READMODE_PROP
-import edu.gemini.spModel.gemini.flamingos2.Flamingos2.ReadMode
-import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
+import seqexec.server.{CleanConfig, ConfigUtilOps, InstrumentSystem, SeqexecFailure}
+import seqexec.server.CleanConfig.extractItem
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.keywords._
 import seqexec.server.tcs.TcsKeywordsReader
-import seqexec.server.ConfigUtilOps
-import seqexec.server.SeqexecFailure
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.data.YesNoType
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.MOS_PREIMAGING_PROP
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.READMODE_PROP
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.ReadMode
-import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
-import cats.implicits._
 
 object Flamingos2Header {
   def header[F[_]: Sync](inst:              InstrumentSystem[F],
@@ -63,19 +53,19 @@ object Flamingos2Header {
   }
 
   object ObsKeywordsReaderODB {
-    def apply[F[_]: Sync](config: Config): ObsKeywordsReader[F] =
+    def apply[F[_]: Sync](config: CleanConfig): ObsKeywordsReader[F] =
       new ObsKeywordsReader[F] {
         def getPreimage: F[YesNoType] =
           EitherT(
             Sync[F].delay(config
-              .extractAs[YesNoType](INSTRUMENT_KEY / MOS_PREIMAGING_PROP)
+              .extractInstAs[YesNoType](MOS_PREIMAGING_PROP)
               .leftMap[Throwable](e =>
                 SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))))).rethrowT
 
         def getReadMode: F[ReadMode] =
           EitherT(
             Sync[F].delay(config
-              .extractAs[ReadMode](INSTRUMENT_KEY / READMODE_PROP)
+              .extractInstAs[ReadMode](READMODE_PROP)
               .leftMap[Throwable](e =>
                 SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))))).rethrowT
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/Gcal.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/Gcal.scala
@@ -6,7 +6,6 @@ package seqexec.server.gcal
 import cats._
 import cats.implicits._
 import cats.effect.Sync
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.calunit.CalUnitConstants._
 import edu.gemini.spModel.gemini.calunit.CalUnitParams.{Lamp, Shutter}
 import java.util.{Set => JSet}
@@ -18,7 +17,8 @@ import scala.collection.JavaConverters._
 import seqexec.model.enum.Resource
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gcal.GcalController._
-import seqexec.server.{ConfigResult, ConfigUtilOps, SeqexecFailure, System, TrySeq}
+import seqexec.server.{CleanConfig, ConfigResult, ConfigUtilOps, SeqexecFailure, System, TrySeq}
+import seqexec.server.CleanConfig.extractItem
 
 /**
   * Created by jluhrs on 3/21/17.
@@ -32,7 +32,7 @@ final case class Gcal[F[_]] private (controller: GcalController[F], cfg: GcalCon
   /**
     * Called to configure a system, returns a F[ConfigResult]
     */
-  override def configure(config: Config): F[ConfigResult[F]] =
+  override def configure(config: CleanConfig): F[ConfigResult[F]] =
     for{
       _       <- F.delay(Log.info("Start GCAL configuration"))
       _       <- F.delay(Log.debug(s"GCAL configuration: ${cfg.show}"))
@@ -52,7 +52,7 @@ object Gcal {
 
   implicit val shutterEq: Eq[Shutter] = Eq.by(_.ordinal)
 
-  def fromConfig[F[_]: Sync](controller: GcalController[F], isCP: Boolean)(config: Config): TrySeq[Gcal[F]] = {
+  def fromConfig[F[_]: Sync](controller: GcalController[F], isCP: Boolean)(config: CleanConfig): TrySeq[Gcal[F]] = {
       val lamps: Either[ConfigUtilOps.ExtractFailure, List[Lamp]] = config.extractCalibrationAs[JSet[Lamp]](LAMP_PROP)
         .map(_.asScala.toList)
         .recover{ case ConfigUtilOps.KeyNotFound(_) => List.empty[Lamp] }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/Gems.scala
@@ -5,13 +5,13 @@ package seqexec.server.gems
 
 import cats.{Eq, MonadError}
 import cats.implicits._
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw
 import edu.gemini.spModel.guide.StandardGuideOptions
 import edu.gemini.spModel.target.obsComp.TargetObsCompConstants.GUIDE_WITH_OIWFS_PROP
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.{SeqexecFailure, TrySeq}
+import seqexec.server.{CleanConfig, SeqexecFailure, TrySeq}
+import seqexec.server.CleanConfig.extractItem
 import seqexec.server.altair.AltairController.AltairConfig
 import seqexec.server.gems.Gems.GemsWfsState
 import seqexec.server.gems.GemsController.{GemsConfig, OIUsage, Odgw1Usage, Odgw2Usage, Odgw3Usage, Odgw4Usage, P1Usage}
@@ -70,7 +70,7 @@ object Gems {
   )
 
   def fromConfig[F[_]: MonadError[?[_], Throwable]](controller: GemsController[F], guideConfigDb: GuideConfigDb[F])
-                                                         (config: Config)
+                                                         (config: CleanConfig)
   : TrySeq[Gems[F]] = {
     for {
       p1    <- config.extractTelescopeAs[StandardGuideOptions.Value](Tcs.GUIDE_WITH_PWFS1_PROP)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -6,7 +6,6 @@ package seqexec.server.gmos
 import cats._
 import cats.implicits._
 import cats.data.NonEmptyList
-import edu.gemini.spModel.config2.Config
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.ActionType
@@ -16,17 +15,10 @@ import seqexec.model.enum.{Guiding, ObserveCommandResult}
 import seqexec.engine.Action
 import seqexec.engine.ParallelActions
 import seqexec.engine.Result
-import seqexec.server.Response
+import seqexec.server.{CleanConfig, FileIdAllocated, FileIdProvider, InstrumentActions, ObserveActions, ObserveContext, ObserveEnvironment, Response, StepType}
 import seqexec.server.SeqTranslate._
-import seqexec.server.StepType
-import seqexec.server.FileIdAllocated
-import seqexec.server.FileIdProvider
-import seqexec.server.InstrumentActions
-import seqexec.server.ObserveEnvironment
-import seqexec.server.ObserveActions
-import seqexec.server.ObserveContext
 import seqexec.server.ObserveActions._
-import seqexec.server.gmos.GmosController.Config._
+import seqexec.server.gmos.GmosController.Config.{NSConfig, NSPosition}
 import seqexec.server.tcs.TcsController.{InstrumentOffset, OffsetP, OffsetQ}
 import shapeless.tag
 import squants.space.AngleConversions._
@@ -36,7 +28,7 @@ import squants.space.AngleConversions._
   */
 class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger, A <: GmosController.SiteDependentTypes](
   inst:   Gmos[F, A],
-  config: Config
+  config: CleanConfig
 ) extends InstrumentActions[F] {
   override def observationProgressStream(
     env: ObserveEnvironment[F]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosKeywordReader.scala
@@ -10,12 +10,12 @@ import cats.implicits._
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.keywords._
 import seqexec.server.gmos.GmosEpics.RoiStatus
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.data.YesNoType
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.IS_MOS_PREIMAGING_PROP
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import seqexec.model.enum.NodAndShuffleStage.{StageA, StageB}
-import seqexec.server.{ConfigUtilOps, SeqexecFailure}
+import seqexec.server.{CleanConfig, ConfigUtilOps, SeqexecFailure}
+import seqexec.server.CleanConfig.extractItem
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.USE_NS_PROP
 import gsp.math.{Angle, Offset}
 import monocle.Getter
@@ -23,7 +23,7 @@ import seqexec.model.enum.NodAndShuffleStage
 
 final case class RoiValues(xStart: Int, xSize: Int, yStart: Int, ySize: Int)
 
-final case class GmosObsKeywordsReader[F[_]: MonadError[?[_], Throwable]](config: Config) {
+final case class GmosObsKeywordsReader[F[_]: MonadError[?[_], Throwable]](config: CleanConfig) {
   import GmosObsKeywordsReader._
 
   private implicit val BooleanDefaultValue: DefaultHeaderValue[Boolean] = DefaultHeaderValue.FalseDefaultValue

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -7,13 +7,13 @@ import cats.MonadError
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
-import seqexec.server.ConfigUtilOps
+import seqexec.server.{CleanConfig, ConfigUtilOps}
+import seqexec.server.CleanConfig.extractItem
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.{GmosNorthController, NorthTypes, northConfigTypes}
 import seqexec.server.keywords.DhsClient
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.GmosNorthType
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
@@ -25,13 +25,13 @@ import squants.space.Arcseconds
 final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosNorthController[F], dhsClient: DhsClient[F]) extends Gmos[F, NorthTypes](c,
   new SiteSpecifics[NorthTypes] {
     override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
-    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
+    override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
       config.extractAs[NorthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
-    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] =
+    override def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] =
       config.extractAs[NorthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
-    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] =
+    override def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] =
       config.extractAs[NorthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
-    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
+    override def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
       config.extractAs[NorthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
   })(northConfigTypes) {
   override val resource: Instrument = Instrument.GmosN

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -7,13 +7,13 @@ import cats.MonadError
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
-import seqexec.server.ConfigUtilOps
+import seqexec.server.{CleanConfig, ConfigUtilOps}
+import seqexec.server.CleanConfig.extractItem
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.{GmosSouthController, SouthTypes, southConfigTypes}
 import seqexec.server.keywords.DhsClient
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gmos.GmosSouthType
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
@@ -25,13 +25,13 @@ import squants.space.Arcseconds
 final case class GmosSouth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosSouthController[F], dhsClient: DhsClient[F]) extends Gmos[F, SouthTypes](c,
   new SiteSpecifics[SouthTypes] {
     override val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
-    override def extractFilter(config: Config): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
+    override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
       config.extractAs[SouthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
-    override def extractDisperser(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] =
+    override def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] =
       config.extractAs[SouthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
-    override def extractFPU(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] =
+    override def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] =
       config.extractAs[SouthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
-    override def extractStageMode(config: Config): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] =
+    override def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] =
       config.extractAs[SouthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
   })(southConfigTypes) {
   override val resource: Instrument = Instrument.GmosS

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -7,7 +7,6 @@ import cats.data.Kleisli
 import cats.data.EitherT
 import cats.implicits._
 import cats.effect.Sync
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gnirs.GNIRSConstants.{INSTRUMENT_NAME_PROP, WOLLASTON_PRISM_PROP}
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams._
 import edu.gemini.spModel.gemini.gnirs.InstGNIRS._
@@ -24,13 +23,14 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gnirs.GnirsController.{CCConfig, DCConfig, Filter1, Other, ReadMode}
 import seqexec.server._
+import seqexec.server.CleanConfig.extractItem
 import seqexec.server.keywords.{DhsClient, DhsInstrument, KeywordsClient}
 import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
 final case class Gnirs[F[_]: Sync: Logger](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
-  override def sfName(config: Config): LightSinkName = LightSinkName.Gnirs
+  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gnirs
   override val contributorName: String = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"
 
@@ -41,21 +41,21 @@ final case class Gnirs[F[_]: Sync: Logger](controller: GnirsController[F], dhsCl
   override val observeControl: ObserveControl[F] = UnpausableControl(StopObserveCmd(controller.stopObserve),
                                                                 AbortObserveCmd(controller.abortObserve))
 
-  override def observe(config: Config): Kleisli[F, ImageFileId, ObserveCommandResult] =
+  override def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult] =
     Kleisli { fileId =>
       calcObserveTime(config).flatMap { x =>
         controller.observe(fileId, x)
       }
     }
 
-  override def calcObserveTime(config: Config): F[Time] =
+  override def calcObserveTime(config: CleanConfig): F[Time] =
     getDCConfig(config)
       .map(controller.calcTotalExposureTime)
       .getOrElse(60.seconds.pure[F])
 
   override val resource: Instrument = Instrument.Gnirs
 
-  override def configure(config: Config): F[ConfigResult[F]] =
+  override def configure(config: CleanConfig): F[ConfigResult[F]] =
     EitherT.fromEither[F](fromSequenceConfig(config))
       .widenRethrowT
       .flatMap(controller.applyConfig)
@@ -69,7 +69,7 @@ final case class Gnirs[F[_]: Sync: Logger](controller: GnirsController[F], dhsCl
   override def observeProgress(total: Time, elapsed: ElapsedTime): fs2.Stream[F, Progress] =
     controller.observeProgress(total)
 
-  override def instrumentActions(config: Config): InstrumentActions[F] =
+  override def instrumentActions(config: CleanConfig): InstrumentActions[F] =
     InstrumentActions.defaultInstrumentActions[F]
 
 }
@@ -78,16 +78,16 @@ object Gnirs {
 
   val name: String = INSTRUMENT_NAME_PROP
 
-  def extractExposureTime(config: Config): Either[ExtractFailure, Time] =
+  def extractExposureTime(config: CleanConfig): Either[ExtractFailure, Time] =
     config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP).map(_.toDouble.seconds)
 
-  def extractCoadds(config: Config): Either[ExtractFailure, Int] =
+  def extractCoadds(config: CleanConfig): Either[ExtractFailure, Int] =
     config.extractAs[JInt](OBSERVE_KEY / COADDS_PROP).map(_.toInt)
 
-  def fromSequenceConfig(config: Config): TrySeq[GnirsController.GnirsConfig] =
+  def fromSequenceConfig(config: CleanConfig): TrySeq[GnirsController.GnirsConfig] =
     (getCCConfig(config), getDCConfig(config)).mapN(GnirsController.GnirsConfig)
 
-  private def getDCConfig(config: Config): TrySeq[DCConfig] = (for {
+  private def getDCConfig(config: CleanConfig): TrySeq[DCConfig] = (for {
     expTime <- extractExposureTime(config)
     coadds  <- extractCoadds(config)
     readMode <- config.extractAs[ReadMode](INSTRUMENT_KEY / READ_MODE_PROP)
@@ -95,7 +95,7 @@ object Gnirs {
   } yield DCConfig(expTime, coadds, readMode, wellDepth))
     .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
-  private def getCCConfig(config: Config): TrySeq[CCConfig] = config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
+  private def getCCConfig(config: CleanConfig): TrySeq[CCConfig] = config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
     .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))).flatMap{
     case DARK_OBSERVE_TYPE => GnirsController.Dark.asRight
     case BIAS_OBSERVE_TYPE => SeqexecFailure.Unexpected("Bias not supported for GNIRS").asLeft
@@ -111,7 +111,7 @@ object Gnirs {
     }
   }
 
-  private def getCCOtherConfig(config: Config): TrySeq[CCConfig] = (for {
+  private def getCCOtherConfig(config: CleanConfig): TrySeq[CCConfig] = (for {
     xdisp   <- config.extractAs[CrossDispersed](INSTRUMENT_KEY / CROSS_DISPERSED_PROP)
     woll    <- config.extractAs[WollastonPrism](INSTRUMENT_KEY / WOLLASTON_PRISM_PROP)
     mode    <- getCCMode(config, xdisp, woll)
@@ -128,7 +128,7 @@ object Gnirs {
   } yield Other(mode, camera, decker, filter1, filter2, focus, wavel, slitOp) )
     .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
-  private def getCCMode(config: Config, xdispersed: CrossDispersed, woll: WollastonPrism)
+  private def getCCMode(config: CleanConfig, xdispersed: CrossDispersed, woll: WollastonPrism)
   : Either[ExtractFailure, GnirsController.Mode] =
     for {
       acq        <- config.extractAs[AcquisitionMirror](INSTRUMENT_KEY / ACQUISITION_MIRROR_PROP)
@@ -143,7 +143,7 @@ object Gnirs {
       }
     }
 
-  private def getDecker(config: Config, slit: SlitWidth, woll: WollastonPrism, xdisp: CrossDispersed)
+  private def getDecker(config: CleanConfig, slit: SlitWidth, woll: WollastonPrism, xdisp: CrossDispersed)
   : Either[ExtractFailure, GnirsController.Decker] =
     config.extractAs[Decker](INSTRUMENT_KEY / DECKER_PROP).orElse {
       for {
@@ -221,7 +221,7 @@ object Gnirs {
     case _                      => None
   }
 
-  private def getFocus(config: Config): Either[ExtractFailure, GnirsController.Focus] =
+  private def getFocus(config: CleanConfig): Either[ExtractFailure, GnirsController.Focus] =
     config.extractInstAs[Focus](FOCUS_PROP).flatMap{ v =>
       if (v.toString === FocusSuggestion.BEST_FOCUS.displayValue) GnirsController.Focus.Best.asRight
       else v.toString.parseIntOption.map(GnirsController.Focus.Manual(_).asRight)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -7,7 +7,6 @@ import cats.data.Kleisli
 import cats.data.EitherT
 import cats.effect.Sync
 import cats.implicits._
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi._
 import edu.gemini.spModel.obscomp.InstConstants.DARK_OBSERVE_TYPE
 import edu.gemini.spModel.obscomp.InstConstants.OBSERVE_TYPE_PROP
@@ -23,17 +22,12 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.server.ConfigUtilOps.ExtractFailure
-import seqexec.server.ConfigResult
-import seqexec.server.InstrumentSystem
-import seqexec.server.Progress
-import seqexec.server.SeqexecFailure
-import seqexec.server.ConfigUtilOps
-import seqexec.server.TrySeq
+import seqexec.server.{CleanConfig, ConfigResult, ConfigUtilOps, InstrumentActions, InstrumentSystem, Progress, SeqexecFailure, TrySeq}
+import seqexec.server.CleanConfig.extractItem
 import seqexec.server.keywords.DhsClient
 import seqexec.server.keywords.DhsInstrument
 import seqexec.server.keywords.KeywordsClient
 import seqexec.server.InstrumentSystem._
-import seqexec.server.InstrumentActions
 import seqexec.server.gsaoi.GsaoiController._
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.space.Arcseconds
@@ -48,7 +42,7 @@ final case class Gsaoi[F[_]: Sync: Logger](
 
   import Gsaoi._
 
-  override def sfName(config: Config): LightSinkName = LightSinkName.Gsaoi
+  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gsaoi
 
   override val contributorName: String = "GSAOI"
 
@@ -57,7 +51,7 @@ final case class Gsaoi[F[_]: Sync: Logger](
                  AbortObserveCmd[F](controller.abortObserve))
 
   override def observe(
-    config: Config
+    config: CleanConfig
   ): Kleisli[F, ImageFileId, ObserveCommandResult] =
     Kleisli { fileId =>
       EitherT.fromEither[F]{
@@ -68,7 +62,7 @@ final case class Gsaoi[F[_]: Sync: Logger](
         .flatMap(x => controller.observe(fileId, x))
     }
 
-  override def calcObserveTime(config: Config): F[Time] =
+  override def calcObserveTime(config: CleanConfig): F[Time] =
     readDCConfig(config)
       .map(controller.calcTotalExposureTime)
       .getOrElse(Sync[F].delay(60.seconds))
@@ -90,7 +84,7 @@ final case class Gsaoi[F[_]: Sync: Logger](
   /**
     * Called to configure a system
     */
-  override def configure(config: Config): F[ConfigResult[F]] =
+  override def configure(config: CleanConfig): F[ConfigResult[F]] =
     EitherT.fromEither[F](fromSequenceConfig(config))
       .widenRethrowT
       .flatMap(controller.applyConfig)
@@ -101,7 +95,7 @@ final case class Gsaoi[F[_]: Sync: Logger](
   override def notifyObserveEnd: F[Unit] =
     controller.endObserve
 
-  override def instrumentActions(config: Config): InstrumentActions[F] =
+  override def instrumentActions(config: CleanConfig): InstrumentActions[F] =
     InstrumentActions.defaultInstrumentActions[F]
 }
 
@@ -110,11 +104,11 @@ object Gsaoi {
   val name: String = INSTRUMENT_NAME_PROP
 
   private def extractObsType(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, String] =
     config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
 
-  private def readCCConfig(config: Config): Either[ExtractFailure, CCConfig] =
+  private def readCCConfig(config: CleanConfig): Either[ExtractFailure, CCConfig] =
     for {
       obsType      <- extractObsType(config)
       filter       <- config.extractInstAs[Filter](FILTER_PROP)
@@ -127,30 +121,30 @@ object Gsaoi {
       }
 
   private def extractExposureTime(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Time] =
     config
       .extractObsAs[JDouble](EXPOSURE_TIME_PROP)
       .map(_.toDouble.seconds)
 
-  private def extractCoadds(config: Config): Either[ExtractFailure, Coadds] =
+  private def extractCoadds(config: CleanConfig): Either[ExtractFailure, Coadds] =
     config
       .extractInstAs[JInt](COADDS_PROP)
       .map(_.toInt)
       .map(tag[CoaddsI][Int])
 
   private def extractReadMode(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, ReadMode] =
     config.extractInstAs[ReadMode](READ_MODE_PROP)
 
   private def extractRoi(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Roi] =
     config.extractInstAs[Roi](ROI_PROP)
 
   private def extractNrOfFowSamples(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, NumberOfFowSamples] =
     extractReadMode(config).map {
       case ReadMode.BRIGHT      => 1
@@ -158,7 +152,7 @@ object Gsaoi {
       case ReadMode.VERY_FAINT  => 8
     }.map(tag[NumberOfFowSamplesI][Int])
 
-  private def readDCConfig(config: Config): Either[ExtractFailure, DCConfig] =
+  private def readDCConfig(config: CleanConfig): Either[ExtractFailure, DCConfig] =
     for {
       readMode   <- extractReadMode(config)
       roi        <- extractRoi(config)
@@ -167,7 +161,7 @@ object Gsaoi {
       fowSamples <- extractNrOfFowSamples(config)
     } yield DCConfig(readMode, roi, coadds, expTime, fowSamples)
 
-  def fromSequenceConfig(config: Config): TrySeq[GsaoiConfig] =
+  def fromSequenceConfig(config: CleanConfig): TrySeq[GsaoiConfig] =
     for {
       cc <- readCCConfig(config).asTrySeq
       dc <- readDCConfig(config).asTrySeq

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -7,7 +7,6 @@ import cats.data.Kleisli
 import cats.data.EitherT
 import cats.effect.Sync
 import cats.implicits._
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.gemini.nifs.InstNIFS._
 import edu.gemini.spModel.gemini.nifs.InstEngNifs._
 import edu.gemini.spModel.obscomp.InstConstants.DARK_OBSERVE_TYPE
@@ -26,17 +25,14 @@ import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.server.ConfigUtilOps.ExtractFailure
-import seqexec.server.ConfigResult
-import seqexec.server.InstrumentSystem
-import seqexec.server.Progress
-import seqexec.server.TrySeq
+import seqexec.server.{CleanConfig, ConfigResult, InstrumentActions, InstrumentSystem, Progress, TrySeq}
+import seqexec.server.CleanConfig.extractItem
 import seqexec.server.keywords.DhsClient
 import seqexec.server.keywords.DhsInstrument
 import seqexec.server.keywords.KeywordsClient
 import seqexec.server.InstrumentSystem.UnpausableControl
 import seqexec.server.InstrumentSystem.AbortObserveCmd
 import seqexec.server.InstrumentSystem.StopObserveCmd
-import seqexec.server.InstrumentActions
 import seqexec.server.nifs.NifsController._
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.space.Arcseconds
@@ -51,7 +47,7 @@ final case class Nifs[F[_]: Sync: Logger](
 
   import Nifs._
 
-  override def sfName(config: Config): LightSinkName = LightSinkName.Nifs
+  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Nifs
 
   override val contributorName: String = "NIFS"
 
@@ -60,7 +56,7 @@ final case class Nifs[F[_]: Sync: Logger](
                     AbortObserveCmd(controller.abortObserve))
 
   override def observe(
-    config: Config
+    config: CleanConfig
   ): Kleisli[F, ImageFileId, ObserveCommandResult] =
     Kleisli { fileId =>
       EitherT.fromEither[F](getDCConfig(config).asTrySeq)
@@ -68,7 +64,7 @@ final case class Nifs[F[_]: Sync: Logger](
         .flatMap(controller.observe(fileId, _))
     }
 
-  override def calcObserveTime(config: Config): F[Time] =
+  override def calcObserveTime(config: CleanConfig): F[Time] =
     getDCConfig(config)
       .map(controller.calcTotalExposureTime)
       .getOrElse(Sync[F].delay(60.seconds))
@@ -90,7 +86,7 @@ final case class Nifs[F[_]: Sync: Logger](
   /**
     * Called to configure a system
     */
-  override def configure(config: Config): F[ConfigResult[F]] =
+  override def configure(config: CleanConfig): F[ConfigResult[F]] =
     EitherT.fromEither[F](fromSequenceConfig(config))
       .widenRethrowT
       .flatMap(controller.applyConfig)
@@ -101,7 +97,7 @@ final case class Nifs[F[_]: Sync: Logger](
   override def notifyObserveEnd: F[Unit] =
     controller.endObserve
 
-  override def instrumentActions(config: Config): InstrumentActions[F] =
+  override def instrumentActions(config: CleanConfig): InstrumentActions[F] =
     InstrumentActions.defaultInstrumentActions[F]
 }
 
@@ -110,14 +106,14 @@ object Nifs {
   val name: String = INSTRUMENT_NAME_PROP
 
   private def centralWavelength(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, CentralWavelength] =
     config
       .extractInstAs[JDouble](CENTRAL_WAVELENGTH_PROP)
       .map(_.doubleValue)
       .map(tag[CentralWavelengthD][Double])
 
-  private def maskOffset(config: Config): Either[ExtractFailure, MaskOffset] =
+  private def maskOffset(config: CleanConfig): Either[ExtractFailure, MaskOffset] =
     config
       .extractInstAs[JDouble](MASK_OFFSET_PROP)
       .map(_.doubleValue)
@@ -129,7 +125,7 @@ object Nifs {
       case _                 => WindowCover.Opened
     }
 
-  private def otherCCConfig(config: Config): Either[ExtractFailure, CCConfig] =
+  private def otherCCConfig(config: CleanConfig): Either[ExtractFailure, CCConfig] =
     for {
       filter    <- config.extractInstAs[Filter](FILTER_PROP)
       mask      <- config.extractInstAs[Mask](MASK_PROP)
@@ -140,47 +136,47 @@ object Nifs {
       wc        <- extractObsType(config).map(windowCoverFromObserveType)
     } yield StdCCConfig(filter, mask, disperser, imMirror, cw, mo, wc)
 
-  private def getCCConfig(config: Config): Either[ExtractFailure, CCConfig] =
+  private def getCCConfig(config: CleanConfig): Either[ExtractFailure, CCConfig] =
     extractObsType(config).flatMap {
       case DARK_OBSERVE_TYPE => DarkCCConfig.asRight
       case _                 => otherCCConfig(config)
     }
 
   private def extractExposureTime(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Time] =
     config
       .extractObsAs[JDouble](EXPOSURE_TIME_PROP)
       .map(_.toDouble.seconds)
 
-  private def extractCoadds(config: Config): Either[ExtractFailure, Coadds] =
+  private def extractCoadds(config: CleanConfig): Either[ExtractFailure, Coadds] =
     config
       .extractObsAs[JInt](COADDS_PROP)
       .map(_.toInt)
       .map(tag[CoaddsI][Int])
 
   private def extractPeriod(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Option[Period]] =
     config.extractInstInt[PeriodI](PERIOD_PROP)
 
   private def extractNrResets(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Option[NumberOfResets]] =
     config.extractInstInt[NumberOfResetsI](NUMBER_OF_RESETS_PROP)
 
   private def extractNrPeriods(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Option[NumberOfPeriods]] =
     config.extractInstInt[NumberOfPeriodsI](NUMBER_OF_PERIODS_PROP)
 
   private def extractObsReadMode(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, ReadMode] =
     config.extractInstAs[ReadMode](READMODE_PROP)
 
   private def extractEngReadMode(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Option[EngReadMode]] =
     config
       .extractInstAs[EngReadMode](ENGINEERING_READMODE_PROP)
@@ -190,7 +186,7 @@ object Nifs {
       }
 
   private def extractReadMode(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Either[EngReadMode, ReadMode]] =
     for {
       eng <- extractEngReadMode(config)
@@ -198,16 +194,16 @@ object Nifs {
     } yield eng.map(_.asLeft).getOrElse(obs.asRight)
 
   private def extractNrSamples(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, Option[NumberOfSamples]] =
     config.extractInstInt[NumberOfSamplesI](NUMBER_OF_SAMPLES_PROP)
 
   private def extractObsType(
-    config: Config
+    config: CleanConfig
   ): Either[ExtractFailure, String] =
     config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
 
-  private def getDCConfig(config: Config): Either[ExtractFailure, DCConfig] =
+  private def getDCConfig(config: CleanConfig): Either[ExtractFailure, DCConfig] =
     for {
       coadds    <- extractCoadds(config)
       period    <- extractPeriod(config)
@@ -225,7 +221,7 @@ object Nifs {
           StdDCConfig(coadds, period, expTime, nrResets, nrPeriods, samples, readMode)
       }
 
-  def fromSequenceConfig(config: Config): TrySeq[NifsConfig] =
+  def fromSequenceConfig(config: CleanConfig): TrySeq[NifsConfig] =
     for {
       cc <- getCCConfig(config).asTrySeq
       dc <- getDCConfig(config).asTrySeq

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorth.scala
@@ -10,12 +10,12 @@ import cats.implicits._
 import mouse.all._
 import seqexec.model.enum.{M1Source, NodAndShuffleStage, Resource, TipTiltSource}
 import edu.gemini.spModel.target.obsComp.TargetObsCompConstants._
-import edu.gemini.spModel.config2.Config
 import edu.gemini.spModel.core.Wavelength
 import edu.gemini.spModel.guide.StandardGuideOptions
 import monocle.macros.Lenses
 import org.log4s.getLogger
-import seqexec.server.{ConfigResult, InstrumentSystem, SeqexecFailure}
+import seqexec.server.{CleanConfig, ConfigResult, InstrumentSystem, SeqexecFailure}
+import seqexec.server.CleanConfig.extractItem
 import seqexec.server.altair.Altair
 import seqexec.server.altair.AltairController.AltairConfig
 import seqexec.server.tcs.TcsController._
@@ -51,7 +51,7 @@ class TcsNorth[F[_]: Sync: MonadError[?[_], Throwable]] private(tcsController: T
     }
   }
 
-  override def configure(config: Config): F[ConfigResult[F]] =
+  override def configure(config: CleanConfig): F[ConfigResult[F]] =
     buildTcsConfig.flatMap{ cfg =>
       Log.debug(s"Applying TCS configuration: ${subsystems.toList.flatMap(subsystemConfig(cfg, _))}").pure[F] *>
         tcsController.applyConfig(subsystems, gaos, cfg).as(ConfigResult(this))
@@ -162,7 +162,7 @@ object TcsNorth {
                              gaos: Option[Altair[F]],
                              instrument: InstrumentSystem[F],
                              guideConfigDb: GuideConfigDb[F]
-                            )(config: Config,
+                            )(config: CleanConfig,
                               lightPath: LightPath,
                               observingWavelength: Option[Wavelength]
   ): TcsNorth[F] = {

--- a/modules/seqexec/server/src/test/scala/seqexec/server/CleanConfigSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/CleanConfigSpec.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import edu.gemini.spModel.config2.{DefaultConfig, ItemEntry, ItemKey}
+import org.scalatest.{FlatSpec, Matchers}
+import ConfigUtilOps._
+
+class CleanConfigSpec extends FlatSpec with Matchers {
+
+  val k1: ItemKey = new ItemKey("instrument:param1")
+  val k2: ItemKey = new ItemKey("instrument:param2")
+  val k3: ItemKey = new ItemKey("instrument:param3")
+  val strVal: String = "dummy"
+  val jIntVal: java.lang.Integer = 1234
+
+  class Daddy
+
+  class Son extends Daddy
+
+  val c0Val = new Daddy
+  val c1Val = new Son
+
+  val testConfig = new DefaultConfig(
+    Array(
+      new ItemEntry(k1, strVal),
+      new ItemEntry(k2, c0Val)
+    )
+  )
+
+  "CleanConfig" must "fail construction if given a set of overrides with conflicting types" in {
+    an [java.lang.AssertionError] shouldBe thrownBy {
+      new CleanConfig(
+        testConfig,
+        Map(
+          k1 -> (jIntVal:AnyRef)
+        )
+      )
+    }
+  }
+
+  it must "not thrown exception when constructing with overrides of the existing types" in {
+    noException shouldBe thrownBy {
+      new CleanConfig(
+        testConfig,
+        Map(
+          k1 -> "mummy"
+        )
+      )
+    }
+  }
+
+  it must "not thrown exception when constructing with overrides of derived types" in {
+    noException shouldBe thrownBy {
+      new CleanConfig(
+        testConfig,
+        Map(
+          k2 -> c1Val
+        )
+      )
+    }
+  }
+
+  it must "override values in config" in {
+    val newVal = "ymmud"
+
+    val clCfg = new CleanConfig(
+      testConfig,
+      Map(
+        k1 -> newVal
+      )
+    )
+    clCfg.extractAs[String](k1) shouldBe Right(newVal)
+
+  }
+
+}

--- a/modules/seqexec/server/src/test/scala/seqexec/server/ConfigUtilSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/ConfigUtilSpec.scala
@@ -5,12 +5,10 @@ package seqexec.server
 
 import edu.gemini.spModel.config2.{Config, DefaultConfig, ItemEntry, ItemKey}
 import edu.gemini.spModel.seqcomp.SeqConfigNames
-import seqexec.model.enum.SystemName
 import org.scalacheck.{Arbitrary, _}
 import org.scalacheck.Arbitrary._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
-import cats.implicits._
 
 trait ConfigArbitraries {
 
@@ -65,13 +63,6 @@ class ConfigUtilSpec extends FlatSpec with Matchers with EitherValues with Prope
         c.extract(k).as[String].left.value should matchPattern {
           case KeyNotFound(_) =>
         }
-      }
-    }
-    it should "convert to StepConfig" in {
-      forAll { (c: Config) =>
-        // Not much to check but at least verify the amount of subsystems
-        val subsystems = c.getKeys.map(_.getRoot.getName).map(SystemName.unsafeFromString).distinct
-        c.toStepConfig.keys should contain theSameElementsAs subsystems
       }
     }
 }


### PR DESCRIPTION
Flats, arcs and biases steps inserted in a N&S sequence have N&S parameters that the Seqexec might try to apply. This is not supported, and the old Seqexec deals with them by treating them as no N&S steps.
I tried different approaches, like trying to cancel the effects of the N&S parameters everywhere they are used, but at the end I went for the simpler solution of fixing the step configuration by overriding the `useNS` parameter. The class used to read the step configuration is a mutable Java class (`Config`). To avoid mutation I built a wrapper, and passed it instead of the original `Config`.