### PR TITLE
SEQNG-1068 Disabled GMOS CC configuration for Darks and Biases.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -101,7 +101,9 @@ abstract class Gmos[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger, T <: 
       adc              <- config.extractInstAs[ADC](ADC_PROP)
       electronicOffset =  config.extractInstAs[UseElectronicOffset](USE_ELECTRONIC_OFFSETTING_PROP)
       disperser        <- calcDisperser(disp, disperserOrder.toOption, disperserLambda.toOption)
-    } yield configTypes.CCConfig(filter, disperser, fpu, stageMode, dtax, adc, electronicOffset.toOption))
+      obsType          <- config.extractObsAs[String](OBSERVE_TYPE_PROP)
+      isDarkOrBias = List(DARK_OBSERVE_TYPE, BIAS_OBSERVE_TYPE).exists(_ === obsType)
+    } yield configTypes.CCConfig(filter, disperser, fpu, stageMode, dtax, adc, electronicOffset.toOption, isDarkOrBias))
       .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
   private def fromSequenceConfig(config: CleanConfig): Either[SeqexecFailure, GmosController.GmosConfig[T]] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -87,7 +87,8 @@ object GmosController {
       stage: T#GmosStageMode,
       dtaX: DTAX,
       adc: ADC,
-      useElectronicOffset: Option[UseElectronicOffset]
+      useElectronicOffset: Option[UseElectronicOffset],
+      isDarkOrBias: Boolean
     )
 
   }
@@ -259,6 +260,11 @@ object GmosController {
   type GmosNorthController[F[_]] = GmosController[F, NorthTypes]
 
   implicit def configShow[T<:SiteDependentTypes]: Show[GmosConfig[T]] =
-    Show.show { config => s"(${config.cc.filter}, ${config.cc.disperser}, ${config.cc.fpu}, ${config.cc.stage}, ${config.cc.stage}, ${config.cc.dtaX}, ${config.cc.adc}, ${config.cc.useElectronicOffset}, ${config.dc.t}, ${config.dc.b}, ${config.dc.s}, ${config.dc.bi}, ${config.dc.roi.rois} ${config.ns})" }
+    Show.show { config =>
+      val ccShow = if(config.cc.isDarkOrBias) "DarkOrBias"
+      else s"${config.cc.filter}, ${config.cc.disperser}, ${config.cc.fpu}, ${config.cc.stage}, ${config.cc.stage}, ${config.cc.dtaX}, ${config.cc.adc}, ${config.cc.useElectronicOffset}"
+
+      s"($ccShow, ${config.dc.t}, ${config.dc.b}, ${config.dc.s}, ${config.dc.bi}, ${config.dc.roi.rois} ${config.ns})"
+    }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -350,13 +350,18 @@ object GmosControllerEpics extends GmosEncoders {
           applyParam(state.nsState, encode(config.nsState), DC.setNsState)
         ).flattenOption
 
+      // Don't set CC if Dark or Bias
       private def ccParams(state: GmosCCEpicsState, config: Config[T]#CCConfig): List[IO[Unit]] =
-        (setFilters(state, config.filter) ++
+        if(config.isDarkOrBias) List.empty
+        else (
+          setFilters(state, config.filter) ++
           setDisperserParams(state, cfg, config.disperser) ++
           setFPU(state, cfg, config.fpu) ++
           List(setStage(state, config.stage),
             setDtaXOffset(state, config.dtaX),
-            setElectronicOffset(state, config.useElectronicOffset))).flattenOption
+            setElectronicOffset(state, config.useElectronicOffset)
+          )
+        ).flattenOption
 
       override def applyConfig(config: GmosController.GmosConfig[T]): IO[Unit] = retrieveState.flatMap { state =>
         val params = dcParams(state.dc, config.dc) ++


### PR DESCRIPTION
GMOS Darks and Biases don't need to configure the CC. This change skips the CC configuration for those two observe types. 