### PR TITLE
simplifications

### DIFF
--- a/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
+++ b/modules/db/src/main/scala/gem/dao/StaticConfigDao.scala
@@ -82,7 +82,7 @@ object StaticConfigDao {
           Statements.Gmos.insertSouth(oid, gs).run.void
 
     def insertCustomRoiEntries(oid: Observation.Id, i: Instrument, rois: Set[GmosCustomRoiEntry]): ConnectionIO[Unit] =
-      rois.toList.traverse(Statements.Gmos.insertCustomRoiEntry(oid, i, _).run).void
+      rois.toList.traverse_(Statements.Gmos.insertCustomRoiEntry(oid, i, _).run)
 
     def insertNodAndShuffle(oid: Observation.Id, i: Instrument, ns: Option[GmosNodAndShuffle]): ConnectionIO[Unit] =
       ns.fold(().pure[ConnectionIO])(ns => Statements.Gmos.insertNodAndShuffle(oid, i, ns).run.void)

--- a/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetEnvironmentDao.scala
@@ -18,7 +18,7 @@ object TargetEnvironmentDao {
 
   def insert(oid: Observation.Id, e: TargetEnvironment): ConnectionIO[Unit] =
     e.asterism.foldMap(AsterismDao.insert(oid, _)) *>
-    e.userTargets.toList.traverse(UserTargetDao.insert(oid, _)).void
+    e.userTargets.toList.traverse_(UserTargetDao.insert(oid, _))
 
   def selectObs(oid: Observation.Id): ConnectionIO[TargetEnvironment] =
     (AsterismDao.select(oid), UserTargetDao.selectObs(oid)).mapN {

--- a/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
@@ -84,7 +84,7 @@ final class TcsEphemerisExport[M[_]: Sync: ContextShift](xa: Transactor[M]) {
   def exportAll(site: Site, start: Timestamp, end: Timestamp, dir: Path): M[Unit] =
     for {
       ks <- EphemerisDao.selectKeys(site).transact(xa)
-      _  <- ks.toList.traverse(k => exportOne(k, site, start, end, resolve(k, dir))).void
+      _  <- ks.toList.traverse_(k => exportOne(k, site, start, end, resolve(k, dir)))
     } yield ()
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ODBSequencesLoader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ODBSequencesLoader.scala
@@ -79,7 +79,7 @@ final class ODBSequencesLoader[F[_]: ApplicativeError[?[_], Throwable]](odbProxy
     ): F[List[executeEngine.EventType]] = {
     val seqexecList = st.sequences.keys.toList
 
-    val loads = odbList.diff(seqexecList).map(loadEvents).sequence.map(_.flatten)
+    val loads = odbList.diff(seqexecList).traverse(loadEvents).map(_.flatten)
 
     val unloads = seqexecList.diff(odbList).map(unloadEvent)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -87,14 +87,14 @@ trait ObserveActions {
   def notifyObserveStart[F[_]: Applicative](
     env: ObserveEnvironment[F]
   ): F[Unit] =
-    env.otherSys.map(_.notifyObserveStart).sequence.void
+    env.otherSys.traverse_(_.notifyObserveStart)
 
   /**
     * Tell each subsystem that an observe will end
     * Unlike observe start we also tell the instrumetn about it
     */
   def notifyObserveEnd[F[_]: Applicative](env: ObserveEnvironment[F]): F[Unit] =
-    (env.inst +: env.otherSys).map(_.notifyObserveEnd).sequence.void
+    (env.inst +: env.otherSys).traverse_(_.notifyObserveEnd)
 
   /**
     * Close the image, telling either DHS or GDS as it correspond
@@ -122,7 +122,7 @@ trait ObserveActions {
       d <- dataId(env)
       _ <- sendDataStart(env.systems, env.obsId, fileId, d)
       _ <- notifyObserveStart(env)
-      _ <- env.headers(env.ctx).map(_.sendBefore(env.obsId, fileId)).sequence
+      _ <- env.headers(env.ctx).traverse(_.sendBefore(env.obsId, fileId))
       _ <- info(s"Start ${env.inst.resource.show} observation ${env.obsId.format} with label $fileId")
       r <- env.inst.observe(env.config)(fileId)
       _ <- info(s"Completed ${env.inst.resource.show} observation ${env.obsId.format} with label $fileId")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerEpics.scala
@@ -120,7 +120,7 @@ class GemsControllerEpics[F[_]: Async: ApplicativeError[?[_], Throwable]](epicsS
     (
       p.map(_._1).foldLeft(current){case (a, b) => b(a)},
       p.nonEmpty.option{
-        p.map(_._2).sequence *>
+        p.traverse(_._2) *>
         epicsSys.ApdControl.setTimeout(CmdTimeout) *>
         epicsSys.ApdControl.post.void
       }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
@@ -21,7 +21,7 @@ class TcsControllerSim[F[_]: Sync] {
     def configSubsystem(subsystem: Subsystem): F[Unit] =
       info(s"Applying ${subsystem.show} configuration.")
 
-    subsystems.toList.map(configSubsystem).sequence.void
+    subsystems.toList.traverse_(configSubsystem)
   }
 
   def notifyObserveStart: F[Unit] = info("Simulate TCS observe")

--- a/modules/telnetd/src/main/scala/gem/telnetd/command/SiteOpt.scala
+++ b/modules/telnetd/src/main/scala/gem/telnetd/command/SiteOpt.scala
@@ -35,7 +35,7 @@ trait SiteOpt {
   /** Multiple site options, defaulting to GS and GN. */
   val sites: Opts[Set[Site]] =
     Opts.options[String]("site", help = "GN | GS", short = "s")
-      .mapValidated { _.map(validateSite).sequence }
+      .mapValidated { _.traverse(validateSite) }
       .withDefault(NonEmptyList.of(Site.GN, Site.GS))
       .map { nel => Set(nel.toList: _*) }
 


### PR DESCRIPTION
I was playing around with [comby](https://comby.dev) and had it rewrite `map(f).sequence` → `traverse(f)` and `traverse(f).void` → `traverse_(f)`. 

It's really cool. Not as safe and flexible as ScalaFix but a hell of a lot easier.