### PR TITLE
Improve construction of subsystems

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentControllerSim.scala
@@ -169,14 +169,15 @@ object InstrumentControllerSim {
 
   }
 
-  def unsafeApply[F[_]: Sync: Logger: Timer](name: String): InstrumentControllerSim[F] = {
-    val obsStateRef = InstrumentControllerSim.ObserveState.unsafeRef[F]
-    new InstrumentControllerSimImpl[F](name,
-                                       false,
-                                       FiniteDuration(5, SECONDS),
-                                       FiniteDuration(1500, MILLISECONDS),
-                                       FiniteDuration(5, SECONDS),
-                                       obsStateRef)
+  def apply[F[_]: Sync: Logger: Timer](name: String): F[InstrumentControllerSim[F]] = {
+    InstrumentControllerSim.ObserveState.ref[F].map { obsStateRef =>
+      new InstrumentControllerSimImpl[F](name,
+                                         false,
+                                         FiniteDuration(5, SECONDS),
+                                         FiniteDuration(1500, MILLISECONDS),
+                                         FiniteDuration(5, SECONDS),
+                                         obsStateRef)
+    }
   }
 
   def unsafeWithTimes[F[_]: Sync: Logger: Timer](

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Settings.scala
@@ -36,5 +36,7 @@ final case class Settings(site:                    Site,
                           instForceError:          Boolean,
                           failAt:                  Int,
                           odbQueuePollingInterval: Duration,
+                          gpiUrl:                  Uri @@ GpiSettings,
+                          ghostUrl:                Uri @@ GhostSettings,
                           gpiGDS:                  Uri @@ GpiSettings,
                           ghostGDS:                Uri @@ GhostSettings)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Systems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Systems.scala
@@ -3,19 +3,27 @@
 
 package seqexec.server
 
-import seqexec.server.altair.AltairController
-import seqexec.server.flamingos2.Flamingos2Controller
+import cats.effect._
+import cats.implicits._
+import edu.gemini.spModel.core.Peer
+import gem.enum.Site
+import io.chrisdavenport.log4cats.Logger
+import giapi.client.ghost.GhostClient
+import giapi.client.gpi.GpiClient
+import org.http4s.client.Client
+import seqexec.server.altair._
+import seqexec.server.flamingos2._
 import seqexec.server.keywords._
-import seqexec.server.gpi.GpiController
-import seqexec.server.gmos.GmosController._
-import seqexec.server.gsaoi.GsaoiController
-import seqexec.server.ghost.GhostController
-import seqexec.server.gcal.GcalController
-import seqexec.server.gems.GemsController
-import seqexec.server.tcs.{GuideConfigDb, TcsNorthController, TcsSouthController}
-import seqexec.server.gnirs.GnirsController
-import seqexec.server.niri.NiriController
-import seqexec.server.nifs.NifsController
+import seqexec.server.gpi._
+import seqexec.server.gmos._
+import seqexec.server.gsaoi._
+import seqexec.server.ghost._
+import seqexec.server.gcal._
+import seqexec.server.gems._
+import seqexec.server.tcs._
+import seqexec.server.gnirs._
+import seqexec.server.niri._
+import seqexec.server.nifs._
 
 final case class Systems[F[_]](
   odb:        OdbProxy[F],
@@ -36,3 +44,131 @@ final case class Systems[F[_]](
   gems:       GemsController[F],
   guideDb:    GuideConfigDb[F]
 )
+
+object Systems {
+  def odbProxy[F[_]: Sync: Logger](settings: Settings): OdbProxy[F] = OdbProxy[F](new Peer(settings.odbHost, 8443, null),
+    if (settings.odbNotifications) OdbProxy.OdbCommandsImpl[F](new Peer(settings.odbHost, 8442, null))
+    else new OdbProxy.DummyOdbCommands[F])
+
+  def dhs[F[_]: Effect: Timer: Logger](settings: Settings, httpClient: Client[F]): DhsClient[F] =
+    if (settings.dhsControl.command) DhsClientHttp[F](httpClient, settings.dhsURI)
+    else                             DhsClientSim.unsafeApply(settings.date)
+
+  // TODO make instruments controllers generalized on F
+  def gcal(settings: Settings)(implicit L: Logger[IO]): IO[GcalController[IO]] =
+    if (settings.gcalControl.command) GcalControllerEpics(GcalEpics.instance).pure[IO]
+    else                              GcalControllerSim[IO].pure[IO]
+
+  def tcsSouth(settings: Settings, gcdb: GuideConfigDb[IO])(implicit L: Logger[IO]): IO[TcsSouthController[IO]] =
+    if (settings.tcsControl.command && settings.site === Site.GS) TcsSouthControllerEpics(gcdb).pure[IO]
+    else                                                          TcsSouthControllerSim[IO].pure[IO]
+
+  def tcsNorth(settings: Settings)(implicit L: Logger[IO]): IO[TcsNorthController[IO]] =
+    if (settings.tcsControl.command && settings.site === Site.GN) TcsNorthControllerEpics().pure[IO]
+    else                                                          TcsNorthControllerSim[IO].pure[IO]
+
+  def altair(settings: Settings)(implicit L: Logger[IO]): IO[AltairController[IO]] =
+    if (settings.altairControl.command && settings.tcsControl.command) AltairControllerEpics.pure[IO]
+    else                                                               AltairControllerSim[IO].pure[IO]
+
+  def gems(settings: Settings, gsaoiController: GsaoiGuider[IO])(implicit L: Logger[IO]): IO[GemsController[IO]] =
+    if (settings.gemsControl.command && settings.tcsControl.command) GemsControllerEpics(GemsEpics.instance, gsaoiController).pure[IO]
+    else                                                             GemsControllerSim[IO].pure[IO]
+
+  def gsaoi(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[GsaoiFullHandler[IO]] =
+    if (settings.gsaoiControl.command) GsaoiControllerEpics().pure[IO]
+    else                               GsaoiControllerSim[IO]
+
+  def gnirs(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[GnirsController[IO]] =
+    if (settings.gnirsControl.command) GnirsControllerEpics().pure[IO]
+    else                               GnirsControllerSim[IO]
+
+  def niri(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[NiriController[IO]] =
+    if (settings.niriControl.command) NiriControllerEpics().pure[IO]
+    else                              NiriControllerSim[IO]
+
+  def nifs(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[NifsController[IO]] =
+    if (settings.nifsControl.command) NifsControllerEpics().pure[IO]
+    else                              NifsControllerSim[IO]
+
+  def gmosSouth(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[GmosSouthController[IO]] =
+    if (settings.gmosControl.command) GmosSouthControllerEpics().pure[IO]
+    else                              GmosControllerSim.south[IO]
+
+  def gmosNorth(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[GmosNorthController[IO]] =
+    if (settings.gmosControl.command) GmosNorthControllerEpics().pure[IO]
+    else                              GmosControllerSim.north[IO]
+
+  def flamingos2(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[Flamingos2Controller[IO]] =
+    if (settings.f2Control.command) Flamingos2ControllerEpics[IO](Flamingos2Epics.instance).pure[IO]
+    else if (settings.instForceError) Flamingos2ControllerSimBad[IO](settings.failAt)
+    else Flamingos2ControllerSim[IO]
+
+  def gpi[F[_]: ConcurrentEffect: Timer](settings: Settings, httpClient: Client[F]): Resource[F, GpiController[F]] = {
+    def gpiClient(settings: Settings): Resource[F, GpiClient[F]] =
+      if (settings.gpiControl.command) GpiClient.gpiClient[F](settings.gpiUrl.renderString, GpiStatusApply.statusesToMonitor)
+      else                             GpiClient.simulatedGpiClient[F]
+
+    def gpiGDS(settings: Settings, httpClient: Client[F]): Resource[F, GdsClient[F]] =
+      Resource.pure(GdsClient(
+        if (settings.gpiGdsControl.command) httpClient else GdsClient.alwaysOkClient[F],
+        settings.gpiGDS))
+
+    (gpiClient(settings), gpiGDS(settings, httpClient)).mapN(GpiController(_, _))
+  }
+
+  def ghost[F[_]: ConcurrentEffect: Timer](settings: Settings, httpClient: Client[F]): Resource[F, GhostController[F]] = {
+    def ghostClient(settings: Settings): Resource[F, GhostClient[F]] =
+      if (settings.ghostControl.command) GhostClient.ghostClient[F](settings.ghostUrl.renderString)
+       else                              GhostClient.simulatedGhostClient
+
+    def ghostGDS(settings: Settings, httpClient: Client[F]): Resource[F, GdsClient[F]] =
+      Resource.pure(GdsClient(
+        if (settings.ghostGdsControl.command) httpClient else GdsClient.alwaysOkClient[F],
+        settings.ghostGDS))
+
+    (ghostClient(settings), ghostGDS(settings, httpClient)).mapN(GhostController(_, _))
+  }
+
+  def build(httpClient: Client[IO], settings: Settings)(implicit T: Timer[IO], L: Logger[IO], C: ContextShift[IO]): Resource[IO, Systems[IO]] = {
+    for {
+      odbProxy        <- Resource.pure[IO, OdbProxy[IO]](odbProxy[IO](settings))
+      dhsClient       <- Resource.pure[IO, DhsClient[IO]](dhs[IO](settings, httpClient))
+      gcdb            <- Resource.liftF(GuideConfigDb.newDb[IO])
+      gcalController  <- Resource.liftF(gcal(settings))
+      tcsGS           <- Resource.liftF(tcsSouth(settings, gcdb))
+      tcsGN           <- Resource.liftF(tcsNorth(settings))
+      altair          <- Resource.liftF(altair(settings))
+      gsaoiController <- Resource.liftF(gsaoi(settings))
+      gems            <- Resource.liftF(gems(settings, gsaoiController))
+      gnirsController <- Resource.liftF(gnirs(settings))
+      f2Controller    <- Resource.liftF(flamingos2(settings))
+      niriController  <- Resource.liftF(niri(settings))
+      nifsController  <- Resource.liftF(nifs(settings))
+      gmosSController <- Resource.liftF(gmosSouth(settings))
+      gmosNController <- Resource.liftF(gmosNorth(settings))
+      gpiController   <- gpi[IO](settings, httpClient)
+      ghostController <- ghost[IO](settings, httpClient)
+    } yield
+      Systems[IO](
+        odbProxy,
+        dhsClient,
+        tcsGS,
+        tcsGN,
+        gcalController,
+        f2Controller,
+        gmosSController,
+        gmosNController,
+        gnirsController,
+        gsaoiController,
+        gpiController,
+        ghostController,
+        niriController,
+        nifsController,
+        altair,
+        gems,
+        gcdb
+      )
+
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerSim.scala
@@ -37,8 +37,8 @@ final case class Flamingos2ControllerSim[F[_]] private (sim: InstrumentControlle
 }
 
 object Flamingos2ControllerSim {
-  def unsafeApply[F[_]: Sync: Logger: Timer]: Flamingos2Controller[F] =
-    Flamingos2ControllerSim(InstrumentControllerSim.unsafeApply("FLAMINGOS-2"))
+  def apply[F[_]: Sync: Logger: Timer]: F[Flamingos2Controller[F]] =
+    InstrumentControllerSim("FLAMINGOS-2").map(Flamingos2ControllerSim(_))
 
 }
 
@@ -68,10 +68,13 @@ final case class Flamingos2ControllerSimBad[F[_]: MonadError[?[_], Throwable]: L
 }
 
 object Flamingos2ControllerSimBad {
-  def unsafeApply[F[_]: Sync: Logger: Timer](failAt: Int): Flamingos2Controller[F] =
-    Flamingos2ControllerSimBad(
-      failAt,
-      InstrumentControllerSim.unsafeApply("FLAMINGOS-2 (bad)"),
-      Ref.unsafe[F, Int](0))
+  def apply[F[_]: Sync: Logger: Timer](failAt: Int): F[Flamingos2Controller[F]] =
+    (Ref.of[F, Int](0), InstrumentControllerSim("FLAMINGOS-2 (bad)")).mapN { (counter, sim) =>
+      Flamingos2ControllerSimBad(
+        failAt,
+        sim,
+        counter
+      )
+    }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerSim.scala
@@ -3,16 +3,12 @@
 
 package seqexec.server.gcal
 
-import cats.effect.Sync
-import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.server.gcal.GcalController.GcalConfig
-import org.log4s.getLogger
 
 object GcalControllerSim {
-  def apply[F[_]: Sync]: GcalController[F] = new GcalController[F] {
-    private val Log = getLogger
-
+  def apply[F[_]: Logger]: GcalController[F] = new GcalController[F] {
     override def applyConfig(config: GcalConfig): F[Unit] =
-      Sync[F].delay(Log.debug("Simulating GCAL configuration")).void
+      Logger[F].debug("Simulating GCAL configuration")
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerSim.scala
@@ -2,36 +2,33 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package seqexec.server.gems
-import cats.effect.Sync
+
+import cats.Applicative
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.server.tcs.Gaos.{PauseConditionSet, PauseResume, ResumeConditionSet}
-import org.log4s.getLogger
 import seqexec.server.gems.Gems.{GemsWfsState, Cwfs1DetectorState, Cwfs2DetectorState, Cwfs3DetectorState, Odgw1DetectorState, Odgw2DetectorState, Odgw3DetectorState, Odgw4DetectorState}
 import seqexec.server.gems.GemsController.GemsConfig
 
-final class GemsControllerSim[F[_]: Sync] private extends GemsController[F] {
-  import GemsControllerSim._
-
-  override def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
-                          (cfg: GemsConfig)
-  : F[PauseResume[F]] = { PauseResume(
-    Sync[F].delay(Log.info(s"Simulate pausing GeMS loops because of $pauseReasons")).some,
-    Sync[F].delay(Log.info(s"Simulate restoring GeMS configuration $cfg because of $resumeReasons")).some
-  ) }.pure[F]
-
-  override val stateGetter: Gems.GemsWfsState[F] = GemsWfsState[F](
-    (Cwfs1DetectorState.Off:Cwfs1DetectorState).pure[F],
-    (Cwfs2DetectorState.Off:Cwfs2DetectorState).pure[F],
-    (Cwfs3DetectorState.Off:Cwfs3DetectorState).pure[F],
-    (Odgw1DetectorState.Off:Odgw1DetectorState).pure[F],
-    (Odgw2DetectorState.Off:Odgw2DetectorState).pure[F],
-    (Odgw3DetectorState.Off:Odgw3DetectorState).pure[F],
-    (Odgw4DetectorState.Off:Odgw4DetectorState).pure[F]
-  )
-}
-
 object GemsControllerSim {
-  val Log = getLogger
+  def apply[F[_]: Applicative](implicit L: Logger[F]): GemsController[F] =
+    new GemsController[F] {
+      override def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
+                              (cfg: GemsConfig)
+      : F[PauseResume[F]] =
+        PauseResume(
+          L.info(s"Simulate pausing GeMS loops because of $pauseReasons").some,
+          L.info(s"Simulate restoring GeMS configuration $cfg because of $resumeReasons").some
+        ).pure[F]
 
-  def apply[F[_]: Sync]: GemsController[F] = new GemsControllerSim[F]
+      override val stateGetter: Gems.GemsWfsState[F] = GemsWfsState[F](
+        (Cwfs1DetectorState.Off:Cwfs1DetectorState).pure[F],
+        (Cwfs2DetectorState.Off:Cwfs2DetectorState).pure[F],
+        (Cwfs3DetectorState.Off:Cwfs3DetectorState).pure[F],
+        (Odgw1DetectorState.Off:Odgw1DetectorState).pure[F],
+        (Odgw2DetectorState.Off:Odgw2DetectorState).pure[F],
+        (Odgw3DetectorState.Off:Odgw3DetectorState).pure[F],
+        (Odgw4DetectorState.Off:Odgw4DetectorState).pure[F]
+      )
+    }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -247,10 +247,6 @@ object GmosController {
     def this(c: Config[T])(cc: c.CCConfig, dc: DCConfig, ns: NSConfig) = this(cc, dc, c, ns)
   }
 
-  type GmosSouthController[F[_]] = GmosController[F, SouthTypes]
-
-  type GmosNorthController[F[_]] = GmosController[F, NorthTypes]
-
   implicit def configShow[T<:SiteDependentTypes]: Show[GmosConfig[T]] =
     Show.show { config =>
       val ccShow = if(config.cc.isDarkOrBias) "DarkOrBias"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
@@ -147,15 +147,13 @@ object GmosControllerSim {
 
     }
 
-  def unsafeSouth[F[_]: Sync: Logger: Timer]: GmosController[F, SouthTypes] = {
-    val nsConfig: Ref[F, NSObsState] = Ref.unsafe(NSObsState.Zero)
-    val sim: InstrumentControllerSim[F] = InstrumentControllerSim.unsafeApply[F](s"GMOS South")
-    GmosControllerSim[F, SouthTypes](sim, nsConfig)
-  }
+  def south[F[_]: Sync: Logger: Timer]: F[GmosController[F, SouthTypes]] =
+    (Ref.of(NSObsState.Zero), InstrumentControllerSim[F](s"GMOS South")).mapN {(nsConfig, sim) =>
+      GmosControllerSim[F, SouthTypes](sim, nsConfig)
+    }
 
-  def unsafeNorth[F[_]: Sync: Logger: Timer]: GmosController[F, NorthTypes] = {
-    val nsConfig: Ref[F, NSObsState] = Ref.unsafe(NSObsState.Zero)
-    val sim: InstrumentControllerSim[F] = InstrumentControllerSim.unsafeApply[F](s"GMOS North")
-    GmosControllerSim[F, NorthTypes](sim, nsConfig)
-  }
+  def north[F[_]: Sync: Logger: Timer]: F[GmosController[F, NorthTypes]] =
+    (Ref.of(NSObsState.Zero), InstrumentControllerSim[F](s"GMOS North")).mapN {(nsConfig, sim) =>
+      GmosControllerSim[F, NorthTypes](sim, nsConfig)
+    }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -12,7 +12,7 @@ import seqexec.server.{CleanConfig, ConfigUtilOps}
 import seqexec.server.CleanConfig.extractItem
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
-import seqexec.server.gmos.GmosController.{GmosNorthController, NorthTypes, northConfigTypes}
+import seqexec.server.gmos.GmosController.{NorthTypes, northConfigTypes}
 import seqexec.server.keywords.DhsClient
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import edu.gemini.spModel.gemini.gmos.GmosNorthType

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -12,7 +12,7 @@ import seqexec.server.{CleanConfig, ConfigUtilOps}
 import seqexec.server.CleanConfig.extractItem
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
-import seqexec.server.gmos.GmosController.{GmosSouthController, SouthTypes, southConfigTypes}
+import seqexec.server.gmos.GmosController.{SouthTypes, southConfigTypes}
 import seqexec.server.keywords.DhsClient
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import edu.gemini.spModel.gemini.gmos.GmosSouthType

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
@@ -7,6 +7,12 @@ import seqexec.model.enum.NSAction
 import seqexec.model.NSSubexposure
 import seqexec.engine.Result.PartialVal
 
+package object gmos {
+  type GmosSouthController[F[_]] = GmosController[F, GmosController.SouthTypes]
+
+  type GmosNorthController[F[_]] = GmosController[F, GmosController.NorthTypes]
+}
+
 package gmos {
 
   sealed trait NSPartial extends PartialVal {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
@@ -23,6 +23,7 @@ import gem.enum.GpiReadMode
 import giapi.client.commands.Configuration
 import giapi.client.commands.CommandResultException
 import giapi.client.gpi.GpiClient
+import giapi.client.GiapiStatusDb
 import mouse.boolean._
 import org.log4s._
 import scala.concurrent.duration._
@@ -149,6 +150,8 @@ case object AlignAndCalibConfig extends GpiConfig {
 
 trait GpiController[F[_]] extends GiapiInstrumentController[F, GpiConfig] {
   def gdsClient: GdsClient[F]
+
+  def statusDb: GiapiStatusDb[F]
 
   def alignAndCalib: F[Unit]
 }
@@ -307,6 +310,8 @@ object GpiController extends GpiLookupTables with GpiConfigEq {
           case c: RegularGpiConfig => computeRegularConfig(client, c)
           case AlignAndCalibConfig => AlignAndCalibConfig.config.pure[F]
         }
+
+      override def statusDb: GiapiStatusDb[F] = client.statusDb
     }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GdsClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GdsClient.scala
@@ -3,7 +3,7 @@
 
 package seqexec.server.keywords
 
-import cats.effect.IO
+import cats.effect.Sync
 import cats.effect.Timer
 import cats.effect.Effect
 import cats.Functor
@@ -166,8 +166,8 @@ object GdsClient {
   /**
     * Client for testing always returns ok
     */
-  val alwaysOkClient: Client[IO] = {
-    val service = HttpRoutes.of[IO] {
+  def alwaysOkClient[F[_]: Sync]: Client[F] = {
+    val service = HttpRoutes.of[F] {
       case _ =>
         val response =
           <methodResponse>
@@ -177,7 +177,7 @@ object GdsClient {
               </param>
             </params>
           </methodResponse>
-        Response[IO](Status.Ok).withEntity(response).pure[IO]
+        Response[F](Status.Ok).withEntity(response).pure[F]
     }
     Client.fromHttpApp(service.orNotFound)
   }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerSim.scala
@@ -18,32 +18,32 @@ import squants.Time
 import squants.time.TimeConversions._
 
 object NifsControllerSim {
-  def unsafeApply[F[_]: Sync: Logger: Timer]: NifsController[F] =
-    new NifsController[F] {
-      private val sim: InstrumentControllerSim[F] = InstrumentControllerSim.unsafeApply(s"NIRI")
+  def apply[F[_]: Sync: Logger: Timer]: F[NifsController[F]] =
+    InstrumentControllerSim[F](s"NIFS").map { sim =>
+      new NifsController[F] {
 
-      override def observe(fileId: ImageFileId,
-                           cfg:    DCConfig): F[ObserveCommandResult] =
-        calcTotalExposureTime(cfg).flatMap {ot =>
-          sim
-            .observe(fileId, ot)
-        }
+        override def observe(fileId: ImageFileId,
+                             cfg:    DCConfig): F[ObserveCommandResult] =
+          calcTotalExposureTime(cfg).flatMap {ot =>
+            sim
+              .observe(fileId, ot)
+          }
 
-      override def applyConfig(config: NifsConfig): F[Unit] =
-        sim.applyConfig(config)
+        override def applyConfig(config: NifsConfig): F[Unit] =
+          sim.applyConfig(config)
 
-      override def stopObserve: F[Unit] = sim.stopObserve
+        override def stopObserve: F[Unit] = sim.stopObserve
 
-      override def abortObserve: F[Unit] = sim.abortObserve
+        override def abortObserve: F[Unit] = sim.abortObserve
 
-      override def endObserve: F[Unit] = sim.endObserve
+        override def endObserve: F[Unit] = sim.endObserve
 
-      override def observeProgress(total: Time): fs2.Stream[F, Progress] =
-        sim.observeCountdown(total, ElapsedTime(0.seconds))
+        override def observeProgress(total: Time): fs2.Stream[F, Progress] =
+          sim.observeCountdown(total, ElapsedTime(0.seconds))
 
-      override def calcTotalExposureTime(cfg: DCConfig): F[Time] =
-        NifsController.calcTotalExposureTime[F](cfg)
+        override def calcTotalExposureTime(cfg: DCConfig): F[Time] =
+          NifsController.calcTotalExposureTime[F](cfg)
 
+      }
     }
-
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
@@ -3,19 +3,17 @@
 
 package seqexec.server.tcs
 
+import cats.Applicative
 import cats.data.NonEmptySet
-import cats.effect.Sync
-import seqexec.server.tcs.TcsController._
 import cats.implicits._
-import org.log4s.getLogger
+import io.chrisdavenport.log4cats.Logger
+import seqexec.server.tcs.TcsController._
 import seqexec.model.enum.NodAndShuffleStage
 
 
-class TcsControllerSim[F[_]: Sync] {
+class TcsControllerSim[F[_]: Applicative: Logger] {
 
-  import TcsControllerSim.Log
-
-  def info(msg: String): F[Unit] = Sync[F].delay(Log.info(msg))
+  def info(msg: String): F[Unit] = Logger[F].info(msg)
 
   def applyConfig(subsystems: NonEmptySet[Subsystem]): F[Unit] = {
     def configSubsystem(subsystem: Subsystem): F[Unit] =
@@ -30,10 +28,4 @@ class TcsControllerSim[F[_]: Sync] {
 
   def nod(stage: NodAndShuffleStage, offset: InstrumentOffset, guided: Boolean): F[Unit] =
     info(s"Simulate TCS Nod to position ${stage.symbol}, offset=$offset, guided=$guided")
-}
-
-object TcsControllerSim {
-
-  val Log = getLogger
-
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerSim.scala
@@ -4,13 +4,14 @@
 package seqexec.server.tcs
 
 import cats.data.NonEmptySet
-import cats.effect.Sync
+import cats.Applicative
+import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.NodAndShuffleStage
 import seqexec.server.altair.Altair
 import seqexec.server.tcs.TcsController.{InstrumentOffset, Subsystem}
 import seqexec.server.tcs.TcsNorthController.TcsNorthConfig
 
-class TcsNorthControllerSim[F[_]: Sync] private extends TcsNorthController[F] {
+class TcsNorthControllerSim[F[_]: Applicative: Logger] private extends TcsNorthController[F] {
  val sim = new TcsControllerSim[F]
 
   override def applyConfig(subsystems: NonEmptySet[Subsystem],
@@ -30,6 +31,6 @@ class TcsNorthControllerSim[F[_]: Sync] private extends TcsNorthController[F] {
 
 object TcsNorthControllerSim {
 
-  def apply[F[_]: Sync]: TcsNorthController[F] = new TcsNorthControllerSim[F]
+  def apply[F[_]: Applicative: Logger]: TcsNorthController[F] = new TcsNorthControllerSim[F]
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerSim.scala
@@ -4,13 +4,14 @@
 package seqexec.server.tcs
 
 import cats.data.NonEmptySet
-import cats.effect.Sync
+import cats.Applicative
+import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.NodAndShuffleStage
 import seqexec.server.gems.Gems
 import seqexec.server.tcs.TcsController.{InstrumentOffset, Subsystem}
 import seqexec.server.tcs.TcsSouthController.TcsSouthConfig
 
-class TcsSouthControllerSim[F[_]: Sync] private extends TcsSouthController[F] {
+class TcsSouthControllerSim[F[_]: Applicative: Logger] private extends TcsSouthController[F] {
   val sim = new TcsControllerSim[F]
 
   override def applyConfig(subsystems: NonEmptySet[TcsController.Subsystem],
@@ -28,6 +29,6 @@ class TcsSouthControllerSim[F[_]: Sync] private extends TcsSouthController[F] {
 
 object TcsSouthControllerSim {
 
-  def apply[F[_]: Sync]: TcsSouthController[F] = new TcsSouthControllerSim[F]
+  def apply[F[_]: Applicative: Logger]: TcsSouthController[F] = new TcsSouthControllerSim[F]
 
 }


### PR DESCRIPTION
Constructions of subsystems has been distributed across several places, web server and the seqexec engine. It also uses some unsafe actions. 
This PR tides this removing the `unsafe` calls and it puts the initialization of all systems in one place plus some other internal improvements