### PR TITLE
SEQNG-906 GMOS stop, abort and pause allowed only if acquiring and with enough time left

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/GmosParameters.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/GmosParameters.scala
@@ -6,6 +6,9 @@ package seqexec.model
 import cats.Eq
 import cats.implicits._
 import shapeless.tag.@@
+import scala.concurrent.duration.SECONDS
+
+import scala.concurrent.duration.FiniteDuration
 
 trait GmosParameters {
   trait NsPairsI
@@ -21,6 +24,10 @@ trait GmosParameters {
   implicit val nsPairsEq: Eq[NsPairs] = Eq.by(x => x: Int)
   implicit val nsRowsEq: Eq[NsRows] = Eq.by(x => x: Int)
   implicit val nsCyclesEq: Eq[NsCycles] = Eq.by(x => x: Int)
+
+  // Remaining time when it is not safe to stop, pause or abort
+  val SafetyCutoff: FiniteDuration = new FiniteDuration(3, SECONDS)
+
 }
 
 object GmosParameters extends GmosParameters

--- a/modules/seqexec/server/src/main/resources/Gmos.xml
+++ b/modules/seqexec/server/src/main/resources/Gmos.xml
@@ -469,6 +469,11 @@
             <type>STRING</type>
             <description>GMOS detector controller s/w</description>
         </attribute>
+        <attribute name="obsAcq">
+            <channel>sad:dc:acq.VAL</channel>
+            <type>INTEGER</type>
+            <description>Observation is aquiring</description>
+        </attribute>
     </Status>
     <Status name="gmos::status">
         <top>gm</top>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -18,7 +18,7 @@ import seqexec.model.GmosParameters._
 import seqexec.server.EpicsCodex.EncodeEpicsValue
 import seqexec.server.EpicsUtil._
 import seqexec.server.InstrumentSystem.ElapsedTime
-import seqexec.server.{EpicsUtil, Progress, SeqexecFailure}
+import seqexec.server.{EpicsCommand, EpicsUtil, Progress, SeqexecFailure}
 import seqexec.server.EpicsCodex._
 import seqexec.server.gmos.GmosController.Config._
 import seqexec.server.gmos.GmosController._
@@ -403,32 +403,25 @@ object GmosControllerEpics extends GmosEncoders {
         sys.dhsConnected.map(_.trim === DhsConnected).ifM(IO.unit,
           IO.raiseError(SeqexecFailure.Execution("GMOS is not connected to DHS")))
 
-      // Remaining time when it is not safe to stop, pause or abort
-      val SafetyCutoff = 3.0 // seconds
+      private def protectedObserveCommand(name: String, cmd: EpicsCommand): IO[Unit] = {
+        val safetyCutoffAsDouble: Double = SafetyCutoff.toSeconds.toDouble
 
-      override def stopObserve: IO[Unit] = (sys.dcIsAcquiring, sys.countdown).mapN { case (isAcq, timeLeft) =>
-        if(!isAcq)
-          L.info("Gmos Stop Observe canceled because it is not acquiring.")
-        else if(timeLeft <= 3.0)
-          L.info(s"Gmos Stop Observe canceled because there is less than $SafetyCutoff seconds left.")
-        else
-          L.info("Stop Gmos exposure") *>
-            sys.stopCmd.setTimeout[IO](DefaultTimeout)
-            sys.stopCmd.mark[IO] *>
-            sys.stopCmd.post[IO].void
-      }.flatten
+        (sys.dcIsAcquiring, sys.countdown).mapN { case (isAcq, timeLeft) =>
+          if(!isAcq)
+            L.info(s"Gmos $name Observe canceled because it is not acquiring.")
+          else if(timeLeft <= safetyCutoffAsDouble)
+            L.info(s"Gmos $name Observe canceled because there is less than $safetyCutoffAsDouble seconds left.")
+          else
+            L.info(s"$name Gmos exposure") *>
+              cmd.setTimeout[IO](DefaultTimeout)
+              cmd.mark[IO] *>
+              cmd.post[IO].void
+        }.flatten
+      }
 
-      override def abortObserve: IO[Unit] = (sys.dcIsAcquiring, sys.countdown).mapN { case (isAcq, timeLeft) =>
-        if (!isAcq)
-          L.info("Gmos Abort Observe canceled because it is not acquiring.")
-        else if (timeLeft <= SafetyCutoff)
-          L.info(s"Gmos Abort Observe canceled because there is less than $SafetyCutoff seconds left.")
-        else
-          L.info("Abort Gmos exposure") *>
-            sys.abortCmd.setTimeout[IO](DefaultTimeout) *>
-            sys.abortCmd.mark[IO] *>
-            sys.abortCmd.post[IO].void
-      }.flatten
+      override def stopObserve: IO[Unit] = protectedObserveCommand("Stop", sys.stopCmd)
+
+      override def abortObserve: IO[Unit] = protectedObserveCommand("Abort", sys.abortCmd)
 
       override def endObserve: IO[Unit] =
         L.debug("Send endObserve to Gmos") *>
@@ -436,17 +429,7 @@ object GmosControllerEpics extends GmosEncoders {
           sys.endObserveCmd.mark[IO] *>
           sys.endObserveCmd.post[IO].void
 
-      override def pauseObserve: IO[Unit] = (sys.dcIsAcquiring, sys.countdown).mapN { case (isAcq, timeLeft) =>
-        if (!isAcq)
-          L.info("Gmos Pause Observe canceled because it is not acquiring.")
-        else if (timeLeft <= SafetyCutoff)
-          L.info(s"Gmos Pause Observe canceled because there is less than $SafetyCutoff seconds left.")
-        else
-          L.info("Send pause to Gmos") *>
-            sys.pauseCmd.setTimeout[IO](DefaultTimeout) *>
-            sys.pauseCmd.mark[IO] *>
-            sys.pauseCmd.post[IO].void
-      }.flatten
+      override def pauseObserve: IO[Unit] = protectedObserveCommand("Pause", sys.pauseCmd)
 
       override def resumePaused(expTime: Time): IO[ObserveCommandResult] = for {
         _   <- L.debug("Resume Gmos observation")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
@@ -218,6 +218,8 @@ class GmosEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String])
 
   def dcName: F[String] = dcRead("gmosdc")
 
+  def dcIsAcquiring: F[Boolean] = dcReadI("obsAcq").map(_ =!= 0)
+
   private val observeCAttr: CaAttribute[CarState] = dcState.addEnum("observeC",
     s"${GmosTop}dc:observeC", classOf[CarState])
   def observeState: Option[CarState] = Option(observeCAttr.value)


### PR DESCRIPTION
GMOS detector controller can crash during an observation if the stop, abort or pause command are issued at the wrong time. This PR assures they are not.