### PR TITLE
SEQNG-1076 Fix building distributions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,9 @@ name := Settings.Definitions.name
 organization in Global := "edu.gemini.ocs"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
+
+ThisBuild / publishArtifact in (Compile, packageDoc) := false
+
 // Gemini repository
 resolvers in ThisBuild += "Gemini Repository" at "https://github.com/gemini-hlsw/maven-repo/raw/master/releases"
 
@@ -572,6 +575,14 @@ lazy val app_seqexec_server = preventPublication(project.in(file("app/seqexec-se
     mappings in Universal += {
       val jar = (packageBin in Compile).value
       jar -> ("lib/" + jar.getName)
+    },
+    mappings in Universal := {
+      // filter out sjs jar files. otherwise it could generate some conflicts
+      val universalMappings = (mappings in Universal).value
+      val filtered = universalMappings filter {
+        case (_, name) => !name.contains("_sjs")
+      }
+      filtered
     },
     mappings in Universal += {
       val f = (resourceDirectory in Compile).value / "update_smartgcal"


### PR DESCRIPTION
When trying to do a release we found 2 issues 
Javadocs were attempted to be built but there is a problem with `@typeclass`
More complicated `sjs` jar files were now included and that created troubles with the log4s dependenecy

We should aim to remove that in favor of log4cats but http4s depends on log4s anyway

At the end it was down to sbt magic. I suspect the original source of this is 
https://github.com/gemini-hlsw/ocs3/commit/fcc665143b6e8402f840cb8bddbb6f12db366ffb
or 
https://github.com/gemini-hlsw/ocs3/commit/5beb16c0c8819fe6d101dfff6b69ad37999be126