### PR TITLE
SEQNG-1063 Turn off GCAL lamps for GMOS darks and biases.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
@@ -75,9 +75,11 @@ trait SequenceConfiguration {
        .leftMap(explainExtractError),
      extractInstrument(config)).mapN { (obsType, inst) =>
       obsType match {
-        case SCIENCE_OBSERVE_TYPE => extractGaos(inst)
-        case BIAS_OBSERVE_TYPE | DARK_OBSERVE_TYPE =>
-          StepType.DarkOrBias(inst).asRight
+        case SCIENCE_OBSERVE_TYPE                                    => extractGaos(inst)
+        case BIAS_OBSERVE_TYPE | DARK_OBSERVE_TYPE                   => inst match {
+          case Instrument.GmosN | Instrument.GmosS => StepType.ExclusiveDarkOrBias(inst).asRight
+          case _                                   => StepType.DarkOrBias(inst).asRight
+        }
         case FLAT_OBSERVE_TYPE | ARC_OBSERVE_TYPE | CAL_OBSERVE_TYPE =>
           StepType.FlatOrArc(inst).asRight
         case _ => Unexpected("Unknown step type " + obsType).asLeft

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
@@ -20,20 +20,22 @@ object StepType {
   final case class FlatOrArc(override val instrument: Instrument) extends StepType
   final case class DarkOrBias(override val instrument: Instrument) extends StepType
   final case class DarkOrBiasNS(override val instrument: Instrument) extends StepType
+  final case class ExclusiveDarkOrBias(override val instrument: Instrument) extends StepType
   case object AlignAndCalib extends StepType {
     override val instrument: Instrument = Instrument.Gpi
   }
 
   implicit val eqStepType: Eq[StepType] = Eq.instance {
-    case (CelestialObject(i), CelestialObject(j)) => i === j
-    case (Dark(i), Dark(j))                       => i === j
-    case (NodAndShuffle(i), NodAndShuffle(j))     => i === j
-    case (Gems(i), Gems(j))                       => i === j
-    case (AltairObs(i), AltairObs(j))             => i === j
-    case (FlatOrArc(i), FlatOrArc(j))             => i === j
-    case (DarkOrBias(i), DarkOrBias(j))           => i === j
-    case (DarkOrBiasNS(i), DarkOrBiasNS(j))       => i === j
-    case (AlignAndCalib, AlignAndCalib)           => true
-    case _                                        => false
+    case (CelestialObject(i), CelestialObject(j))         => i === j
+    case (Dark(i), Dark(j))                               => i === j
+    case (NodAndShuffle(i), NodAndShuffle(j))             => i === j
+    case (Gems(i), Gems(j))                               => i === j
+    case (AltairObs(i), AltairObs(j))                     => i === j
+    case (FlatOrArc(i), FlatOrArc(j))                     => i === j
+    case (DarkOrBias(i), DarkOrBias(j))                   => i === j
+    case (DarkOrBiasNS(i), DarkOrBiasNS(j))               => i === j
+    case (ExclusiveDarkOrBias(i), ExclusiveDarkOrBias(j)) => i === j
+    case (AlignAndCalib, AlignAndCalib)                   => true
+    case _                                                => false
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -118,9 +118,9 @@ abstract class Gmos[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger, T <: 
     val stdType = SequenceConfiguration.calcStepType(config)
     if (Gmos.isNodAndShuffle(config)) {
       stdType.flatMap {
-        case StepType.DarkOrBias(_)      => StepType.DarkOrBiasNS(instrument).asRight
-        case StepType.CelestialObject(_) => StepType.NodAndShuffle(instrument).asRight
-        case st                          => SeqexecFailure.Unexpected(s"N&S is not supported for steps of type $st")
+        case StepType.ExclusiveDarkOrBias(_) => StepType.DarkOrBiasNS(instrument).asRight
+        case StepType.CelestialObject(_)     => StepType.NodAndShuffle(instrument).asRight
+        case st                              => SeqexecFailure.Unexpected(s"N&S is not supported for steps of type $st")
           .asLeft
       }
     } else {


### PR DESCRIPTION
GMOS is picky when it comes to taking darks and biases, so this PR turns the GCAL lamps off for them. A consequence is that GMOS darks and biases will prevent the execution of other calibrations in parallel, because they take control of GCAL.