### PR TITLE
SEQNG-1055 Use dataId in call to sequenceStart.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -4,18 +4,16 @@
 package seqexec.server
 
 import cats._
-import cats.data.EitherT
 import cats.implicits._
-import edu.gemini.spModel.obscomp.InstConstants._
 import fs2.Stream
 import gem.Observation
 import io.chrisdavenport.log4cats.Logger
 import seqexec.engine._
 import seqexec.model.dhs._
 import seqexec.model.enum.ObserveCommandResult
-import seqexec.server.ConfigUtilOps._
 import seqexec.server.InstrumentSystem.ElapsedTime
 import squants.time.TimeConversions._
+import SeqTranslate.dataIdFromConfig
 
 /**
   * Methods usedd to generate observation related actions
@@ -110,14 +108,7 @@ trait ObserveActions {
   def dataId[F[_]: MonadError[?[_], Throwable]](
     env: ObserveEnvironment[F]
   ): F[DataId] =
-    EitherT
-      .fromEither[F](
-        env.config
-          .extractObsAs[String](DATA_LABEL_PROP)
-          .map(toDataId)
-          .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
-      )
-      .widenRethrowT
+    dataIdFromConfig[F](env.config)
 
   /**
     * Preamble for observations. It tells the odb, the subsystems

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -47,6 +47,8 @@ import seqexec.server.altair.AltairLgsHeader
 import seqexec.server.altair.AltairKeywordReaderEpics
 import seqexec.server.altair.AltairKeywordReaderDummy
 import seqexec.server.gems.{Gems, GemsEpics, GemsHeader, GemsKeywordReaderDummy, GemsKeywordReaderEpics}
+import seqexec.server.CleanConfig.extractItem
+import seqexec.server.ConfigUtilOps._
 import squants.Time
 import squants.time.TimeConversions._
 
@@ -567,7 +569,7 @@ object SeqTranslate {
     def toAction(kind: ActionType): Action[F] = fromF[F](kind, x.map(r => Result.OK(Response.Configured(r.sys.resource))))
   }
 
-  def dataIdFromConfig[F[_]: MonadError[?[_], Throwable]](config: Config): F[DataId] =
+  def dataIdFromConfig[F[_]: MonadError[?[_], Throwable]](config: CleanConfig): F[DataId] =
     EitherT
       .fromEither[F](
         config


### PR DESCRIPTION
Fixed bug where the notification send to the ODB to signal the start of the sequence execution was not using the dataId.