### PR TITLE
[SEQNG-1078] N&S progress messages and total remaining time.

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -17,7 +17,7 @@ import japgolly.scalajs.react.extra.TimerSupport
 import monocle.macros.Lenses
 import react.common.Css
 import seqexec.model.dhs.ImageFileId
-import seqexec.model.{NSRunningState, NSSubexposure, NodAndShuffleStatus, ObservationProgress, StepId}
+import seqexec.model.{NodAndShuffleStatus, ObservationProgress, StepId}
 import seqexec.model.operations._
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.model.{ClientStatus, StopOperation}
@@ -46,9 +46,6 @@ object NodAndShuffleProgressMessage extends ProgressLabel {
   @Lenses
   protected case class State(progressConnect: ReactConnectProxy[Option[ObservationProgress]])
 
-  implicit val nsSubReuse: Reusability[NSSubexposure] = Reusability.derive[NSSubexposure]
-  implicit val nsStateReuse: Reusability[NSRunningState] = Reusability.derive[NSRunningState]
-  implicit val nsStatusReuse: Reusability[NodAndShuffleStatus] = Reusability.derive[NodAndShuffleStatus]
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
   implicit val stateReuse: Reusability[State] = Reusability.always
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -12,10 +12,12 @@ import seqexec.model.enum.NodAndShuffleStage
 import seqexec.web.client.components.{DividedProgress, SeqexecStyles}
 import cats.implicits._
 import diode.react.ReactConnectProxy
+import gem.Observation
 import japgolly.scalajs.react.extra.TimerSupport
 import monocle.macros.Lenses
 import react.common.Css
-import seqexec.model.{NodAndShuffleStatus, ObservationProgress}
+import seqexec.model.dhs.ImageFileId
+import seqexec.model.{NSRunningState, NSSubexposure, NodAndShuffleStatus, ObservationProgress, StepId}
 import seqexec.model.operations._
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.model.{ClientStatus, StopOperation}
@@ -23,6 +25,57 @@ import seqexec.web.client.reusability._
 import seqexec.web.client.semanticui._
 
 import scala.math.max
+
+final case class NodAndShuffleProgressMessage(
+                                               obsId : Observation.Id,
+                                               stepId: StepId,
+                                               fileId: ImageFileId,
+                                               stopping: Boolean,
+                                               paused: Boolean,
+                                               nsStatus: NodAndShuffleStatus
+                                             ) extends ReactProps {
+  @inline def render: VdomElement = NodAndShuffleProgressMessage.component(this)
+
+  protected[steps] val connect =
+    SeqexecCircuit.connect(SeqexecCircuit.obsProgressReader(obsId, stepId))
+}
+
+object NodAndShuffleProgressMessage extends ProgressLabel {
+  type Props = NodAndShuffleProgressMessage
+
+  @Lenses
+  protected case class State(progressConnect: ReactConnectProxy[Option[ObservationProgress]])
+
+  implicit val nsSubReuse: Reusability[NSSubexposure] = Reusability.derive[NSSubexposure]
+  implicit val nsStateReuse: Reusability[NSRunningState] = Reusability.derive[NSRunningState]
+  implicit val nsStatusReuse: Reusability[NodAndShuffleStatus] = Reusability.derive[NodAndShuffleStatus]
+  implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
+  implicit val stateReuse: Reusability[State] = Reusability.always
+
+  protected[steps] val component = ScalaComponent
+    .builder[Props]("NodAndShuffleProgress")
+    .initialStateFromProps(p => State(p.connect))
+    .render_PS { (p, s) =>
+      <.div(
+        SeqexecStyles.specialStateLabel,
+        SeqexecStyles.progressMessage,
+        p.nsStatus.state.map[VdomElement] { nsState =>
+          s.progressConnect { proxy =>
+            val nodCount = NodAndShuffleStage.NsSequence.length
+            val nodMillis = p.nsStatus.nodExposureTime.toMilliseconds.toInt
+            val cycleMillis = nodMillis * nodCount
+            val remainingCycles = p.nsStatus.cycles - nsState.sub.cycle - 1
+            val remainingNods = nodCount - nsState.sub.stageIndex - 1
+            val remainingNodMillis = proxy().foldMap(_.remaining.toMilliseconds.toInt)
+            val remainingMillis = remainingCycles * cycleMillis + remainingNods * nodMillis + remainingNodMillis
+            <.span(label(p.fileId, remainingMillis, p.stopping, p.paused))
+          }
+        } getOrElse <.span(p.fileId)
+        )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+}
 
 final case class SmoothDividedProgressBar(
   sections            : List[DividedProgress.Label],

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -194,7 +194,7 @@ object StepsControlButtons {
         p.stepId,
         p.isObservePaused,
         p.tabOperations
-        )
+      )
     }
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -24,7 +24,7 @@ import react.common._
 import react.common.implicits._
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.StepType
-import seqexec.model.{NSRunningState, NSSubexposure, NodAndShuffleStatus, NodAndShuffleStep, RunningStep, SequenceState, StandardStep, Step, StepId, StepState}
+import seqexec.model.{RunningStep, SequenceState, Step, StepId, StepState}
 import seqexec.web.client.model.lenses._
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.TabOperations
@@ -496,23 +496,6 @@ object StepsTable extends Columns {
     val InitialState: State = State(InitialTableState, None, None, 0)
   }
 
-  val stdStepReuse: Reusability[StandardStep] =
-    Reusability.caseClassExcept('config)
-  implicit val nsSubexposureReuse: Reusability[NSSubexposure] =
-    Reusability.derive[NSSubexposure]
-  implicit val nsRunningStateReuse: Reusability[NSRunningState] =
-    Reusability.derive[NSRunningState]
-  implicit val nsStatus: Reusability[NodAndShuffleStatus] =
-    Reusability.derive[NodAndShuffleStatus]
-  val nsStepReuse: Reusability[NodAndShuffleStep] =
-    Reusability.caseClassExcept('config)
-
-  implicit val stepReuse: Reusability[Step] =
-    Reusability {
-      case (a: StandardStep, b: StandardStep)           => stdStepReuse.test(a, b)
-      case (a: NodAndShuffleStep, b: NodAndShuffleStep) => nsStepReuse.test(a, b)
-      case _                                            => false
-    }
   implicit val propsReuse: Reusability[Props] =
     Reusability.by(x => (x.canOperate, x.selectedStep, x.stepsList))
   implicit val tcReuse: Reusability[TableColumn] = Reusability.byRef

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -24,16 +24,7 @@ import react.common._
 import react.common.implicits._
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.StepType
-import seqexec.model.StepState
-import seqexec.model.Step
-import seqexec.model.StepId
-import seqexec.model.StandardStep
-import seqexec.model.NodAndShuffleStep
-import seqexec.model.NodAndShuffleStatus
-import seqexec.model.SequenceState
-import seqexec.model.RunningStep
-import seqexec.model.NSSubexposure
-import seqexec.model.NSRunningState
+import seqexec.model.{NSRunningState, NSSubexposure, NodAndShuffleStatus, NodAndShuffleStep, RunningStep, SequenceState, StandardStep, Step, StepId, StepState}
 import seqexec.web.client.model.lenses._
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.TabOperations
@@ -573,13 +564,14 @@ object StepsTable extends Columns {
   ): CellRenderer[js.Object, js.Object, StepRow] =
     (_, _, _, row: StepRow, _) =>
       StepProgressCell(b.props.status,
-                       f.instrument,
-                       f.id,
-                       f.state,
-                       row.step,
+                       StepStateSummary(
+                         row.step,
+                         f.id,
+                         f.instrument,
+                         b.props.tabOperations,
+                         f.state),
                        b.state.selected,
-                       b.props.isPreview,
-                       b.props.tabOperations)
+                       b.props.isPreview)
 
   def stepStatusRenderer(
     offsetsDisplay: OffsetsDisplay

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -46,6 +46,22 @@ package object reusability {
   implicit val obsIdReuse: Reusability[Observation.Id]      = Reusability.byEq
   implicit val observerReuse: Reusability[Observer]         = Reusability.byEq
   implicit val stepConfigReuse: Reusability[StepConfig]     = Reusability.byEq
+  val stdStepReuse: Reusability[StandardStep] =
+    Reusability.caseClassExcept('config)
+  implicit val nsSubexposureReuse: Reusability[NSSubexposure] =
+    Reusability.derive[NSSubexposure]
+  implicit val nsRunningStateReuse: Reusability[NSRunningState] =
+    Reusability.derive[NSRunningState]
+  implicit val nsStatus: Reusability[NodAndShuffleStatus] =
+    Reusability.derive[NodAndShuffleStatus]
+  val nsStepReuse: Reusability[NodAndShuffleStep] =
+    Reusability.caseClassExcept('config)
+  implicit val stepReuse: Reusability[Step] =
+    Reusability {
+      case (a: StandardStep, b: StandardStep)           => stdStepReuse.test(a, b)
+      case (a: NodAndShuffleStep, b: NodAndShuffleStep) => nsStepReuse.test(a, b)
+      case _                                            => false
+    }
   implicit val stepStateSnapshotReuse: Reusability[StepStateSummary] =
     Reusability.byEq
   implicit val seqStateReuse: Reusability[SequenceState]    = Reusability.byEq
@@ -95,20 +111,4 @@ package object reusability {
     Reusability.derive[M2GuideConfig]
   implicit val configReuse: Reusability[TelescopeGuideConfig] =
     Reusability.derive[TelescopeGuideConfig]
-  val stdStepReuse: Reusability[StandardStep] =
-    Reusability.caseClassExcept('config)
-  implicit val nsSubexposureReuse: Reusability[NSSubexposure] =
-    Reusability.derive[NSSubexposure]
-  implicit val nsRunningStateReuse: Reusability[NSRunningState] =
-    Reusability.derive[NSRunningState]
-  implicit val nsStatus: Reusability[NodAndShuffleStatus] =
-    Reusability.derive[NodAndShuffleStatus]
-  val nsStepReuse: Reusability[NodAndShuffleStep] =
-    Reusability.caseClassExcept('config)
-  implicit val stepReuse: Reusability[Step] =
-    Reusability {
-      case (a: StandardStep, b: StandardStep)           => stdStepReuse.test(a, b)
-      case (a: NodAndShuffleStep, b: NodAndShuffleStep) => nsStepReuse.test(a, b)
-      case _                                            => false
-    }
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -9,20 +9,12 @@ import gem.Observation
 import gem.util.Enumerated
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
+
 import scala.collection.immutable.SortedMap
 import seqexec.model.enum.Resource
 import seqexec.model.enum.ServerLogLevel
 import seqexec.model.dhs._
-import seqexec.model.Observer
-import seqexec.model.QueueId
-import seqexec.model.Step
-import seqexec.model.StepConfig
-import seqexec.model.StepState
-import seqexec.model.UserDetails
-import seqexec.model.SequenceState
-import seqexec.model.M1GuideConfig
-import seqexec.model.M2GuideConfig
-import seqexec.model.TelescopeGuideConfig
+import seqexec.model.{M1GuideConfig, M2GuideConfig, NSRunningState, NSSubexposure, NodAndShuffleStatus, NodAndShuffleStep, Observer, QueueId, SequenceState, StandardStep, Step, StepConfig, StepState, TelescopeGuideConfig, UserDetails}
 import seqexec.web.client.model.AvailableTab
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.model.SectionVisibilityState
@@ -54,7 +46,6 @@ package object reusability {
   implicit val obsIdReuse: Reusability[Observation.Id]      = Reusability.byEq
   implicit val observerReuse: Reusability[Observer]         = Reusability.byEq
   implicit val stepConfigReuse: Reusability[StepConfig]     = Reusability.byEq
-  implicit val stepReuse: Reusability[Step]                 = Reusability.byEq
   implicit val stepStateSnapshotReuse: Reusability[StepStateSummary] =
     Reusability.byEq
   implicit val seqStateReuse: Reusability[SequenceState]    = Reusability.byEq
@@ -104,4 +95,20 @@ package object reusability {
     Reusability.derive[M2GuideConfig]
   implicit val configReuse: Reusability[TelescopeGuideConfig] =
     Reusability.derive[TelescopeGuideConfig]
+  val stdStepReuse: Reusability[StandardStep] =
+    Reusability.caseClassExcept('config)
+  implicit val nsSubexposureReuse: Reusability[NSSubexposure] =
+    Reusability.derive[NSSubexposure]
+  implicit val nsRunningStateReuse: Reusability[NSRunningState] =
+    Reusability.derive[NSRunningState]
+  implicit val nsStatus: Reusability[NodAndShuffleStatus] =
+    Reusability.derive[NodAndShuffleStatus]
+  val nsStepReuse: Reusability[NodAndShuffleStep] =
+    Reusability.caseClassExcept('config)
+  implicit val stepReuse: Reusability[Step] =
+    Reusability {
+      case (a: StandardStep, b: StandardStep)           => stdStepReuse.test(a, b)
+      case (a: NodAndShuffleStep, b: NodAndShuffleStep) => nsStepReuse.test(a, b)
+      case _                                            => false
+    }
 }


### PR DESCRIPTION
I undid the previous changes to the progress bar component and abstracted away the logic to compute the progress message, which is now shared with a specialized component to show it in N&S.

@cquiroz I'd appreciate your input on generalizing the standard and N&S step reusability instances without `config`.