### PR TITLE
SEQNG-1048 Fixes actions for N&S on multiple cycles

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
@@ -54,8 +54,8 @@ trait InstrumentActions[F[_]] {
 object InstrumentActions {
 
   /**
-   * This is the default observe action, just a simple observe call
-   */
+    * This is the default observe action, just a simple observe call
+    */
   def defaultObserveActions[F[_]](
     observeResults: Stream[F, Result[F]]
   ): List[ParallelActions[F]] =
@@ -67,11 +67,13 @@ object InstrumentActions {
       )
     )
 
-  def safeObserve[F[_]: MonadError[?[_], Throwable]: Logger](
-    env: ObserveEnvironment[F], doObserve: (ImageFileId, ObserveEnvironment[F]) => Stream[F, Result[F]]
+  def launchObserve[F[_]: MonadError[?[_], Throwable]: Logger](
+    env:       ObserveEnvironment[F],
+    doObserve: (ImageFileId, ObserveEnvironment[F]) => Stream[F, Result[F]]
   ): Stream[F, Result[F]] =
     Stream.eval(FileIdProvider.fileId(env)).flatMap { fileId =>
-      Stream.emit(Result.Partial(FileIdAllocated(fileId))) ++ doObserve(fileId, env)
+      Stream.emit(Result.Partial(FileIdAllocated(fileId))) ++
+        doObserve(fileId, env)
     }
 
   /**
@@ -90,7 +92,7 @@ object InstrumentActions {
         post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
       ): List[ParallelActions[F]] =
         defaultObserveActions(
-          post(safeObserve(env, ObserveActions.stdObserve[F]), env)
+          post(launchObserve(env, ObserveActions.stdObserve[F]), env)
         )
 
       def runInitialAction(stepType: StepType): Boolean = true

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -165,7 +165,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
   }
 
   private def deliverObserveCmd(seqId: Observation.Id, f: ObserveControl[IO] => IO[Unit])(st: EngineState)(
-    implicit tio: Timer[IO]
+    implicit tio: Timer[IO], cio: Concurrent[IO]
   ): Option[Stream[IO, executeEngine.EventType]] = {
     def isObserving(v: Action[IO]): Boolean = v.kind === ActionType.Observe && (v.state.runState match {
       case ActionState.Started => true
@@ -224,7 +224,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
   }
 
   def pauseObserve(seqId: Observation.Id)(
-    implicit tio: Timer[IO]
+    implicit tio: Timer[IO], cio: Concurrent[IO]
   ): EngineState => Option[Stream[IO, executeEngine.EventType]] = {
     def f(oc: ObserveControl[IO]): IO[Unit] = oc match {
       case CompleteControl(_, _, PauseObserveCmd(pause), _, _, _) => pause
@@ -324,7 +324,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
   }
 
   def toInstrumentSys(inst: Instrument)(
-    implicit ev: Timer[IO]
+    implicit ev: Timer[IO], cio: Concurrent[IO]
   ): TrySeq[InstrumentSystem[IO]] = inst match {
     case Instrument.F2    => TrySeq(Flamingos2(systems.flamingos2, systems.dhs))
     case Instrument.GmosS => TrySeq(GmosSouth(systems.gmosSouth, systems.dhs))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -8,6 +8,7 @@ import cats.data.Kleisli
 import cats.data.EitherT
 import cats.data.NonEmptyList
 import cats.implicits._
+import cats.effect.Concurrent
 import gem.enum.LightSinkName
 import gsp.math.Angle
 import gsp.math.Offset
@@ -40,7 +41,7 @@ import squants.space.Length
 import squants.{Seconds, Time}
 import squants.space.LengthConversions._
 
-abstract class Gmos[F[_]: MonadError[?[_], Throwable]: Logger, T <: GmosController.SiteDependentTypes]
+abstract class Gmos[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger, T <: GmosController.SiteDependentTypes]
 (controller: GmosController[F, T], ss: SiteSpecifics[T])
 (configTypes: GmosController.Config[T]) extends DhsInstrument[F] with InstrumentSystem[F] {
   import Gmos._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
@@ -25,16 +25,33 @@ import seqexec.server.Progress
 import squants.Time
 import scala.concurrent.duration._
 
+/**
+  * Keep track of the current execution state
+  */
 @Lenses
 final case class NSCurrent(
   fileId:        ImageFileId,
+  totalCycles:   Int,
   exposureCount: Int,
   expTime:       Time
-)
+) {
+  def lastSubexposure: Boolean =
+    (exposureCount + 1) === totalCycles * Gmos.NsSequence.length
+
+  val cycle = exposureCount / Gmos.NsSequence.length
+}
+
+object NSCurrent {
+  implicit val showNSCurrent: Show[NSCurrent] = Show.show { a =>
+    s"NS State: file=${a.fileId}, cycle=${a.cycle + 1}, stage=${Gmos.NsSequence.toList
+      .lift(a.exposureCount % Gmos.NsSequence.length)
+      .getOrElse("Unknown")}/${a.exposureCount % Gmos.NsSequence.length}, subexposure=${a.exposureCount + 1}, expTime=${a.expTime}"
+  }
+}
 
 /**
- * Used to keep the internal state of NS
- */
+  * Used to keep the internal state of NS
+  */
 @Lenses
 final case class NSObsState(config: NSConfig, current: Option[NSCurrent])
 
@@ -52,6 +69,7 @@ object NSObsState {
 
   val expTime: Optional[NSObsState, Time] =
     NSObsState.current ^<-? some ^|-> NSCurrent.expTime
+
 }
 
 object GmosControllerSim {
@@ -67,17 +85,18 @@ object GmosControllerSim {
         nsConfig.modify {
           case s @ NSObsState(NSConfig.NoNodAndShuffle, _) =>
             (s, s)
-          case s @ NSObsState(NSConfig.NodAndShuffle(_, _, _), _) =>
+          case s @ NSObsState(NSConfig.NodAndShuffle(cycles, _, _), _) =>
+            // Initialize the current state
             val update =
-              NSObsState.current.set(NSCurrent(fileId, 0, expTime).some)
+              NSObsState.current.set(NSCurrent(fileId, cycles, 0, expTime).some)
             (update(s), update(s))
         } >>= {
-          case NSObsState(NSConfig.NoNodAndShuffle, _) =>
-            sim.observe(fileId, expTime) // Regular observation
-          case NSObsState(NSConfig.NodAndShuffle(_, _, _), _) =>
-            sim.log(s"Simulate Gmos N&S observation with label $fileId and $expTime") *>
+          case NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(curr)) =>
+            sim.log(s"Simulate Gmos N&S observation ${curr.show}") *>
               // Initial N&S obs
               sim.observe(fileId, expTime).as(ObserveCommandResult.Partial)
+          case NSObsState(_, _) =>
+            sim.observe(fileId, expTime) // Regular observation
         }
 
       override def applyConfig(config: GmosConfig[T]): F[Unit] =
@@ -98,22 +117,23 @@ object GmosControllerSim {
 
       override def resumePaused(expTime: Time): F[ObserveCommandResult] =
         nsConfig.modify {
-          case s @ NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(NSCurrent(_, exposureCount, _)))
-              if exposureCount < Gmos.NsSequence.length =>
-              // We should keep track of where on a N&S Sequence are we
-            (NSObsState.exposureCount.modify(_ + 1)(s),
-             NSObsState.exposureCount.modify(_ + 1)(s))
+          case s @ NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(curr))
+              if !curr.lastSubexposure =>
+            // We should keep track of where on a N&S Sequence are we
+            // Let's just increase the exposure counter
+            val upd = NSObsState.exposureCount.modify(_ + 1)
+            (upd(s), upd(s))
           case s =>
             (s, s)
         } >>= {
-          case NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(NSCurrent(fileId, exposureCount, expTime)))
-              if exposureCount < Gmos.NsSequence.length - 1 =>
-            sim.log(s"Next Nod ${exposureCount + 1}, stage: ${Gmos.NsSequence.toList.lift(exposureCount).getOrElse("Unknown")}") *>
-              sim.observe(fileId, expTime).as(ObserveCommandResult.Partial)
-          case NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(NSCurrent(fileId, exposureCount, expTime)))
-              if exposureCount === Gmos.NsSequence.length - 1 =>
-            sim.log(s"Final Nod ${exposureCount + 1}, stage: ${Gmos.NsSequence.toList.lift(exposureCount).getOrElse("Unknown")}") *>
-              sim.observe(fileId, expTime)
+          case NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(curr))
+              if !curr.lastSubexposure =>
+            sim.log(s"Next Nod ${curr.show}") *>
+              sim.observe(curr.fileId, expTime).as(ObserveCommandResult.Partial)
+          case NSObsState(NSConfig.NodAndShuffle(_, _, _), Some(curr))
+              if curr.lastSubexposure =>
+            sim.log(s"Final Nod ${curr.show}") *>
+              sim.observe(curr.fileId, expTime)
           case _ =>
             // Regular observation
             sim.resumePaused

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -149,7 +149,7 @@ class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Concurrent: Logge
     // Configure GMOS rows
     Stream.eval(
       inst.configureShuffle(rowsToShuffle).as(Result.Partial(NSRowsConfigure))
-    ).mergeHaltBoth(
+    ).merge(
       // TCS Nod
       (env.getTcs, nsPositionO).mapN {
         case (tcs, nsPos) =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -5,23 +5,41 @@ package seqexec.server.gmos
 
 import cats._
 import cats.implicits._
-import cats.data.NonEmptyList
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
-import seqexec.model.ActionType
 import seqexec.model.dhs._
+import seqexec.model.enum.NodAndShuffleStage
 import seqexec.model.enum.NodAndShuffleStage._
-import seqexec.model.enum.{Guiding, ObserveCommandResult}
-import seqexec.engine.Action
+import seqexec.model.enum.Guiding
+import seqexec.model.enum.ObserveCommandResult
 import seqexec.engine.ParallelActions
 import seqexec.engine.Result
-import seqexec.server.{CleanConfig, FileIdAllocated, FileIdProvider, InstrumentActions, ObserveActions, ObserveContext, ObserveEnvironment, Response, StepType}
-import seqexec.server.SeqTranslate._
+import seqexec.server.CleanConfig
+import seqexec.server.FileIdAllocated
+import seqexec.server.FileIdProvider
+import seqexec.server.InstrumentActions
+import seqexec.server.ObserveActions
+import seqexec.server.ObserveContext
+import seqexec.server.ObserveEnvironment
+import seqexec.server.StepType
+import seqexec.server.InstrumentActions._
 import seqexec.server.ObserveActions._
-import seqexec.server.gmos.GmosController.Config.{NSConfig, NSPosition}
-import seqexec.server.tcs.TcsController.{InstrumentOffset, OffsetP, OffsetQ}
+import seqexec.server.gmos.GmosController.Config._
+import seqexec.server.tcs.TcsController.InstrumentOffset
+import seqexec.server.tcs.TcsController.OffsetP
+import seqexec.server.tcs.TcsController.OffsetQ
 import shapeless.tag
 import squants.space.AngleConversions._
+
+final case class Subexposure(
+  totalCycles: Int,
+  cycle:       Int,
+  id:          Int,
+  stage:       NodAndShuffleStage
+) {
+  val firstSubexposure = cycle === 0 && id === 0
+  val lastSubexposure  = cycle === totalCycles - 1 && id === Gmos.NsSequence.length - 1
+}
 
 /**
   * Gmos needs different actions for N&S
@@ -43,32 +61,32 @@ class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger, A <: Gmos
     dataId: DataId,
     env:    ObserveEnvironment[F]
   )(r:      ObserveCommandResult): Stream[F, Result[F]] =
-    Stream.eval(r match {
-      case ObserveCommandResult.Success =>
-        okTail(fileId, dataId, stopped = false, env).map(Stream.emit)
-      case ObserveCommandResult.Stopped =>
-        okTail(fileId, dataId, stopped = true, env).map(Stream.emit)
-      case ObserveCommandResult.Aborted =>
-        abortTail(env.systems, env.obsId, fileId).map(Stream.emit)
-      case ObserveCommandResult.Paused =>
-        env.inst
-          .calcObserveTime(env.config)
-          .map(
-            e =>
-              Stream.emit(
-                Result
-                  .Paused(ObserveContext(observeTail(fileId, dataId, env), e))
-              )
-          )
-      case ObserveCommandResult.Partial =>
-        Stream
-          .emits[F, Result[F]](
-            List(Result.Partial(NSStep), Result.OK(Response.Ignored))
-          )
-          .pure[F]
-    }).flatten
+    Stream
+      .eval(r match {
+        case ObserveCommandResult.Success =>
+          okTail(fileId, dataId, stopped = false, env).map(Stream.emit)
+        case ObserveCommandResult.Stopped =>
+          okTail(fileId, dataId, stopped = true, env).map(Stream.emit)
+        case ObserveCommandResult.Aborted =>
+          abortTail(env.systems, env.obsId, fileId).map(Stream.emit)
+        case ObserveCommandResult.Paused =>
+          env.inst
+            .calcObserveTime(env.config)
+            .map(
+              e =>
+                Stream.emit(
+                  Result
+                    .Paused(ObserveContext(observeTail(fileId, dataId, env), e))
+                )
+            )
+        case ObserveCommandResult.Partial =>
+          Stream
+            .emit[F, Result[F]](Result.Partial(NSStep))
+            .pure[F]
+      })
+      .flatten
 
-  private def startObserve(
+  private def initialObserve(
     fileId: ImageFileId,
     env:    ObserveEnvironment[F]
   ): Stream[F, Result[F]] =
@@ -78,130 +96,128 @@ class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger, A <: Gmos
       ret              <- observeTail(fileId, dataId, env)(result)
     } yield ret
 
-  private def completeObserve(
+  private def lastObserve(
     fileId: ImageFileId,
     env:    ObserveEnvironment[F]
   ): Stream[F, Result[F]] =
-    Stream.eval(for {
-      dataId  <- dataId(env)
-      timeout <- inst.calcObserveTime(env.config)
-      ret     <- inst.continueCommand(timeout)
-    } yield observeTail(fileId, dataId, env)(ret)).flatten
+    // the last step completes the observations doing an observeTail
+    Stream
+      .eval(for {
+        dataId  <- dataId(env)
+        timeout <- inst.calcObserveTime(env.config)
+        ret     <- inst.continueCommand(timeout)
+      } yield observeTail(fileId, dataId, env)(ret))
+      .flatten ++
+      Stream.emit[F, Result[F]](Result.Partial(NSComplete))
 
-  private def observe(i: Int, env: ObserveEnvironment[F])(fileId: ImageFileId): Stream[F, Result[F]] =
-    if (i === 0) {
-      // The first steps allocates a file and runs the firt observe
-      Stream.emit[F, Result[F]](Result.Partial(FileIdAllocated(fileId))) ++
-        startObserve(fileId, env)
-    } else if (i === Gmos.NsSequence.length - 1) {
-      // the last step completes the observations with a complete and a tail
-      completeObserve(fileId, env) ++
-        Stream.emit[F, Result[F]](Result.Partial(NSComplete))
-    } else {
-      // Steps in betweet do a continue
-      Stream
-        .eval(
-          inst
-            .calcObserveTime(env.config)
-            .flatMap(inst.continueCommand)
-        )
-        .as(Result.Partial(NSContinue)) ++
-        Stream.emit(Result.OK(Response.Ignored))
-    }
-
-  // TODO reduce duplication with respect to InstrumentActions.safeObserve
-  private def safeObserve(
-    i: Int,
+  private def continueObserve(
     env: ObserveEnvironment[F]
   ): Stream[F, Result[F]] =
-    Stream.eval(FileIdProvider.fileId(env)).flatMap { fileId =>
-      observe(i, env)(fileId)
-    }
+    // Steps in between do a continue
+    Stream
+      .eval(
+        inst
+          .calcObserveTime(env.config)
+          .flatMap(inst.continueCommand)
+      )
+      .as(Result.Partial(NSContinue))
+
+  // Calculate the subexposures
+  private def subexposures(
+    cycles: Int
+  ): List[Subexposure] =
+    (for {
+      i     <- 0 until cycles
+      j     <- 0 until Gmos.NsSequence.length
+      stage = Gmos.NsSequence.toList.lift(j).getOrElse(StageA)
+    } yield Subexposure(cycles, i, j, stage)).toList
 
   /**
-   * Calculate the actions for a N&S cycle
-   */
-  private def actionPositions(
-    env:   ObserveEnvironment[F],
-    rows:  Int,
+    * Stream of actions of one sub exposure
+    */
+  def oneSubExposure(
+    fileId:    ImageFileId,
+    sub:       Subexposure,
+    rows:      Int,
     positions: Vector[NSPosition],
-    post:  (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
-  ): List[ParallelActions[F]] =
-    Gmos.NsSequence.zipWithIndex
-      .map {
-        case (stage, i) =>
-          val rowsToShuffle = if (stage === StageA) 0 else rows
-          val nsPositionO = positions.find(_.stage === stage)
-          List(
-            // Configure rows to shuffle
-            NonEmptyList(
-              inst
-                .configureShuffle(rowsToShuffle)
-                .as(Response.Configured(inst.resource))
-                .toAction(ActionType.Configure(inst.resource)),
-              (env.getTcs, nsPositionO).mapN{ case (tcs, nsPos) =>
-                tcs.nod(
-                  stage,
-                  InstrumentOffset(
-                    tag[OffsetP](nsPos.offset.p.toRadians.radians), tag[OffsetQ](nsPos.offset.q.toRadians.radians)),
-                  nsPos.guide === Guiding.Guide
-                ).toAction(ActionType.Configure(tcs.resource))
-              }.toList
-            ),
-            // Do an obs observe/continue
-            NonEmptyList.one(
-              Action(
-                ActionType.Observe,
-                post( // post lets upstream to mix progress events
-                  safeObserve(i, env),
-                  env
+    env:       ObserveEnvironment[F],
+    post:      (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+  ): Stream[F, Result[F]] = {
+    val rowsToShuffle = if (sub.stage === StageA) 0 else rows
+    val nsPositionO   = positions.find(_.stage === sub.stage)
+    // Configure GMOS rows
+    Stream.eval(
+      inst.configureShuffle(rowsToShuffle).as(Result.Partial(NSRowsConfigure))
+    ) ++
+      // TCS Nod
+      (env.getTcs, nsPositionO).mapN {
+        case (tcs, nsPos) =>
+          Stream.eval(
+            tcs
+              .nod(
+                sub.stage,
+                InstrumentOffset(
+                  tag[OffsetP](nsPos.offset.p.toRadians.radians),
+                  tag[OffsetQ](nsPos.offset.q.toRadians.radians)
                 ),
-                Action.State(Action.ActionState.Idle, Nil)
+                nsPos.guide === Guiding.Guide
               )
-            )
+              .as(Result.Partial(NSTCSNod))
           )
-      }
-      .toList
-      .flatten
+      }.orEmpty ++
+      // Observes for each subexposure
+      (if (sub.firstSubexposure) {
+         post(initialObserve(fileId, env), env)
+       } else if (sub.lastSubexposure) {
+         post(lastObserve(fileId, env), env)
+       } else {
+         post(continueObserve(env), env)
+       })
+  }
 
-  private def nsActions(env:  ObserveEnvironment[F],
-                        post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
-                       )
-  : List[ParallelActions[F]] =
+  private def doObserve(
+    fileId: ImageFileId,
+    env:    ObserveEnvironment[F],
+    post:   (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+  ): Stream[F, Result[F]] =
     Gmos
       .nsConfig(config)
-      .map {
+      .foldMap {
         case NSConfig.NoNodAndShuffle =>
-          // This shouldn't happen but we need to code it anyway
-          Nil
+          Stream.empty
         case NSConfig.NodAndShuffle(cycles, rows, positions) =>
           // Initial notification of N&S Starting
-          NonEmptyList.one(
-            Action(ActionType.Undefined,
-                   Stream.emits[F, Result[F]](
-                     List(Result.Partial(NSStart),
-                          Result.OK(Response.Ignored))
-                   ),
-                   Action.State(Action.ActionState.Idle, Nil))
-          ) ::
-            actionPositions(env, rows, positions, post) // Add steps for each cycle
-              .replicateA(cycles)
-              .toList
-              .flatten
+          Stream.emit[F, Result[F]](Result.Partial(NSStart)) ++
+            // each subexposure actions
+            subexposures(cycles)
+              .map {
+                oneSubExposure(fileId, _, rows, positions, env, post)
+              }
+              .reduceOption(_ ++ _)
+              .orEmpty
       }
-      .getOrElse(Nil)
+
+  def launchObserve(
+    env:  ObserveEnvironment[F],
+    post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+  ): Stream[F, Result[F]] =
+    Stream.eval(FileIdProvider.fileId(env)).flatMap { fileId =>
+      Stream.emit(Result.Partial(FileIdAllocated(fileId))) ++ doObserve(fileId, env, post)
+    }
 
   override def observeActions(
     env:  ObserveEnvironment[F],
     post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
   ): List[ParallelActions[F]] =
     env.stepType match {
-      case StepType.NodAndShuffle(i) if i === inst.resource => nsActions(env, post)
-      case StepType.DarkOrBiasNS(i) if i === inst.resource  => nsActions(env, post)
+      case StepType.NodAndShuffle(i) if i === inst.resource =>
+        defaultObserveActions(launchObserve(env, post))
+      case StepType.DarkOrBiasNS(i) if i === inst.resource  =>
+        defaultObserveActions(launchObserve(env, post))
 
       case _ =>
         // Regular GMOS obseravtions behave as any instrument
-        InstrumentActions.defaultInstrumentActions[F].observeActions(env, post)
+        defaultInstrumentActions[F].observeActions(env, post)
     }
 
   def runInitialAction(stepType: StepType): Boolean = true

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -5,6 +5,7 @@ package seqexec.server.gmos
 
 import cats.MonadError
 import cats.implicits._
+import cats.effect.Concurrent
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.{CleanConfig, ConfigUtilOps}
@@ -21,7 +22,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosNorthController[F], dhsClient: DhsClient[F]) extends Gmos[F, NorthTypes](c,
+final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](c: GmosNorthController[F], dhsClient: DhsClient[F]) extends Gmos[F, NorthTypes](c,
   new SiteSpecifics[NorthTypes] {
     override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
     override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
@@ -42,5 +43,5 @@ final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosNor
 object GmosNorth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosController[F, NorthTypes], dhsClient: DhsClient[F]): GmosNorth[F] = new GmosNorth[F](c, dhsClient)
+  def apply[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](c: GmosController[F, NorthTypes], dhsClient: DhsClient[F]): GmosNorth[F] = new GmosNorth[F](c, dhsClient)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -5,6 +5,7 @@ package seqexec.server.gmos
 
 import cats.MonadError
 import cats.implicits._
+import cats.effect.Concurrent
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.{CleanConfig, ConfigUtilOps}
@@ -21,7 +22,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosSouth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosSouthController[F], dhsClient: DhsClient[F]) extends Gmos[F, SouthTypes](c,
+final case class GmosSouth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](c: GmosSouthController[F], dhsClient: DhsClient[F]) extends Gmos[F, SouthTypes](c,
   new SiteSpecifics[SouthTypes] {
     override val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
     override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
@@ -43,5 +44,5 @@ final case class GmosSouth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosSou
 object GmosSouth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosController[F, SouthTypes], dhsClient: DhsClient[F]): GmosSouth[F] = new GmosSouth[F](c, dhsClient)
+  def apply[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](c: GmosController[F, SouthTypes], dhsClient: DhsClient[F]): GmosSouth[F] = new GmosSouth[F](c, dhsClient)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
@@ -8,6 +8,8 @@ import seqexec.engine.Result.PartialVal
 package gmos {
   // N&S Partials. TODO add more details about the current step
   case object NSStart extends PartialVal
+  case object NSRowsConfigure extends PartialVal
+  case object NSTCSNod extends PartialVal
   case object NSStep extends PartialVal
   case object NSContinue extends PartialVal
   case object NSComplete extends PartialVal


### PR DESCRIPTION
N&S with multiple cycles was not properly done, in part because of a misunderstanding  of the  `replicateA`, method. However the simple fix also showed some other issues which led to a larger rewrite.
N&S was originally done with multiple actions for each subexposure but instead it needs to be done with a single large action

More was discussed about this here:
https://gist.github.com/cquiroz/50ae3fe89711243a9f06a0515c257bad

The simulator also needed updates to support multiple cycles