### PR TITLE
Simplify calling React components. `sequence/steps` components.

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/OffsetDisplayCell.scala
@@ -5,7 +5,6 @@ package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Reusability
 import react.common.implicits._
@@ -17,13 +16,20 @@ import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.semanticui.elements.icon.Icon.{IconBan, IconCrosshairs}
 import seqexec.web.client.semanticui.Size
 import seqexec.web.client.reusability._
+import web.client.ReactProps
 
 /**
   * Component to display the offsets
   */
-object OffsetsDisplayCell {
+final case class OffsetsDisplayCell(
+  offsetsDisplay: OffsetsDisplay,
+  step: Step
+) extends ReactProps {
+  @inline def render: VdomElement = OffsetsDisplayCell.component(this)
+}
 
-  final case class Props(offsetsDisplay: OffsetsDisplay, step: Step)
+object OffsetsDisplayCell {
+  type Props = OffsetsDisplayCell
 
   implicit val doubleReuse: Reusability[Double] = Reusability.double(0.0001)
   implicit val ofdReuse: Reusability[OffsetsDisplay] = Reusability.derive[OffsetsDisplay]
@@ -32,7 +38,7 @@ object OffsetsDisplayCell {
   private val guidingIcon = IconCrosshairs.copyIcon(color = "green".some, size = Size.Large)
   private val noGuidingIcon = IconBan.copyIcon(size = Size.Large)
 
-  private val component = ScalaComponent.builder[Props]("OffsetsDisplayCell")
+  protected val component = ScalaComponent.builder[Props]("OffsetsDisplayCell")
     .stateless
     .render_P { p =>
       p.offsetsDisplay match {
@@ -81,6 +87,4 @@ object OffsetsDisplayCell {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/RunFromStep.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/RunFromStep.scala
@@ -4,7 +4,6 @@
 package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
-import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
@@ -19,22 +18,29 @@ import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.popup.Popup
 import seqexec.web.client.semanticui.elements.icon.Icon.IconPlay
 import seqexec.web.client.reusability._
+import web.client.ReactProps
 
 /**
   * Contains the control to start a step from an arbitrary point
   */
+final case class RunFromStep(
+  id:               Observation.Id,
+  stepId:           Int,
+  resourceInFlight: Boolean,
+  runFrom:          StartFromOperation
+) extends ReactProps {
+  @inline def render: VdomElement = RunFromStep.component(this)
+}
+
 object RunFromStep {
-  final case class Props(id:               Observation.Id,
-                         stepId:           Int,
-                         resourceInFlight: Boolean,
-                         runFrom:          StartFromOperation)
+  type Props = RunFromStep
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   def requestRunFrom(id: Observation.Id, stepId: Int): Callback =
     SeqexecCircuit.dispatchCB(RequestRunFrom(id, stepId))
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("RunFromStep")
     .render_P { p =>
       <.div(
@@ -55,6 +61,4 @@ object RunFromStep {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SequenceTabContent.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import diode.react.ReactConnectProxy
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.ScalaComponent
-import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
 import react.common.implicits._
@@ -15,22 +14,28 @@ import seqexec.web.client.circuit._
 import seqexec.web.client.model.Pages.SeqexecPages
 import seqexec.web.client.model.SectionVisibilityState.SectionClosed
 import seqexec.web.client.model.SectionVisibilityState.SectionOpen
-import seqexec.web.client.semanticui.{ Size => _, _ }
+import seqexec.web.client.semanticui.{Size => _, _}
 import seqexec.web.client.components.sequence.toolbars.SequenceDefaultToolbar
 import seqexec.web.client.components.sequence.toolbars.StepConfigToolbar
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.reusability._
+import web.client.ReactProps
 
 /**
   * Content of a single tab with a sequence
   */
-object SequenceTabContent {
-  final case class Props(router:  RouterCtl[SeqexecPages],
-                         content: SequenceTabContentFocus) {
+final case class SequenceTabContent(
+  router:  RouterCtl[SeqexecPages],
+  content: SequenceTabContentFocus
+) extends ReactProps {
+  @inline def render: VdomElement = SequenceTabContent.component(this)
 
-    val stepsConnect: ReactConnectProxy[StepsTableAndStatusFocus] =
-      SeqexecCircuit.connect(SeqexecCircuit.stepsTableReader(content.id))
-  }
+  val stepsConnect: ReactConnectProxy[StepsTableAndStatusFocus] =
+    SeqexecCircuit.connect(SeqexecCircuit.stepsTableReader(content.id))
+}
+
+object SequenceTabContent {
+  type Props = SequenceTabContent
 
   implicit val stcfReuse: Reusability[SequenceTabContentFocus] =
     Reusability.derive[SequenceTabContentFocus]
@@ -58,7 +63,7 @@ object SequenceTabContent {
         p.stepsConnect { x =>
           <.div(
             ^.height := "100%",
-            StepsTable(StepsTable.Props(p.router, p.content.canOperate, x()))
+            StepsTable(p.router, p.content.canOperate, x())
           )
         }
 
@@ -70,13 +75,13 @@ object SequenceTabContent {
             val hs = focus.configTableState
             <.div(
               ^.height := "100%",
-              StepConfigTable(StepConfigTable.Props(steps, hs))
+              StepConfigTable(steps, hs)
             )
           }.getOrElse(<.div())
         }
     }
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("SequenceTabContent")
     .stateless
     .render_P { p =>
@@ -109,7 +114,4 @@ object SequenceTabContent {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] =
-    component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepBreakStopCell.scala
@@ -5,7 +5,6 @@ package seqexec.web.client.components.sequence.steps
 
 import gem.Observation
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.implicits._
@@ -18,19 +17,26 @@ import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.semanticui.elements.icon.Icon
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.reusability._
+import web.client.ReactProps
 
 /**
   * Component to display an icon for the state
   */
+final case class StepBreakStopCell(
+  clientStatus:       ClientStatus,
+  step:               Step,
+  rowHeight:          Int,
+  obsId:              Observation.Id,
+  firstRunnableIndex: Int,
+  breakPointEnterCB:  Int => Callback,
+  breakPointLeaveCB:  Int => Callback,
+  heightChangeCB:     Int => Callback
+) extends ReactProps {
+  @inline def render: VdomElement = StepBreakStopCell.component(this)
+}
+
 object StepBreakStopCell {
-  final case class Props(clientStatus:       ClientStatus,
-                         step:               Step,
-                         rowHeight:          Int,
-                         obsId:              Observation.Id,
-                         firstRunnableIndex: Int,
-                         breakPointEnterCB:  Int => Callback,
-                         breakPointLeaveCB:  Int => Callback,
-                         heightChangeCB:     Int => Callback)
+  type Props = StepBreakStopCell
 
   implicit val propsReuse: Reusability[Props] =
     Reusability.caseClassExcept[Props]('heightChangeCB,
@@ -52,7 +58,7 @@ object StepBreakStopCell {
     Callback.when(p.clientStatus.canOperate)(
       SeqexecCircuit.dispatchCB(FlipSkipStep(p.obsId, p.step)))
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("StepBreakStopCell")
     .stateless
     .render_P { p =>
@@ -95,6 +101,4 @@ object StepBreakStopCell {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepSettings.scala
@@ -5,11 +5,11 @@ package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import gem.Observation
+import japgolly.scalajs.react.component.Scala.Unmounted
 import react.common.implicits._
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.StepType
@@ -22,16 +22,21 @@ import seqexec.web.client.semanticui.elements.label.Label
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.semanticui.Size
 import seqexec.web.client.reusability._
+import web.client.ReactProps
 
 /**
   * Component to display an item of a sequence
   */
+final case class StepItemCell(value: Option[String]) extends ReactProps {
+  @inline def render: VdomElement = StepItemCell.component(this)
+}
+
 object StepItemCell {
-  final case class Props(value: Option[String])
+  type Props = StepItemCell
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("StepItemCell")
     .stateless
     .render_P { p =>
@@ -42,19 +47,21 @@ object StepItemCell {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }
 
 /**
   * Component to display the exposure time and coadds
   */
+final case class ExposureTimeCell(s: Step, i: Instrument) extends ReactProps {
+  @inline def render: VdomElement = ExposureTimeCell.component(this)
+}
+
 object ExposureTimeCell {
-  final case class Props(s: Step, i: Instrument)
+  type Props = ExposureTimeCell
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("ExposureTimeCell")
     .stateless
     .render_P { p =>
@@ -91,8 +98,6 @@ object ExposureTimeCell {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }
 
 /**
@@ -112,16 +117,22 @@ object StepIdCell {
 /**
   * Component to link to the settings
   */
+final case class SettingsCell(
+  ctl:        RouterCtl[Pages.SeqexecPages],
+  instrument: Instrument,
+  obsId:      Observation.Id,
+  index:      Int,
+  isPreview:  Boolean
+) extends ReactProps {
+  @inline def render: VdomElement = SettingsCell.component(this)
+}
+
 object SettingsCell {
-  final case class Props(ctl:        RouterCtl[Pages.SeqexecPages],
-                         instrument: Instrument,
-                         obsId:      Observation.Id,
-                         index:      Int,
-                         isPreview:  Boolean)
+  type Props = SettingsCell
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("SettingsCell")
     .stateless
     .render_P { p =>
@@ -140,19 +151,25 @@ object SettingsCell {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(i: Props): Unmounted[Props, Unit, Unit] = component(i)
 }
 
 /**
   * Component to display the object type
   */
+final case class ObjectTypeCell(
+  instrument: Instrument,
+  step: Step,
+  size: Size
+) extends ReactProps {
+  @inline def render: VdomElement = ObjectTypeCell.component(this)
+}
+
 object ObjectTypeCell {
-  final case class Props(instrument: Instrument, step: Step, size: Size)
+  type Props = ObjectTypeCell
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("ObjectTypeCell")
     .stateless
     .render_P { p =>
@@ -177,6 +194,4 @@ object ObjectTypeCell {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(i: Props): Unmounted[Props, Unit, Unit] = component(i)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -3,7 +3,6 @@
 
 package seqexec.web.client.components.sequence.steps
 
-import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
@@ -28,19 +27,26 @@ import seqexec.web.client.semanticui.elements.icon.Icon.IconPlay
 import seqexec.web.client.semanticui.elements.icon.Icon.IconStop
 import seqexec.web.client.semanticui.elements.icon.Icon.IconTrash
 import seqexec.web.client.reusability._
+import web.client.ReactProps
 
 /**
   * Contains the control buttons like stop/abort at the row level
   */
+final case class StepsControlButtons(
+  id:              Observation.Id,
+  instrument:      Instrument,
+  sequenceState:   SequenceState,
+  stepId:          Int,
+  isObservePaused: Boolean,
+  tabOperations:   TabOperations
+) extends ReactProps {
+  @inline def render: VdomElement = StepsControlButtons.component(this)
+
+  val requestInFlight = tabOperations.stepRequestInFlight
+}
+
 object StepsControlButtons {
-  final case class Props(id:              Observation.Id,
-                         instrument:      Instrument,
-                         sequenceState:   SequenceState,
-                         stepId:          Int,
-                         isObservePaused: Boolean,
-                         tabOperations:   TabOperations) {
-    val requestInFlight = tabOperations.stepRequestInFlight
-  }
+  type Props = StepsControlButtons
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
@@ -56,7 +62,7 @@ object StepsControlButtons {
   def requestObsResume(id: Observation.Id, stepId: Int): Callback =
     SeqexecCircuit.dispatchCB(RequestObsResume(id, stepId))
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("StepsControlButtons")
     .render_P { p =>
       <.div(
@@ -135,6 +141,4 @@ object StepsControlButtons {
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTools.scala
@@ -5,7 +5,6 @@ package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import gem.Observation
@@ -19,64 +18,78 @@ import seqexec.web.client.semanticui.elements.icon.Icon
 import seqexec.web.client.semanticui.elements.icon.Icon._
 import seqexec.web.client.services.HtmlConstants.iconEmpty
 import seqexec.web.client.reusability._
+import web.client.ReactProps
 
 /**
   * Component to display an icon for the state
   */
+final case class StepToolsCell(
+  clientStatus:       ClientStatus,
+  step:               Step,
+  rowHeight:          Int,
+  secondRowHeight:    Int,
+  isPreview:          Boolean,
+  nextStepToRun:      Option[Int],
+  obsId:              Observation.Id,
+  firstRunnableIndex: Int,
+  breakPointEnterCB:  Int => Callback,
+  breakPointLeaveCB:  Int => Callback,
+  heightChangeCB:     Int => Callback
+) extends ReactProps {
+  @inline def render: VdomElement = StepToolsCell.component(this)
+}
+
 object StepToolsCell {
-  final case class Props(clientStatus:       ClientStatus,
-                         step:               Step,
-                         rowHeight:          Int,
-                         secondRowHeight:    Int,
-                         isPreview:          Boolean,
-                         nextStepToRun:      Option[Int],
-                         obsId:              Observation.Id,
-                         firstRunnableIndex: Int,
-                         breakPointEnterCB:  Int => Callback,
-                         breakPointLeaveCB:  Int => Callback,
-                         heightChangeCB:     Int => Callback)
+  type Props = StepToolsCell
 
   implicit val propsReuse: Reusability[Props] =
     Reusability.caseClassExcept[Props]('heightChangeCB,
                                        'breakPointEnterCB,
                                        'breakPointLeaveCB)
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("StepToolsCell")
     .stateless
     .render_P { p =>
       <.div(
         SeqexecStyles.controlCell,
         StepBreakStopCell(
-          StepBreakStopCell.Props(p.clientStatus,
-                                  p.step,
-                                  p.rowHeight,
-                                  p.obsId,
-                                  p.firstRunnableIndex,
-                                  p.breakPointEnterCB,
-                                  p.breakPointLeaveCB,
-                                  p.heightChangeCB))
-          .when(p.clientStatus.isLogged)
-          .unless(p.isPreview),
+          p.clientStatus,
+          p.step,
+          p.rowHeight,
+          p.obsId,
+          p.firstRunnableIndex,
+          p.breakPointEnterCB,
+          p.breakPointLeaveCB,
+          p.heightChangeCB
+        ).when(p.clientStatus.isLogged)
+         .unless(p.isPreview),
         StepIconCell(
-          StepIconCell.Props(p.step.status,
-                             p.step.skip,
-                             p.nextStepToRun.forall(_ === p.step.id),
-                             p.rowHeight - p.secondRowHeight
-                           ))
+          p.step.status,
+          p.step.skip,
+          p.nextStepToRun.forall(_ === p.step.id),
+          p.rowHeight - p.secondRowHeight
+        )
       )
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }
 
 /**
   * Component to display an icon for the state
   */
+final case class StepIconCell(
+  status: StepState,
+  skip: Boolean,
+  nextToRun: Boolean,
+  height: Int
+) extends ReactProps {
+  @inline def render: VdomElement = StepIconCell.component(this)
+}
+
 object StepIconCell {
-  final case class Props(status: StepState, skip: Boolean, nextToRun: Boolean, height: Int)
+  type Props = StepIconCell
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
@@ -105,7 +118,7 @@ object StepIconCell {
       case _                   => SeqexecStyles.iconCell
     }
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("StepIconCell")
     .stateless
     .render_P(
@@ -117,6 +130,4 @@ object StepIconCell {
       ))
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -4,7 +4,6 @@
 package seqexec.web.client.components.sequence.steps
 
 import cats.implicits._
-import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ReactEvent
@@ -27,20 +26,25 @@ import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.icon.Icon
 import seqexec.web.client.semanticui.elements.icon.Icon.{IconAttention, IconCheckmark, IconCircleNotched}
 import seqexec.web.client.semanticui.Size
+import web.client.ReactProps
 
 import scala.scalajs.js
 
 /**
   * Contains the control buttons for each subsystem
   */
+final case class SubsystemControlCell(
+  id: Observation.Id,
+  stepId: Int,
+  resources: List[Resource],
+  resourcesCalls: SortedMap[Resource, ResourceRunOperation],
+  canOperate: Boolean
+) extends ReactProps {
+    @inline def render: VdomElement = SubsystemControlCell.component(this)
+}
+
 object SubsystemControlCell {
-  final case class Props(
-    id:             Observation.Id,
-    stepId:         Int,
-    resources:      List[Resource],
-    resourcesCalls: SortedMap[Resource, ResourceRunOperation],
-    canOperate:     Boolean
-  )
+  type Props = SubsystemControlCell
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
@@ -91,7 +95,7 @@ object SubsystemControlCell {
       case _                                               => none
     }
 
-  private val component = ScalaComponent
+  protected val component = ScalaComponent
     .builder[Props]("SubsystemControl")
     .render_P { p =>
       <.div(
@@ -117,13 +121,11 @@ object SubsystemControlCell {
                 extraStyles = if(!p.canOperate) List(SeqexecStyles.defaultCursor) else List.empty
               ),
               r.show
+              )
             )
-          )
         }.toTagMod
-      )
+        )
     }
     .configure(Reusability.shouldComponentUpdate)
     .build
-
-  def apply(p: Props): Unmounted[Props, Unit, Unit] = component(p)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/TabsArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/tabs/TabsArea.scala
@@ -37,7 +37,7 @@ object TabsArea {
         tabsConnect(x =>
           React.Fragment(x().toList.collect {
             case t: SequenceTabContentFocus =>
-              SequenceTabContent(SequenceTabContent.Props(p.router, t)): VdomNode
+              SequenceTabContent(p.router, t): VdomNode
             case t =>
               CalQueueTabContent(
                 CalQueueTabContent.Props(t.canOperate,

--- a/modules/shared/web/client/src/main/scala/web/client/ReactProps.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/ReactProps.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package web.client
 
 import japgolly.scalajs.react.vdom.html_<^.VdomElement

--- a/modules/shared/web/client/src/main/scala/web/client/ReactProps.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/ReactProps.scala
@@ -1,0 +1,11 @@
+package web.client
+
+import japgolly.scalajs.react.vdom.html_<^.VdomElement
+
+trait ReactProps {
+  @inline def render: VdomElement
+}
+
+object ReactProps {
+  implicit def props2component(p: ReactProps): VdomElement = p.render
+}


### PR DESCRIPTION
This is a refactor to change the way in which components and their props are defined so that the call site code is simpler.

So far, all components in the `sequence/steps` package are refactored.
