### PR TITLE
SEQNG-1072 Fixes to execute N&S in Epics

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -149,10 +149,6 @@ abstract class Gmos[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger, T <: 
       .flatMap(controller.applyConfig)
       .as(ConfigResult(this))
 
-  def configureShuffle(rows: Int): F[ConfigResult[F]] =
-    controller.setRowsToShuffle(rows)
-      .as(ConfigResult(this))
-
   override def calcObserveTime(config: CleanConfig): F[Time] =
     (Gmos.expTimeF[F](config), Gmos.nsConfigF[F](config)).mapN {(v, ns) =>
       v / ns.exposureDivider.toDouble

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -29,8 +29,6 @@ trait GmosController[F[_], T <: GmosController.SiteDependentTypes] {
 
   def applyConfig(config: GmosConfig[T]): F[Unit]
 
-  def setRowsToShuffle(rows: Int): F[Unit]
-
   def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult]
 
   // endObserve is to notify the completion of the observation, not to cause its end.

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
@@ -24,7 +24,6 @@ import seqexec.server.gmos.GmosController.Config.NSConfig
 import seqexec.server.InstrumentControllerSim
 import seqexec.server.Progress
 import squants.Time
-import scala.concurrent.duration._
 
 /**
   * Keep track of the current execution state
@@ -74,7 +73,7 @@ object NSObsState {
 }
 
 object GmosControllerSim {
-  def apply[F[_]: FlatMap: Timer, T <: SiteDependentTypes](
+  def apply[F[_]: FlatMap, T <: SiteDependentTypes](
     sim:      InstrumentControllerSim[F],
     nsConfig: Ref[F, NSObsState]
   ): GmosController[F, T] =
@@ -103,10 +102,6 @@ object GmosControllerSim {
       override def applyConfig(config: GmosConfig[T]): F[Unit] =
         nsConfig.set(NSObsState.fromConfig(config.ns)) *> // Keep the state of NS Config
           sim.applyConfig(config)
-
-      override def setRowsToShuffle(rows: Int): F[Unit] =
-        sim.log(s"Set rows to shuffle to $rows") *>
-          Timer[F].sleep(new FiniteDuration(2, SECONDS))
 
       override def stopObserve: F[Unit] = sim.stopObserve
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorthControllerEpics.scala
@@ -5,6 +5,7 @@ package seqexec.server.gmos
 
 import cats.effect.IO
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.server.EpicsCodex
 import seqexec.server.EpicsCodex.EncodeEpicsValue
 import seqexec.server.gmos.GmosController.Config.Beam
@@ -112,5 +113,6 @@ object GmosNorthEncoders extends GmosControllerEpics.Encoders[NorthTypes] {
 }
 
 object GmosNorthControllerEpics {
-  def apply(): GmosController[IO, NorthTypes] = GmosControllerEpics[NorthTypes](northConfigTypes)(GmosNorthEncoders)
+  def apply()(implicit L: Logger[IO]): GmosController[IO, NorthTypes] =
+    GmosControllerEpics[NorthTypes](northConfigTypes)(GmosNorthEncoders, L)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouthControllerEpics.scala
@@ -5,6 +5,7 @@ package seqexec.server.gmos
 
 import cats.effect.IO
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.server.EpicsCodex.EncodeEpicsValue
 import seqexec.server.gmos.GmosController.Config.Beam
 import seqexec.server.gmos.GmosController.{SouthTypes, southConfigTypes}
@@ -110,5 +111,6 @@ object GmosSouthEncoders extends GmosControllerEpics.Encoders[SouthTypes] {
 }
 
 object GmosSouthControllerEpics {
-  def apply(): GmosController[IO, SouthTypes] = GmosControllerEpics[SouthTypes](southConfigTypes)(GmosSouthEncoders)
+  def apply()(implicit L: Logger[IO]): GmosController[IO, SouthTypes] =
+    GmosControllerEpics[SouthTypes](southConfigTypes)(GmosSouthEncoders, L)
 }


### PR DESCRIPTION
This PR adds some fixes to successfully run N&S with epics, thanks @jluhrs 
The two main changes are

* Remove the call to set rows in between stages
* Handle the response of the observe pause differently if N&S

There are few other logger related changes