### PR TITLE
SEQNG-1071 Handle errors thrown during filedId reads for N&S

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -120,13 +120,6 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
     } yield buildStep(is, systems, headers, stepType)
   }
 
-  def catchObsErrors[F[_]](t: Throwable): Stream[F, Result[F]] = t match {
-    case e: SeqexecFailure =>
-      Stream.emit(Result.Error(SeqexecFailure.explain(e)))
-    case e: Throwable =>
-      Stream.emit(Result.Error(SeqexecFailure.explain(SeqexecFailure.SeqexecException(e))))
-  }
-
   def sequence(obsId: Observation.Id, sequence: SeqexecSequence)(
     implicit cio: Concurrent[IO],
              tio: Timer[IO]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -166,7 +166,7 @@ class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Concurrent: Logge
   ): Stream[F, Result[F]] =
     Stream.eval(FileIdProvider.fileId(env)).flatMap { fileId =>
       Stream.emit(Result.Partial(FileIdAllocated(fileId))) ++ doObserve(fileId, env, post)
-    }
+    }.handleErrorWith(catchObsErrors[F])
 
   override def observeActions(
     env:  ObserveEnvironment[F],


### PR DESCRIPTION
While testing I noted that one specific error (Retrieving the fileId) wasn't properly handled for N&S
This PR fixes this adding an extra obs handler. For all other observations this is done at the upper level but N&S has a slightly different structure