### PR TITLE
SEQNG-328 N&S interrupt commands

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
@@ -182,6 +182,8 @@ object Sequence {
       */
     val current: Execution[F]
 
+    val currentStep: Option[Step[F]]
+
     val done: List[Step[F]]
 
     /**
@@ -301,6 +303,8 @@ object Sequence {
           // Execution
           .focus
 
+      override val currentStep: Option[Step[F]] = zipper.focus.toStep.some
+
       override val pending: List[Step[F]] = zipper.pending
 
       override def rollback: Zipper[F] = self.copy(zipper = zipper.rollback)
@@ -398,6 +402,8 @@ object Sequence {
       override val next: Option[State[F]] = None
 
       override val current: Execution[F] = Execution.empty
+
+      override val currentStep: Option[Step[F]] = none
 
       override val pending: List[Step[F]] = Nil
 

--- a/modules/seqexec/model/src/main/scala/seqexec/model/enum/ObserveCommandResult.scala
+++ b/modules/seqexec/model/src/main/scala/seqexec/model/enum/ObserveCommandResult.scala
@@ -12,9 +12,8 @@ object ObserveCommandResult {
   case object Paused  extends ObserveCommandResult
   case object Stopped extends ObserveCommandResult
   case object Aborted extends ObserveCommandResult
-  case object Partial extends ObserveCommandResult // Used for N&S
 
   /** @group Typeclass Instances */
   implicit val ObserveCommandResultEnumerated: Enumerated[ObserveCommandResult] =
-    Enumerated.of(Success, Paused, Stopped, Aborted, Partial)
+    Enumerated.of(Success, Paused, Stopped, Aborted)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
@@ -78,7 +78,7 @@ object InstrumentActions {
   /**
     * Default Actions for most instruments it basically delegates to ObserveActions
     */
-  def defaultInstrumentActions[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger]
+  def defaultInstrumentActions[F[_]: Concurrent: Logger]
     : InstrumentActions[F] =
     new InstrumentActions[F] {
       def observationProgressStream(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -166,7 +166,7 @@ trait ObserveActions {
         abortTail(env.systems, env.obsId, fileId)
       case ObserveCommandResult.Paused =>
         env.inst.calcObserveTime(env.config)
-          .flatMap(totalTime => env.inst.observeControl match {
+          .flatMap(totalTime => env.inst.observeControl(env.config) match {
             case c: CompleteControl[F] => Result.Paused(
               ObserveContext[F](
                 (elapsed: Time) => Stream.eval(c.continue.self(elapsed)).flatMap(observeTail(fileId, dataId, env)),
@@ -179,10 +179,6 @@ trait ObserveActions {
               SeqexecFailure.Execution("Observation paused for an instrument that does not support pause")
                 .raiseError[F, Result[F]]
           })
-      case ObserveCommandResult.Partial =>
-        // This shouldn't happen in normal observations. Raise an error
-        MonadError[F, Throwable]
-          .raiseError[Result[F]](SeqexecFailure.Execution("Unsupported Partial observation"))
     })
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -159,7 +159,7 @@ class SeqTranslate(site: Site, systems: Systems[IO], settings: TranslateSettings
     implicit tio: Timer[IO], cio: Concurrent[IO]
   ): Option[Stream[IO, executeEngine.EventType]] = {
 
-    def isObserving(v: Action[IO]): Boolean = v.kind === ActionType.Observe && v.state.runState.started
+    def isObserving[F[_]](v: Action[F]): Boolean = v.kind === ActionType.Observe && v.state.runState.started
 
     st.sequences.get(seqId)
       .flatMap { obsSeq =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -31,7 +31,7 @@ import squants.time.{Seconds, Time}
 
 import scala.reflect.ClassTag
 
-final case class Flamingos2[F[_]: Sync: Timer: Logger: Concurrent](
+final case class Flamingos2[F[_]: Timer: Logger: Concurrent](
   f2Controller: Flamingos2Controller[F],
   dhsClient: DhsClient[F]
 ) extends DhsInstrument[F] with InstrumentSystem[F] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -5,8 +5,7 @@ package seqexec.server.flamingos2
 
 import cats.data.Kleisli
 import cats.data.EitherT
-import cats.effect.Sync
-import cats.effect.Timer
+import cats.effect.{Concurrent, Sync, Timer}
 import cats.implicits._
 import fs2.Stream
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.{Reads, _}
@@ -32,7 +31,10 @@ import squants.time.{Seconds, Time}
 
 import scala.reflect.ClassTag
 
-final case class Flamingos2[F[_]: Sync: Timer: Logger](f2Controller: Flamingos2Controller[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
+final case class Flamingos2[F[_]: Sync: Timer: Logger: Concurrent](
+  f2Controller: Flamingos2Controller[F],
+  dhsClient: DhsClient[F]
+) extends DhsInstrument[F] with InstrumentSystem[F] {
 
   import Flamingos2._
 
@@ -46,7 +48,7 @@ final case class Flamingos2[F[_]: Sync: Timer: Logger](f2Controller: Flamingos2C
 
   override val keywordsClient: KeywordsClient[F] = this
 
-  override val observeControl: InstrumentSystem.ObserveControl[F] = InstrumentSystem.Uncontrollable
+  override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] = InstrumentSystem.Uncontrollable
 
   // FLAMINGOS-2 does not support abort or stop.
   override def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -30,7 +30,7 @@ import squants.time.Time
 
 import scala.reflect.ClassTag
 
-final case class Ghost[F[_]: Sync: Logger: Concurrent](controller: GhostController[F])
+final case class Ghost[F[_]: Logger: Concurrent](controller: GhostController[F])
     extends GdsInstrument[F]
     with InstrumentSystem[F] {
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -5,7 +5,7 @@ package seqexec.server.ghost
 
 import cats.data.Kleisli
 import cats.data.EitherT
-import cats.effect.Sync
+import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import fs2.Stream
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
@@ -30,7 +30,7 @@ import squants.time.Time
 
 import scala.reflect.ClassTag
 
-final case class Ghost[F[_]: Sync: Logger](controller: GhostController[F])
+final case class Ghost[F[_]: Sync: Logger: Concurrent](controller: GhostController[F])
     extends GdsInstrument[F]
     with InstrumentSystem[F] {
 
@@ -44,7 +44,7 @@ final case class Ghost[F[_]: Sync: Logger](controller: GhostController[F])
 
   override val contributorName: String = "ghost"
 
-  override val observeControl: InstrumentSystem.ObserveControl[F] =
+  override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
     InstrumentSystem.Uncontrollable
 
   override def observe(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -45,7 +45,7 @@ import squants.{Seconds, Time}
 import squants.space.LengthConversions._
 import shapeless.tag
 
-abstract class Gmos[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger, T <: GmosController.SiteDependentTypes]
+abstract class Gmos[F[_]: Concurrent: Logger, T <: GmosController.SiteDependentTypes]
 (val controller: GmosController[F, T], ss: SiteSpecifics[T], nsCmdR: Ref[F, Option[NSObserveCommand]])
 (configTypes: GmosController.Config[T]) extends DhsInstrument[F] with InstrumentSystem[F] {
   import Gmos._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -48,6 +48,8 @@ trait GmosController[F[_], T <: GmosController.SiteDependentTypes] {
 
   def observeProgress(total: Time, elapsed: ElapsedTime): fs2.Stream[F, Progress]
 
+  def nsCount: F[Int]
+
 }
 
 object GmosController {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -385,16 +385,7 @@ object GmosControllerEpics extends GmosEncoders {
         failOnDHSNotConected *>
           sys.observeCmd.setLabel(fileId) *>
           sys.observeCmd.setTimeout[IO](expTime + ReadoutTimeout) *>
-          sys.observeCmd.post[IO].flatMap {
-            case ObserveCommandResult.Paused =>
-              sys.nsState.map(GmosEncoders.nsStateDecoder.decode).map {
-                case Some(NodAndShuffleState.NodShuffle) =>
-                  ObserveCommandResult.Partial
-                case _ =>
-                  ObserveCommandResult.Paused
-                }
-            case x => x.pure[IO]
-          }
+          sys.observeCmd.post[IO]
 
       private def failOnDHSNotConected: IO[Unit] =
         sys.dhsConnected.map(_.trim === DhsConnected).ifM(IO.unit,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -458,7 +458,11 @@ object GmosControllerEpics extends GmosEncoders {
           IO(sys.observeState))
       }
 
-  }
+      override def nsCount: IO[Int] = for{
+        a <- sys.aExpCount
+        b <- sys.bExpCount
+      } yield a + b
+    }
 
   // Parameters to define a ROI
   sealed abstract case class XStart(value: Int)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
@@ -94,7 +94,7 @@ object GmosControllerSim {
           case NSObsState(NSConfig.NodAndShuffle(_, _, _, _), Some(curr)) =>
             sim.log(s"Simulate Gmos N&S observation ${curr.show}") *>
               // Initial N&S obs
-              sim.observe(fileId, expTime).as(ObserveCommandResult.Partial)
+              sim.observe(fileId, expTime).as(ObserveCommandResult.Paused)
           case NSObsState(_, _) =>
             sim.observe(fileId, expTime) // Regular observation
         }
@@ -125,7 +125,7 @@ object GmosControllerSim {
           case NSObsState(NSConfig.NodAndShuffle(_, _, _, _), Some(curr))
               if !curr.lastSubexposure =>
             sim.log(s"Next Nod ${curr.show}") *>
-              sim.observe(curr.fileId, expTime).as(ObserveCommandResult.Partial)
+              sim.observe(curr.fileId, expTime).as(ObserveCommandResult.Paused)
           case NSObsState(NSConfig.NodAndShuffle(_, _, _, _), Some(curr))
               if curr.lastSubexposure =>
             sim.log(s"Final Nod ${curr.show}") *>
@@ -145,7 +145,7 @@ object GmosControllerSim {
       ): fs2.Stream[F, Progress] =
         sim.observeCountdown(total, elapsed)
 
-      override def nsCount: F[Int] = nsConfig.get.map(_.current.map(_.exposureCount).orNull)
+      override def nsCount: F[Int] = nsConfig.get.map(_.current.map(_.exposureCount).getOrElse(0))
     }
 
   def south[F[_]: Sync: Logger: Timer]: F[GmosController[F, SouthTypes]] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
@@ -145,6 +145,7 @@ object GmosControllerSim {
       ): fs2.Stream[F, Progress] =
         sim.observeCountdown(total, elapsed)
 
+      override def nsCount: F[Int] = nsConfig.get.map(_.current.map(_.exposureCount).orNull)
     }
 
   def south[F[_]: Sync: Logger: Timer]: F[GmosController[F, SouthTypes]] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerSim.scala
@@ -145,7 +145,7 @@ object GmosControllerSim {
       ): fs2.Stream[F, Progress] =
         sim.observeCountdown(total, elapsed)
 
-      override def nsCount: F[Int] = nsConfig.get.map(_.current.map(_.exposureCount).getOrElse(0))
+      override def nsCount: F[Int] = nsConfig.get.map(_.current.foldMap(_.exposureCount))
     }
 
   def south[F[_]: Sync: Logger: Timer]: F[GmosController[F, SouthTypes]] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.gmos
 
-import cats._
 import cats.implicits._
 import cats.effect.Concurrent
 import cats.effect.concurrent.Ref
@@ -32,7 +31,7 @@ import squants.space.AngleConversions._
 /**
   * Gmos needs different actions for N&S
   */
-class GmosInstrumentActions[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger, A <: GmosController.SiteDependentTypes](
+class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDependentTypes](
   inst:   Gmos[F, A],
   config: CleanConfig
 ) extends InstrumentActions[F] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.gmos
 
-import cats.MonadError
 import cats.implicits._
 import cats.effect.Concurrent
 import cats.effect.concurrent.Ref
@@ -23,7 +22,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](
+final case class GmosNorth[F[_]: Concurrent: Logger](
   c: GmosNorthController[F],
   dhsClient: DhsClient[F],
   nsCmdR: Ref[F, Option[NSObserveCommand]]
@@ -50,7 +49,7 @@ final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger
 object GmosNorth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](
+  def apply[F[_]: Concurrent: Logger](
     c: GmosController[F, NorthTypes],
     dhsClient: DhsClient[F],
     nsCmdR: Ref[F, Option[NSObserveCommand]]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -20,7 +20,6 @@ import edu.gemini.spModel.gemini.gmos.GmosNorthType
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
-import seqexec.server.gmos.NSPartial.NSObserveCommand
 import squants.Length
 import squants.space.Arcseconds
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -6,6 +6,7 @@ package seqexec.server.gmos
 import cats.MonadError
 import cats.implicits._
 import cats.effect.Concurrent
+import cats.effect.concurrent.Ref
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.{CleanConfig, ConfigUtilOps}
@@ -19,10 +20,15 @@ import edu.gemini.spModel.gemini.gmos.GmosNorthType
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
+import seqexec.server.gmos.NSPartial.NSObserveCommand
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](c: GmosNorthController[F], dhsClient: DhsClient[F]) extends Gmos[F, NorthTypes](c,
+final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](
+  c: GmosNorthController[F],
+  dhsClient: DhsClient[F],
+  nsCmdR: Ref[F, Option[NSObserveCommand]]
+) extends Gmos[F, NorthTypes](c,
   new SiteSpecifics[NorthTypes] {
     override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
     override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
@@ -33,7 +39,9 @@ final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger
       config.extractInstAs[NorthTypes#FPU](FPU_PROP_NAME)
     override def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
       config.extractInstAs[NorthTypes#GmosStageMode](STAGE_MODE_PROP)
-  })(northConfigTypes) {
+  },
+  nsCmdR
+)(northConfigTypes) {
   override val resource: Instrument = Instrument.GmosN
   override val dhsInstrumentName: String = "GMOS-N"
   // TODO Use different value if using electronic offsets
@@ -43,5 +51,9 @@ final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger
 object GmosNorth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](c: GmosController[F, NorthTypes], dhsClient: DhsClient[F]): GmosNorth[F] = new GmosNorth[F](c, dhsClient)
+  def apply[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](
+    c: GmosController[F, NorthTypes],
+    dhsClient: DhsClient[F],
+    nsCmdR: Ref[F, Option[NSObserveCommand]]
+  ): GmosNorth[F] = new GmosNorth[F](c, dhsClient, nsCmdR)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.gmos
 
-import cats.MonadError
 import cats.implicits._
 import cats.effect.Concurrent
 import cats.effect.concurrent.Ref
@@ -23,7 +22,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosSouth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](
+final case class GmosSouth[F[_]: Concurrent: Logger](
  c: GmosSouthController[F],
  dhsClient: DhsClient[F],
  nsCmdR: Ref[F, Option[NSObserveCommand]]
@@ -52,7 +51,7 @@ final case class GmosSouth[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger
 object GmosSouth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: MonadError[?[_], Throwable]: Concurrent: Logger](
+  def apply[F[_]: Concurrent: Logger](
     c: GmosController[F, SouthTypes],
     dhsClient: DhsClient[F],
     nsCmdR: Ref[F, Option[NSObserveCommand]]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -20,7 +20,6 @@ import edu.gemini.spModel.gemini.gmos.GmosSouthType
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
-import seqexec.server.gmos.NSPartial.NSObserveCommand
 import squants.Length
 import squants.space.Arcseconds
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
@@ -48,7 +48,11 @@ package gmos {
     case object NSSubPaused extends InternalPartialVal
     case object NSFinalObs extends InternalPartialVal
 
-    sealed trait NSObserveCommand extends Product with Serializable
+  }
+
+  sealed trait NSObserveCommand extends Product with Serializable
+
+  object NSObserveCommand {
     case object StopGracefully extends NSObserveCommand
     case object StopImmediately extends NSObserveCommand
     case object AbortGracefully extends NSObserveCommand
@@ -56,12 +60,10 @@ package gmos {
     case object PauseGracefully extends NSObserveCommand
     case object PauseImmediately extends NSObserveCommand
 
-    object NSObserveCommand {
-      implicit val nsObserveCommandEnum: Enumerated[NSObserveCommand] =
-        Enumerated.of(
-          StopGracefully, StopImmediately,AbortGracefully, AbortImmediately, PauseGracefully, PauseImmediately
-        )
-    }
-
+    implicit val nsObserveCommandEnum: Enumerated[NSObserveCommand] =
+      Enumerated.of(
+        StopGracefully, StopImmediately,AbortGracefully, AbortImmediately, PauseGracefully, PauseImmediately
+      )
   }
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/package.scala
@@ -15,6 +15,8 @@ package object gmos {
 
 package gmos {
 
+  import gem.util.Enumerated
+
   sealed trait NSPartial extends PartialVal {
     def ongoingAction: NSAction
     def sub: NSSubexposure
@@ -45,5 +47,21 @@ package gmos {
     case object NSContinue extends InternalPartialVal
     case object NSSubPaused extends InternalPartialVal
     case object NSFinalObs extends InternalPartialVal
+
+    sealed trait NSObserveCommand extends Product with Serializable
+    case object StopGracefully extends NSObserveCommand
+    case object StopImmediately extends NSObserveCommand
+    case object AbortGracefully extends NSObserveCommand
+    case object AbortImmediately extends NSObserveCommand
+    case object PauseGracefully extends NSObserveCommand
+    case object PauseImmediately extends NSObserveCommand
+
+    object NSObserveCommand {
+      implicit val nsObserveCommandEnum: Enumerated[NSObserveCommand] =
+        Enumerated.of(
+          StopGracefully, StopImmediately,AbortGracefully, AbortImmediately, PauseGracefully, PauseImmediately
+        )
+    }
+
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -28,7 +28,7 @@ import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
-final case class Gnirs[F[_]: Sync: Logger: Concurrent](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
+final case class Gnirs[F[_]: Logger: Concurrent](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
   override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gnirs
   override val contributorName: String = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -6,7 +6,7 @@ package seqexec.server.gnirs
 import cats.data.Kleisli
 import cats.data.EitherT
 import cats.implicits._
-import cats.effect.Sync
+import cats.effect.{Concurrent, Sync}
 import edu.gemini.spModel.gemini.gnirs.GNIRSConstants.{INSTRUMENT_NAME_PROP, WOLLASTON_PRISM_PROP}
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams._
 import edu.gemini.spModel.gemini.gnirs.InstGNIRS._
@@ -28,7 +28,7 @@ import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
-final case class Gnirs[F[_]: Sync: Logger](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
+final case class Gnirs[F[_]: Sync: Logger: Concurrent](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
   override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gnirs
   override val contributorName: String = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"
@@ -37,8 +37,11 @@ final case class Gnirs[F[_]: Sync: Logger](controller: GnirsController[F], dhsCl
 
   import Gnirs._
   import InstrumentSystem._
-  override val observeControl: ObserveControl[F] = UnpausableControl(StopObserveCmd(controller.stopObserve),
-                                                                AbortObserveCmd(controller.abortObserve))
+  override def observeControl(config: CleanConfig): ObserveControl[F] =
+    UnpausableControl(
+      StopObserveCmd(_ => controller.stopObserve),
+      AbortObserveCmd(_ => controller.abortObserve)
+    )
 
   override def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult] =
     Kleisli { fileId =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -6,7 +6,7 @@ package seqexec.server.gpi
 import cats._
 import cats.data.EitherT
 import cats.data.Kleisli
-import cats.effect.Timer
+import cats.effect.{Concurrent, Timer}
 import cats.implicits._
 import edu.gemini.spModel.gemini.gpi.Gpi._
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
@@ -36,7 +36,7 @@ import squants.time.Milliseconds
 import squants.time.Seconds
 import squants.time.Time
 
-final case class Gpi[F[_]: MonadError[?[_], Throwable]: Timer: Logger](controller: GpiController[F])
+final case class Gpi[F[_]: MonadError[?[_], Throwable]: Timer: Logger: Concurrent](controller: GpiController[F])
     extends GdsInstrument[F]
     with InstrumentSystem[F] {
 
@@ -63,7 +63,7 @@ final case class Gpi[F[_]: MonadError[?[_], Throwable]: Timer: Logger](controlle
       SequenceConfiguration.calcStepType(config)
     }
 
-  override val observeControl: InstrumentSystem.ObserveControl[F] =
+  override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
     InstrumentSystem.Uncontrollable
 
   override def observe(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -36,7 +36,7 @@ import squants.time.Milliseconds
 import squants.time.Seconds
 import squants.time.Time
 
-final case class Gpi[F[_]: MonadError[?[_], Throwable]: Timer: Logger: Concurrent](controller: GpiController[F])
+final case class Gpi[F[_]: Timer: Logger: Concurrent](controller: GpiController[F])
     extends GdsInstrument[F]
     with InstrumentSystem[F] {
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiInstrumentActions.scala
@@ -4,6 +4,7 @@
 package seqexec.server.gpi
 
 import cats._
+import cats.effect.Concurrent
 import cats.implicits._
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
@@ -17,7 +18,7 @@ import seqexec.server.ObserveEnvironment
 /**
   * Gpi needs different actions for A&C
   */
-class GpiInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger]
+class GpiInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger: Concurrent]
     extends InstrumentActions[F] {
 
   override def observationProgressStream(
@@ -26,13 +27,12 @@ class GpiInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger]
     ObserveActions.observationProgressStream(env)
 
   override def observeActions(
-    env:  ObserveEnvironment[F],
-    post: (Stream[F, Result[F]], ObserveEnvironment[F]) => Stream[F, Result[F]]
+    env:  ObserveEnvironment[F]
   ): List[ParallelActions[F]] =
     if (env.stepType === StepType.AlignAndCalib) {
       Nil
     } else {
-      InstrumentActions.defaultInstrumentActions[F].observeActions(env, post)
+      InstrumentActions.defaultInstrumentActions[F].observeActions(env)
     }
 
   override def runInitialAction(stepType: StepType): Boolean =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiInstrumentActions.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.gpi
 
-import cats._
 import cats.effect.Concurrent
 import cats.implicits._
 import fs2.Stream
@@ -18,7 +17,7 @@ import seqexec.server.ObserveEnvironment
 /**
   * Gpi needs different actions for A&C
   */
-class GpiInstrumentActions[F[_]: MonadError[?[_], Throwable]: Logger: Concurrent]
+class GpiInstrumentActions[F[_]: Logger: Concurrent]
     extends InstrumentActions[F] {
 
   override def observationProgressStream(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -33,7 +33,7 @@ import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Gsaoi[F[_]: Sync: Logger: Concurrent](
+final case class Gsaoi[F[_]: Logger: Concurrent](
   controller: GsaoiController[F],
   dhsClient:  DhsClient[F])
     extends DhsInstrument[F]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -38,7 +38,7 @@ import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Nifs[F[_]: Sync: Logger: Concurrent](
+final case class Nifs[F[_]: Logger: Concurrent](
   controller: NifsController[F],
   dhsClient:  DhsClient[F])
     extends DhsInstrument[F]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -5,7 +5,7 @@ package seqexec.server.nifs
 
 import cats.data.Kleisli
 import cats.data.EitherT
-import cats.effect.Sync
+import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import edu.gemini.spModel.gemini.nifs.InstNIFS._
 import edu.gemini.spModel.gemini.nifs.InstEngNifs._
@@ -38,7 +38,7 @@ import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Nifs[F[_]: Sync: Logger](
+final case class Nifs[F[_]: Sync: Logger: Concurrent](
   controller: NifsController[F],
   dhsClient:  DhsClient[F])
     extends DhsInstrument[F]
@@ -50,9 +50,9 @@ final case class Nifs[F[_]: Sync: Logger](
 
   override val contributorName: String = "NIFS"
 
-  override val observeControl: InstrumentSystem.ObserveControl[F] =
-    UnpausableControl(StopObserveCmd(controller.stopObserve),
-                    AbortObserveCmd(controller.abortObserve))
+  override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
+    UnpausableControl(StopObserveCmd(_ => controller.stopObserve),
+      AbortObserveCmd(_ => controller.abortObserve))
 
   override def observe(
     config: CleanConfig

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -32,7 +32,7 @@ import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Niri[F[_]: Sync: Timer: Logger: Concurrent](controller: NiriController[F], dhsClient: DhsClient[F])
+final case class Niri[F[_]: Timer: Logger: Concurrent](controller: NiriController[F], dhsClient: DhsClient[F])
   extends DhsInstrument[F] with InstrumentSystem[F] {
 
   import Niri._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -5,8 +5,7 @@ package seqexec.server.niri
 
 import cats.data.EitherT
 import cats.data.Kleisli
-import cats.effect.Sync
-import cats.effect.Timer
+import cats.effect.{Concurrent, Sync, Timer}
 import cats.implicits._
 import edu.gemini.spModel.gemini.niri.InstNIRI._
 import edu.gemini.spModel.gemini.niri.Niri.{Camera, WellDepth, ReadMode => OCSReadMode}
@@ -33,7 +32,7 @@ import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Niri[F[_]: Sync: Timer: Logger](controller: NiriController[F], dhsClient: DhsClient[F])
+final case class Niri[F[_]: Sync: Timer: Logger: Concurrent](controller: NiriController[F], dhsClient: DhsClient[F])
   extends DhsInstrument[F] with InstrumentSystem[F] {
 
   import Niri._
@@ -46,9 +45,11 @@ final case class Niri[F[_]: Sync: Timer: Logger](controller: NiriController[F], 
   }.getOrElse(LightSinkName.Niri_f6)
 
   override val contributorName: String = "mko-dc-data-niri"
-  override val observeControl: InstrumentSystem.ObserveControl[F] =
-    UnpausableControl(StopObserveCmd(controller.stopObserve),
-                    AbortObserveCmd(controller.abortObserve))
+  override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
+    UnpausableControl(
+      StopObserveCmd(_ => controller.stopObserve),
+      AbortObserveCmd(_ => controller.abortObserve)
+    )
 
   override def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult] =
     Kleisli { fileId =>

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -144,24 +144,24 @@ class SeqTranslateSpec extends AnyFlatSpec {
                 gsaoiKeywords     = false,
                 gemsKeywords      = false)
 
-  private val translator = SeqTranslate(Site.GS, systems, translatorSettings)
+  private val translator = SeqTranslate(Site.GS, systems, translatorSettings).unsafeRunSync
 
   "SeqTranslate" should "trigger stopObserve command only if exposure is in progress" in {
-    assert(translator.stopObserve(seqId).apply(s0).isDefined)
-    assert(translator.stopObserve(seqId).apply(s1).isEmpty)
-    assert(translator.stopObserve(seqId).apply(s2).isEmpty)
-    assert(translator.stopObserve(seqId).apply(s3).isDefined)
-    assert(translator.stopObserve(seqId).apply(s4).isDefined)
-    assert(translator.stopObserve(seqId).apply(s5).isEmpty)
+    assert(translator.stopObserve(seqId, graceful = false).apply(s0).isDefined)
+    assert(translator.stopObserve(seqId, graceful = false).apply(s1).isEmpty)
+    assert(translator.stopObserve(seqId, graceful = false).apply(s2).isEmpty)
+    assert(translator.stopObserve(seqId, graceful = false).apply(s3).isDefined)
+    assert(translator.stopObserve(seqId, graceful = false).apply(s4).isDefined)
+    assert(translator.stopObserve(seqId, graceful = false).apply(s5).isEmpty)
   }
 
   "SeqTranslate" should "trigger abortObserve command only if exposure is in progress" in {
-    assert(translator.abortObserve(seqId).apply(s0).isDefined)
-    assert(translator.abortObserve(seqId).apply(s1).isEmpty)
-    assert(translator.abortObserve(seqId).apply(s2).isEmpty)
-    assert(translator.abortObserve(seqId).apply(s3).isDefined)
-    assert(translator.abortObserve(seqId).apply(s4).isDefined)
-    assert(translator.abortObserve(seqId).apply(s5).isEmpty)
+    assert(translator.abortObserve(seqId, graceful = false).apply(s0).isDefined)
+    assert(translator.abortObserve(seqId, graceful = false).apply(s1).isEmpty)
+    assert(translator.abortObserve(seqId, graceful = false).apply(s2).isEmpty)
+    assert(translator.abortObserve(seqId, graceful = false).apply(s3).isDefined)
+    assert(translator.abortObserve(seqId, graceful = false).apply(s4).isDefined)
+    assert(translator.abortObserve(seqId, graceful = false).apply(s5).isEmpty)
   }
 
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
@@ -124,7 +124,7 @@ object TestCommon {
 
   private val sm = SeqexecMetrics.build[IO](Site.GS, new CollectorRegistry()).unsafeRunSync
 
-  val seqexecEngine: SeqexecEngine = Systems.build(GdsClient.alwaysOkClient, defaultSettings).use(SeqexecEngine(_, defaultSettings, sm).pure[IO]).unsafeRunSync
+  val seqexecEngine: SeqexecEngine = Systems.build(GdsClient.alwaysOkClient, defaultSettings).use(SeqexecEngine(_, defaultSettings, sm)).unsafeRunSync
 
   def advanceOne(q: EventQueue[IO], s0: EngineState, put: IO[Either[SeqexecFailure, Unit]]): IO[Option[EngineState]] =
     advanceN(q, s0, put, 1L)

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -79,20 +79,38 @@ class SeqexecCommandRoutes(auth:       AuthenticationService,
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "stop" as _ =>
       for {
-        _    <- se.stopObserve(inputQueue, obsId)
+        _    <- se.stopObserve(inputQueue, obsId, graceful = false)
         resp <- Ok(s"Stop requested for $obsId on step $stepId")
+      } yield resp
+
+    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "stopGracefully" as _ =>
+      for {
+        _    <- se.stopObserve(inputQueue, obsId, graceful = true)
+        resp <- Ok(s"Stop gracefully requested for $obsId on step $stepId")
       } yield resp
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "abort" as _ =>
       for {
-        _    <- se.abortObserve(inputQueue, obsId)
+        _    <- se.abortObserve(inputQueue, obsId, graceful = false)
         resp <- Ok(s"Abort requested for $obsId on step $stepId")
+      } yield resp
+
+    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "abortGracefully" as _ =>
+      for {
+        _    <- se.abortObserve(inputQueue, obsId, graceful = true)
+        resp <- Ok(s"Abort gracefully requested for $obsId on step $stepId")
       } yield resp
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "pauseObs" as _ =>
       for {
-        _    <- se.pauseObserve(inputQueue, obsId)
+        _    <- se.pauseObserve(inputQueue, obsId, graceful = false)
         resp <- Ok(s"Pause observation requested for $obsId on step $stepId")
+      } yield resp
+
+    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "pauseObsGracefully" as _ =>
+      for {
+        _    <- se.pauseObserve(inputQueue, obsId, graceful = true)
+        resp <- Ok(s"Pause observation gracefully requested for $obsId on step $stepId")
       } yield resp
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "resumeObs" as _ =>

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -273,7 +273,8 @@ object WebServerLauncher extends IOApp with LogInitialization with SeqexecConfig
         seqc <- Resource.liftF(SeqexecEngine.seqexecConfiguration.run(cfg))
         met  <- Resource.liftF(SeqexecMetrics.build[IO](site, collector))
         sys  <- Systems.build(httpClient, seqc)
-      } yield SeqexecEngine(sys, seqc, met)
+        seqE <- Resource.liftF(SeqexecEngine(sys, seqc, met))
+      } yield seqE
 
     def webServerIO(
       in:  Queue[IO, executeEngine.EventType],


### PR DESCRIPTION
Implementation of the N&S interruption commands pause, pause gracefully, stop, stop gracefully, and abort.
This PR also includes the commands to resume, stop or abort a paused N&S observation.
The commands were tested sending HTTP commands with curl.