### PR TITLE
[SEQNG-333] Display of Nod and Shuffle Step

### DIFF
--- a/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/Step.scala
@@ -191,6 +191,10 @@ object Step {
       case _                                                          => false
     }
 
+    def isMultiLevel: Boolean = s match {
+      case _: NodAndShuffleStep => true
+      case _                    => false
+    }
   }
 }
 

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -444,6 +444,15 @@ body {
   margin-left: 20px;
 }
 
+.SeqexecStyles-nodAndShuffleDetailRow {
+  display: flex;
+  justifyContent: spaceBetween;
+}
+
+.SeqexecStyles-nodAndShuffleControls {
+  margin-left: 14px;
+}
+
 .SeqexecStyles-observationProgressBar {
   margin: 0 !important;
   height: 1em !important;
@@ -457,6 +466,11 @@ body {
 .SeqexecStyles-observationLabel {
   text-align: center;
   width: 100%;
+}
+
+.SeqexecStyles-dividedProgress {
+  width: 100%;
+  display: flex;
 }
 
 .SeqexecStyles-dividedProgressSectionLeft {

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -446,7 +446,6 @@ body {
 
 .SeqexecStyles-nodAndShuffleDetailRow {
   display: flex;
-  justifyContent: spaceBetween;
 }
 
 .SeqexecStyles-nodAndShuffleControls {

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -538,6 +538,10 @@ body {
   white-space: nowrap;
 }
 
+.SeqexecStyles-progressMessage {
+  font-weight: bold;
+}
+
 .SeqexecStyles-subsystems {
   margin-left: auto;
   padding-right: 7px;

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -5,6 +5,9 @@
 @background_color_5: #f5f5f5;
 @background_color_6: #f9fafb;
 @table_row_left_padding: 1em;
+@table_detail_row_right_padding: 2em;
+@table_detail_row_top_padding: 1em;
+@table_detail_row_bottom_padding: 1em;
 @breakpoint_line_color: #a5673f;
 @breakpoint_done_line_color: darkgray;
 @gutter_end_color: rgba(
@@ -429,13 +432,13 @@ body {
   margin-bottom: 1em;
 }
 
-.SeqexecStyles-acProgressRow {
+.SeqexecStyles-tableDetailRow {
   display: flex;
   flex-grow: 1;
   flex-direction: column;
   width: 100%;
   height: 100%;
-  padding: @table_row_left_padding;
+  padding: @table_detail_row_top_padding @table_detail_row_right_padding @table_detail_row_bottom_padding @table_row_left_padding;
   z-index: 100;
   position: relative;
   margin-left: 20px;
@@ -1143,10 +1146,10 @@ body {
   flex-direction: column;
 }
 .SeqexecStyles-expandedTopRow {
-  height: 50%;
+  height: 100%;
 }
 .SeqexecStyles-expandedBottomRow {
-  height: 50%;
+  height: 100%;
   background: @secondaryBackground;
   position: relative;
   z-index: 100;

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -446,16 +446,51 @@ body {
 
 .SeqexecStyles-observationProgressBar {
   margin: 0 !important;
+  height: 1em !important;
   width: 100%;
 }
 
 .SeqexecStyles-observationBar {
-  height: 1em !important;
+  height: 100% !important;
 }
 
 .SeqexecStyles-observationLabel {
   text-align: center;
   width: 100%;
+}
+
+.SeqexecStyles-dividedProgressSectionLeft {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.SeqexecStyles-dividedProgressSectionMiddle {
+  border-radius: 0 !important;
+  border-left: 1px solid black !important;
+}
+
+.SeqexecStyles-dividedProgressSectionRight {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+  border-left: 1px solid black !important;
+}
+
+.SeqexecStyles-dividedProgressBar {
+  min-width: 0 !important;
+}
+
+.SeqexecStyles-dividedProgressBarLeft {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.SeqexecStyles-dividedProgressBarMiddle {
+  border-radius: 0 !important;
+}
+
+.SeqexecStyles-dividedProgressBarRight {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
 }
 
 .SeqexecStyles-guidingCell {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -211,6 +211,14 @@ object actions {
     case i: NodAndShuffleStep => (i.id, i.status, i.configStatus, i.nsStatus)
   }
 
+  private object Printer {
+    private val pprinter: PPrinter =
+      PPrinter(defaultHeight = Int.MaxValue, colorApplyPrefix = fansi.Color.Blue)
+
+    def apply(x: Any): String =
+      fansi.Str.join(pprinter.tokenize(x, initialOffset = 4).toSeq:_*).toString
+  }
+
   implicit val show: Show[Action] = Show.show {
     case FlipBreakpointStep(oid, st) =>
       s"FlipBreakpointStep(${oid.format}, ${st.id})"

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -211,14 +211,6 @@ object actions {
     case i: NodAndShuffleStep => (i.id, i.status, i.configStatus, i.nsStatus)
   }
 
-  private object Printer {
-    private val pprinter: PPrinter =
-      PPrinter(defaultHeight = Int.MaxValue, colorApplyPrefix = fansi.Color.Blue)
-
-    def apply(x: Any): String =
-      fansi.Str.join(pprinter.tokenize(x, initialOffset = 4).toSeq:_*).toString
-  }
-
   implicit val show: Show[Action] = Show.show {
     case FlipBreakpointStep(oid, st) =>
       s"FlipBreakpointStep(${oid.format}, ${st.id})"

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
@@ -1,0 +1,52 @@
+package seqexec.web.client.components
+
+import japgolly.scalajs.react.{Reusability, ScalaComponent}
+import japgolly.scalajs.react.vdom.html_<^.VdomElement
+import react.common.Css
+import seqexec.web.client.semanticui.elements.progress.Progress
+import web.client.ReactProps
+
+/**
+  * Progress bar divided in steps
+  *
+  * NOT IMPLEMENTED YET. JUST RENDERS A REGULAR PROGRESS BAR.
+  *
+  */
+final case class DividedProgress(
+  label:       String,
+  total:       Long,
+  value:       Long,
+  indicating:  Boolean = false,
+  progress:    Boolean = false,
+  color:       Option[String] = None,
+  progressCls: List[Css] = Nil,
+  barCls:      List[Css],
+  labelCls:    List[Css] = Nil
+) extends ReactProps {
+  @inline def render: VdomElement = DividedProgress.component(this)
+}
+
+object DividedProgress {
+  type Props = DividedProgress
+
+  implicit val propsReuse: Reusability[Props] = Reusability.byRef
+
+  protected val component = ScalaComponent
+    .builder[Props]("DividedProgress")
+    .stateless
+    .render_P(p =>
+                Progress(Progress.Props(
+                  p.label,
+                  p.total,
+                  p.value,
+                  p.indicating,
+                  p.progress,
+                  p.color,
+                  p.progressCls,
+                  p.barCls,
+                  p.labelCls
+                ))
+              )
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
@@ -1,7 +1,11 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.web.client.components
 
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
+import react.common.implicits._
 import react.common.Css
 import cats.implicits._
 import seqexec.web.client.semanticui.elements.progress.Progress
@@ -58,10 +62,7 @@ object DividedProgress {
             SeqexecStyles.dividedProgressBarRight
 
       <.span(
-
-        ^.width := "100%",
-        ^.display.flex,
-
+        SeqexecStyles.dividedProgress,
         p.sections.zip(sectionValuesAndColors).zip(sectionProgressStyles).zip(sectionBarStyles.padTo(countSections, Css.Zero)).toTagMod {
           case (((label, (sectionValue, sectionColor)), sectionProgressStyle), sectionBarStyle) =>
             Progress(Progress.Props(
@@ -74,7 +75,7 @@ object DividedProgress {
               p.progressCls :+ sectionProgressStyle,
               p.barCls ++ List(sectionBarStyle, SeqexecStyles.dividedProgressBar),
               p.labelCls
-              ))
+            ))
         }
         )
     }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
@@ -1,52 +1,83 @@
 package seqexec.web.client.components
 
-import japgolly.scalajs.react.{Reusability, ScalaComponent}
-import japgolly.scalajs.react.vdom.html_<^.VdomElement
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
 import react.common.Css
+import cats.implicits._
 import seqexec.web.client.semanticui.elements.progress.Progress
 import web.client.ReactProps
 
 /**
   * Progress bar divided in steps
-  *
-  * NOT IMPLEMENTED YET. JUST RENDERS A REGULAR PROGRESS BAR.
-  *
   */
 final case class DividedProgress(
-  label:       String,
-  total:       Long,
-  value:       Long,
-  indicating:  Boolean = false,
-  progress:    Boolean = false,
-  color:       Option[String] = None,
-  progressCls: List[Css] = Nil,
-  barCls:      List[Css],
-  labelCls:    List[Css] = Nil
-) extends ReactProps {
+                                  sections            : List[DividedProgress.Label],
+                                  sectionTotal        : DividedProgress.Quantity,
+                                  value               : DividedProgress.Quantity,
+                                  indicating          : Boolean = false,
+                                  progress            : Boolean = false,
+                                  completeSectionColor: Option[String] = None,
+                                  ongoingSectionColor : Option[String] = None,
+                                  progressCls         : List[Css] = Nil,
+                                  barCls              : List[Css],
+                                  labelCls            : List[Css] = Nil
+                                ) extends ReactProps {
   @inline def render: VdomElement = DividedProgress.component(this)
 }
 
 object DividedProgress {
   type Props = DividedProgress
 
+  type Label = String
+  type Quantity = Int
+
   implicit val propsReuse: Reusability[Props] = Reusability.byRef
 
   protected val component = ScalaComponent
     .builder[Props]("DividedProgress")
     .stateless
-    .render_P(p =>
-                Progress(Progress.Props(
-                  p.label,
-                  p.total,
-                  p.value,
-                  p.indicating,
-                  p.progress,
-                  p.color,
-                  p.progressCls,
-                  p.barCls,
-                  p.labelCls
-                ))
-              )
+    .render_P { p =>
+      val sectionProgressStyles: List[Css] =
+        SeqexecStyles.dividedProgressSectionLeft +:
+          List.fill(p.sections.length - 2)(SeqexecStyles.dividedProgressSectionMiddle) :+
+          SeqexecStyles.dividedProgressSectionRight
+
+      val countSections = p.sections.length
+      val completeSections = p.value / countSections
+      val sectionValuesAndColors: List[(Quantity, Option[String])] =
+        (List.fill(completeSections)((p.sectionTotal, p.completeSectionColor)) :+
+          ((p.value % countSections, p.ongoingSectionColor))) ++
+          List.fill(countSections - completeSections - 1)((0, None))
+
+      val sectionBarStyles: List[Css] =
+        if (completeSections === 0)
+          List.empty
+        else
+          SeqexecStyles.dividedProgressBarLeft +:
+            List.fill(completeSections - 1)(SeqexecStyles.dividedProgressBarMiddle) :+
+            SeqexecStyles.dividedProgressBarRight
+
+      <.span(
+
+        ^.width := "100%",
+        ^.display.flex,
+
+        p.sections.zip(sectionValuesAndColors).zip(sectionProgressStyles).zip(sectionBarStyles.padTo(countSections, Css.Zero)).toTagMod {
+          case (((label, (sectionValue, sectionColor)), sectionProgressStyle), sectionBarStyle) =>
+            Progress(Progress.Props(
+              label,
+              p.sectionTotal.toLong,
+              sectionValue.toLong,
+              p.indicating,
+              p.progress,
+              sectionColor,
+              p.progressCls :+ sectionProgressStyle,
+              p.barCls ++ List(sectionBarStyle, SeqexecStyles.dividedProgressBar),
+              p.labelCls
+              ))
+        }
+        )
+    }
     .configure(Reusability.shouldComponentUpdate)
     .build
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -185,8 +185,9 @@ object SeqexecStyles {
 
   val configuringRow: Css = Css("SeqexecStyles-configuringRow")
 
-  val specialStateLabel: Css =
-    Css("SeqexecStyles-specialStateLabel")
+  val specialStateLabel: Css = Css("SeqexecStyles-specialStateLabel")
+
+  val progressMessage: Css = Css("SeqexecStyles-progressMessage")
 
   val subsystems: Css = Css("SeqexecStyles-subsystems")
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -18,8 +18,8 @@ object SeqexecStyles {
   val TableBorderWidth: Double = 1.0
   val TableRightPadding: Int   = 13
 
-  val acProgressRow: Css =
-    Css("SeqexecStyles-acProgressRow")
+  val tableDetailRow: Css =
+    Css("SeqexecStyles-tableDetailRow")
 
   val expandedRunningRow: Css =
     Css("SeqexecStyles-expandedRunningRow")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -341,6 +341,9 @@ object SeqexecStyles {
   val defaultCursor: Css =
     Css("SeqexecStyles-defaultCursor")
 
+  val dividedProgress: Css =
+    Css("SeqexecStyles-dividedProgress")
+
   val dividedProgressSectionLeft: Css =
     Css("SeqexecStyles-dividedProgressSectionLeft")
 
@@ -361,4 +364,10 @@ object SeqexecStyles {
 
   val dividedProgressBarRight: Css =
     Css("SeqexecStyles-dividedProgressBarRight")
+
+  val nodAndShuffleDetailRow: Css =
+    Css("SeqexecStyles-nodAndShuffleDetailRow")
+
+  val nodAndShuffleControls: Css =
+    Css("SeqexecStyles-nodAndShuffleControls")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -340,4 +340,25 @@ object SeqexecStyles {
 
   val defaultCursor: Css =
     Css("SeqexecStyles-defaultCursor")
+
+  val dividedProgressSectionLeft: Css =
+    Css("SeqexecStyles-dividedProgressSectionLeft")
+
+  val dividedProgressSectionMiddle: Css =
+    Css("SeqexecStyles-dividedProgressSectionMiddle")
+
+  val dividedProgressSectionRight: Css =
+    Css("SeqexecStyles-dividedProgressSectionRight")
+
+  val dividedProgressBar: Css =
+    Css("SeqexecStyles-dividedProgressBar")
+
+  val dividedProgressBarLeft: Css =
+    Css("SeqexecStyles-dividedProgressBarLeft")
+
+  val dividedProgressBarMiddle: Css =
+    Css("SeqexecStyles-dividedProgressBarMiddle")
+
+  val dividedProgressBarRight: Css =
+    Css("SeqexecStyles-dividedProgressBarRight")
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/AlignAndCalibProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/AlignAndCalibProgress.scala
@@ -46,7 +46,7 @@ object ACProgressBar {
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
   implicit val stateReuse: Reusability[State] = Reusability.derive[State]
 
-  val enum = Enumerated[AlignAndCalibStep]
+  val acSteps = Enumerated[AlignAndCalibStep]
   implicit val showACS: Show[AlignAndCalibStep] = Show.show {
     case NoAction           => ""
     case StartGuiding       => "Start Guiding"
@@ -94,13 +94,13 @@ object ACProgressBar {
       val msg = if (isInError) "Error" else s.msg
       Progress(Progress.Props(
         s"Align and Calib: $msg",
-        total       = enum.all.length - 1,
+        total       = acSteps.all.length - 1,
         value       = max(0, s.counter),
         color       = if (isInError) "red".some else "green".some,
         progressCls = List(SeqexecStyles.observationProgressBar),
         barCls      = List(SeqexecStyles.observationBar),
         labelCls    = List(SeqexecStyles.observationLabel)
-      ))
+        ))
     }
     .componentWillReceiveProps(x =>
       x.modStateL(State.counter)(_ + 1) >> x.setStateL(State.msg)(x.nextProps.step.show))

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/AlignAndCalibProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/AlignAndCalibProgress.scala
@@ -17,7 +17,7 @@ import seqexec.web.client.reusability._
 import seqexec.web.client.semanticui.elements.progress.Progress
 import seqexec.web.client.model.AlignAndCalibStep
 import seqexec.web.client.model.AlignAndCalibStep._
-import seqexec.web.client.model.StepItems.StepStateSnapshot
+import seqexec.web.client.model.StepItems.StepStateSummary
 import seqexec.web.client.reusability._
 import web.client.ReactProps
 
@@ -25,7 +25,7 @@ import scala.math.max
 
 final case class ACProgressBar(
   step: AlignAndCalibStep,
-  state: StepStateSnapshot
+  state: StepStateSummary
 ) extends ReactProps {
   @inline def render: VdomElement = ACProgressBar.component(this)
 }
@@ -94,8 +94,8 @@ object ACProgressBar {
       val msg = if (isInError) "Error" else s.msg
       Progress(Progress.Props(
         s"Align and Calib: $msg",
-        total       = enum.all.length.toLong - 1,
-        value       = max(0, s.counter.toLong),
+        total       = enum.all.length - 1,
+        value       = max(0, s.counter),
         color       = if (isInError) "red".some else "green".some,
         progressCls = List(SeqexecStyles.observationProgressBar),
         barCls      = List(SeqexecStyles.observationBar),
@@ -111,7 +111,7 @@ object ACProgressBar {
 /**
   * Component to wrap the progress bar
   */
-final case class AlignAndCalibProgress(state: StepStateSnapshot) extends ReactProps {
+final case class AlignAndCalibProgress(state: StepStateSummary) extends ReactProps {
   @inline def render: VdomElement = AlignAndCalibProgress.component(this)
 
   protected[steps] val connect =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/AlignAndCalibProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/AlignAndCalibProgress.scala
@@ -43,7 +43,6 @@ object ACProgressBar {
     }
   }
 
-  implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.never
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
   implicit val stateReuse: Reusability[State] = Reusability.derive[State]
 
@@ -122,7 +121,6 @@ final case class AlignAndCalibProgress(state: StepStateSnapshot) extends ReactPr
 object AlignAndCalibProgress {
   type Props = AlignAndCalibProgress
 
-  implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.never
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   protected val component = ScalaComponent

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ControlButtonResolver.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ControlButtonResolver.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components.sequence.steps
+
+import seqexec.model.{SequenceState, Step}
+import seqexec.web.client.model.ClientStatus
+
+trait ControlButtonResolver[A] {
+  def extractor(a: A): (ClientStatus, SequenceState, Step)
+
+  def controlButtonsActive(a: A): Boolean = {
+    val (clientStatus, state, step) = extractor(a)
+    clientStatus.isLogged && state.isRunning &&
+      (step.isObserving || step.isObservePaused || state.userStopRequested)
+  }
+}
+
+object ControlButtonResolver {
+  def build[A](extractorFn: A => (ClientStatus, SequenceState, Step)): ControlButtonResolver[A] =
+    new ControlButtonResolver[A] {
+      override def extractor(a: A): (ClientStatus, SequenceState, Step) = extractorFn(a)
+    }
+}
+

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ControlButtonResolver.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ControlButtonResolver.scala
@@ -6,7 +6,7 @@ package seqexec.web.client.components.sequence.steps
 import seqexec.model.{SequenceState, Step}
 import seqexec.web.client.model.ClientStatus
 
-trait ControlButtonResolver[A] {
+sealed trait ControlButtonResolver[A] {
   def extractor(a: A): (ClientStatus, SequenceState, Step)
 
   def controlButtonsActive(a: A): Boolean = {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -1,0 +1,120 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components.sequence.steps
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import seqexec.web.client.model.StepItems.StepStateSnapshot
+import web.client.ReactProps
+import japgolly.scalajs.react.internal.CatsReactExt
+import seqexec.web.client.components.{DividedProgress, SeqexecStyles}
+import cats.syntax.option._
+import seqexec.web.client.semanticui.elements.button.Button
+import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
+import seqexec.web.client.semanticui.elements.popup.Popup
+
+final case class NodAndShuffleCycleProgress(state: StepStateSnapshot) extends ReactProps {
+  @inline def render: VdomElement = NodAndShuffleCycleProgress.component(this)
+}
+
+object NodAndShuffleCycleProgress extends CatsReactExt {
+  type Props = NodAndShuffleCycleProgress
+
+  implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.byEq
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+
+  protected val component = ScalaComponent
+    .builder[Props]("NodAndShuffleCycleProgress")
+    .stateless
+    .render_P { p =>
+      val isInError = !p.state.isNSRunning && p.state.isNSInError
+      val msg = if (isInError) "Error" else "Running..."
+
+      <.span(
+
+        ^.display.flex,
+        ^.justifyContent.spaceBetween,
+
+        DividedProgress(
+          s"Nod and Shuffle Cycle: $msg",
+          total = 100, //enum.all.length.toLong - 1,
+          value = 33, //max(0, s.counter.toLong),
+          color = if (isInError) "red".some else "green".some,
+          progressCls = List(SeqexecStyles.observationProgressBar),
+          barCls = List(SeqexecStyles.observationBar),
+          labelCls = List(SeqexecStyles.observationLabel)
+          ),
+        <.span(
+
+          ^.marginLeft := "14px",
+
+          Popup(
+            Popup.Props("button", "Pause the current cycle"),
+            Button(
+              Button.Props(icon = Some(IconPause),
+                           color = Some("teal"),
+                           //                         onClick = requestObsPause(p.id, p.stepId),
+                           //                         disabled = p.requestInFlight || p.isObservePaused
+                           )
+              )
+            )
+
+          )
+        )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+}
+
+final case class NodAndShuffleNodProgress(state  : StepStateSnapshot) extends ReactProps {
+  @inline def render: VdomElement = NodAndShuffleNodProgress.component(this)
+}
+
+object NodAndShuffleNodProgress extends CatsReactExt {
+  type Props = NodAndShuffleNodProgress
+
+  implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.byEq
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+
+  protected val component = ScalaComponent
+    .builder[Props]("NodAndShuffleNodProgress")
+    .stateless
+    .render_P { p =>
+      val isInError = !p.state.isNSRunning && p.state.isNSInError
+      val msg = if (isInError) "Error" else "Running..."
+
+      <.span(
+
+        ^.display.flex,
+        ^.justifyContent.spaceBetween,
+
+      DividedProgress(
+        s"Nod and Shuffle Nod: $msg",
+        total = 100, //enum.all.length.toLong - 1,
+        value = 33, //max(0, s.counter.toLong),
+        color = if (isInError) "red".some else "green".some,
+        progressCls = List(SeqexecStyles.observationProgressBar),
+        barCls = List(SeqexecStyles.observationBar),
+        labelCls = List(SeqexecStyles.observationLabel)
+        ),
+      <.span(
+
+        ^.marginLeft := "14px",
+
+          Popup(
+          Popup.Props("button", "Pause the current nod"),
+          Button(
+            Button.Props(icon = Some(IconPause),
+                         color = Some("teal"),
+                         //                         onClick = requestObsPause(p.id, p.stepId),
+                         //                         disabled = p.requestInFlight || p.isObservePaused
+                         )
+            )
+          )
+        )
+      )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -9,7 +9,8 @@ import seqexec.web.client.model.StepItems.StepStateSnapshot
 import web.client.ReactProps
 import japgolly.scalajs.react.internal.CatsReactExt
 import seqexec.web.client.components.{DividedProgress, SeqexecStyles}
-import cats.syntax.option._
+//import cats.syntax.option._
+import cats.implicits._
 import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
 import seqexec.web.client.semanticui.elements.popup.Popup
@@ -24,12 +25,15 @@ object NodAndShuffleCycleProgress extends CatsReactExt {
   implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.byEq
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
+  private val cycleSections: List[DividedProgress.Label] =
+    List.range(1, 8).map(_.show)
+
   protected val component = ScalaComponent
     .builder[Props]("NodAndShuffleCycleProgress")
     .stateless
     .render_P { p =>
       val isInError = !p.state.isNSRunning && p.state.isNSInError
-      val msg = if (isInError) "Error" else "Running..."
+//      val msg = if (isInError) "Error" else "Running..."
 
       <.span(
 
@@ -37,10 +41,13 @@ object NodAndShuffleCycleProgress extends CatsReactExt {
         ^.justifyContent.spaceBetween,
 
         DividedProgress(
-          s"Nod and Shuffle Cycle: $msg",
-          total = 100, //enum.all.length.toLong - 1,
+          //            s"Nod and Shuffle Cycle: $msg",
+          cycleSections,
+          10,
+          //            total = 100, //enum.all.length.toLong - 1,
           value = 33, //max(0, s.counter.toLong),
-          color = if (isInError) "red".some else "green".some,
+          completeSectionColor = if (isInError) "red".some else "green".some,
+          ongoingSectionColor = if (isInError) "red".some else "blue".some,
           progressCls = List(SeqexecStyles.observationProgressBar),
           barCls = List(SeqexecStyles.observationBar),
           labelCls = List(SeqexecStyles.observationLabel)
@@ -77,43 +84,49 @@ object NodAndShuffleNodProgress extends CatsReactExt {
   implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.byEq
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
+  private val nodSections: List[DividedProgress.Label] =
+    List("B", "A", "A", "B")
+
   protected val component = ScalaComponent
     .builder[Props]("NodAndShuffleNodProgress")
     .stateless
     .render_P { p =>
       val isInError = !p.state.isNSRunning && p.state.isNSInError
-      val msg = if (isInError) "Error" else "Running..."
+//      val msg = if (isInError) "Error" else "Running..."
 
       <.span(
 
         ^.display.flex,
         ^.justifyContent.spaceBetween,
 
-      DividedProgress(
-        s"Nod and Shuffle Nod: $msg",
-        total = 100, //enum.all.length.toLong - 1,
-        value = 33, //max(0, s.counter.toLong),
-        color = if (isInError) "red".some else "green".some,
-        progressCls = List(SeqexecStyles.observationProgressBar),
-        barCls = List(SeqexecStyles.observationBar),
-        labelCls = List(SeqexecStyles.observationLabel)
-        ),
-      <.span(
+        DividedProgress(
+          //          s"Nod and Shuffle Nod: $msg",
+          nodSections,
+          sectionTotal = 2,
+          //          total = 100, //enum.all.length.toLong - 1,
+          value = 5, //max(0, s.counter.toLong),
+          completeSectionColor = if (isInError) "red".some else "green".some,
+          ongoingSectionColor = if (isInError) "red".some else "blue".some,
+          progressCls = List(SeqexecStyles.observationProgressBar),
+          barCls = List(SeqexecStyles.observationBar),
+//          labelCls = List(SeqexecStyles.observationLabel)
+          ),
+        <.span(
 
-        ^.marginLeft := "14px",
+          ^.marginLeft := "14px",
 
           Popup(
-          Popup.Props("button", "Pause the current nod"),
-          Button(
-            Button.Props(icon = Some(IconPause),
-                         color = Some("teal"),
-                         //                         onClick = requestObsPause(p.id, p.stepId),
-                         //                         disabled = p.requestInFlight || p.isObservePaused
-                         )
+            Popup.Props("button", "Pause the current nod"),
+            Button(
+              Button.Props(icon = Some(IconPause),
+                           color = Some("teal"),
+                           //                         onClick = requestObsPause(p.id, p.stepId),
+                           //                         disabled = p.requestInFlight || p.isObservePaused
+                           )
+              )
             )
           )
         )
-      )
     }
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -103,9 +103,8 @@ object  NodAndShuffleProgress {
     .render_PS { (p, s) =>
       s.progressConnect { proxy =>
         val (totalMillis, remainingMillis) =
-          proxy()
-            .map(p => (p.total.toMilliseconds.toInt, p.remaining.toMilliseconds.toInt))
-            .getOrElse((0, 0))
+          proxy().foldMap(p =>
+            (p.total.toMilliseconds.toInt, p.remaining.toMilliseconds.toInt))
         val elapsedMillis = totalMillis - max(0, remainingMillis)
 
         p.summary.nsStatus.map[VdomElement] { nsStatus =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -89,6 +89,9 @@ object  NodAndShuffleProgress {
   type Props = NodAndShuffleProgress
 
   @Lenses
+  // From diode doc (Usage with React): "Having a single reference to (connect)
+  // during your components lifecycle ensures that React will update your
+  // component rather than unmounting and remounting it."
   final case class State(progressConnect: ReactConnectProxy[Option[ObservationProgress]])
 
   implicit val propsReuse: Reusability[Props] = Reusability.by(_.summary)
@@ -199,7 +202,7 @@ trait NodAndShuffleRow[L <: OperationLevel] {
   implicit val propsControlButtonResolver: ControlButtonResolver[Props] =
     ControlButtonResolver.build(p => (p.clientStatus, p.stateSummary.state, p.stateSummary.step))
 
-  implicit private val operationLevelType: OperationLevelType[L] = implicitly[OperationLevelType[L]]
+  implicit protected val operationLevelType: OperationLevelType[L]
 
   protected def progressControl(summary: StepStateSummary): VdomElement
 
@@ -242,6 +245,9 @@ object NodAndShuffleCycleRow extends NodAndShuffleRow[OperationLevel.NsCycle] {
 
   implicit lazy val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
+  implicit protected val operationLevelType: OperationLevelType[OperationLevel.NsCycle] =
+    implicitly[OperationLevelType[OperationLevel.NsCycle]]
+
   protected def progressControl(summary: StepStateSummary): VdomElement =
     NodAndShuffleCycleProgress(summary)
 }
@@ -260,6 +266,9 @@ object NodAndShuffleNodRow extends NodAndShuffleRow[OperationLevel.NsNod] {
   type Props = NodAndShuffleNodRowProps
 
   implicit lazy val propsReuse: Reusability[Props] = Reusability.derive[Props]
+
+  implicit protected val operationLevelType: OperationLevelType[OperationLevel.NsNod] =
+    implicitly[OperationLevelType[OperationLevel.NsNod]]
 
   protected def progressControl(summary: StepStateSummary): VdomElement =
     NodAndShuffleNodProgress(summary)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -8,9 +8,10 @@ import japgolly.scalajs.react.vdom.html_<^._
 import seqexec.web.client.model.StepItems.StepStateSnapshot
 import web.client.ReactProps
 import japgolly.scalajs.react.internal.CatsReactExt
+import seqexec.model.enum.NodAndShuffleStage
 import seqexec.web.client.components.{DividedProgress, SeqexecStyles}
-//import cats.syntax.option._
 import cats.implicits._
+import seqexec.model.NodAndShuffleStep
 import seqexec.web.client.semanticui.elements.button.Button
 import seqexec.web.client.semanticui.elements.icon.Icon.IconPause
 import seqexec.web.client.semanticui.elements.popup.Popup
@@ -25,13 +26,11 @@ object NodAndShuffleCycleProgress extends CatsReactExt {
   implicit val stepReuse: Reusability[StepStateSnapshot] = Reusability.byEq
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  private val cycleSections: List[DividedProgress.Label] =
-    List.range(1, 8).map(_.show)
-
   protected val component = ScalaComponent
     .builder[Props]("NodAndShuffleCycleProgress")
     .stateless
     .render_P { p =>
+      val nsStatus = p.state.step.asInstanceOf[NodAndShuffleStep].nsStatus
       val isInError = !p.state.isNSRunning && p.state.isNSInError
 //      val msg = if (isInError) "Error" else "Running..."
 
@@ -42,10 +41,9 @@ object NodAndShuffleCycleProgress extends CatsReactExt {
 
         DividedProgress(
           //            s"Nod and Shuffle Cycle: $msg",
-          cycleSections,
-          10,
-          //            total = 100, //enum.all.length.toLong - 1,
-          value = 33, //max(0, s.counter.toLong),
+          List.range(1, nsStatus.cycles + 1).map(_.show),
+          nsStatus.nodExposureTime.toSeconds.toInt * NodAndShuffleStage.NsSequence.length,
+          value = 8,
           completeSectionColor = if (isInError) "red".some else "green".some,
           ongoingSectionColor = if (isInError) "red".some else "blue".some,
           progressCls = List(SeqexecStyles.observationProgressBar),
@@ -85,12 +83,13 @@ object NodAndShuffleNodProgress extends CatsReactExt {
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   private val nodSections: List[DividedProgress.Label] =
-    List("B", "A", "A", "B")
+    NodAndShuffleStage.NsSequence.map(_.symbol.name).toList
 
   protected val component = ScalaComponent
     .builder[Props]("NodAndShuffleNodProgress")
     .stateless
     .render_P { p =>
+      val nsStatus = p.state.step.asInstanceOf[NodAndShuffleStep].nsStatus
       val isInError = !p.state.isNSRunning && p.state.isNSInError
 //      val msg = if (isInError) "Error" else "Running..."
 
@@ -102,9 +101,8 @@ object NodAndShuffleNodProgress extends CatsReactExt {
         DividedProgress(
           //          s"Nod and Shuffle Nod: $msg",
           nodSections,
-          sectionTotal = 2,
-          //          total = 100, //enum.all.length.toLong - 1,
-          value = 5, //max(0, s.counter.toLong),
+          sectionTotal = nsStatus.nodExposureTime.toSeconds.toInt,
+          value = 5,
           completeSectionColor = if (isInError) "red".some else "green".some,
           ongoingSectionColor = if (isInError) "red".some else "blue".some,
           progressCls = List(SeqexecStyles.observationProgressBar),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SmoothProgressBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/SmoothProgressBar.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components.sequence.steps
+
+import cats.implicits._
+import japgolly.scalajs.react.extra.TimerSupport
+import japgolly.scalajs.react.{BackendScope, Callback, Reusability}
+import monocle.macros.Lenses
+import web.client.ReactProps
+
+import scala.concurrent.duration._
+import scala.math.max
+import scala.math.min
+
+trait SmoothProgressBarProps extends ReactProps {
+  val value: Int
+  val maxValue: Int
+  val stopping: Boolean
+  val paused: Boolean
+}
+
+trait SmoothProgressBar[P <: SmoothProgressBarProps] {
+  @Lenses
+  protected case class State(maxValue: Int, value: Int, skipStep: Boolean)
+
+  protected object State {
+    def fromProps(p: P): State = State(p.maxValue, p.value, skipStep = false)
+  }
+
+  implicit protected val stateReuse: Reusability[State] = Reusability.derive[State]
+
+  protected class Backend(b: BackendScope[P, State]) extends TimerSupport {
+    private val periodUpdate: Int = 50
+    // This depends on the server side frequency of updates
+    private val remoteUpdatePeriod: Int = 1000
+
+    def setupTimer: Callback =
+      setInterval(tickTotal, periodUpdate.millisecond)
+
+    def newStateFromProps(prev: P, next: P): Callback =
+      b.modState { s =>
+        if (prev.paused =!= next.paused || prev.stopping =!= next.stopping) {
+          s
+        } else if (next.stopping) {
+          s
+        } else {
+          State(next.maxValue, max(next.value, s.value), s.value > next.value)
+        }
+      }
+
+    def tickTotal: Callback = b.props.zip(b.state) >>= {
+      case (p, s) =>
+        val next = min(s.value + periodUpdate, p.value + remoteUpdatePeriod)
+        b.modState(State.value.set(min(p.maxValue, next)))
+         .when(!s.skipStep && !p.paused && !p.stopping) *>
+          b.modState(State.skipStep.set(false))
+    }
+  }
+
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -54,8 +54,8 @@ final case class StepProgressCell(
   def isStopping: Boolean =
     tabOperations.stopRequested === StopOperation.StopInFlight
 
-  val stateSnapshot: StepStateSnapshot =
-    StepStateSnapshot(step, obsId, instrument, tabOperations, state)
+  val stateSummary: StepStateSummary =
+    StepStateSummary(step, obsId, instrument, tabOperations, state)
 }
 
 object StepProgressCell {
@@ -181,10 +181,10 @@ object StepProgressCell {
       ).when(props.step.canRunFrom && props.clientStatus.canOperate),
       <.div(
         SeqexecStyles.specialStateLabel,
-        if (props.stateSnapshot.isAC) {//} && !props.stateSnapshot.anyError) {
-          if (props.stateSnapshot.isACRunning) {
+        if (props.stateSummary.isAC) {//} && !props.stateSnapshot.anyError) {
+          if (props.stateSummary.isACRunning) {
             "Running Align & Calib..."
-          } else if (props.stateSnapshot.anyError) {
+          } else if (props.stateSummary.anyError) {
             props.step.show
           } else {
             "Align & Calib"

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -181,7 +181,7 @@ object StepProgressCell {
       ).when(props.step.canRunFrom && props.clientStatus.canOperate),
       <.div(
         SeqexecStyles.specialStateLabel,
-        if (props.stateSummary.isAC) {//} && !props.stateSnapshot.anyError) {
+        if (props.stateSummary.isAC) {
           if (props.stateSummary.isACRunning) {
             "Running Align & Calib..."
           } else if (props.stateSummary.anyError) {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -55,13 +55,15 @@ final case class StepProgressCell(
     tabOperations.stopRequested === StopOperation.StopInFlight
 
   val stateSnapshot: StepStateSnapshot =
-    StepStateSnapshot(step, instrument, tabOperations, state)
+    StepStateSnapshot(step, obsId, instrument, tabOperations, state)
 }
 
 object StepProgressCell {
   type Props = StepProgressCell
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+  implicit val propsControlButtonResolver: ControlButtonResolver[Props] =
+    ControlButtonResolver.build(p => (p.clientStatus, p.state, p.step))
 
   def labelColor(status: ActionStatus): String = status match {
     case ActionStatus.Pending   => "gray"
@@ -102,10 +104,6 @@ object StepProgressCell {
       )
     )
 
-  def controlButtonsActive(props: Props): Boolean =
-    props.clientStatus.isLogged && props.state.isRunning &&
-      (props.step.isObserving || props.step.isObservePaused || props.state.userStopRequested)
-
   def stepObservationStatusAndFile(
     props:  Props,
     stepId: StepId,
@@ -113,20 +111,22 @@ object StepProgressCell {
   ): VdomElement =
     <.div(
       SeqexecStyles.configuringRow,
-      ObservationProgressBar(
+      ObservationProgressDisplay(
         props.obsId,
         stepId,
         fileId,
         stopping = props.isStopping,
-        paused   = false),
+        paused   = false,
+        hideBar  = props.step.isMultiLevel),
       StepsControlButtons(
         props.obsId,
         props.instrument,
         props.state,
         props.step.id,
         props.step.isObservePaused,
+        props.step.isMultiLevel,
         props.tabOperations
-      ).when(controlButtonsActive(props))
+      ).when(props.controlButtonsActive)
     )
 
   def stepObservationPaused(props:  Props,
@@ -134,20 +134,22 @@ object StepProgressCell {
                             fileId: ImageFileId): VdomElement =
     <.div(
       SeqexecStyles.configuringRow,
-      ObservationProgressBar(
+      ObservationProgressDisplay(
         props.obsId,
         stepId,
         fileId,
         stopping = false,
-        paused = true),
+        paused = true,
+        hideBar  = props.step.isMultiLevel),
       StepsControlButtons(
         props.obsId,
         props.instrument,
         props.state,
         props.step.id,
         props.step.isObservePaused,
+        props.step.isMultiLevel,
         props.tabOperations
-      ).when(controlButtonsActive(props))
+      ).when(props.controlButtonsActive)
     )
 
   def stepObservationPausing(props: Props): VdomElement =
@@ -163,8 +165,9 @@ object StepProgressCell {
         props.state,
         props.step.id,
         props.step.isObservePaused,
+        props.step.isMultiLevel,
         props.tabOperations
-      ).when(controlButtonsActive(props))
+      ).when(props.controlButtonsActive)
     )
 
   def stepSubsystemControl(props: Props): VdomElement =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -11,7 +11,7 @@ import gem.Observation
 import react.common.implicits._
 import seqexec.model._
 import seqexec.model.enum._
-import seqexec.model.operations.ObservationOperations._
+import seqexec.model.operations.Operations._
 import seqexec.model.operations._
 import seqexec.web.client.actions.RequestAbort
 import seqexec.web.client.actions.RequestObsPause
@@ -28,6 +28,121 @@ import seqexec.web.client.semanticui.elements.icon.Icon.IconStop
 import seqexec.web.client.semanticui.elements.icon.Icon.IconTrash
 import seqexec.web.client.reusability._
 import web.client.ReactProps
+
+/**
+  * Contains a set of control buttons like stop/abort
+  */
+final case class ControlButtons(
+                                      id:              Observation.Id,
+                                      operations:      List[Operations[_]],
+                                      sequenceState:   SequenceState,
+                                      stepId:          Int,
+                                      isObservePaused: Boolean,
+                                      tabOperations:   TabOperations
+                                    ) extends ReactProps {
+  @inline def render: VdomElement = ControlButtons.component(this)
+
+  val requestInFlight = tabOperations.stepRequestInFlight
+}
+
+object ControlButtons {
+  type Props = ControlButtons
+
+  implicit val operationsReuse: Reusability[Operations[_]] = Reusability.derive[Operations[_]]
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+
+  def requestStop(id: Observation.Id, stepId: Int): Callback =
+    SeqexecCircuit.dispatchCB(RequestStop(id, stepId))
+
+  def requestAbort(id: Observation.Id, stepId: Int): Callback =
+    SeqexecCircuit.dispatchCB(RequestAbort(id, stepId))
+
+  def requestObsPause(id: Observation.Id, stepId: Int): Callback =
+    SeqexecCircuit.dispatchCB(RequestObsPause(id, stepId))
+
+  def requestObsResume(id: Observation.Id, stepId: Int): Callback =
+    SeqexecCircuit.dispatchCB(RequestObsResume(id, stepId))
+
+  protected val component = ScalaComponent
+    .builder[Props]("ControlButtons")
+    .render_P { p =>
+      <.div(
+        ^.cls := "ui icon buttons",
+        SeqexecStyles.notInMobile,
+        p.operations
+         .map {
+           case PauseObservation =>
+             Popup(
+               Popup.Props("button", "Pause the current exposure"),
+               Button(
+                 Button.Props(icon  = Some(IconPause),
+                              color = Some("teal"),
+                              onClick =
+                                requestObsPause(p.id, p.stepId),
+                              disabled = p.requestInFlight || p.isObservePaused))
+               )
+           case StopObservation =>
+             Popup(
+               Popup.Props("button", "Stop the current exposure early"),
+               Button(
+                 Button.Props(icon     = Some(IconStop),
+                              color    = Some("orange"),
+                              onClick  = requestStop(p.id, p.stepId),
+                              disabled = p.requestInFlight))
+               )
+           case AbortObservation =>
+             Popup(
+               Popup.Props("button", "Abort the current exposure"),
+               Button(
+                 Button.Props(
+                   icon     = Some(IconTrash),
+                   color    = Some("red"),
+                   onClick  = requestAbort(p.id, p.stepId),
+                   disabled = p.requestInFlight))
+               )
+           case ResumeObservation =>
+             Popup(
+               Popup.Props("button", "Resume the current exposure"),
+               Button(
+                 Button.Props(icon  = Some(IconPlay),
+                              color = Some("blue"),
+                              onClick =
+                                requestObsResume(p.id, p.stepId),
+                              disabled = p.requestInFlight || !p.isObservePaused))
+               )
+           // N&S operations
+           case PauseImmediatelyObservation =>
+             Popup(
+               Popup.Props("button", "Pause the current exposure immediately"),
+               Button(
+                 Button.Props(icon = Some(IconPause), color = Some("teal"))))
+           case PauseGracefullyObservation =>
+             Popup(Popup.Props("button",
+                               "Pause the current exposure at the end of the cycle"),
+                   Button(
+                     Button.Props(icon  = Some(IconPause),
+                                  color = Some("teal"),
+                                  basic = true)))
+           case StopImmediatelyObservation =>
+             Popup(
+               Popup.Props("button", "Stop the current exposure immediately"),
+               Button(
+                 Button.Props(icon = Some(IconStop), color = Some("orange"))))
+           case StopGracefullyObservation =>
+             Popup(Popup.Props("button",
+                               "Stop the current exposure at the end of the cycle"),
+                   Button(
+                     Button.Props(icon  = Some(IconStop),
+                                  color = Some("orange"),
+                                  basic = true)))
+         }
+         .toTagMod
+        )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+}
+
 
 /**
   * Contains the control buttons like stop/abort at the row level
@@ -65,79 +180,14 @@ object StepsControlButtons {
   protected val component = ScalaComponent
     .builder[Props]("StepsControlButtons")
     .render_P { p =>
-      <.div(
-        ^.cls := "ui icon buttons",
-        SeqexecStyles.notInMobile,
-        p.instrument
-          .observationOperations(p.isObservePaused)
-          .map {
-            case PauseObservation =>
-              Popup(
-                Popup.Props("button", "Pause the current exposure"),
-                Button(
-                  Button.Props(icon  = Some(IconPause),
-                               color = Some("teal"),
-                               onClick =
-                                 requestObsPause(p.id, p.stepId),
-                               disabled = p.requestInFlight || p.isObservePaused))
-              )
-            case StopObservation =>
-              Popup(
-                Popup.Props("button", "Stop the current exposure early"),
-                Button(
-                  Button.Props(icon     = Some(IconStop),
-                               color    = Some("orange"),
-                               onClick  = requestStop(p.id, p.stepId),
-                               disabled = p.requestInFlight))
-              )
-            case AbortObservation =>
-              Popup(
-                Popup.Props("button", "Abort the current exposure"),
-                Button(
-                  Button.Props(
-                    icon     = Some(IconTrash),
-                    color    = Some("red"),
-                    onClick  = requestAbort(p.id, p.stepId),
-                    disabled = p.requestInFlight))
-              )
-            case ResumeObservation =>
-              Popup(
-                Popup.Props("button", "Resume the current exposure"),
-                Button(
-                  Button.Props(icon  = Some(IconPlay),
-                               color = Some("blue"),
-                               onClick =
-                                 requestObsResume(p.id, p.stepId),
-                               disabled = p.requestInFlight || !p.isObservePaused))
-              )
-            // Hamamatsu operations
-            case PauseImmediatelyObservation =>
-              Popup(
-                Popup.Props("button", "Pause the current exposure immediately"),
-                Button(
-                  Button.Props(icon = Some(IconPause), color = Some("teal"))))
-            case PauseGracefullyObservation =>
-              Popup(Popup.Props("button",
-                                "Pause the current exposure gracefully"),
-                    Button(
-                      Button.Props(icon  = Some(IconPause),
-                                   color = Some("teal"),
-                                   basic = true)))
-            case StopImmediatelyObservation =>
-              Popup(
-                Popup.Props("button", "Stop the current exposure immediately"),
-                Button(
-                  Button.Props(icon = Some(IconStop), color = Some("orange"))))
-            case StopGracefullyObservation =>
-              Popup(Popup.Props("button",
-                                "Stop the current exposure gracefully"),
-                    Button(
-                      Button.Props(icon  = Some(IconStop),
-                                   color = Some("orange"),
-                                   basic = true)))
-          }
-          .toTagMod
-      )
+      ControlButtons(
+        p.id,
+        p.instrument.operations[OperationLevel.Observation](p.isObservePaused),
+        p.sequenceState,
+        p.stepId,
+        p.isObservePaused,
+        p.tabOperations
+        )
     }
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -33,13 +33,13 @@ import web.client.ReactProps
   * Contains a set of control buttons like stop/abort
   */
 final case class ControlButtons(
-                                      id:              Observation.Id,
-                                      operations:      List[Operations[_]],
-                                      sequenceState:   SequenceState,
-                                      stepId:          Int,
-                                      isObservePaused: Boolean,
-                                      tabOperations:   TabOperations
-                                    ) extends ReactProps {
+  id:              Observation.Id,
+  operations:      List[Operations[_]],
+  sequenceState:   SequenceState,
+  stepId:          Int,
+  isObservePaused: Boolean,
+  tabOperations:   TabOperations
+) extends ReactProps {
   @inline def render: VdomElement = ControlButtons.component(this)
 
   val requestInFlight = tabOperations.stepRequestInFlight
@@ -113,28 +113,34 @@ object ControlButtons {
            // N&S operations
            case PauseImmediatelyObservation =>
              Popup(
-               Popup.Props("button", "Pause the current exposure immediately"),
+               Popup.Props("button", "Pause the current exposure immediately (Not Yet Implemented)"),
                Button(
-                 Button.Props(icon = Some(IconPause), color = Some("teal"))))
+                 Button.Props(disabled = true,
+                              icon = Some(IconPause),
+                              color = Some("teal"),
+                              basic = true)))
            case PauseGracefullyObservation =>
              Popup(Popup.Props("button",
-                               "Pause the current exposure at the end of the cycle"),
+                               "Pause the current exposure at the end of the cycle (Not Yet Implemented)"),
                    Button(
-                     Button.Props(icon  = Some(IconPause),
-                                  color = Some("teal"),
-                                  basic = true)))
+                     Button.Props(disabled = true,
+                                  icon  = Some(IconPause),
+                                  color = Some("teal"))))
            case StopImmediatelyObservation =>
              Popup(
-               Popup.Props("button", "Stop the current exposure immediately"),
+               Popup.Props("button", "Stop the current exposure immediately (Not Yet Implemented)"),
                Button(
-                 Button.Props(icon = Some(IconStop), color = Some("orange"))))
+                 Button.Props(disabled = true,
+                              icon = Some(IconStop),
+                              color = Some("orange"),
+                              basic = true)))
            case StopGracefullyObservation =>
              Popup(Popup.Props("button",
-                               "Stop the current exposure at the end of the cycle"),
+                               "Stop the current exposure at the end of the cycle (Not Yet Implemented)"),
                    Button(
-                     Button.Props(icon  = Some(IconStop),
-                                  color = Some("orange"),
-                                  basic = true)))
+                     Button.Props(disabled = true,
+                                  icon  = Some(IconStop),
+                                  color = Some("orange"))))
          }
          .toTagMod
         )
@@ -153,6 +159,7 @@ final case class StepsControlButtons(
   sequenceState:   SequenceState,
   stepId:          Int,
   isObservePaused: Boolean,
+  isMultiLevel:    Boolean,
   tabOperations:   TabOperations
 ) extends ReactProps {
   @inline def render: VdomElement = StepsControlButtons.component(this)
@@ -182,7 +189,7 @@ object StepsControlButtons {
     .render_P { p =>
       ControlButtons(
         p.id,
-        p.instrument.operations[OperationLevel.Observation](p.isObservePaused),
+        p.instrument.operations[OperationLevel.Observation](p.isObservePaused, p.isMultiLevel),
         p.sequenceState,
         p.stepId,
         p.isObservePaused,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -60,64 +60,49 @@ import web.client.ReactProps
 import web.client.table._
 
 trait Columns {
-  val ControlWidth: Double = 40
-  val StepWidth: Double = 60
-  val ExecutionWidth: Double = 350
-  val ExecutionMinWidth: Double = 350
-  val OffsetWidthBase: Double = 75
-  val OffsetIconWidth: Double = 23.02
-  val OffsetPadding: Double = 12
-  val ExposureWidth: Double = 75
-  val ExposureMinWidth: Double = 83.667 + SeqexecStyles.TableBorderWidth
-  val DisperserWidth: Double = 100
-  val DisperserMinWidth: Double = 100 + SeqexecStyles.TableBorderWidth
-  val ObservingModeWidth: Double = 180
+  val ControlWidth: Double          = 40
+  val StepWidth: Double             = 60
+  val ExecutionWidth: Double        = 350
+  val ExecutionMinWidth: Double     = 350
+  val OffsetWidthBase: Double       = 75
+  val OffsetIconWidth: Double       = 23.02
+  val OffsetPadding: Double         = 12
+  val ExposureWidth: Double         = 75
+  val ExposureMinWidth: Double      = 83.667 + SeqexecStyles.TableBorderWidth
+  val DisperserWidth: Double        = 100
+  val DisperserMinWidth: Double     = 100 + SeqexecStyles.TableBorderWidth
+  val ObservingModeWidth: Double    = 180
   val ObservingModeMinWidth: Double = 130.8 + SeqexecStyles.TableBorderWidth
-  val FilterWidth: Double = 180
-  val FilterMinWidth: Double = 100
-  val FPUWidth: Double = 100
-  val FPUMinWidth: Double = 46.667 + SeqexecStyles.TableBorderWidth
-  val CameraWidth: Double = 180
-  val CameraMinWidth: Double = 10
-  val DeckerWidth: Double = 110
-  val DeckerMinWidth: Double = 10
-  val ImagingMirrorWidth: Double = 180
+  val FilterWidth: Double           = 180
+  val FilterMinWidth: Double        = 100
+  val FPUWidth: Double              = 100
+  val FPUMinWidth: Double           = 46.667 + SeqexecStyles.TableBorderWidth
+  val CameraWidth: Double           = 180
+  val CameraMinWidth: Double        = 10
+  val DeckerWidth: Double           = 110
+  val DeckerMinWidth: Double        = 10
+  val ImagingMirrorWidth: Double    = 180
   val ImagingMirrorMinWidth: Double = 10
-  val ObjectTypeWidth: Double = 75
-  val SettingsWidth: Double = 34
-  val ReadModeMinWidth: Double = 180
-  val ReadModeWidth: Double = 230
+  val ObjectTypeWidth: Double       = 75
+  val SettingsWidth: Double         = 34
+  val ReadModeMinWidth: Double      = 180
+  val ReadModeWidth: Double         = 230
 
   sealed trait TableColumn extends Product with Serializable
-
   case object ControlColumn extends TableColumn
-
   case object StepColumn extends TableColumn
-
   case object ExecutionColumn extends TableColumn
-
   case object OffsetColumn extends TableColumn
-
   case object ObservingModeColumn extends TableColumn
-
   case object ExposureColumn extends TableColumn
-
   case object DisperserColumn extends TableColumn
-
   case object FilterColumn extends TableColumn
-
   case object FPUColumn extends TableColumn
-
   case object CameraColumn extends TableColumn
-
   case object DeckerColumn extends TableColumn
-
   case object ReadModeColumn extends TableColumn
-
   case object ImagingMirrorColumn extends TableColumn
-
   case object ObjectTypeColumn extends TableColumn
-
   case object SettingsColumn extends TableColumn
 
   val columnsDefaultWidth: Map[TableColumn, Double] = Map(
@@ -136,7 +121,7 @@ trait Columns {
     ImagingMirrorColumn -> ImagingMirrorWidth,
     ObjectTypeColumn -> ObjectTypeWidth,
     SettingsColumn -> SettingsWidth
-    )
+  )
 
   object TableColumn {
     implicit val equal: Eq[TableColumn] = Eq.fromUniversalEquals
@@ -146,131 +131,131 @@ trait Columns {
 
   val ControlColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ControlColumn,
-    name = "control",
-    label = "",
+    name    = "control",
+    label   = "",
     visible = true,
-    width = FixedColumnWidth.unsafeFromDouble(ControlWidth)
-    )
+    width   = FixedColumnWidth.unsafeFromDouble(ControlWidth)
+  )
 
   val StepMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     StepColumn,
-    name = "idx",
-    label = "Step",
+    name    = "idx",
+    label   = "Step",
     visible = true,
-    width = FixedColumnWidth.unsafeFromDouble(StepWidth)
-    )
+    width   = FixedColumnWidth.unsafeFromDouble(StepWidth)
+  )
 
   val ExecutionMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExecutionColumn,
-    name = "state",
-    label = "Execution Progress",
+    name    = "state",
+    label   = "Execution Progress",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ExecutionMinWidth),
-    grow = 20
-    )
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, ExecutionMinWidth),
+    grow    = 20
+  )
 
   val OffsetMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     OffsetColumn,
-    name = "offsets",
-    label = "Offsets",
+    name    = "offsets",
+    label   = "Offsets",
     visible = true,
-    width = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase)
-    )
+    width   = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase)
+  )
 
   val ObservingModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObservingModeColumn,
-    name = "obsMode",
-    label = "Observing Mode",
+    name    = "obsMode",
+    label   = "Observing Mode",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth)
-    )
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth)
+  )
 
   val ExposureMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExposureColumn,
-    name = "exposure",
-    label = "Exposure",
+    name    = "exposure",
+    label   = "Exposure",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth)
-    )
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth)
+  )
 
   val DisperserMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DisperserColumn,
-    name = "disperser",
-    label = "Disperser",
+    name    = "disperser",
+    label   = "Disperser",
     visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth)
-    )
+    width   = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth)
+  )
 
   val FilterMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FilterColumn,
-    name = "filter",
-    label = "Filter",
-    visible = true,
+    name       = "filter",
+    label      = "Filter",
+    visible    = true,
     removeable = 2,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth)
-    )
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth)
+  )
 
   val FPUMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FPUColumn,
-    name = "fpu",
-    label = "FPU",
+    name       = "fpu",
+    label      = "FPU",
     removeable = 3,
-    visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth)
-    )
+    visible    = true,
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth)
+  )
 
   val CameraMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     CameraColumn,
-    name = "camera",
-    label = "Camera",
-    visible = true,
+    name       = "camera",
+    label      = "Camera",
+    visible    = true,
     removeable = 4,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth)
-    )
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth)
+  )
 
   val DeckerMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DeckerColumn,
-    name = "camera",
-    label = "Decker",
+    name       = "camera",
+    label      = "Decker",
     removeable = 5,
-    visible = true,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth)
-    )
+    visible    = true,
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth)
+  )
 
   val ReadModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ReadModeColumn,
-    name = "camera",
-    label = "ReadMode",
-    visible = true,
+    name       = "camera",
+    label      = "ReadMode",
+    visible    = true,
     removeable = 6,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth)
-    )
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth)
+  )
 
   val ImagingMirrorMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ImagingMirrorColumn,
-    name = "camera",
-    label = "ImagingMirror",
-    visible = true,
+    name       = "camera",
+    label      = "ImagingMirror",
+    visible    = true,
     removeable = 7,
-    width = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorMinWidth)
-    )
+    width      = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorMinWidth)
+  )
 
   val ObjectTypeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObjectTypeColumn,
-    name = "type",
-    label = "Type",
-    visible = true,
+    name       = "type",
+    label      = "Type",
+    visible    = true,
     removeable = 1,
-    width = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth)
-    )
+    width      = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth)
+  )
 
   val SettingsMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     SettingsColumn,
-    name = "set",
-    label = "",
+    name    = "set",
+    label   = "",
     visible = true,
-    width = FixedColumnWidth.unsafeFromDouble(SettingsWidth)
-    )
+    width   = FixedColumnWidth.unsafeFromDouble(SettingsWidth)
+  )
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] =
     NonEmptyList.of(
@@ -289,7 +274,7 @@ trait Columns {
       ImagingMirrorMeta,
       ObjectTypeMeta,
       SettingsMeta
-      )
+    )
 
   val allTC = all.map(_.column)
 
@@ -303,45 +288,45 @@ trait Columns {
     DeckerColumn -> DeckerMinWidth,
     ImagingMirrorColumn -> ImagingMirrorMinWidth,
     ReadModeColumn -> ReadModeMinWidth
-    )
+  )
 }
 
 /**
   * Container for a table with the steps
   */
 final case class StepsTable(
-                             router    : RouterCtl[SeqexecPages],
-                             canOperate: Boolean,
-                             stepsTable: StepsTableAndStatusFocus
-                           ) extends ReactProps {
+                        router:     RouterCtl[SeqexecPages],
+                        canOperate: Boolean,
+                        stepsTable: StepsTableAndStatusFocus
+                      ) extends ReactProps {
   @inline def render: VdomElement = StepsTable.component(this)
 
   import StepsTable._ // Import static members from Columns
 
-  val status: ClientStatus = stepsTable.status
-  val steps: Option[StepsTableFocus] = stepsTable.stepsTable
-  val instrument: Option[Instrument] = steps.map(_.instrument)
+  val status: ClientStatus             = stepsTable.status
+  val steps: Option[StepsTableFocus]   = stepsTable.stepsTable
+  val instrument: Option[Instrument]   = steps.map(_.instrument)
   val runningStep: Option[RunningStep] = steps.flatMap(_.runningStep)
-  val obsId: Option[Observation.Id] = steps.map(_.id)
+  val obsId: Option[Observation.Id]    = steps.map(_.id)
   val tableState: TableState[TableColumn] =
     steps.map(_.tableState).getOrElse(State.InitialTableState)
-  val stepsList: List[Step] = steps.foldMap(_.steps)
+  val stepsList: List[Step]        = steps.foldMap(_.steps)
   val selectedStep: Option[StepId] = steps.flatMap(_.selectedStep)
-  val rowCount: Int = stepsList.length
-  val nextStepToRun: Int = steps.foldMap(_.nextStepToRun).orEmpty
+  val rowCount: Int                = stepsList.length
+  val nextStepToRun: Int           = steps.foldMap(_.nextStepToRun).orEmpty
   def tabOperations: TabOperations =
     steps.map(_.tabOperations).getOrElse(TabOperations.Default)
   val showDisperser: Boolean = showProp(InstrumentProperties.Disperser)
-  val showExposure: Boolean = showProp(InstrumentProperties.Exposure)
-  val showFilter: Boolean = showProp(InstrumentProperties.Filter)
-  val showFPU: Boolean = showProp(InstrumentProperties.FPU)
-  val showCamera: Boolean = showProp(InstrumentProperties.Camera)
-  val showDecker: Boolean = showProp(InstrumentProperties.Decker)
+  val showExposure: Boolean  = showProp(InstrumentProperties.Exposure)
+  val showFilter: Boolean    = showProp(InstrumentProperties.Filter)
+  val showFPU: Boolean       = showProp(InstrumentProperties.FPU)
+  val showCamera: Boolean    = showProp(InstrumentProperties.Camera)
+  val showDecker: Boolean    = showProp(InstrumentProperties.Decker)
   val showImagingMirror: Boolean = showProp(
     InstrumentProperties.ImagingMirror
     )
-  val isPreview: Boolean = steps.exists(_.isPreview)
-  val hasControls: Boolean = canOperate && !isPreview
+  val isPreview: Boolean        = steps.exists(_.isPreview)
+  val hasControls: Boolean      = canOperate && !isPreview
   val canSetBreakpoint: Boolean = canOperate && !isPreview
   val showObservingMode: Boolean = showProp(
     InstrumentProperties.ObservingMode
@@ -351,19 +336,22 @@ final case class StepsTable(
   val sequenceState: Option[SequenceState] = steps.map(_.state)
 
   def stepSnapshot(step: Step): Option[StepStateSnapshot] =
-    (instrument, sequenceState).mapN(StepStateSnapshot(step, _, tabOperations, _))
+    (obsId, instrument, sequenceState).mapN(StepStateSnapshot(step, _, _, tabOperations, _))
 
-  def showRowDetails(step: Step): Boolean =
-    stepSnapshot(step).forall(_.detailRows > 0)
+  def detailRowCount(step: Step, selected: Option[StepId]): Option[Int] =
+    stepSnapshot(step).map(_.detailRows(selected.filter(_ => stepSelectionAllowed(step.id))))
 
-  def rowDetailsHeight(step: Step): Int =
-    stepSnapshot(step)
-      .map(s => SeqexecStyles.runningBottomRowHeight * s.detailRows)
+  def showRowDetails(step: Step, selected: Option[StepId]): Boolean =
+    detailRowCount(step, selected).forall(_ > 0)
+
+  def rowDetailsHeight(step: Step, selected: Option[StepId]): Int =
+    detailRowCount(step, selected)
+      .map(_ * SeqexecStyles.runningBottomRowHeight)
       .orEmpty
 
   def stepSelectionAllowed(sid: StepId): Boolean =
-    canControlSubsystems(sid) && !tabOperations.resourceInFlight(sid) && !sequenceState
-      .exists(_.isRunning)
+    canControlSubsystems(sid) && !tabOperations.resourceInFlight(sid) &&
+      !sequenceState.exists(_.isRunning)
 
   def rowGetter(idx: Int): StepRow =
     steps.flatMap(_.steps.lift(idx)).fold(StepRow.Zero)(StepRow.apply)
@@ -388,7 +376,7 @@ final case class StepsTable(
     }
 
   val offsetWidth: Option[Double] = {
-    val (p, q) = stepsList.sequenceOffsetWidths
+    val (p, q)     = stepsList.sequenceOffsetWidths
     val labelWidth = max(pLabelWidth, qLabelWidth)
     (max(p, q) + labelWidth + OffsetIconWidth + OffsetPadding * 4).some
   }
@@ -453,12 +441,12 @@ final case class StepsTable(
 }
 
 object StepsTable extends Columns {
-  type Backend = RenderScope[Props, State, Unit]
+  type Backend      = RenderScope[Props, State, Unit]
   type ReceiveProps = ComponentWillReceiveProps[Props, State, Unit]
 
   private val MIDDLE_BUTTON = 1 // As defined by React.js
 
-  val HeightWithOffsets: Int = 40
+  val HeightWithOffsets: Int    = 40
   val BreakpointLineHeight: Int = 5
 
   // ScalaJS defined trait
@@ -485,11 +473,11 @@ object StepsTable extends Columns {
 
   @Lenses
   final case class State(
-                          tableState     : TableState[TableColumn],
-                          breakpointHover: Option[Int],
-                          selected       : Option[StepId],
-                          scrollCount    : Int
-                        ) {
+    tableState:      TableState[TableColumn],
+    breakpointHover: Option[Int],
+    selected:        Option[StepId],
+    scrollCount:     Int
+  ) {
 
     def visibleCols(p: Props): State =
       State.columns.set(NonEmptyList.fromListUnsafe(p.shownForInstrument))(this)
@@ -543,18 +531,18 @@ object StepsTable extends Columns {
     l.zipWithIndex.find(!_._1.isFinished).map(_._2).getOrElse(l.length)
 
   def stepControlRenderer(
-                           f                      : StepsTableFocus,
-                           b                      : Backend,
-                           rowBreakpointHoverOnCB : Int => Callback,
-                           rowBreakpointHoverOffCB: Int => Callback,
-                           recomputeHeightsCB     : Int => Callback
-                         ): CellRenderer[js.Object, js.Object, StepRow] =
+    f:                       StepsTableFocus,
+    b:                       Backend,
+    rowBreakpointHoverOnCB:  Int => Callback,
+    rowBreakpointHoverOffCB: Int => Callback,
+    recomputeHeightsCB:      Int => Callback
+  ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       StepToolsCell(
         b.props.status,
         row.step,
         rowHeight(b)(row.step.id),
-        b.props.rowDetailsHeight(row.step),
+        b.props.rowDetailsHeight(row.step, b.state.selected),
         f.isPreview,
         f.nextStepToRun,
         f.id,
@@ -562,15 +550,15 @@ object StepsTable extends Columns {
         rowBreakpointHoverOnCB,
         rowBreakpointHoverOffCB,
         recomputeHeightsCB
-        )
+      )
 
   val stepIdRenderer: CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) => StepIdCell(row.step.id)
 
   def settingsControlRenderer(
-                               p: Props,
-                               f: StepsTableFocus
-                             ): CellRenderer[js.Object, js.Object, StepRow] =
+    p: Props,
+    f: StepsTableFocus
+  ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       SettingsCell(p.router,
                    f.instrument,
@@ -579,9 +567,9 @@ object StepsTable extends Columns {
                    p.isPreview)
 
   def stepProgressRenderer(
-                            f: StepsTableFocus,
-                            b: Backend
-                          ): CellRenderer[js.Object, js.Object, StepRow] =
+    f: StepsTableFocus,
+    b: Backend
+  ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       StepProgressCell(b.props.status,
                        f.instrument,
@@ -593,39 +581,39 @@ object StepsTable extends Columns {
                        b.props.tabOperations)
 
   def stepStatusRenderer(
-                          offsetsDisplay: OffsetsDisplay
-                        ): CellRenderer[js.Object, js.Object, StepRow] =
+    offsetsDisplay: OffsetsDisplay
+  ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       OffsetsDisplayCell(offsetsDisplay, row.step)
 
   def stepItemRenderer(
-                        f: Step => Option[String]
-                      ): CellRenderer[js.Object, js.Object, StepRow] =
+    f: Step => Option[String]
+  ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) => StepItemCell(f(row.step))
 
   private def stepItemRendererS(f: Step => Option[String]) =
     stepItemRenderer(f(_).map(_.sentenceCase))
 
   def stepExposureRenderer(
-                            i: Instrument
-                          ): CellRenderer[js.Object, js.Object, StepRow] =
+    i: Instrument
+  ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       ExposureTimeCell(row.step, i)
 
   def stepFPURenderer(
-                       i: Instrument
-                     ): CellRenderer[js.Object, js.Object, StepRow] =
+    i: Instrument
+  ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) => {
       val fpu = row.step
-                   .fpu(i)
-                   .orElse(row.step.fpuOrMask(i).map(_.sentenceCase))
+        .fpu(i)
+        .orElse(row.step.fpuOrMask(i).map(_.sentenceCase))
       StepItemCell(fpu)
     }
 
   def stepObjectTypeRenderer(
-                              i   : Instrument,
-                              size: SSize
-                            ): CellRenderer[js.Object, js.Object, StepRow] =
+    i:    Instrument,
+    size: SSize
+  ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       ObjectTypeCell(i, row.step, size)
 
@@ -690,9 +678,9 @@ object StepsTable extends Columns {
   def rowHeight(b: Backend)(i: Int): Int = {
     val row = b.props.rowGetter(i)
     row match {
-      case StepRow(_) if b.props.showRowDetails(row.step)                         =>
+      case StepRow(s) if b.props.showRowDetails(s, b.state.selected)              =>
         // Selected
-        SeqexecStyles.runningRowHeight + b.props.rowDetailsHeight(row.step)
+        SeqexecStyles.runningRowHeight + b.props.rowDetailsHeight(s, b.state.selected)
       case StepRow(s)
         if s.status === StepState.Running && s.breakpoint                         =>
         // Row running with a breakpoint set
@@ -737,13 +725,13 @@ object StepsTable extends Columns {
     <.span(
       ^.title := "Control",
       IconSettings
-      )
+  )
 
   val settingsHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
     <.span(
       ^.title := "Settings",
       IconBrowser
-      )
+  )
 
   private val fixedHeaderRenderer: TableColumn => HeaderRenderer[js.Object] = {
     case ControlColumn  => controlHeaderRenderer
@@ -752,8 +740,8 @@ object StepsTable extends Columns {
   }
 
   private def columnCellRenderer(
-                                  b: Backend,
-                                  c: TableColumn): CellRenderer[js.Object, js.Object, StepRow] = {
+    b: Backend,
+    c: TableColumn): CellRenderer[js.Object, js.Object, StepRow] = {
     val optR = c match {
       case ControlColumn       =>
         b.props.steps.map(
@@ -783,46 +771,46 @@ object StepsTable extends Columns {
 
   // Columns for the table
   private def colBuilder(
-                          b   : Backend,
-                          size: Size
-                        ): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb => {
+    b:    Backend,
+    size: Size
+  ): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb => {
     def updateState(s: TableState[TableColumn]): Callback =
       (b.modState(State.tableState.set(s)) *> b.props.obsId
-                                               .map(i => SeqexecCircuit.dispatchCB(UpdateStepTableState(i, s)))
-                                               .getOrEmpty).when_(size.width > 0)
+        .map(i => SeqexecCircuit.dispatchCB(UpdateStepTableState(i, s)))
+        .getOrEmpty).when_(size.width > 0)
 
     tb match {
       case ColumnRenderArgs(meta, _, width, true)  =>
         Column(
           Column.propsNoFlex(
-            width = width,
+            width   = width,
             dataKey = meta.name,
-            label = meta.label,
+            label   = meta.label,
             headerRenderer = resizableHeaderRenderer(
               b.state.tableState
-               .resizeColumn(meta.column,
-                             size,
-                             updateState,
-                             b.props.visibleColumns,
-                             b.props.columnWidths)
-              ),
+                .resizeColumn(meta.column,
+                              size,
+                              updateState,
+                              b.props.visibleColumns,
+                              b.props.columnWidths)
+            ),
             headerClassName = headerClassName(meta.column).foldMap(_.htmlClass),
-            cellRenderer = columnCellRenderer(b, meta.column),
-            className = columnClassName(meta.column).foldMap(_.htmlClass)
-            )
+            cellRenderer    = columnCellRenderer(b, meta.column),
+            className       = columnClassName(meta.column).foldMap(_.htmlClass)
           )
+        )
       case ColumnRenderArgs(meta, _, width, false) =>
         Column(
           Column.propsNoFlex(
-            width = width,
-            dataKey = meta.name,
-            label = meta.label,
-            headerRenderer = fixedHeaderRenderer(meta.column),
+            width           = width,
+            dataKey         = meta.name,
+            label           = meta.label,
+            headerRenderer  = fixedHeaderRenderer(meta.column),
             headerClassName = headerClassName(meta.column).foldMap(_.htmlClass),
-            cellRenderer = columnCellRenderer(b, meta.column),
-            className = columnClassName(meta.column).foldMap(_.htmlClass)
-            )
+            cellRenderer    = columnCellRenderer(b, meta.column),
+            className       = columnClassName(meta.column).foldMap(_.htmlClass)
           )
+        )
     }
   }
 
@@ -832,14 +820,14 @@ object StepsTable extends Columns {
   // Aditionally if we programatically scroll to a position we get another call
   // Only after that we assume scroll is user initatied
   def updateScrollPosition(b: Backend, pos: JsNumber): Callback = {
-    val posMod = b.setStateL(State.scrollPosition)(pos)
+    val posMod            = b.setStateL(State.scrollPosition)(pos)
     // This is done to ignore the scrolls made automatically upon startup
     val hasScrolledBefore = b.state.scrollCount > 2
-    val modMod = b.setStateL(State.userModified)(IsModified).when_(hasScrolledBefore)
-    val scrollCountMods = b.modStateL(State.scrollCount)(_ + 1)
+    val modMod            = b.setStateL(State.userModified)(IsModified).when_(hasScrolledBefore)
+    val scrollCountMods   = b.modStateL(State.scrollCount)(_ + 1)
     // Separately calculate the state to send upstream
     val newTs = if (hasScrolledBefore) {
-      (State.userModified.set(IsModified) >>> State.scrollPosition.set(pos)) (b.state)
+      (State.userModified.set(IsModified) >>> State.scrollPosition.set(pos))(b.state)
     } else {
       State.scrollPosition.set(pos)(b.state)
     }
@@ -851,8 +839,8 @@ object StepsTable extends Columns {
       modMod *>
       // And silently update the model
       b.props.obsId
-       .map(id =>
-              SeqexecCircuit.dispatchCB(UpdateStepTableState(id, newTs.tableState))).getOrEmpty)
+        .map(id =>
+          SeqexecCircuit.dispatchCB(UpdateStepTableState(id, newTs.tableState))).getOrEmpty)
       .when_(posDiff > 1) // Only update the state if the change is significant
   }
 
@@ -890,32 +878,32 @@ object StepsTable extends Columns {
           ^.cls := "ui center aligned segment noRows",
           ^.height := size.height.px,
           "No Steps"
-          ),
+        ),
       overscanRowCount = SeqexecStyles.overscanRowCount,
-      height = max(1, size.height.toInt),
-      rowCount = b.props.rowCount,
-      rowHeight = rowHeight(b) _,
-      rowClassName = rowClassName(b) _,
-      width = max(1, size.width.toInt),
-      rowGetter = b.props.rowGetter _,
-      scrollToIndex = startScrollToIndex(b),
-      scrollTop = startScrollTop(b.state),
-      onRowClick = singleClick(b),
+      height           = max(1, size.height.toInt),
+      rowCount         = b.props.rowCount,
+      rowHeight        = rowHeight(b) _,
+      rowClassName     = rowClassName(b) _,
+      width            = max(1, size.width.toInt),
+      rowGetter        = b.props.rowGetter _,
+      scrollToIndex    = startScrollToIndex(b),
+      scrollTop        = startScrollTop(b.state),
+      onRowClick       = singleClick(b),
       onScroll =
         (a, _, pos) => updateScrollPosition(b, pos).when_(a.toDouble > 0),
       scrollToAlignment = ScrollToAlignment.Center,
-      headerClassName = SeqexecStyles.tableHeader.htmlClass,
-      headerHeight = SeqexecStyles.headerHeight,
-      rowRenderer = stepsRowRenderer(b.props)
-      )
+      headerClassName   = SeqexecStyles.tableHeader.htmlClass,
+      headerHeight      = SeqexecStyles.headerHeight,
+      rowRenderer       = stepsRowRenderer(b.props, b.state.selected)
+    )
 
   // We want clicks to be processed only if the click is not on the first row with the breakpoint/skip controls
   private def allowedClick(
-                            p         : Props,
-                            index     : Int,
-                            onRowClick: Option[OnRowClick]
-                          )(e: ReactMouseEvent): Callback =
-  // If alt is pressed or middle button flip the breakpoint
+    p:          Props,
+    index:      Int,
+    onRowClick: Option[OnRowClick]
+  )(e:          ReactMouseEvent): Callback =
+    // If alt is pressed or middle button flip the breakpoint
     if (e.altKey || e.button === MIDDLE_BUTTON) {
       e.preventDefaultCB >>
         (p.obsId, p.stepsList.find(_.id === index + 1))
@@ -934,21 +922,21 @@ object StepsTable extends Columns {
         .getOrEmpty
     }
 
-  private def stepsRowRenderer(p: Props) =
-    (className       : String,
-     columns         : Array[VdomNode],
-     index           : Int,
-     _               : Boolean,
-     key             : String,
-     _               : StepRow,
-     onRowClick      : Option[OnRowClick],
+  private def stepsRowRenderer(p: Props, selected: Option[StepId]) =
+    (className:        String,
+     columns:          Array[VdomNode],
+     index:            Int,
+     _:                Boolean,
+     key:              String,
+     _:                StepRow,
+     onRowClick:       Option[OnRowClick],
      onRowDoubleClick: Option[OnRowClick],
-     _               : Option[OnRowClick],
-     _               : Option[OnRowClick],
-     _               : Option[OnRowClick],
-     style           : Style) => {
+     _:                Option[OnRowClick],
+     _:                Option[OnRowClick],
+     _:                Option[OnRowClick],
+     style:            Style) => {
       p.rowGetter(index) match {
-        case StepRow(s) if p.showRowDetails(s) && index === s.id =>
+        case StepRow(s) if p.showRowDetails(s, selected) && index === s.id =>
           <.div(
             ^.key := key,
             ^.style := Style.toJsObject(style),
@@ -966,7 +954,7 @@ object StepsTable extends Columns {
                 if (s.isAC)
                   List(AlignAndCalibProgress.apply)
                 else if (s.isNS)
-                  List(NodAndShuffleCycleProgress.apply, NodAndShuffleNodProgress.apply)
+                  List(NodAndShuffleCycleRow(p.status), NodAndShuffleNodRow(p.status))
                 else
                   List.empty
 
@@ -978,7 +966,7 @@ object StepsTable extends Columns {
                   ^.onMouseDown ==> allowedClick(p, index, onRowClick),
                   ^.onDoubleClick -->? onRowDoubleClick.map(h => h(index)),
                   rowComponent(s)
-                  )
+                )
               }
             }
           )
@@ -1003,20 +991,20 @@ object StepsTable extends Columns {
 
   def rowBreakpointHoverOnCB(b: Backend)(index: Int): Callback =
     (if (b.props.rowGetter(index).step.breakpoint)
-      b.modState(State.breakpointHover.set(None))
-    else b.modState(State.breakpointHover.set(index.some))) *>
+       b.modState(State.breakpointHover.set(None))
+     else b.modState(State.breakpointHover.set(index.some))) *>
       recomputeRowHeightsCB(index)
 
   def rowBreakpointHoverOffCB(b: Backend)(index: Int): Callback =
     b.modState(State.breakpointHover.set(None)) *> recomputeRowHeightsCB(index)
 
-  private def updateStep(b    : ReceiveProps,
-                         p    : Props,
+  private def updateStep(b:     ReceiveProps,
+                         p:     Props,
                          obsId: Observation.Id,
-                         i    : StepId): Callback =
+                         i:     StepId): Callback =
     SeqexecCircuit.dispatchCB(UpdateSelectedStep(obsId, i)) *>
       b.setStateL(State.selected)(i.some)
-       .when_(p.canControlSubsystems(i))
+        .when_(p.canControlSubsystems(i))
 
   private def scrollTo(i: StepId): Callback =
     ref.get.flatMapCB(_.raw.scrollToRowCB(i))
@@ -1027,7 +1015,7 @@ object StepsTable extends Columns {
       .when_(
         cur.tabOperations.runRequested =!= next.tabOperations.runRequested
           && next.tabOperations.runRequested === RunOperation.RunInFlight
-        )
+      )
 
   private def selectStepCB(b: ReceiveProps): Callback = {
     val (cur: Props, next: Props) = (b.currentProps, b.nextProps)
@@ -1109,8 +1097,8 @@ object StepsTable extends Columns {
         size => {
           val ts =
             b.state.tableState
-             .columnBuilder(size, colBuilder(b, size), b.props.columnWidths)
-             .map(_.vdomElement)
+              .columnBuilder(size, colBuilder(b, size), b.props.columnWidths)
+              .map(_.vdomElement)
 
           if (size.width > 0) {
             ref
@@ -1125,10 +1113,10 @@ object StepsTable extends Columns {
             _.recalculateWidths(s,
                                 b.props.visibleColumns,
                                 b.props.columnWidths))
-        ))
+      ))
 
   def initialState(p: Props): State =
-    (State.tableState.set(p.tableState) >>> State.selected.set(p.selectedStep)) (State.InitialState)
+    (State.tableState.set(p.tableState) >>> State.selected.set(p.selectedStep))(State.InitialState)
 
   protected val component = ScalaComponent
     .builder[Props]("StepsTable")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -60,49 +60,64 @@ import web.client.ReactProps
 import web.client.table._
 
 trait Columns {
-  val ControlWidth: Double          = 40
-  val StepWidth: Double             = 60
-  val ExecutionWidth: Double        = 350
-  val ExecutionMinWidth: Double     = 350
-  val OffsetWidthBase: Double       = 75
-  val OffsetIconWidth: Double       = 23.02
-  val OffsetPadding: Double         = 12
-  val ExposureWidth: Double         = 75
-  val ExposureMinWidth: Double      = 83.667 + SeqexecStyles.TableBorderWidth
-  val DisperserWidth: Double        = 100
-  val DisperserMinWidth: Double     = 100 + SeqexecStyles.TableBorderWidth
-  val ObservingModeWidth: Double    = 180
+  val ControlWidth: Double = 40
+  val StepWidth: Double = 60
+  val ExecutionWidth: Double = 350
+  val ExecutionMinWidth: Double = 350
+  val OffsetWidthBase: Double = 75
+  val OffsetIconWidth: Double = 23.02
+  val OffsetPadding: Double = 12
+  val ExposureWidth: Double = 75
+  val ExposureMinWidth: Double = 83.667 + SeqexecStyles.TableBorderWidth
+  val DisperserWidth: Double = 100
+  val DisperserMinWidth: Double = 100 + SeqexecStyles.TableBorderWidth
+  val ObservingModeWidth: Double = 180
   val ObservingModeMinWidth: Double = 130.8 + SeqexecStyles.TableBorderWidth
-  val FilterWidth: Double           = 180
-  val FilterMinWidth: Double        = 100
-  val FPUWidth: Double              = 100
-  val FPUMinWidth: Double           = 46.667 + SeqexecStyles.TableBorderWidth
-  val CameraWidth: Double           = 180
-  val CameraMinWidth: Double        = 10
-  val DeckerWidth: Double           = 110
-  val DeckerMinWidth: Double        = 10
-  val ImagingMirrorWidth: Double    = 180
+  val FilterWidth: Double = 180
+  val FilterMinWidth: Double = 100
+  val FPUWidth: Double = 100
+  val FPUMinWidth: Double = 46.667 + SeqexecStyles.TableBorderWidth
+  val CameraWidth: Double = 180
+  val CameraMinWidth: Double = 10
+  val DeckerWidth: Double = 110
+  val DeckerMinWidth: Double = 10
+  val ImagingMirrorWidth: Double = 180
   val ImagingMirrorMinWidth: Double = 10
-  val ObjectTypeWidth: Double       = 75
-  val SettingsWidth: Double         = 34
-  val ReadModeMinWidth: Double      = 180
-  val ReadModeWidth: Double         = 230
+  val ObjectTypeWidth: Double = 75
+  val SettingsWidth: Double = 34
+  val ReadModeMinWidth: Double = 180
+  val ReadModeWidth: Double = 230
 
   sealed trait TableColumn extends Product with Serializable
+
   case object ControlColumn extends TableColumn
+
   case object StepColumn extends TableColumn
+
   case object ExecutionColumn extends TableColumn
+
   case object OffsetColumn extends TableColumn
+
   case object ObservingModeColumn extends TableColumn
+
   case object ExposureColumn extends TableColumn
+
   case object DisperserColumn extends TableColumn
+
   case object FilterColumn extends TableColumn
+
   case object FPUColumn extends TableColumn
+
   case object CameraColumn extends TableColumn
+
   case object DeckerColumn extends TableColumn
+
   case object ReadModeColumn extends TableColumn
+
   case object ImagingMirrorColumn extends TableColumn
+
   case object ObjectTypeColumn extends TableColumn
+
   case object SettingsColumn extends TableColumn
 
   val columnsDefaultWidth: Map[TableColumn, Double] = Map(
@@ -121,7 +136,7 @@ trait Columns {
     ImagingMirrorColumn -> ImagingMirrorWidth,
     ObjectTypeColumn -> ObjectTypeWidth,
     SettingsColumn -> SettingsWidth
-  )
+    )
 
   object TableColumn {
     implicit val equal: Eq[TableColumn] = Eq.fromUniversalEquals
@@ -131,131 +146,131 @@ trait Columns {
 
   val ControlColumnMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ControlColumn,
-    name    = "control",
-    label   = "",
+    name = "control",
+    label = "",
     visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(ControlWidth)
-  )
+    width = FixedColumnWidth.unsafeFromDouble(ControlWidth)
+    )
 
   val StepMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     StepColumn,
-    name    = "idx",
-    label   = "Step",
+    name = "idx",
+    label = "Step",
     visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(StepWidth)
-  )
+    width = FixedColumnWidth.unsafeFromDouble(StepWidth)
+    )
 
   val ExecutionMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExecutionColumn,
-    name    = "state",
-    label   = "Execution Progress",
+    name = "state",
+    label = "Execution Progress",
     visible = true,
-    width   = VariableColumnWidth.unsafeFromDouble(0.1, ExecutionMinWidth),
-    grow    = 20
-  )
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ExecutionMinWidth),
+    grow = 20
+    )
 
   val OffsetMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     OffsetColumn,
-    name    = "offsets",
-    label   = "Offsets",
+    name = "offsets",
+    label = "Offsets",
     visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase)
-  )
+    width = FixedColumnWidth.unsafeFromDouble(OffsetWidthBase)
+    )
 
   val ObservingModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObservingModeColumn,
-    name    = "obsMode",
-    label   = "Observing Mode",
+    name = "obsMode",
+    label = "Observing Mode",
     visible = true,
-    width   = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth)
-  )
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ObservingModeMinWidth)
+    )
 
   val ExposureMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ExposureColumn,
-    name    = "exposure",
-    label   = "Exposure",
+    name = "exposure",
+    label = "Exposure",
     visible = true,
-    width   = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth)
-  )
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ExposureMinWidth)
+    )
 
   val DisperserMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DisperserColumn,
-    name    = "disperser",
-    label   = "Disperser",
+    name = "disperser",
+    label = "Disperser",
     visible = true,
-    width   = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth)
-  )
+    width = VariableColumnWidth.unsafeFromDouble(0.1, DisperserMinWidth)
+    )
 
   val FilterMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FilterColumn,
-    name       = "filter",
-    label      = "Filter",
-    visible    = true,
+    name = "filter",
+    label = "Filter",
+    visible = true,
     removeable = 2,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth)
-  )
+    width = VariableColumnWidth.unsafeFromDouble(0.1, FilterMinWidth)
+    )
 
   val FPUMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     FPUColumn,
-    name       = "fpu",
-    label      = "FPU",
+    name = "fpu",
+    label = "FPU",
     removeable = 3,
-    visible    = true,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth)
-  )
+    visible = true,
+    width = VariableColumnWidth.unsafeFromDouble(0.1, FPUMinWidth)
+    )
 
   val CameraMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     CameraColumn,
-    name       = "camera",
-    label      = "Camera",
-    visible    = true,
+    name = "camera",
+    label = "Camera",
+    visible = true,
     removeable = 4,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth)
-  )
+    width = VariableColumnWidth.unsafeFromDouble(0.1, CameraMinWidth)
+    )
 
   val DeckerMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     DeckerColumn,
-    name       = "camera",
-    label      = "Decker",
+    name = "camera",
+    label = "Decker",
     removeable = 5,
-    visible    = true,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth)
-  )
+    visible = true,
+    width = VariableColumnWidth.unsafeFromDouble(0.1, DeckerMinWidth)
+    )
 
   val ReadModeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ReadModeColumn,
-    name       = "camera",
-    label      = "ReadMode",
-    visible    = true,
+    name = "camera",
+    label = "ReadMode",
+    visible = true,
     removeable = 6,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth)
-  )
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ReadModeMinWidth)
+    )
 
   val ImagingMirrorMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ImagingMirrorColumn,
-    name       = "camera",
-    label      = "ImagingMirror",
-    visible    = true,
+    name = "camera",
+    label = "ImagingMirror",
+    visible = true,
     removeable = 7,
-    width      = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorMinWidth)
-  )
+    width = VariableColumnWidth.unsafeFromDouble(0.1, ImagingMirrorMinWidth)
+    )
 
   val ObjectTypeMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     ObjectTypeColumn,
-    name       = "type",
-    label      = "Type",
-    visible    = true,
+    name = "type",
+    label = "Type",
+    visible = true,
     removeable = 1,
-    width      = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth)
-  )
+    width = FixedColumnWidth.unsafeFromDouble(ObjectTypeWidth)
+    )
 
   val SettingsMeta: ColumnMeta[TableColumn] = ColumnMeta[TableColumn](
     SettingsColumn,
-    name    = "set",
-    label   = "",
+    name = "set",
+    label = "",
     visible = true,
-    width   = FixedColumnWidth.unsafeFromDouble(SettingsWidth)
-  )
+    width = FixedColumnWidth.unsafeFromDouble(SettingsWidth)
+    )
 
   val all: NonEmptyList[ColumnMeta[TableColumn]] =
     NonEmptyList.of(
@@ -274,7 +289,7 @@ trait Columns {
       ImagingMirrorMeta,
       ObjectTypeMeta,
       SettingsMeta
-    )
+      )
 
   val allTC = all.map(_.column)
 
@@ -288,45 +303,45 @@ trait Columns {
     DeckerColumn -> DeckerMinWidth,
     ImagingMirrorColumn -> ImagingMirrorMinWidth,
     ReadModeColumn -> ReadModeMinWidth
-  )
+    )
 }
 
 /**
   * Container for a table with the steps
   */
 final case class StepsTable(
-                        router:     RouterCtl[SeqexecPages],
-                        canOperate: Boolean,
-                        stepsTable: StepsTableAndStatusFocus
-                      ) extends ReactProps {
+                             router    : RouterCtl[SeqexecPages],
+                             canOperate: Boolean,
+                             stepsTable: StepsTableAndStatusFocus
+                           ) extends ReactProps {
   @inline def render: VdomElement = StepsTable.component(this)
 
   import StepsTable._ // Import static members from Columns
 
-  val status: ClientStatus             = stepsTable.status
-  val steps: Option[StepsTableFocus]   = stepsTable.stepsTable
-  val instrument: Option[Instrument]   = steps.map(_.instrument)
+  val status: ClientStatus = stepsTable.status
+  val steps: Option[StepsTableFocus] = stepsTable.stepsTable
+  val instrument: Option[Instrument] = steps.map(_.instrument)
   val runningStep: Option[RunningStep] = steps.flatMap(_.runningStep)
-  val obsId: Option[Observation.Id]    = steps.map(_.id)
+  val obsId: Option[Observation.Id] = steps.map(_.id)
   val tableState: TableState[TableColumn] =
     steps.map(_.tableState).getOrElse(State.InitialTableState)
-  val stepsList: List[Step]        = steps.foldMap(_.steps)
+  val stepsList: List[Step] = steps.foldMap(_.steps)
   val selectedStep: Option[StepId] = steps.flatMap(_.selectedStep)
-  val rowCount: Int                = stepsList.length
-  val nextStepToRun: Int           = steps.foldMap(_.nextStepToRun).orEmpty
+  val rowCount: Int = stepsList.length
+  val nextStepToRun: Int = steps.foldMap(_.nextStepToRun).orEmpty
   def tabOperations: TabOperations =
     steps.map(_.tabOperations).getOrElse(TabOperations.Default)
   val showDisperser: Boolean = showProp(InstrumentProperties.Disperser)
-  val showExposure: Boolean  = showProp(InstrumentProperties.Exposure)
-  val showFilter: Boolean    = showProp(InstrumentProperties.Filter)
-  val showFPU: Boolean       = showProp(InstrumentProperties.FPU)
-  val showCamera: Boolean    = showProp(InstrumentProperties.Camera)
-  val showDecker: Boolean    = showProp(InstrumentProperties.Decker)
+  val showExposure: Boolean = showProp(InstrumentProperties.Exposure)
+  val showFilter: Boolean = showProp(InstrumentProperties.Filter)
+  val showFPU: Boolean = showProp(InstrumentProperties.FPU)
+  val showCamera: Boolean = showProp(InstrumentProperties.Camera)
+  val showDecker: Boolean = showProp(InstrumentProperties.Decker)
   val showImagingMirror: Boolean = showProp(
     InstrumentProperties.ImagingMirror
     )
-  val isPreview: Boolean        = steps.exists(_.isPreview)
-  val hasControls: Boolean      = canOperate && !isPreview
+  val isPreview: Boolean = steps.exists(_.isPreview)
+  val hasControls: Boolean = canOperate && !isPreview
   val canSetBreakpoint: Boolean = canOperate && !isPreview
   val showObservingMode: Boolean = showProp(
     InstrumentProperties.ObservingMode
@@ -338,12 +353,13 @@ final case class StepsTable(
   def stepSnapshot(step: Step): Option[StepStateSnapshot] =
     (instrument, sequenceState).mapN(StepStateSnapshot(step, _, tabOperations, _))
 
-  def showSecondRow(step: Step): Boolean = stepSnapshot(step).forall(_.displayDetails)
+  def showRowDetails(step: Step): Boolean =
+    stepSnapshot(step).forall(_.detailRows > 0)
 
-  def secondRowHeight(step: Step): Int = stepSnapshot(step) match {
-    case Some(s) if s.displayDetails => SeqexecStyles.runningBottomRowHeight
-    case _                           => 0
-  }
+  def rowDetailsHeight(step: Step): Int =
+    stepSnapshot(step)
+      .map(s => SeqexecStyles.runningBottomRowHeight * s.detailRows)
+      .orEmpty
 
   def stepSelectionAllowed(sid: StepId): Boolean =
     canControlSubsystems(sid) && !tabOperations.resourceInFlight(sid) && !sequenceState
@@ -372,7 +388,7 @@ final case class StepsTable(
     }
 
   val offsetWidth: Option[Double] = {
-    val (p, q)     = stepsList.sequenceOffsetWidths
+    val (p, q) = stepsList.sequenceOffsetWidths
     val labelWidth = max(pLabelWidth, qLabelWidth)
     (max(p, q) + labelWidth + OffsetIconWidth + OffsetPadding * 4).some
   }
@@ -437,12 +453,12 @@ final case class StepsTable(
 }
 
 object StepsTable extends Columns {
-  type Backend      = RenderScope[Props, State, Unit]
+  type Backend = RenderScope[Props, State, Unit]
   type ReceiveProps = ComponentWillReceiveProps[Props, State, Unit]
 
   private val MIDDLE_BUTTON = 1 // As defined by React.js
 
-  val HeightWithOffsets: Int    = 40
+  val HeightWithOffsets: Int = 40
   val BreakpointLineHeight: Int = 5
 
   // ScalaJS defined trait
@@ -469,11 +485,11 @@ object StepsTable extends Columns {
 
   @Lenses
   final case class State(
-    tableState:      TableState[TableColumn],
-    breakpointHover: Option[Int],
-    selected:        Option[StepId],
-    scrollCount:     Int
-  ) {
+                          tableState     : TableState[TableColumn],
+                          breakpointHover: Option[Int],
+                          selected       : Option[StepId],
+                          scrollCount    : Int
+                        ) {
 
     def visibleCols(p: Props): State =
       State.columns.set(NonEmptyList.fromListUnsafe(p.shownForInstrument))(this)
@@ -527,18 +543,18 @@ object StepsTable extends Columns {
     l.zipWithIndex.find(!_._1.isFinished).map(_._2).getOrElse(l.length)
 
   def stepControlRenderer(
-    f:                       StepsTableFocus,
-    b:                       Backend,
-    rowBreakpointHoverOnCB:  Int => Callback,
-    rowBreakpointHoverOffCB: Int => Callback,
-    recomputeHeightsCB:      Int => Callback
-  ): CellRenderer[js.Object, js.Object, StepRow] =
+                           f                      : StepsTableFocus,
+                           b                      : Backend,
+                           rowBreakpointHoverOnCB : Int => Callback,
+                           rowBreakpointHoverOffCB: Int => Callback,
+                           recomputeHeightsCB     : Int => Callback
+                         ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       StepToolsCell(
         b.props.status,
         row.step,
         rowHeight(b)(row.step.id),
-        b.props.secondRowHeight(row.step),
+        b.props.rowDetailsHeight(row.step),
         f.isPreview,
         f.nextStepToRun,
         f.id,
@@ -546,15 +562,15 @@ object StepsTable extends Columns {
         rowBreakpointHoverOnCB,
         rowBreakpointHoverOffCB,
         recomputeHeightsCB
-      )
+        )
 
   val stepIdRenderer: CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) => StepIdCell(row.step.id)
 
   def settingsControlRenderer(
-    p: Props,
-    f: StepsTableFocus
-  ): CellRenderer[js.Object, js.Object, StepRow] =
+                               p: Props,
+                               f: StepsTableFocus
+                             ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       SettingsCell(p.router,
                    f.instrument,
@@ -563,9 +579,9 @@ object StepsTable extends Columns {
                    p.isPreview)
 
   def stepProgressRenderer(
-    f: StepsTableFocus,
-    b: Backend
-  ): CellRenderer[js.Object, js.Object, StepRow] =
+                            f: StepsTableFocus,
+                            b: Backend
+                          ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       StepProgressCell(b.props.status,
                        f.instrument,
@@ -577,39 +593,39 @@ object StepsTable extends Columns {
                        b.props.tabOperations)
 
   def stepStatusRenderer(
-    offsetsDisplay: OffsetsDisplay
-  ): CellRenderer[js.Object, js.Object, StepRow] =
+                          offsetsDisplay: OffsetsDisplay
+                        ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       OffsetsDisplayCell(offsetsDisplay, row.step)
 
   def stepItemRenderer(
-    f: Step => Option[String]
-  ): CellRenderer[js.Object, js.Object, StepRow] =
+                        f: Step => Option[String]
+                      ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) => StepItemCell(f(row.step))
 
   private def stepItemRendererS(f: Step => Option[String]) =
     stepItemRenderer(f(_).map(_.sentenceCase))
 
   def stepExposureRenderer(
-    i: Instrument
-  ): CellRenderer[js.Object, js.Object, StepRow] =
+                            i: Instrument
+                          ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       ExposureTimeCell(row.step, i)
 
   def stepFPURenderer(
-    i: Instrument
-  ): CellRenderer[js.Object, js.Object, StepRow] =
+                       i: Instrument
+                     ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) => {
       val fpu = row.step
-        .fpu(i)
-        .orElse(row.step.fpuOrMask(i).map(_.sentenceCase))
+                   .fpu(i)
+                   .orElse(row.step.fpuOrMask(i).map(_.sentenceCase))
       StepItemCell(fpu)
     }
 
   def stepObjectTypeRenderer(
-    i:    Instrument,
-    size: SSize
-  ): CellRenderer[js.Object, js.Object, StepRow] =
+                              i   : Instrument,
+                              size: SSize
+                            ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       ObjectTypeCell(i, row.step, size)
 
@@ -641,19 +657,19 @@ object StepsTable extends Columns {
       b.props.rowGetter(i),
       b.props.canSetBreakpoint,
       b.state.breakpointHover) match {
-      case (-1, _, _, _) =>
+      case (-1, _, _, _)                                           =>
         // Header
         SeqexecStyles.headerRowStyle
-      case (_, StepRow(s), true, _) if s.breakpoint =>
+      case (_, StepRow(s), true, _) if s.breakpoint                =>
         // row with control elements and breakpoint
         breakpointAndControlRowStyle(b.props.rowGetter(i - 1).step) |+| stepRowStyle(s)
-      case (_, StepRow(s), false, _) if s.breakpoint =>
+      case (_, StepRow(s), false, _) if s.breakpoint               =>
         // row with breakpoint
         breakpointRowStyle(b.props.rowGetter(i - 1).step) |+| stepRowStyle(s)
       case (j, StepRow(s), _, Some(k)) if !s.breakpoint && j === k =>
         // row with breakpoint and hover
         SeqexecStyles.stepRowWithBreakpointHover |+| stepRowStyle(s)
-      case (_, StepRow(s), _, _) =>
+      case (_, StepRow(s), _, _)                                   =>
         // Regular row
         SeqexecStyles.stepRow |+| stepRowStyle(s)
     }).htmlClass
@@ -674,60 +690,60 @@ object StepsTable extends Columns {
   def rowHeight(b: Backend)(i: Int): Int = {
     val row = b.props.rowGetter(i)
     row match {
-      case StepRow(_) if b.props.showSecondRow(row.step) =>
+      case StepRow(_) if b.props.showRowDetails(row.step)                         =>
         // Selected
-        SeqexecStyles.runningRowHeight + b.props.secondRowHeight(row.step)
+        SeqexecStyles.runningRowHeight + b.props.rowDetailsHeight(row.step)
       case StepRow(s)
-          if s.status === StepState.Running && s.breakpoint =>
+        if s.status === StepState.Running && s.breakpoint                         =>
         // Row running with a breakpoint set
         SeqexecStyles.runningRowHeight + BreakpointLineHeight
-      case StepRow(s) if s.status === StepState.Running =>
+      case StepRow(s) if s.status === StepState.Running                           =>
         // Row running
         SeqexecStyles.runningRowHeight
       case StepRow(s)
-          if b.state.selected.exists(_ === s.id) && !s.skip &&
-            (b.props.canControlSubsystems(s.id) || b.props.subsystemsNotIdle(s.id))=>
+        if b.state.selected.exists(_ === s.id) && !s.skip &&
+          (b.props.canControlSubsystems(s.id) || b.props.subsystemsNotIdle(s.id)) =>
         // Selected
         SeqexecStyles.runningRowHeight
-      case StepRow(s) if s.breakpoint =>
+      case StepRow(s) if s.breakpoint                                             =>
         // Row with a breakpoint set
         baseHeight(b.props) + BreakpointLineHeight
-      case _ =>
+      case _                                                                      =>
         // default row
         baseHeight(b.props)
     }
   }
 
   val columnClassName: TableColumn => Option[Css] = {
-    case ControlColumn                => SeqexecStyles.controlCellRow.some
-    case StepColumn | ExecutionColumn => SeqexecStyles.paddedStepRow.some
+    case ControlColumn                        => SeqexecStyles.controlCellRow.some
+    case StepColumn | ExecutionColumn         => SeqexecStyles.paddedStepRow.some
     case ObservingModeColumn | ExposureColumn | DisperserColumn | FilterColumn |
-        FPUColumn | CameraColumn | ObjectTypeColumn | DeckerColumn |
-        ReadModeColumn | ImagingMirrorColumn =>
+         FPUColumn | CameraColumn | ObjectTypeColumn | DeckerColumn |
+         ReadModeColumn | ImagingMirrorColumn =>
       SeqexecStyles.centeredCell.some
-    case SettingsColumn => SeqexecStyles.settingsCellRow.some
-    case _              => none
+    case SettingsColumn                       => SeqexecStyles.settingsCellRow.some
+    case _                                    => none
   }
 
   val headerClassName: TableColumn => Option[Css] = {
-    case ControlColumn =>
+    case ControlColumn  =>
       (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
     case SettingsColumn =>
       (SeqexecStyles.centeredCell |+| SeqexecStyles.tableHeaderIcons).some
-    case _ => none
+    case _              => none
   }
 
   val controlHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
     <.span(
       ^.title := "Control",
       IconSettings
-  )
+      )
 
   val settingsHeaderRenderer: HeaderRenderer[js.Object] = (_, _, _, _, _, _) =>
     <.span(
       ^.title := "Settings",
       IconBrowser
-  )
+      )
 
   private val fixedHeaderRenderer: TableColumn => HeaderRenderer[js.Object] = {
     case ControlColumn  => controlHeaderRenderer
@@ -736,8 +752,8 @@ object StepsTable extends Columns {
   }
 
   private def columnCellRenderer(
-    b: Backend,
-    c: TableColumn): CellRenderer[js.Object, js.Object, StepRow] = {
+                                  b: Backend,
+                                  c: TableColumn): CellRenderer[js.Object, js.Object, StepRow] = {
     val optR = c match {
       case ControlColumn       =>
         b.props.steps.map(
@@ -767,46 +783,46 @@ object StepsTable extends Columns {
 
   // Columns for the table
   private def colBuilder(
-    b:    Backend,
-    size: Size
-  ): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb => {
+                          b   : Backend,
+                          size: Size
+                        ): ColumnRenderArgs[TableColumn] => Table.ColumnArg = tb => {
     def updateState(s: TableState[TableColumn]): Callback =
       (b.modState(State.tableState.set(s)) *> b.props.obsId
-        .map(i => SeqexecCircuit.dispatchCB(UpdateStepTableState(i, s)))
-        .getOrEmpty).when_(size.width > 0)
+                                               .map(i => SeqexecCircuit.dispatchCB(UpdateStepTableState(i, s)))
+                                               .getOrEmpty).when_(size.width > 0)
 
     tb match {
-      case ColumnRenderArgs(meta, _, width, true) =>
+      case ColumnRenderArgs(meta, _, width, true)  =>
         Column(
           Column.propsNoFlex(
-            width   = width,
+            width = width,
             dataKey = meta.name,
-            label   = meta.label,
+            label = meta.label,
             headerRenderer = resizableHeaderRenderer(
               b.state.tableState
-                .resizeColumn(meta.column,
-                              size,
-                              updateState,
-                              b.props.visibleColumns,
-                              b.props.columnWidths)
-            ),
+               .resizeColumn(meta.column,
+                             size,
+                             updateState,
+                             b.props.visibleColumns,
+                             b.props.columnWidths)
+              ),
             headerClassName = headerClassName(meta.column).foldMap(_.htmlClass),
-            cellRenderer    = columnCellRenderer(b, meta.column),
-            className       = columnClassName(meta.column).foldMap(_.htmlClass)
+            cellRenderer = columnCellRenderer(b, meta.column),
+            className = columnClassName(meta.column).foldMap(_.htmlClass)
+            )
           )
-        )
       case ColumnRenderArgs(meta, _, width, false) =>
         Column(
           Column.propsNoFlex(
-            width           = width,
-            dataKey         = meta.name,
-            label           = meta.label,
-            headerRenderer  = fixedHeaderRenderer(meta.column),
+            width = width,
+            dataKey = meta.name,
+            label = meta.label,
+            headerRenderer = fixedHeaderRenderer(meta.column),
             headerClassName = headerClassName(meta.column).foldMap(_.htmlClass),
-            cellRenderer    = columnCellRenderer(b, meta.column),
-            className       = columnClassName(meta.column).foldMap(_.htmlClass)
+            cellRenderer = columnCellRenderer(b, meta.column),
+            className = columnClassName(meta.column).foldMap(_.htmlClass)
+            )
           )
-        )
     }
   }
 
@@ -816,14 +832,14 @@ object StepsTable extends Columns {
   // Aditionally if we programatically scroll to a position we get another call
   // Only after that we assume scroll is user initatied
   def updateScrollPosition(b: Backend, pos: JsNumber): Callback = {
-    val posMod            = b.setStateL(State.scrollPosition)(pos)
+    val posMod = b.setStateL(State.scrollPosition)(pos)
     // This is done to ignore the scrolls made automatically upon startup
     val hasScrolledBefore = b.state.scrollCount > 2
-    val modMod            = b.setStateL(State.userModified)(IsModified).when_(hasScrolledBefore)
-    val scrollCountMods   = b.modStateL(State.scrollCount)(_ + 1)
+    val modMod = b.setStateL(State.userModified)(IsModified).when_(hasScrolledBefore)
+    val scrollCountMods = b.modStateL(State.scrollCount)(_ + 1)
     // Separately calculate the state to send upstream
     val newTs = if (hasScrolledBefore) {
-      (State.userModified.set(IsModified) >>> State.scrollPosition.set(pos))(b.state)
+      (State.userModified.set(IsModified) >>> State.scrollPosition.set(pos)) (b.state)
     } else {
       State.scrollPosition.set(pos)(b.state)
     }
@@ -835,8 +851,8 @@ object StepsTable extends Columns {
       modMod *>
       // And silently update the model
       b.props.obsId
-        .map(id =>
-          SeqexecCircuit.dispatchCB(UpdateStepTableState(id, newTs.tableState))).getOrEmpty)
+       .map(id =>
+              SeqexecCircuit.dispatchCB(UpdateStepTableState(id, newTs.tableState))).getOrEmpty)
       .when_(posDiff > 1) // Only update the state if the change is significant
   }
 
@@ -874,32 +890,32 @@ object StepsTable extends Columns {
           ^.cls := "ui center aligned segment noRows",
           ^.height := size.height.px,
           "No Steps"
-        ),
+          ),
       overscanRowCount = SeqexecStyles.overscanRowCount,
-      height           = max(1, size.height.toInt),
-      rowCount         = b.props.rowCount,
-      rowHeight        = rowHeight(b) _,
-      rowClassName     = rowClassName(b) _,
-      width            = max(1, size.width.toInt),
-      rowGetter        = b.props.rowGetter _,
-      scrollToIndex    = startScrollToIndex(b),
-      scrollTop        = startScrollTop(b.state),
-      onRowClick       = singleClick(b),
+      height = max(1, size.height.toInt),
+      rowCount = b.props.rowCount,
+      rowHeight = rowHeight(b) _,
+      rowClassName = rowClassName(b) _,
+      width = max(1, size.width.toInt),
+      rowGetter = b.props.rowGetter _,
+      scrollToIndex = startScrollToIndex(b),
+      scrollTop = startScrollTop(b.state),
+      onRowClick = singleClick(b),
       onScroll =
         (a, _, pos) => updateScrollPosition(b, pos).when_(a.toDouble > 0),
       scrollToAlignment = ScrollToAlignment.Center,
-      headerClassName   = SeqexecStyles.tableHeader.htmlClass,
-      headerHeight      = SeqexecStyles.headerHeight,
-      rowRenderer       = stepsRowRenderer(b.props)
-    )
+      headerClassName = SeqexecStyles.tableHeader.htmlClass,
+      headerHeight = SeqexecStyles.headerHeight,
+      rowRenderer = stepsRowRenderer(b.props)
+      )
 
   // We want clicks to be processed only if the click is not on the first row with the breakpoint/skip controls
   private def allowedClick(
-    p:          Props,
-    index:      Int,
-    onRowClick: Option[OnRowClick]
-  )(e:          ReactMouseEvent): Callback =
-    // If alt is pressed or middle button flip the breakpoint
+                            p         : Props,
+                            index     : Int,
+                            onRowClick: Option[OnRowClick]
+                          )(e: ReactMouseEvent): Callback =
+  // If alt is pressed or middle button flip the breakpoint
     if (e.altKey || e.button === MIDDLE_BUTTON) {
       e.preventDefaultCB >>
         (p.obsId, p.stepsList.find(_.id === index + 1))
@@ -919,20 +935,20 @@ object StepsTable extends Columns {
     }
 
   private def stepsRowRenderer(p: Props) =
-    (className:        String,
-     columns:          Array[VdomNode],
-     index:            Int,
-     _:                Boolean,
-     key:              String,
-     _:                StepRow,
-     onRowClick:       Option[OnRowClick],
+    (className       : String,
+     columns         : Array[VdomNode],
+     index           : Int,
+     _               : Boolean,
+     key             : String,
+     _               : StepRow,
+     onRowClick      : Option[OnRowClick],
      onRowDoubleClick: Option[OnRowClick],
-     _:                Option[OnRowClick],
-     _:                Option[OnRowClick],
-     _:                Option[OnRowClick],
-     style:            Style) => {
+     _               : Option[OnRowClick],
+     _               : Option[OnRowClick],
+     _               : Option[OnRowClick],
+     style           : Style) => {
       p.rowGetter(index) match {
-        case StepRow(s) if p.showSecondRow(s) && index === s.id =>
+        case StepRow(s) if p.showRowDetails(s) && index === s.id =>
           <.div(
             ^.key := key,
             ^.style := Style.toJsObject(style),
@@ -945,25 +961,36 @@ object StepsTable extends Columns {
               ^.onDoubleClick -->? onRowDoubleClick.map(h => h(index)),
               columns.toTagMod
             ),
-            p.stepSnapshot(s).map {s =>
-              <.div(
-                SeqexecStyles.expandedBottomRow,
-                SeqexecStyles.acProgressRow,
-              ^.onMouseDown ==> allowedClick(p, index, onRowClick),
-              ^.onDoubleClick -->? onRowDoubleClick.map(h => h(index)),
-                AlignAndCalibProgress(s),
-                ^.key := s"$key-base"
-              )}
+            p.stepSnapshot(s).whenDefined { s =>
+              val rowComponents: List[StepStateSnapshot => ReactProps] =
+                if (s.isAC)
+                  List(AlignAndCalibProgress.apply)
+                else if (s.isNS)
+                  List(NodAndShuffleCycleProgress.apply, NodAndShuffleNodProgress.apply)
+                else
+                  List.empty
+
+              rowComponents.zipWithIndex.toTagMod { case (rowComponent, rowIdx) =>
+                <.div(
+                  ^.key := s"$key-subRow-$rowIdx",
+                  SeqexecStyles.expandedBottomRow,
+                  SeqexecStyles.tableDetailRow,
+                  ^.onMouseDown ==> allowedClick(p, index, onRowClick),
+                  ^.onDoubleClick -->? onRowDoubleClick.map(h => h(index)),
+                  rowComponent(s)
+                  )
+              }
+            }
           )
-        case _ =>
-            <.div(
-              ^.cls := className,
-              ^.key := key,
-              ^.role := "row",
-              ^.style := Style.toJsObject(style),
-              ^.onMouseDown ==> allowedClick(p, index, onRowClick),
-              ^.onDoubleClick -->? onRowDoubleClick.map(h => h(index)),
-              columns.toTagMod
+        case _                                                   =>
+          <.div(
+            ^.cls := className,
+            ^.key := key,
+            ^.role := "row",
+            ^.style := Style.toJsObject(style),
+            ^.onMouseDown ==> allowedClick(p, index, onRowClick),
+            ^.onDoubleClick -->? onRowDoubleClick.map(h => h(index)),
+            columns.toTagMod
             )
       }
     }
@@ -976,20 +1003,20 @@ object StepsTable extends Columns {
 
   def rowBreakpointHoverOnCB(b: Backend)(index: Int): Callback =
     (if (b.props.rowGetter(index).step.breakpoint)
-       b.modState(State.breakpointHover.set(None))
-     else b.modState(State.breakpointHover.set(index.some))) *>
+      b.modState(State.breakpointHover.set(None))
+    else b.modState(State.breakpointHover.set(index.some))) *>
       recomputeRowHeightsCB(index)
 
   def rowBreakpointHoverOffCB(b: Backend)(index: Int): Callback =
     b.modState(State.breakpointHover.set(None)) *> recomputeRowHeightsCB(index)
 
-  private def updateStep(b:     ReceiveProps,
-                         p:     Props,
+  private def updateStep(b    : ReceiveProps,
+                         p    : Props,
                          obsId: Observation.Id,
-                         i:     StepId): Callback =
+                         i    : StepId): Callback =
     SeqexecCircuit.dispatchCB(UpdateSelectedStep(obsId, i)) *>
       b.setStateL(State.selected)(i.some)
-        .when_(p.canControlSubsystems(i))
+       .when_(p.canControlSubsystems(i))
 
   private def scrollTo(i: StepId): Callback =
     ref.get.flatMapCB(_.raw.scrollToRowCB(i))
@@ -1000,26 +1027,26 @@ object StepsTable extends Columns {
       .when_(
         cur.tabOperations.runRequested =!= next.tabOperations.runRequested
           && next.tabOperations.runRequested === RunOperation.RunInFlight
-      )
+        )
 
   private def selectStepCB(b: ReceiveProps): Callback = {
     val (cur: Props, next: Props) = (b.currentProps, b.nextProps)
     // Update the selected step as the run proceeds
     (next.obsId, cur.runningStep, next.runningStep) match {
-      case (Some(obsId), Some(RunningStep(i, _)), None) =>
+      case (Some(obsId), Some(RunningStep(i, _)), None)                                       =>
         // This happens when a sequence stops, e.g. with a pasue
         updateStep(b, next, obsId, i)
       case (Some(obsId), Some(RunningStep(i, _)), Some(RunningStep(j, _)))
-          if i =!= j =>
+        if i =!= j                                                                            =>
         // This happens when we keep running and move to the next step
         // If the user hasn't scrolled we'll focus on the next step
         updateStep(b, next, obsId, j) *>
           scrollTo(j)
       case (Some(obsId), _, Some(RunningStep(j, _)))
-          if cur.sequenceState =!= next.sequenceState && next.sequenceState.exists(_.isRunning) =>
+        if cur.sequenceState =!= next.sequenceState && next.sequenceState.exists(_.isRunning) =>
         // When we start running
         updateStep(b, next, obsId, j)
-      case _ =>
+      case _                                                                                  =>
         Callback.empty
     }
   }
@@ -1082,8 +1109,8 @@ object StepsTable extends Columns {
         size => {
           val ts =
             b.state.tableState
-              .columnBuilder(size, colBuilder(b, size), b.props.columnWidths)
-              .map(_.vdomElement)
+             .columnBuilder(size, colBuilder(b, size), b.props.columnWidths)
+             .map(_.vdomElement)
 
           if (size.width > 0) {
             ref
@@ -1098,10 +1125,10 @@ object StepsTable extends Columns {
             _.recalculateWidths(s,
                                 b.props.visibleColumns,
                                 b.props.columnWidths))
-      ))
+        ))
 
   def initialState(p: Props): State =
-    (State.tableState.set(p.tableState) >>> State.selected.set(p.selectedStep))(State.InitialState)
+    (State.tableState.set(p.tableState) >>> State.selected.set(p.selectedStep)) (State.InitialState)
 
   protected val component = ScalaComponent
     .builder[Props]("StepsTable")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -444,8 +444,8 @@ object StepsTable extends Columns {
   type Backend      = RenderScope[Props, State, Unit]
   type ReceiveProps = ComponentWillReceiveProps[Props, State, Unit]
 
-  private val MIDDLE_BUTTON = 1 // As defined by React.js
-  private val HEADER_ROW = -1
+  private val MiddleButton = 1 // As defined by React.js
+  private val HeaderRow = -1
 
   val HeightWithOffsets: Int    = 40
   val BreakpointLineHeight: Int = 5
@@ -646,7 +646,7 @@ object StepsTable extends Columns {
       b.props.rowGetter(i),
       b.props.canSetBreakpoint,
       b.state.breakpointHover) match {
-      case (HEADER_ROW, _, _, _)                                   =>
+      case (HeaderRow, _, _, _)                                   =>
         // Header
         SeqexecStyles.headerRowStyle
       case (_, StepRow(s), true, _) if s.breakpoint                =>
@@ -905,7 +905,7 @@ object StepsTable extends Columns {
     onRowClick: Option[OnRowClick]
   )(e:          ReactMouseEvent): Callback =
     // If alt is pressed or middle button flip the breakpoint
-    if (e.altKey || e.button === MIDDLE_BUTTON) {
+    if (e.altKey || e.button === MiddleButton) {
       e.preventDefaultCB >>
         (p.obsId, p.stepsList.find(_.id === index + 1))
           .mapN(

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/package.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.client.components.sequence
+
+package object steps {
+  implicit class ControlButtonResolverSyntax[A](val a: A) extends AnyVal {
+    def controlButtonsActive(implicit resolver: ControlButtonResolver[A]): Boolean =
+      resolver.controlButtonsActive(a)
+  }
+}

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/package.scala
@@ -4,7 +4,7 @@
 package seqexec.web.client.components.sequence
 
 package object steps {
-  implicit class ControlButtonResolverSyntax[A](val a: A) extends AnyVal {
+  implicit class ControlButtonResolverOps[A](val a: A) extends AnyVal {
     def controlButtonsActive(implicit resolver: ControlButtonResolver[A]): Boolean =
       resolver.controlButtonsActive(a)
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -39,6 +39,7 @@ import seqexec.web.client.model.TabSelected
 import seqexec.web.client.model.SoundSelection
 import seqexec.web.client.model.GlobalLog
 import seqexec.web.client.circuit._
+import seqexec.web.client.model.StepItems.StepStateSnapshot
 import squants.Time
 import shapeless.tag.@@
 
@@ -54,6 +55,8 @@ package object reusability {
   implicit val observerReuse: Reusability[Observer]         = Reusability.byEq
   implicit val stepConfigReuse: Reusability[StepConfig]     = Reusability.byEq
   implicit val stepReuse: Reusability[Step]                 = Reusability.byEq
+  implicit val stepStateSnapshotReuse: Reusability[StepStateSnapshot] =
+    Reusability.byEq
   implicit val seqStateReuse: Reusability[SequenceState]    = Reusability.byEq
   implicit val clientStatusReuse: Reusability[ClientStatus] = Reusability.byEq
   implicit val stepTTReuse: Reusability[StepsTableTypeSelection] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -39,7 +39,7 @@ import seqexec.web.client.model.TabSelected
 import seqexec.web.client.model.SoundSelection
 import seqexec.web.client.model.GlobalLog
 import seqexec.web.client.circuit._
-import seqexec.web.client.model.StepItems.StepStateSnapshot
+import seqexec.web.client.model.StepItems.StepStateSummary
 import squants.Time
 import shapeless.tag.@@
 
@@ -55,7 +55,7 @@ package object reusability {
   implicit val observerReuse: Reusability[Observer]         = Reusability.byEq
   implicit val stepConfigReuse: Reusability[StepConfig]     = Reusability.byEq
   implicit val stepReuse: Reusability[Step]                 = Reusability.byEq
-  implicit val stepStateSnapshotReuse: Reusability[StepStateSnapshot] =
+  implicit val stepStateSnapshotReuse: Reusability[StepStateSummary] =
     Reusability.byEq
   implicit val seqStateReuse: Reusability[SequenceState]    = Reusability.byEq
   implicit val clientStatusReuse: Reusability[ClientStatus] = Reusability.byEq

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/progress/Progress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/semanticui/elements/progress/Progress.scala
@@ -17,8 +17,8 @@ import web.client.facades.semanticui.SemanticUIProgress._
   */
 object Progress {
   final case class Props(label:       String,
-                         total:       Long,
-                         value:       Long,
+                         total:       Int,
+                         value:       Int,
                          indicating:  Boolean = false,
                          progress:    Boolean = false,
                          color:       Option[String] = None,


### PR DESCRIPTION
Display cycle and subexposure progress for N&S steps in Seqexec UI, shown when a step is selected or running.

Also display graceful and immediate pause and stop buttons when the user is logged in and the step is running.

![image](https://user-images.githubusercontent.com/1895643/66151767-5b678980-e5ee-11e9-97b5-f888bf92117d.png)

This PR integrates the changes from https://github.com/gemini-hlsw/ocs3/pull/1114 but not yet the ones from https://github.com/gemini-hlsw/ocs3/pull/1119 (no running state yet).