### PR TITLE
SEQNG-1040 Fixed issue with mixing real GeMS with simulated GSAOI.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerEpics.scala
@@ -153,7 +153,7 @@ object GemsControllerEpics {
   val Log = getLogger
 
   def apply[F[_]: Async](epicsSys: => GemsEpics[F],
-                         gsaoiGuider: => GsaoiGuider[F]
+                         gsaoiGuider: GsaoiGuider[F]
                         )
   : GemsController[F] = new GemsControllerEpics[F](epicsSys, gsaoiGuider)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerEpics.scala
@@ -96,7 +96,7 @@ object GsaoiControllerEpics {
     guiding: Boolean
   )
 
-  def apply(): GsaoiController[IO] with GsaoiGuider[IO] = new GsaoiController[IO] with GsaoiGuider[IO] {
+  def apply(): GsaoiFullHandler[IO] = new GsaoiFullHandler[IO] {
 
     private val epicsSys = GsaoiEpics.instance
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerEpics.scala
@@ -96,7 +96,7 @@ object GsaoiControllerEpics {
     guiding: Boolean
   )
 
-  def apply(): GsaoiController[IO] = new GsaoiController[IO] {
+  def apply(): GsaoiController[IO] with GsaoiGuider[IO] = new GsaoiController[IO] with GsaoiGuider[IO] {
 
     private val epicsSys = GsaoiEpics.instance
 
@@ -205,5 +205,28 @@ object GsaoiControllerEpics {
       gd <- epicsSys.guiding
     } yield EpicsGsaoiConfig(fl, uw, wc, rm, ro, co, et, fo, gd)
 
+    override def currentState: IO[GsaoiGuider.GuideState] = for {
+      guide <- epicsSys.guiding
+      m1    <- epicsSys.odgw1Multiplier
+      m2    <- epicsSys.odgw1Multiplier
+      m3    <- epicsSys.odgw1Multiplier
+      m4    <- epicsSys.odgw1Multiplier
+    } yield new GsaoiGuider.GuideState {
+      override def isGuideActive: Boolean = guide
+
+      override def isOdgwGuiding(odgwId: GsaoiGuider.OdgwId): Boolean = {
+        import GsaoiGuider.OdgwId._
+        odgwId match {
+          case Odgw1 => guide && m1 > 0
+          case Odgw2 => guide && m2 > 0
+          case Odgw3 => guide && m3 > 0
+          case Odgw4 => guide && m4 > 0
+        }
+      }
+    }
+
+    override def guide: IO[Unit] = epicsSys.guideCmd.mark[IO] *> epicsSys.guideCmd.post[IO].void
+
+    override def endGuide: IO[Unit] = epicsSys.endGuideCmd.mark[IO] *> epicsSys.guideCmd.post[IO].void
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerSim.scala
@@ -18,8 +18,8 @@ import squants.Time
 import squants.time.TimeConversions._
 
 object GsaoiControllerSim {
-  def unsafeApply[F[_]: Sync: Logger: Timer]: GsaoiController[F] =
-    new GsaoiController[F] {
+  def unsafeApply[F[_]: Sync: Logger: Timer]: GsaoiController[F] with GsaoiGuider[F] =
+    new GsaoiController[F] with GsaoiGuider[F] {
       private val sim: InstrumentControllerSim[F] = InstrumentControllerSim.unsafeApply(s"GSAOI")
 
       override def observe(fileId: ImageFileId,
@@ -40,6 +40,15 @@ object GsaoiControllerSim {
       override def observeProgress(total: Time): fs2.Stream[F, Progress] =
         sim.observeCountdown(total, ElapsedTime(0.seconds))
 
+      override def currentState: F[GsaoiGuider.GuideState] = (new GsaoiGuider.GuideState {
+        override def isGuideActive: Boolean = false
+
+        override def isOdgwGuiding(odgwId: GsaoiGuider.OdgwId): Boolean = false
+      }).pure[F]
+
+      override def guide: F[Unit] = ().pure[F]
+
+      override def endGuide: F[Unit] = ().pure[F]
     }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerSim.scala
@@ -3,6 +3,7 @@
 
 package seqexec.server.gsaoi
 
+import cats.Applicative
 import cats.effect.Sync
 import cats.effect.Timer
 import cats.implicits._
@@ -18,8 +19,8 @@ import squants.Time
 import squants.time.TimeConversions._
 
 object GsaoiControllerSim {
-  def unsafeApply[F[_]: Sync: Logger: Timer]: GsaoiController[F] with GsaoiGuider[F] =
-    new GsaoiController[F] with GsaoiGuider[F] {
+  def unsafeApply[F[_]: Sync: Logger: Timer]: GsaoiFullHandler[F] =
+    new GsaoiFullHandler[F] {
       private val sim: InstrumentControllerSim[F] = InstrumentControllerSim.unsafeApply(s"GSAOI")
 
       override def observe(fileId: ImageFileId,
@@ -46,9 +47,9 @@ object GsaoiControllerSim {
         override def isOdgwGuiding(odgwId: GsaoiGuider.OdgwId): Boolean = false
       }).pure[F]
 
-      override def guide: F[Unit] = ().pure[F]
+      override def guide: F[Unit] = Applicative[F].unit
 
-      override def endGuide: F[Unit] = ().pure[F]
+      override def endGuide: F[Unit] = Applicative[F].unit
     }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiGuider.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiGuider.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.gsaoi
+
+import gem.util.Enumerated
+
+trait GsaoiGuider[F[_]] {
+  import GsaoiGuider._
+  def currentState: F[GuideState]
+  def guide: F[Unit]
+  def endGuide: F[Unit]
+}
+
+object GsaoiGuider {
+
+  sealed trait OdgwId extends Product with Serializable
+
+  object OdgwId {
+    case object Odgw1 extends OdgwId
+    case object Odgw2 extends OdgwId
+    case object Odgw3 extends OdgwId
+    case object Odgw4 extends OdgwId
+
+    implicit val odgwIdEnumerated: Enumerated[OdgwId] = Enumerated.of(Odgw1, Odgw2, Odgw3, Odgw4)
+
+  }
+
+  trait GuideState {
+    def isGuideActive: Boolean
+    def isOdgwGuiding(odgwId: OdgwId): Boolean
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/package.scala
@@ -7,6 +7,10 @@ import cats.Eq
 import cats.implicits._
 import edu.gemini.seqexec.server.gsaoi.DhsConnected
 
+package gsaoi{
+  trait GsaoiFullHandler[F[_]] extends GsaoiController[F] with GsaoiGuider[F]
+}
+
 package object gsaoi {
   implicit val dhsConnectedEq: Eq[DhsConnected] = Eq.by(_.ordinal)
 }


### PR DESCRIPTION
The real GeMS code needs access to GSAOI statuses and commands. The issue was that it was using `GsaoiEpics.instance` even if Gsaoi was internally simulated (and therefore, `GsaoiEpics.instance` was not initialized). I opted for creating an interface for GeMS to access GSAOI functionality, one that is instantiated following the Gsaoi simulation parameter. Besides fixing the bug, this implementation has the advantage of allowing mixing real GeMS control with simulated GSAOI. 