### PR TITLE
SEQNG-1083 Refactored paused observation commands

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -166,13 +166,13 @@ trait ObserveActions {
         abortTail(env.systems, env.obsId, fileId)
       case ObserveCommandResult.Paused =>
         env.inst.calcObserveTime(env.config)
-          .flatMap(t => env.inst.observeControl match {
+          .flatMap(totalTime => env.inst.observeControl match {
             case c: CompleteControl[F] => Result.Paused(
               ObserveContext[F](
-                (t: Time) => Stream.eval(c.continue.self(t)).flatMap(observeTail(fileId, dataId, env)),
+                (elapsed: Time) => Stream.eval(c.continue.self(elapsed)).flatMap(observeTail(fileId, dataId, env)),
                 Stream.eval(c.stopPaused.self).flatMap(observeTail(fileId, dataId, env)),
                 Stream.eval(c.abortPaused.self).flatMap(observeTail(fileId, dataId, env)),
-                t
+                totalTime
               )
             ).pure[F].widen[Result[F]]
             case _                     =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -57,7 +57,7 @@ abstract class Gmos[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger, T <: 
   val continueCommand: Time => F[ObserveCommandResult] =
     controller.resumePaused
 
-  override val observeControl: InstrumentSystem.ObserveControl[F] = CompleteControl(
+  override val observeControl: InstrumentSystem.CompleteControl[F] = CompleteControl(
     StopObserveCmd(controller.stopObserve),
     AbortObserveCmd(controller.abortObserve),
     PauseObserveCmd(controller.pauseObserve),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -24,6 +24,7 @@ import seqexec.server.tcs.TcsController.InstrumentOffset
 import seqexec.server.tcs.TcsController.OffsetP
 import seqexec.server.tcs.TcsController.OffsetQ
 import shapeless.tag
+import squants.Time
 import squants.space.AngleConversions._
 
 /**
@@ -61,7 +62,12 @@ class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Concurrent: Logge
             e =>
               Result
                 .Paused(
-                  ObserveContext(r => Stream.eval(observeTail(fileId, dataId, env)(r)), e)
+                  ObserveContext(
+                    (_: Time) => Stream.emit(Result.Error("Resuming a paused GMOS N&S observation is not yet supported")),
+                    Stream.emit(Result.Error("Stopping a paused GMOS N&S observation is not yet supported")),
+                    Stream.emit(Result.Error("Aborting a paused GMOS N&S observation is not yet supported")),
+                    e
+                  )
                 )
           )
       case ObserveCommandResult.Partial =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -71,7 +71,12 @@ package server {
     val default: HeaderExtraData = HeaderExtraData(Conditions.Default, None, None)
   }
 
-  final case class ObserveContext[F[_]](t: ObserveCommandResult => Stream[F, Result[F]], expTime: Time) extends PauseContext[F]
+  final case class ObserveContext[F[_]](
+    resumePaused: Time => Stream[F, Result[F]],
+    stopPaused: Stream[F, Result[F]],
+    abortPaused: Stream[F, Result[F]],
+    expTime: Time
+  ) extends PauseContext[F]
 
 }
 

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -14,9 +14,7 @@ import gem.Observation
 import gem.enum.Site
 import io.chrisdavenport.log4cats.noop.NoOpLogger
 import java.time.LocalDate
-
 import org.http4s.Uri._
-
 import scala.concurrent.ExecutionContext
 import seqexec.engine.{Action, Result, Sequence}
 import seqexec.model.enum.Instrument.GmosS


### PR DESCRIPTION
Paused observations commands were build from two pieces: a function that would send a command to the instrument and wait for a result, and a function that would process that result. The first function could be a continue, a stop or an abort, and it does not depend on the actual observation, only the instrument. The second function does depend on the observation, and was build at the moment the observation was paused.
This scheme covered all instruments, except for GMOS N&S. This PR changes that. Now, when the observation is paused, three functions are built: one to continue the observation, one to stop it, and one to abort it. For normal observations they are built the same way than before. When the user call for resuming, stopping or aborting the paused observation, the right function is retrieved and called. This allows to have specialized functions for N&S without changing the way the commands are called by the web server. 
