### PR TITLE
SEQNG-1088 Set electronic offset in between nods

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -185,13 +185,12 @@ object Gmos {
       .map(_.booleanValue())
       .getOrElse(false)
 
-  def ccElectronicOffset(config: CleanConfig): UseElectronicOffset = {
-    tag[UseElectronicOffsetI][Boolean](
+  def ccElectronicOffset(config: CleanConfig): ElectronicOffset =
+    ElectronicOffset.fromBoolean(
       config.extractInstAs[java.lang.Boolean](USE_ELECTRONIC_OFFSETTING_PROP)
         .map(_.booleanValue())
         .getOrElse(false) // We should always set electronic offset to false unless explicitly enabled
     )
-  }
 
   private def configToAngle(s: String): Either[ExtractFailure, Angle] =
     s.parseDoubleOption

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -23,9 +23,6 @@ import seqexec.server.InstrumentSystem.ElapsedTime
 import seqexec.server._
 import squants.{Length, Time}
 import shapeless.tag
-import shapeless.tag.@@
-
-trait UseElectronicOffsetI
 
 trait GmosController[F[_], T <: GmosController.SiteDependentTypes] {
   import GmosController._
@@ -77,7 +74,7 @@ object GmosController {
       stage: T#GmosStageMode,
       dtaX: DTAX,
       adc: ADC,
-      useElectronicOffset: UseElectronicOffset,
+      useElectronicOffset: ElectronicOffset,
       isDarkOrBias: Boolean
     )
 
@@ -86,7 +83,6 @@ object GmosController {
   object Config {
     type DTAX                = edu.gemini.spModel.gemini.gmos.GmosCommonType.DTAX
     type ADC                 = edu.gemini.spModel.gemini.gmos.GmosCommonType.ADC
-    type UseElectronicOffset = Boolean @@ UseElectronicOffsetI
     type DisperserOrder      = edu.gemini.spModel.gemini.gmos.GmosCommonType.Order
     type Binning             = edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning
     type AmpReadMode         = edu.gemini.spModel.gemini.gmos.GmosCommonType.AmpReadMode
@@ -132,6 +128,20 @@ object GmosController {
       /** @group Typeclass Instances */
       implicit val BeamEnumerated: Enumerated[Beam] =
         Enumerated.of(InBeam, OutOfBeam)
+    }
+
+    sealed trait ElectronicOffset extends Product with Serializable
+
+    object ElectronicOffset {
+      case object ElectronicOffsetOn extends ElectronicOffset
+      case object ElectronicOffsetOff extends ElectronicOffset
+
+      def fromBoolean(v: Boolean): ElectronicOffset =
+        if (v) ElectronicOffsetOn else ElectronicOffsetOff
+
+      /** @group Typeclass Instances */
+      implicit val ElectronicOffsetEnumerated: Enumerated[ElectronicOffset] =
+        Enumerated.of(ElectronicOffsetOn, ElectronicOffsetOff)
     }
 
     sealed trait GmosFPU extends Product with Serializable

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -133,15 +133,15 @@ object GmosController {
     sealed trait ElectronicOffset extends Product with Serializable
 
     object ElectronicOffset {
-      case object ElectronicOffsetOn extends ElectronicOffset
-      case object ElectronicOffsetOff extends ElectronicOffset
+      case object On extends ElectronicOffset
+      case object Off extends ElectronicOffset
 
       def fromBoolean(v: Boolean): ElectronicOffset =
-        if (v) ElectronicOffsetOn else ElectronicOffsetOff
+        if (v) On else Off
 
       /** @group Typeclass Instances */
       implicit val ElectronicOffsetEnumerated: Enumerated[ElectronicOffset] =
-        Enumerated.of(ElectronicOffsetOn, ElectronicOffsetOff)
+        Enumerated.of(On, Off)
     }
 
     sealed trait GmosFPU extends Product with Serializable

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -23,6 +23,9 @@ import seqexec.server.InstrumentSystem.ElapsedTime
 import seqexec.server._
 import squants.{Length, Time}
 import shapeless.tag
+import shapeless.tag.@@
+
+trait UseElectronicOffsetI
 
 trait GmosController[F[_], T <: GmosController.SiteDependentTypes] {
   import GmosController._
@@ -74,7 +77,7 @@ object GmosController {
       stage: T#GmosStageMode,
       dtaX: DTAX,
       adc: ADC,
-      useElectronicOffset: Option[UseElectronicOffset],
+      useElectronicOffset: UseElectronicOffset,
       isDarkOrBias: Boolean
     )
 
@@ -83,7 +86,7 @@ object GmosController {
   object Config {
     type DTAX                = edu.gemini.spModel.gemini.gmos.GmosCommonType.DTAX
     type ADC                 = edu.gemini.spModel.gemini.gmos.GmosCommonType.ADC
-    type UseElectronicOffset = edu.gemini.spModel.gemini.gmos.InstGmosCommon.UseElectronicOffsettingRuling
+    type UseElectronicOffset = Boolean @@ UseElectronicOffsetI
     type DisperserOrder      = edu.gemini.spModel.gemini.gmos.GmosCommonType.Order
     type Binning             = edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning
     type AmpReadMode         = edu.gemini.spModel.gemini.gmos.GmosCommonType.AmpReadMode

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -71,8 +71,8 @@ trait GmosEncoders {
 
   implicit val electronicOffsetEncoder: EncodeEpicsValue[ElectronicOffset, Int] =
     EncodeEpicsValue {
-      case ElectronicOffset.ElectronicOffsetOn => 1
-      case ElectronicOffset.ElectronicOffsetOff => 0
+      case ElectronicOffset.On  => 1
+      case ElectronicOffset.Off => 0
     }
 
   val InBeamVal: String    = "IN-BEAM"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
@@ -274,8 +274,10 @@ class GmosEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String])
 
   def stageMode: F[String] = read("stageMode")
 
-  def useElectronicOffsetting: F[Boolean] = readI("useElectronicOffsetting")
-    .map(_ =!= 0)
+  def useElectronicOffsetting: F[Boolean] =
+    electronicOffset.map(_ =!= 0)
+
+  def electronicOffset: F[Int] = readI("useElectronicOffsetting")
 
   def disperserWavel: F[Double] = readD("disperserLambda")
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosEpics.scala
@@ -274,9 +274,6 @@ class GmosEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String])
 
   def stageMode: F[String] = read("stageMode")
 
-  def useElectronicOffsetting: F[Boolean] =
-    electronicOffset.map(_ =!= 0)
-
   def electronicOffset: F[Int] = readI("useElectronicOffsetting")
 
   def disperserWavel: F[Double] = readD("disperserLambda")

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -112,7 +112,6 @@ class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Concurrent: Logge
     post:      (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
   ): Stream[F, Result[F]] = {
     val nsPositionO   = positions.find(_.stage === sub.stage)
-    // Configure GMOS rows
     // TCS Nod
     (env.getTcs, nsPositionO).mapN {
       case (tcs, nsPos) =>


### PR DESCRIPTION
Tests showed that e-offset wasn't being properly set with N&S.
This PR fixes it, the core reason was a badly read type from the ocs config