### PR TITLE
SEQNG-1069B Send to the client the state of running ns actions

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Action.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Action.scala
@@ -4,6 +4,7 @@
 package seqexec.engine
 
 import fs2.Stream
+import monocle.Lens
 import seqexec.engine.Result.Error
 import seqexec.engine.Result.PartialVal
 import seqexec.engine.Result.PauseContext
@@ -21,6 +22,10 @@ final case class Action[F[_]](
 
 object Action {
 
+  def runStateL[F[_]]: Lens[Action[F], ActionState[F]] =
+    Action.state ^|-> State.runState
+
+  @Lenses
   final case class State[F[_]](
     runState: ActionState[F],
     partials: List[PartialVal]

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Execution.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Execution.scala
@@ -51,10 +51,10 @@ final case class Execution[F[_]](execution: List[Action[F]]) {
     * If the index doesn't exist, `Current` is returned unmodified.
     */
   def mark(i: Int)(r: Result[F]): Execution[F] =
-    Execution((execution &|-? index(i)).modify(a => a.copy(state = actionStateFromResult(r)(a.state))))
+    Execution((execution &|-? index(i) ^|-> Action.state).modify(actionStateFromResult(r)))
 
   def start(i: Int): Execution[F] =
-    Execution((execution &|-? index(i)).modify(a => a.copy(state = a.state.copy(runState = ActionState.Started))))
+    Execution((execution &|-? index(i) ^|-> Action.runStateL).set(ActionState.Started))
 }
 
 object Execution {
@@ -70,13 +70,13 @@ object Execution {
 
   def errored[F[_]](ex: Execution[F]): Boolean = ex.execution.exists(_.state.runState match {
     case ActionState.Failed(_) => true
-    case _                => false
+    case _                     => false
   })
 
   def finished[F[_]](ex: Execution[F]): Boolean = ex.execution.forall(_.state.runState match {
     case ActionState.Completed(_) => true
     case ActionState.Failed(_)    => true
-    case _                   => false
+    case _                        => false
   })
 
   def progressRatio[F[_]](ex: Execution[F]): (Int, Int) = (ex.results.length, ex.execution.length)

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
@@ -328,11 +328,9 @@ object Sequence {
         GenLens[Zipper[F]](_.zipper)
 
       override def mark(i: Int)(r: Result[F]): State[F] = {
-
         val currentExecutionL: Lens[Zipper[F], Execution[F]] = zipperL ^|-> Sequence.Zipper.current
 
         currentExecutionL.modify(_.mark(i)(r))(self)
-
       }
 
       override def start(i: Int): State[F] = {
@@ -340,7 +338,6 @@ object Sequence {
         val currentExecutionL: Lens[Zipper[F], Execution[F]] = zipperL ^|-> Sequence.Zipper.current
 
         currentExecutionL.modify(_.start(i))(self).clearSingles
-
       }
 
       // Some rules:

--- a/modules/seqexec/model/src/main/scala/seqexec/model/NSSubexposure.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/NSSubexposure.scala
@@ -32,7 +32,7 @@ object NSSubexposure {
     cycle:       NsCycles,
     stageIndex:  Int
   ): Option[NSSubexposure] =
-    if (totalCycles >= 0 && cycle >= 0 && cycle < totalCycles && stageIndex >= 0 && stageIndex < NsSequence.length) {
+    if (totalCycles >= 0 && cycle >= 0 && cycle <= totalCycles && stageIndex >= 0 && stageIndex < NsSequence.length) {
       NSSubexposure(totalCycles, cycle, stageIndex, NsSequence.toList.lift(stageIndex).getOrElse(StageA)).some
     } else none
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/NodAndShuffleStatus.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/NodAndShuffleStatus.scala
@@ -10,16 +10,24 @@ import seqexec.model.GmosParameters._
 import monocle.macros.Lenses
 import squants.Time
 
+final case class NSRunningState(action: NSAction, sub: NSSubexposure)
+
+object NSRunningState {
+  implicit val equalNSRunningState: Eq[NSRunningState] =
+    Eq.by(x => (x.action, x.sub))
+}
+
 @Lenses
 final case class NodAndShuffleStatus(
   observing: ActionStatus,
   totalExposureTime: Time,
   nodExposureTime: Time,
-  cycles: NsCycles
+  cycles: NsCycles,
+  state: Option[NSRunningState]
 )
 
 object NodAndShuffleStatus {
 
   implicit val equalNodAndShuffleStatus: Eq[NodAndShuffleStatus] =
-    Eq.by(x => (x.observing, x.totalExposureTime, x.nodExposureTime, x.cycles))
+    Eq.by(x => (x.observing, x.totalExposureTime, x.nodExposureTime, x.cycles, x.state))
 }

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/NSAction.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/NSAction.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.enum
+
+import gem.util.Enumerated
+
+sealed trait NSAction extends Product with Serializable
+
+object NSAction {
+  case object Start extends NSAction
+  case object NodStart extends NSAction
+  case object NodComplete extends NSAction
+  case object ConfigureRowsStart extends NSAction
+  case object ConfigureRowsComplete extends NSAction
+  case object StageObserveStart extends NSAction
+  case object StageObserveComplete extends NSAction
+  case object Done extends NSAction
+
+  /** @group Typeclass Instances */
+  implicit val NSActionEnumerated: Enumerated[NSAction] =
+    Enumerated.of(Start,
+                  NodStart,
+                  NodComplete,
+                  ConfigureRowsStart,
+                  ConfigureRowsComplete,
+                  StageObserveStart,
+                  StageObserveComplete,
+                  Done)
+}

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/NSAction.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/NSAction.scala
@@ -11,8 +11,6 @@ object NSAction {
   case object Start extends NSAction
   case object NodStart extends NSAction
   case object NodComplete extends NSAction
-  case object ConfigureRowsStart extends NSAction
-  case object ConfigureRowsComplete extends NSAction
   case object StageObserveStart extends NSAction
   case object StageObserveComplete extends NSAction
   case object Done extends NSAction
@@ -22,8 +20,6 @@ object NSAction {
     Enumerated.of(Start,
                   NodStart,
                   NodComplete,
-                  ConfigureRowsStart,
-                  ConfigureRowsComplete,
                   StageObserveStart,
                   StageObserveComplete,
                   Done)

--- a/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/ModelSpec.scala
@@ -25,6 +25,7 @@ import seqexec.model.arb.ArbDhsTypes._
 import seqexec.model.arb.ArbTime._
 import seqexec.model.arb.ArbNSSubexposure._
 import seqexec.model.arb.ArbGmosParameters._
+import seqexec.model.arb.ArbNSRunningState._
 import squants.time.Time
 import squants.time.TimeUnit
 
@@ -97,4 +98,6 @@ final class ModelSpec extends CatsSuite {
   checkAll("Eq[DataId]", EqTests[DataId].eqv)
   checkAll("Eq[NsPairs]", EqTests[NsPairs].eqv)
   checkAll("Eq[NsRows]", EqTests[NsRows].eqv)
+  checkAll("Eq[NSAction]", EqTests[NSAction].eqv)
+  checkAll("Eq[NSRunningState]", EqTests[NSRunningState].eqv)
 }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNSRunningState.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNSRunningState.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.model.arb
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import gem.arb.ArbEnumerated._
+import seqexec.model._
+import seqexec.model.enum._
+import seqexec.model.arb.ArbNSSubexposure._
+
+trait ArbNSRunningState {
+  implicit val nsRunningStateArb = Arbitrary[NSRunningState] {
+    for {
+      a <- arbitrary[NSAction]
+      u <- arbitrary[NSSubexposure]
+    } yield NSRunningState(a, u)
+  }
+
+  implicit val nsRunningStateCogen: Cogen[NSRunningState] =
+    Cogen[(NSAction, NSSubexposure)].contramap { x =>
+      (x.action, x.sub)
+    }
+
+}
+
+object ArbNSRunningState extends ArbNSRunningState

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNSSubexposure.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNSSubexposure.scala
@@ -18,7 +18,7 @@ trait ArbNSSubexposure {
     for {
       t  <- Gen.posNum[Int].map(tag[NsCyclesI][Int])
       c  <- Gen.choose(0, t).map(tag[NsCyclesI][Int])
-      i  <- Gen.choose(0, NsSequence.length)
+      i  <- Gen.choose(0, NsSequence.length - 1)
     } yield
       NSSubexposure(t, c, i).getOrElse(NSSubexposure.Zero)
   }

--- a/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNodAndShuffleStep.scala
+++ b/modules/seqexec/model/src/test/scala/seqexec/model/arb/ArbNodAndShuffleStep.scala
@@ -15,6 +15,7 @@ import seqexec.model.arb.ArbStepState._
 import seqexec.model.arb.ArbDhsTypes._
 import seqexec.model.arb.ArbTime._
 import seqexec.model.arb.ArbGmosParameters._
+import seqexec.model.arb.ArbNSRunningState._
 import squants._
 
 trait ArbNodAndShuffleStep {
@@ -24,7 +25,8 @@ trait ArbNodAndShuffleStep {
       t  <- arbitrary[Time]
       n  <- arbitrary[Time]
       c  <- arbitrary[NsCycles]
-    } yield NodAndShuffleStatus(as, t, n, c)
+      s  <- arbitrary[Option[NSRunningState]]
+    } yield NodAndShuffleStatus(as, t, n, c, s)
   }
 
   implicit val nodAndShuffleStatusCogen: Cogen[NodAndShuffleStatus] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepsView.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepsView.scala
@@ -41,7 +41,7 @@ object StepsView {
   def splitAfter[A](l: List[A])(p: A => Boolean): (List[A], List[A]) =
     l.splitAt(l.indexWhere(p) + 1)
 
-  private[server] def separateActions[F[_]](ls: NonEmptyList[Action[F]]): (List[Action[F]], List[Action[F]]) =
+  def separateActions[F[_]](ls: NonEmptyList[Action[F]]): (List[Action[F]], List[Action[F]]) =
     ls.toList.partition(_.state.runState match {
         case ActionState.Completed(_) => false
         case ActionState.Failed(_)    => false
@@ -49,7 +49,7 @@ object StepsView {
       }
     )
 
-  private def actionsToResources[F[_]](s: NonEmptyList[Action[F]]) =
+  def actionsToResources[F[_]](s: NonEmptyList[Action[F]]): (List[Resource], List[Resource]) =
     separateActions(s).bimap(_.map(_.kind).flatMap(kindToResource), _.map(_.kind).flatMap(kindToResource))
 
   private[server] def configStatus[F[_]](executions: List[ParallelActions[F]]): List[(Resource, ActionStatus)] = {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -56,7 +56,7 @@ object GmosController {
 
     case class BuiltInFPU(fpu: T#FPU) extends GmosFPU
 
-    sealed trait GmosDisperser
+    sealed trait GmosDisperser extends Product with Serializable
     object GmosDisperser {
       case object Mirror extends GmosDisperser
       case class Order0(disperser: T#Disperser) extends GmosDisperser

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/NodAndShuffleState.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/NodAndShuffleState.scala
@@ -16,4 +16,5 @@ object NodAndShuffleState {
   /** @group Typeclass Instances */
   implicit val NSStageEnumerated: Enumerated[NodAndShuffleState] =
     Enumerated.of(NodShuffle, Classic)
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
@@ -20,12 +20,6 @@ package gmos {
     case class NSStart(sub: NSSubexposure) extends NSPartial {
       override val ongoingAction = NSAction.Start
     }
-    case class NSRowsConfigureStart(sub: NSSubexposure) extends NSPartial {
-      override val ongoingAction = NSAction.ConfigureRowsStart
-    }
-    case class NSRowsConfigureComplete(sub: NSSubexposure) extends NSPartial {
-      override val ongoingAction = NSAction.ConfigureRowsComplete
-    }
     case class NSTCSNodStart(sub: NSSubexposure) extends NSPartial {
       override val ongoingAction = NSAction.NodStart
     }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
@@ -3,14 +3,47 @@
 
 package seqexec.server
 
+import seqexec.model.enum.NSAction
+import seqexec.model.NSSubexposure
 import seqexec.engine.Result.PartialVal
 
 package gmos {
-  // N&S Partials. TODO add more details about the current step
-  case object NSStart extends PartialVal
-  case object NSRowsConfigure extends PartialVal
-  case object NSTCSNod extends PartialVal
-  case object NSStep extends PartialVal
-  case object NSContinue extends PartialVal
-  case object NSComplete extends PartialVal
+
+  sealed trait NSPartial extends PartialVal {
+    def ongoingAction: NSAction
+    def sub: NSSubexposure
+  }
+  object NSPartial {
+    def unapply(s: NSPartial): Option[(NSAction, NSSubexposure)] =
+      Some((s.ongoingAction, s.sub))
+
+    case class NSStart(sub: NSSubexposure) extends NSPartial {
+      override val ongoingAction = NSAction.Start
+    }
+    case class NSRowsConfigureStart(sub: NSSubexposure) extends NSPartial {
+      override val ongoingAction = NSAction.ConfigureRowsStart
+    }
+    case class NSRowsConfigureComplete(sub: NSSubexposure) extends NSPartial {
+      override val ongoingAction = NSAction.ConfigureRowsComplete
+    }
+    case class NSTCSNodStart(sub: NSSubexposure) extends NSPartial {
+      override val ongoingAction = NSAction.NodStart
+    }
+    case class NSTCSNodComplete(sub: NSSubexposure) extends NSPartial {
+      override val ongoingAction = NSAction.NodComplete
+    }
+    case class NSSubexposureStart(sub: NSSubexposure) extends NSPartial {
+      override val ongoingAction = NSAction.StageObserveStart
+    }
+    case class NSSubexposureEnd(sub: NSSubexposure) extends NSPartial {
+      override val ongoingAction = NSAction.StageObserveComplete
+    }
+    case class NSComplete(sub: NSSubexposure) extends NSPartial {
+      override val ongoingAction = NSAction.Done
+    }
+
+    case object NSContinue extends InternalPartialVal
+    case object NSSubPaused extends InternalPartialVal
+    case object NSFinalObs extends InternalPartialVal
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/partials.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/partials.scala
@@ -7,6 +7,9 @@ import seqexec.engine.Result.PartialVal
 import seqexec.model.dhs.ImageFileId
 import squants.Time
 
+// Marker trait for partials that won't result on a client message
+trait InternalPartialVal extends PartialVal
+
 final case class FileIdAllocated(fileId: ImageFileId) extends PartialVal
 final case class RemainingTime(self: Time) extends AnyVal
 final case class Progress(total: Time, remaining: RemainingTime) extends PartialVal {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -32,6 +32,8 @@ import seqexec.model.NodAndShuffleStep
 import seqexec.model.NodAndShuffleStatus
 import seqexec.model.SequenceState
 import seqexec.model.RunningStep
+import seqexec.model.NSSubexposure
+import seqexec.model.NSRunningState
 import seqexec.web.client.model.lenses._
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.TabOperations
@@ -500,6 +502,10 @@ object StepsTable extends Columns {
 
   val stdStepReuse: Reusability[StandardStep] =
     Reusability.caseClassExcept('config)
+  implicit val nsSubexposureReuse: Reusability[NSSubexposure] =
+    Reusability.derive[NSSubexposure]
+  implicit val nsRunningStateReuse: Reusability[NSRunningState] =
+    Reusability.derive[NSRunningState]
   implicit val nsStatus: Reusability[NodAndShuffleStatus] =
     Reusability.derive[NodAndShuffleStatus]
   val nsStepReuse: Reusability[NodAndShuffleStep] =

--- a/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/web/shared/src/main/scala/seqexec/web/model/boopickle/ModelBooPicklers.scala
@@ -13,6 +13,7 @@ import gem.util.Enumerated
 import java.time.Instant
 import seqexec.model._
 import seqexec.model.enum._
+import seqexec.model.GmosParameters._
 import seqexec.model.events._
 import seqexec.model.dhs._
 import shapeless.tag
@@ -124,6 +125,16 @@ trait ModelBooPicklers extends GemModelBooPicklers {
   implicit val imageIdPickler = transformPickler((s: String) => tag[ImageFileIdT](s))(identity)
   implicit val standardStepPickler = generatePickler[StandardStep]
   implicit def taggedIntPickler[A]: Pickler[Int @@ A] = transformPickler((s: Int) => tag[A](s))(identity)
+  implicit val nsStagePickler = enumeratedPickler[NodAndShuffleStage]
+  implicit val nsActionPickler = enumeratedPickler[NSAction]
+  implicit val nsSubexposurePickler: Pickler[NSSubexposure] =
+    transformPickler[NSSubexposure, (NsCycles, NsCycles, Int)]{
+      case ((t: NsCycles, c: NsCycles, i: Int)) =>
+        NSSubexposure
+          .apply(t, c, i)
+          .getOrElse(throw new RuntimeException("Failed to decode ns subexposure"))
+        }((ns: NSSubexposure) => (ns.totalCycles, ns.cycle, ns.stageIndex))
+  implicit val nsRunningStatePickler = generatePickler[NSRunningState]
   implicit val nsStatusPickler = generatePickler[NodAndShuffleStatus]
   implicit val nsStepPickler = generatePickler[NodAndShuffleStep]
 

--- a/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/seqexec/web/shared/src/test/scala/seqexec/web/model/boopickle/ModelBooPicklersSpec.scala
@@ -21,6 +21,8 @@ import seqexec.model.arb.ArbStep._
 import seqexec.model.arb.ArbStepState._
 import seqexec.model.arb.ArbStandardStep._
 import seqexec.model.arb.ArbNodAndShuffleStep._
+import seqexec.model.arb.ArbNSSubexposure._
+import seqexec.model.arb.ArbNSRunningState._
 import seqexec.model.arb.ArbTime._
 import squants.time.Time
 
@@ -87,8 +89,12 @@ final class BoopicklingSpec extends CatsSuite with ModelBooPicklers with ArbObse
   checkAll("Pickler[StepState]", PicklerTests[StepState].pickler)
   checkAll("Pickler[ActionStatus]", PicklerTests[ActionStatus].pickler)
   checkAll("Pickler[StandardStep]", PicklerTests[StandardStep].pickler)
+  checkAll("Pickler[NodAndShuffleStage]", PicklerTests[NodAndShuffleStage].pickler)
+  checkAll("Pickler[NSSubexposure]", PicklerTests[NSSubexposure].pickler)
+  checkAll("Pickler[NSAction]", PicklerTests[NSAction].pickler)
   checkAll("Pickler[NodAndShuffleStatus]", PicklerTests[NodAndShuffleStatus].pickler)
   checkAll("Pickler[NodAndShuffleStep]", PicklerTests[NodAndShuffleStep].pickler)
+  checkAll("Pickler[NSRunningState]", PicklerTests[NSRunningState].pickler)
   checkAll("Pickler[Step]", PicklerTests[Step].pickler)
   checkAll("Pickler[QueueId]", PicklerTests[QueueId].pickler)
   checkAll("Pickler[Time]", PicklerTests[Time].pickler)


### PR DESCRIPTION
This is the second part of sending N&S updates to the client. This PR adds a field to `NodAndShuffleStatus` containing the state of the current execution
There are some changes on the way N&S actions are structured to send events before and after each substage is produced