### PR TITLE
Refactor of TCS Epics controllers

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -591,7 +591,7 @@ object SeqexecEngine extends SeqexecConfiguration {
     }._2
   }
 
-  /*
+  /**
    * shouldSchedule checks if a set of sequences are candidates for been run in a queue.
    * It is used to check if sequences added to a queue should be started.
    */

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -160,13 +160,13 @@ package object server {
   implicit class ControlStrategyOps(v: ControlStrategy) {
     val connect: Boolean = v match {
       case ControlStrategy.Simulated => false
-      case _         => true
+      case _                         => true
     }
     // If connected, then use real values for keywords
     val realKeywords: Boolean = connect
     val command: Boolean = v match {
       case ControlStrategy.FullControl => true
-      case _           => false
+      case _                           => false
     }
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/AoFold.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/AoFold.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+/** AO fold position */
+sealed trait AoFold extends Product with Serializable {
+  val active: Boolean
+}
+object AoFold {
+  case object In extends AoFold {
+    override val active: Boolean = true
+  }
+  case object Out extends AoFold {
+    override val active: Boolean = false
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/BasicEpicsTcsConfig.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/BasicEpicsTcsConfig.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import edu.gemini.spModel.core.Wavelength
+import monocle.macros.Lenses
+import squants.Angle
+import seqexec.model.TelescopeGuideConfig
+import seqexec.server.tcs.TcsController._
+
+final case class InstrumentPorts(
+  flamingos2Port: Int,
+  ghostPort: Int,
+  gmosPort: Int,
+  gnirsPort: Int,
+  gpiPort: Int,
+  gsaoiPort: Int,
+  nifsPort: Int,
+  niriPort: Int
+)
+
+@Lenses
+final case class BaseEpicsTcsConfig(
+  iaa: Angle,
+  offset: FocalPlaneOffset,
+  wavelA: Wavelength,
+  pwfs1: GuiderConfig,
+  pwfs2: GuiderConfig,
+  oiwfs: GuiderConfig,
+  telescopeGuideConfig: TelescopeGuideConfig,
+  aoFold: AoFold,
+  useAo: Boolean,
+  scienceFoldPosition: Option[ScienceFold],
+  hrwfsPickupPosition: HrwfsPickupPosition,
+  instPorts: InstrumentPorts
+) {
+  val instrumentOffset: InstrumentOffset = offset.toInstrumentOffset(iaa)
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideControl.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/GuideControl.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import seqexec.server.tcs.TcsController._
+import seqexec.server.EpicsCommand
+import seqexec.server.tcs.TcsEpics.{ProbeFollowCmd, ProbeGuideCmd}
+
+final case class GuideControl[F[_]](subs: Subsystem,
+                                    parkCmd: EpicsCommand,
+                                    nodChopGuideCmd: ProbeGuideCmd[F],
+                                    followCmd: ProbeFollowCmd[F])

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFold.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFold.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import cats._
+import cats.implicits._
+import gem.enum.LightSinkName
+import seqexec.server.tcs.TcsController._
+
+sealed trait ScienceFold extends Product with Serializable
+
+object ScienceFold {
+  case object Parked extends ScienceFold
+  final case class Position(source: LightSource, sink: LightSinkName, port: Int) extends ScienceFold
+
+  implicit val positionEq: Eq[Position] = Eq.by(x => (x.source, x.sink, x.port))
+
+  implicit val eq: Eq[ScienceFold] = Eq.instance{
+    case (Parked, Parked)           => true
+    case (a: Position, b: Position) => a === b
+    case _                          => false
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFoldPositionCodex.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/ScienceFoldPositionCodex.scala
@@ -7,15 +7,13 @@ import cats.implicits._
 import atto._, Atto._
 import gem.enum.LightSinkName
 import seqexec.server.EpicsCodex.{DecodeEpicsValue, EncodeEpicsValue}
+import seqexec.server.tcs.TcsController.LightSource._
 import seqexec.server.tcs.TcsController.LightSource
-import seqexec.server.tcs.TcsControllerEpicsCommon.ScienceFold.{Parked, Position}
-import seqexec.server.tcs.TcsControllerEpicsCommon.ScienceFold
+import seqexec.server.tcs.ScienceFold.{Parked, Position}
 
 // Decoding and encoding the science fold position require some common definitions, therefore I
 // put them inside an object
-private[server] object ScienceFoldPositionCodex {
-
-  import LightSource._
+private[server] trait ScienceFoldPositionCodex {
 
   private val AO_PREFIX = "ao2"
   private val GCAL_PREFIX = "gcal2"
@@ -43,6 +41,6 @@ private[server] object ScienceFoldPositionCodex {
     }
   })
 
-
-
 }
+
+object ScienceFoldPositionCodex extends ScienceFoldPositionCodex

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigDecoders.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigDecoders.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import cats.implicits._
+import edu.gemini.seqexec.server.tcs.{BinaryOnOff, BinaryYesNo}
+import seqexec.model.enum.MountGuideOption
+import seqexec.model.enum.ComaOption
+import seqexec.model.enum.M1Source
+import seqexec.model.enum.TipTiltSource
+import seqexec.model.M1GuideConfig
+import seqexec.model.M2GuideConfig
+import seqexec.server.EpicsCodex.DecodeEpicsValue
+import seqexec.server.tcs.TcsController.FollowOption.{FollowOff, FollowOn}
+import seqexec.server.tcs.TcsController._
+
+trait TcsConfigDecoders {
+  // Code to retrieve the current configuration from TCS. Include a lot of decoders
+  implicit val decodeMountGuideOption: DecodeEpicsValue[Int, MountGuideOption] =
+    DecodeEpicsValue((d: Int) => if (d === 0) MountGuideOption.MountGuideOff else MountGuideOption.MountGuideOn)
+
+  implicit val decodeM1GuideSource: DecodeEpicsValue[String, M1Source] = DecodeEpicsValue((s: String)
+  => s.trim match {
+      case "PWFS1" => M1Source.PWFS1
+      case "PWFS2" => M1Source.PWFS2
+      case "OIWFS" => M1Source.OIWFS
+      case "GAOS"  => M1Source.GAOS
+      case _       => M1Source.PWFS1
+    })
+
+  def decodeM1Guide(r: BinaryOnOff, s: M1Source): M1GuideConfig =
+    if (r === BinaryOnOff.Off) M1GuideConfig.M1GuideOff
+    else M1GuideConfig.M1GuideOn(s)
+
+  def decodeGuideSourceOption(s: String): Boolean = s.trim =!= "OFF"
+
+  implicit val decodeComaOption: DecodeEpicsValue[String, ComaOption] = DecodeEpicsValue((s: String)
+  => if (s.trim === "Off") ComaOption.ComaOff else ComaOption.ComaOn)
+
+  def decodeM2Guide(s: BinaryOnOff, u: ComaOption, v: Set[TipTiltSource]): M2GuideConfig =
+    if (s === BinaryOnOff.Off) M2GuideConfig.M2GuideOff
+    else M2GuideConfig.M2GuideOn(u, v)
+
+  implicit val decodeAoFold: DecodeEpicsValue[String, AoFold] = DecodeEpicsValue((s: String) =>
+    if(s.trim === "IN") AoFold.In
+    else AoFold.Out
+  )
+
+  implicit val decodeFollowOption: DecodeEpicsValue[String, FollowOption] = DecodeEpicsValue((s: String)
+  => if (s.trim === "Off") FollowOff else FollowOn)
+
+  implicit val decodeGuideSensorOption: DecodeEpicsValue[BinaryYesNo, GuiderSensorOption] =
+    DecodeEpicsValue((s: BinaryYesNo) => if (s === BinaryYesNo.No) GuiderSensorOff else GuiderSensorOn)
+
+
+  implicit val decodeHwrsPickupPosition: DecodeEpicsValue[String, HrwfsPickupPosition] = DecodeEpicsValue((t: String)
+    => if (t.trim === "IN") HrwfsPickupPosition.IN
+      else HrwfsPickupPosition.OUT)
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
@@ -3,21 +3,18 @@
 
 package seqexec.server.tcs
 
-import cats.Eq
+import cats._
 import cats.data.OneAnd
-import cats.effect.IO
 import cats.implicits._
 import mouse.boolean._
-import edu.gemini.seqexec.server.tcs.{BinaryOnOff, BinaryYesNo}
+import edu.gemini.seqexec.server.tcs.BinaryYesNo
 import edu.gemini.spModel.core.Wavelength
 import seqexec.model.enum.MountGuideOption
 import seqexec.model.enum.ComaOption
 import seqexec.model.enum.M1Source
 import seqexec.model.enum.TipTiltSource
-import seqexec.model.M1GuideConfig
-import seqexec.model.M2GuideConfig
 import seqexec.model.TelescopeGuideConfig
-import seqexec.server.EpicsCodex.{DecodeEpicsValue, decode}
+import seqexec.server.EpicsCodex.decode
 import seqexec.server.tcs.TcsController.FollowOption.{FollowOff, FollowOn}
 import seqexec.server.SeqexecFailure
 import seqexec.server.SeqexecFailure.NullEpicsError
@@ -31,296 +28,268 @@ import seqexec.server.gems.Gems.Odgw3DetectorState.{Off => _, On => _, _}
 import seqexec.server.gems.Gems.Odgw4DetectorState.{Off => _, On => _, _}
 import seqexec.server.tcs.GemsSource.{Cwfs1, Cwfs2, Cwfs3, Odgw1, Odgw2, Odgw3, Odgw4}
 import seqexec.server.tcs.TcsController._
-import seqexec.server.tcs.TcsControllerEpicsCommon.{AoFold, InstrumentPorts, InvalidPort, ScienceFold}
 import seqexec.server.tcs.TcsEpics.VirtualGemsTelescope
 import shapeless.tag
 import squants.{Angle, Length}
 import squants.space.{Angstroms, Degrees, Millimeters}
 
+sealed trait TcsConfigRetriever[F[_]] {
+  def retrieveBaseConfiguration: F[BaseEpicsTcsConfig]
+
+  def retrieveConfigurationNorth(getAoFollow: F[Boolean]): F[TcsNorthControllerEpicsAo.EpicsTcsAoConfig]
+
+  def retrieveConfigurationSouth(gemsSt: GemsWfsState[F]): F[TcsSouthControllerEpicsAo.EpicsTcsAoConfig]
+}
+
 object TcsConfigRetriever {
+  private class TcsConfigRetrieverImpl[F[_]: MonadError[?[_], Throwable]](
+    epicsSys: TcsEpics[F]) extends TcsConfigRetriever[F]
+                           with    TcsConfigDecoders
+                           with    ScienceFoldPositionCodex {
 
-  // Code to retrieve the current configuration from TCS. Include a lot of decoders
-  implicit private val decodeMountGuideOption: DecodeEpicsValue[Int, MountGuideOption] = DecodeEpicsValue((d: Int)
-  => if (d === 0) MountGuideOption.MountGuideOff else MountGuideOption.MountGuideOn)
+    private def getGuideConfig: F[TelescopeGuideConfig] = {
+      for {
+        mountGuide <- epicsSys.absorbTipTilt.map(decode[Int, MountGuideOption])
+        m1Source   <- epicsSys.m1GuideSource.map(decode[String, M1Source])
+        m1Guide    <- epicsSys.m1Guide.map(decodeM1Guide(_, m1Source))
+        m2p1Guide  <- epicsSys.m2p1Guide.map(decodeGuideSourceOption)
+        m2p2Guide  <- epicsSys.m2p2Guide.map(decodeGuideSourceOption)
+        m2oiGuide  <- epicsSys.m2oiGuide.map(decodeGuideSourceOption)
+        m2aoGuide  <- epicsSys.m2aoGuide.map(decodeGuideSourceOption)
+        m2Coma     <- epicsSys.comaCorrect.map(decode[String, ComaOption])
+        m2Guide    <- epicsSys.m2GuideState.map(decodeM2Guide(_, m2Coma, List((m2p1Guide, TipTiltSource.PWFS1),
+          (m2p2Guide, TipTiltSource.PWFS2), (m2oiGuide, TipTiltSource.OIWFS),
+          (m2aoGuide, TipTiltSource.GAOS)).foldLeft(Set.empty[TipTiltSource])((s: Set[TipTiltSource], v: (Boolean, TipTiltSource)) => if (v._1) s + v._2 else s)))
+      } yield TelescopeGuideConfig(mountGuide, m1Guide, m2Guide)
+    }.adaptError{ case e => SeqexecFailure.Unexpected(s"Unable to read guide configuration from TCS: $e")}
 
-  implicit private val decodeM1GuideSource: DecodeEpicsValue[String, M1Source] = DecodeEpicsValue((s: String)
-  => s.trim match {
-      case "PWFS1" => M1Source.PWFS1
-      case "PWFS2" => M1Source.PWFS2
-      case "OIWFS" => M1Source.OIWFS
-      case "GAOS"  => M1Source.GAOS
-      case _       => M1Source.PWFS1
-    })
+    private def getAoFold: F[AoFold] = epicsSys.aoFoldPosition.map(decode[String, AoFold])
 
-  private def decodeM1Guide(r: BinaryOnOff, s: M1Source): M1GuideConfig =
-    if (r === BinaryOnOff.Off) M1GuideConfig.M1GuideOff
-    else M1GuideConfig.M1GuideOn(s)
+    private def decodeNodChopOption(s: String): Boolean = s.trim === "On"
 
-  private def decodeGuideSourceOption(s: String): Boolean = s.trim =!= "OFF"
-
-  implicit private val decodeComaOption: DecodeEpicsValue[String, ComaOption] = DecodeEpicsValue((s: String)
-  => if (s.trim === "Off") ComaOption.ComaOff else ComaOption.ComaOn)
-
-  private def decodeM2Guide(s: BinaryOnOff, u: ComaOption, v: Set[TipTiltSource]): M2GuideConfig =
-    if (s === BinaryOnOff.Off) M2GuideConfig.M2GuideOff
-    else M2GuideConfig.M2GuideOn(u, v)
-
-  implicit private val decodeAoFold: DecodeEpicsValue[String, AoFold] = DecodeEpicsValue((s: String) =>
-    if(s.trim === "IN") AoFold.In
-    else AoFold.Out
-  )
-
-  private def getGuideConfig: IO[TelescopeGuideConfig] = {
-    for {
-      mountGuide <-  TcsEpics.instance.absorbTipTilt.map(decode[Int, MountGuideOption])
-      m1Source   <-  TcsEpics.instance.m1GuideSource.map(decode[String, M1Source])
-      m1Guide    <-  TcsEpics.instance.m1Guide.map(decodeM1Guide(_, m1Source))
-      m2p1Guide  <-  TcsEpics.instance.m2p1Guide.map(decodeGuideSourceOption)
-      m2p2Guide  <-  TcsEpics.instance.m2p2Guide.map(decodeGuideSourceOption)
-      m2oiGuide  <-  TcsEpics.instance.m2oiGuide.map(decodeGuideSourceOption)
-      m2aoGuide  <-  TcsEpics.instance.m2aoGuide.map(decodeGuideSourceOption)
-      m2Coma     <-  TcsEpics.instance.comaCorrect.map(decode[String, ComaOption])
-      m2Guide    <-  TcsEpics.instance.m2GuideState.map(decodeM2Guide(_, m2Coma, List((m2p1Guide, TipTiltSource.PWFS1),
-        (m2p2Guide, TipTiltSource.PWFS2), (m2oiGuide, TipTiltSource.OIWFS),
-        (m2aoGuide, TipTiltSource.GAOS)).foldLeft(Set.empty[TipTiltSource])((s: Set[TipTiltSource], v: (Boolean, TipTiltSource)) => if (v._1) s + v._2 else s)))
-    } yield TelescopeGuideConfig(mountGuide, m1Guide, m2Guide)
-  }.adaptError{ case e => SeqexecFailure.Unexpected(s"Unable to read guide configuration from TCS: $e")}
-
-  private def getAoFold: IO[AoFold] = TcsEpics.instance.aoFoldPosition.map(decode[String, AoFold])
-
-  private def decodeNodChopOption(s: String): Boolean = s.trim === "On"
-
-  private def getNodChopTrackingConfig(g: TcsEpics.ProbeGuideConfig[IO]): IO[NodChopTrackingConfig] =
-    for {
-      aa <- g.nodachopa.map(decodeNodChopOption)
-      ab <- g.nodachopb.map(decodeNodChopOption)
-      ac <- g.nodachopc.map(decodeNodChopOption)
-      ba <- g.nodbchopa.map(decodeNodChopOption)
-      bb <- g.nodbchopb.map(decodeNodChopOption)
-      bc <- g.nodbchopc.map(decodeNodChopOption)
-      ca <- g.nodcchopa.map(decodeNodChopOption)
-      cb <- g.nodcchopb.map(decodeNodChopOption)
-      cc <- g.nodcchopc.map(decodeNodChopOption)
-    } yield
-      if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).contains(true)) {
-        if (List(aa, bb).forall(_ === true) && List(ab, ac, ba, bc, ca, cb, cc).forall(_ === false)) {
-          NodChopTrackingConfig.Normal
-        } else {
-          List(
-            (aa, NodChop(Beam.A, Beam.A)), (ab, NodChop(Beam.A, Beam.B)), (ac, NodChop(Beam.A, Beam.C)),
-            (ba, NodChop(Beam.B, Beam.A)), (bb, NodChop(Beam.B, Beam.B)), (bc, NodChop(Beam.B, Beam.C)),
-            (ca, NodChop(Beam.C, Beam.A)), (cb, NodChop(Beam.C, Beam.B)), (cc, NodChop(Beam.C, Beam.C))
-          ) collect {
-            case (true, a) => a
-          } match {
-            case h :: t => NodChopTrackingConfig.Special(OneAnd(h, t))
-            case Nil    => NodChopTrackingConfig.AllOff
+    private def getNodChopTrackingConfig(g: TcsEpics.ProbeGuideConfig[F]): F[NodChopTrackingConfig] =
+      for {
+        aa <- g.nodachopa.map(decodeNodChopOption)
+        ab <- g.nodachopb.map(decodeNodChopOption)
+        ac <- g.nodachopc.map(decodeNodChopOption)
+        ba <- g.nodbchopa.map(decodeNodChopOption)
+        bb <- g.nodbchopb.map(decodeNodChopOption)
+        bc <- g.nodbchopc.map(decodeNodChopOption)
+        ca <- g.nodcchopa.map(decodeNodChopOption)
+        cb <- g.nodcchopb.map(decodeNodChopOption)
+        cc <- g.nodcchopc.map(decodeNodChopOption)
+      } yield
+        if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).contains(true)) {
+          if (List(aa, bb).forall(_ === true) && List(ab, ac, ba, bc, ca, cb, cc).forall(_ === false)) {
+            NodChopTrackingConfig.Normal
+          } else {
+            List(
+              (aa, NodChop(Beam.A, Beam.A)), (ab, NodChop(Beam.A, Beam.B)), (ac, NodChop(Beam.A, Beam.C)),
+              (ba, NodChop(Beam.B, Beam.A)), (bb, NodChop(Beam.B, Beam.B)), (bc, NodChop(Beam.B, Beam.C)),
+              (ca, NodChop(Beam.C, Beam.A)), (cb, NodChop(Beam.C, Beam.B)), (cc, NodChop(Beam.C, Beam.C))
+            ) collect {
+              case (true, a) => a
+            } match {
+              case h :: t => NodChopTrackingConfig.Special(OneAnd(h, t))
+              case Nil    => NodChopTrackingConfig.AllOff
+            }
           }
-        }
-      } else NodChopTrackingConfig.AllOff
+        } else NodChopTrackingConfig.AllOff
 
-  private def calcProbeTrackingConfig(f: FollowOption, t: NodChopTrackingConfig): ProbeTrackingConfig = (f, t) match {
-    case (FollowOff, _)                            => ProbeTrackingConfig.Off
-    case (FollowOn, NodChopTrackingConfig.AllOff)  => ProbeTrackingConfig.Frozen
-    case (FollowOn, v:ActiveNodChopTracking)       => ProbeTrackingConfig.On(v)
+    private def calcProbeTrackingConfig(f: FollowOption, t: NodChopTrackingConfig): ProbeTrackingConfig = (f, t) match {
+      case (FollowOff, _)                            => ProbeTrackingConfig.Off
+      case (FollowOn, NodChopTrackingConfig.AllOff)  => ProbeTrackingConfig.Frozen
+      case (FollowOn, v:ActiveNodChopTracking)       => ProbeTrackingConfig.On(v)
+    }
+
+    private def getPwfs1: F[GuiderConfig] = for {
+      prk <- epicsSys.p1Parked
+      trk <- getNodChopTrackingConfig(epicsSys.pwfs1ProbeGuideConfig)
+      fol <- epicsSys.p1FollowS.map(decode[String, FollowOption])
+      wfs <- epicsSys.pwfs1On.map(decode[BinaryYesNo, GuiderSensorOption])
+    } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
+
+    private def getPwfs2: F[GuiderConfig] = for {
+      prk   <- epicsSys.p2Parked
+      trk   <- getNodChopTrackingConfig(epicsSys.pwfs2ProbeGuideConfig)
+      fol   <- epicsSys.p2FollowS.map(decode[String, FollowOption])
+      wfs   <- epicsSys.pwfs2On.map(decode[BinaryYesNo, GuiderSensorOption])
+      useAo <- getUseAo
+    } yield if(useAo) GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, NodChopTrackingConfig.AllOff)), wfs)
+            else GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
+
+    private def getUseAo: F[Boolean] = epicsSys.useAo.map(_ === BinaryYesNo.Yes)
+
+    private def getAowfs(getAoFollow: F[Boolean]): F[ProbeTrackingConfig] = for {
+      aoFol <- getAoFollow.map(if(_) FollowOn else FollowOff)
+      trk   <- getNodChopTrackingConfig(epicsSys.pwfs2ProbeGuideConfig)
+      useAo <- getUseAo
+    } yield if(useAo) calcProbeTrackingConfig(aoFol, trk)
+            else calcProbeTrackingConfig(aoFol, NodChopTrackingConfig.AllOff)
+
+    private def getOiwfs: F[GuiderConfig] = for {
+      prk <- epicsSys.oiParked
+      trk <- getNodChopTrackingConfig(epicsSys.oiwfsProbeGuideConfig)
+      fol <- epicsSys.oiFollowS.map(decode[String, FollowOption])
+      wfs <- epicsSys.oiwfsOn.map(decode[BinaryYesNo, GuiderSensorOption])
+    } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
+
+    private def getScienceFoldPosition: F[Option[ScienceFold]] = for {
+      sfPos    <- epicsSys.sfName
+      sfParked <- epicsSys.sfParked.map(_ =!= 0)
+    } yield if (sfParked) ScienceFold.Parked.some
+            else decode[String, Option[ScienceFold]](sfPos)
+
+    private def getHrwfsPickupPosition: F[HrwfsPickupPosition] = for {
+      hwPos    <- epicsSys.agHwName.map(decode[String, HrwfsPickupPosition])
+      hwParked <- epicsSys.agHwParked.map(_ =!= 0)
+    } yield if (hwParked) HrwfsPickupPosition.Parked
+            else hwPos
+
+    private def getIAA: F[Angle] = epicsSys.instrAA.map(Degrees(_))
+
+    private def getOffsetX: F[Length] = epicsSys.xoffsetPoA1.map(Millimeters(_))
+
+    private def getOffsetY: F[Length] = epicsSys.yoffsetPoA1.map(Millimeters(_))
+
+    private def getWavelength: F[Wavelength] = epicsSys.sourceAWavelength.map(v => Wavelength(Angstroms(v)))
+
+    private def getGemsMap: F[Map[GemsSource, VirtualGemsTelescope]] = for {
+      v1 <- epicsSys.g1MapName
+      v2 <- epicsSys.g2MapName
+      v3 <- epicsSys.g3MapName
+      v4 <- epicsSys.g4MapName
+    } yield List(
+      v1 -> VirtualGemsTelescope.G1,
+      v2 -> VirtualGemsTelescope.G2,
+      v3 -> VirtualGemsTelescope.G3,
+      v4 -> VirtualGemsTelescope.G4
+    ).mapFilter{ case (s, v) => s.map((_, v))}.toMap
+
+    private def getCwfs[T: DetectorStateOps: Eq](getFollow: F[Boolean])
+                                               (g: VirtualGemsTelescope, active: F[T])
+    : F[GuiderConfig] = for {
+      trk <- getNodChopTrackingConfig(epicsSys.gemsGuideConfig(g))
+      fol <- getFollow.map{if(_) FollowOption.FollowOn else FollowOption.FollowOff}
+      wfs <- active.map{x => if(DetectorStateOps.isActive(x)) GuiderSensorOn else GuiderSensorOff}
+    } yield GuiderConfig(calcProbeTrackingConfig(fol, trk), wfs)
+
+    private val getCwfs1: (VirtualGemsTelescope, F[Cwfs1DetectorState]) => F[GuiderConfig] =
+      getCwfs(epicsSys.cwfs1Follow)
+
+    private val getCwfs2: (VirtualGemsTelescope, F[Cwfs2DetectorState]) => F[GuiderConfig] =
+      getCwfs(epicsSys.cwfs1Follow)
+
+    private val getCwfs3: (VirtualGemsTelescope, F[Cwfs3DetectorState]) => F[GuiderConfig] =
+      getCwfs(epicsSys.cwfs1Follow)
+
+    private def getOdgw[T: DetectorStateOps: Eq](getParked: F[Boolean], getFollow: F[Boolean])
+                                            (g: VirtualGemsTelescope, active: F[T])
+    : F[GuiderConfig] = for {
+      prk <- getParked
+      trk <- getNodChopTrackingConfig(epicsSys.gemsGuideConfig(g))
+      fol <- getFollow.map{ if(_) FollowOption.FollowOn else FollowOption.FollowOff}
+      wfs <- active.map{x => if(DetectorStateOps.isActive[T](x)) GuiderSensorOn else GuiderSensorOff}
+    } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
+
+    private val getOdgw1: (VirtualGemsTelescope, F[Odgw1DetectorState]) => F[GuiderConfig] =
+      getOdgw(epicsSys.odgw1Parked, epicsSys.odgw1Follow)
+
+    private val getOdgw2: (VirtualGemsTelescope, F[Odgw2DetectorState]) => F[GuiderConfig] =
+      getOdgw(epicsSys.odgw2Parked, epicsSys.odgw2Follow)
+
+    private val getOdgw3: (VirtualGemsTelescope, F[Odgw3DetectorState]) => F[GuiderConfig] =
+      getOdgw(epicsSys.odgw3Parked, epicsSys.odgw3Follow)
+
+    private val getOdgw4: (VirtualGemsTelescope, F[Odgw4DetectorState]) => F[GuiderConfig] =
+      getOdgw(epicsSys.odgw4Parked, epicsSys.odgw4Follow)
+
+    private def getInstrumentPorts: F[InstrumentPorts] = for {
+      f2    <- epicsSys.f2Port.recover{case NullEpicsError(_) => InvalidPort}
+      ghost <- epicsSys.ghostPort.recover{case NullEpicsError(_) => InvalidPort}
+      gmos  <- epicsSys.gmosPort.recover{case NullEpicsError(_) => InvalidPort}
+      gnirs <- epicsSys.gnirsPort.recover{case NullEpicsError(_) => InvalidPort}
+      gpi   <- epicsSys.gpiPort.recover{case NullEpicsError(_) => InvalidPort}
+      gsaoi <- epicsSys.gsaoiPort.recover{case NullEpicsError(_) => InvalidPort}
+      nifs  <- epicsSys.nifsPort.recover{case NullEpicsError(_) => InvalidPort}
+      niri  <- epicsSys.niriPort.recover{case NullEpicsError(_) => InvalidPort}
+    } yield InstrumentPorts(
+      f2,
+      ghost,
+      gmos,
+      gnirs,
+      gpi,
+      gsaoi,
+      nifs,
+      niri
+    )
+
+    override def retrieveConfigurationNorth(getAoFollow: F[Boolean]): F[TcsNorthControllerEpicsAo.EpicsTcsAoConfig] =
+      for {
+        base <- retrieveBaseConfiguration
+        ao   <- getAowfs(getAoFollow)
+      } yield TcsNorthControllerEpicsAo.EpicsTcsAoConfig(base, ao)
+
+    private def retrieveGemsGuider(mapping: Map[GemsSource, VirtualGemsTelescope],
+                                   gemsSource: GemsSource,
+                                   getGuide: VirtualGemsTelescope => F[GuiderConfig]): F[GuiderConfig] =
+      mapping.get(gemsSource).map(getGuide).getOrElse(GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff).pure[F])
+
+    override def retrieveConfigurationSouth(gemsSt: GemsWfsState[F]): F[TcsSouthControllerEpicsAo.EpicsTcsAoConfig] =
+      for {
+        base    <- retrieveBaseConfiguration
+        mapping <- getGemsMap
+        cwfs1   <- retrieveGemsGuider(mapping, Cwfs1, getCwfs1(_, gemsSt.cwfs1))
+        cwfs2   <- retrieveGemsGuider(mapping, Cwfs2, getCwfs2(_, gemsSt.cwfs2))
+        cwfs3   <- retrieveGemsGuider(mapping, Cwfs3, getCwfs3(_, gemsSt.cwfs3))
+        odgw1   <- retrieveGemsGuider(mapping, Odgw1, getOdgw1(_, gemsSt.odgw1))
+        odgw2   <- retrieveGemsGuider(mapping, Odgw2, getOdgw2(_, gemsSt.odgw2))
+        odgw3   <- retrieveGemsGuider(mapping, Odgw3, getOdgw3(_, gemsSt.odgw3))
+        odgw4   <- retrieveGemsGuider(mapping, Odgw4, getOdgw4(_, gemsSt.odgw4))
+      } yield TcsSouthControllerEpicsAo.EpicsTcsAoConfig(
+        base,
+        mapping,
+        cwfs1,
+        cwfs2,
+        cwfs3,
+        odgw1,
+        odgw2,
+        odgw3,
+        odgw4
+      )
+
+    override def retrieveBaseConfiguration: F[BaseEpicsTcsConfig] =
+      for {
+        iaa   <- getIAA
+        offX  <- getOffsetX
+        offY  <- getOffsetY
+        wl    <- getWavelength
+        p1    <- getPwfs1
+        p2    <- getPwfs2
+        oi    <- getOiwfs
+        tgc   <- getGuideConfig
+        aof   <- getAoFold
+        useAo <- getUseAo
+        sf    <- getScienceFoldPosition
+        hr    <- getHrwfsPickupPosition
+        ports <- getInstrumentPorts
+      } yield BaseEpicsTcsConfig(
+        iaa,
+        FocalPlaneOffset(tag[OffsetX](offX), tag[OffsetY](offY)),
+        wl,
+        p1,
+        p2,
+        oi,
+        tgc,
+        aof,
+        useAo,
+        sf,
+        hr,
+        ports
+      )
+
   }
 
-  implicit private val decodeFollowOption: DecodeEpicsValue[String, FollowOption] = DecodeEpicsValue((s: String)
-  => if (s.trim === "Off") FollowOff else FollowOn)
-
-  implicit private val decodeGuideSensorOption: DecodeEpicsValue[BinaryYesNo, GuiderSensorOption] =
-    DecodeEpicsValue((s: BinaryYesNo) => if (s === BinaryYesNo.No) GuiderSensorOff else GuiderSensorOn)
-
-  private def getPwfs1: IO[GuiderConfig] = for {
-    prk <- TcsEpics.instance.p1Parked
-    trk <- getNodChopTrackingConfig(TcsEpics.instance.pwfs1ProbeGuideConfig)
-    fol <- TcsEpics.instance.p1FollowS.map(decode[String, FollowOption])
-    wfs <- TcsEpics.instance.pwfs1On.map(decode[BinaryYesNo, GuiderSensorOption])
-  } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
-
-  private def getPwfs2: IO[GuiderConfig] = for {
-    prk   <- TcsEpics.instance.p2Parked
-    trk   <- getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig)
-    fol   <- TcsEpics.instance.p2FollowS.map(decode[String, FollowOption])
-    wfs   <- TcsEpics.instance.pwfs2On.map(decode[BinaryYesNo, GuiderSensorOption])
-    useAo <- getUseAo
-  } yield if(useAo) GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, NodChopTrackingConfig.AllOff)), wfs)
-          else GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
-
-  private def getUseAo: IO[Boolean] = TcsEpics.instance.useAo.map(_ === BinaryYesNo.Yes)
-
-  private def getAowfs(getAoFollow: IO[Boolean]): IO[ProbeTrackingConfig] = for {
-    aoFol <- getAoFollow.map(if(_) FollowOn else FollowOff)
-    trk   <- getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig)
-    useAo <- getUseAo
-  } yield if(useAo) calcProbeTrackingConfig(aoFol, trk)
-          else calcProbeTrackingConfig(aoFol, NodChopTrackingConfig.AllOff)
-
-  private def getOiwfs: IO[GuiderConfig] = for {
-    prk <- TcsEpics.instance.oiParked
-    trk <- getNodChopTrackingConfig(TcsEpics.instance.oiwfsProbeGuideConfig)
-    fol <- TcsEpics.instance.oiFollowS.map(decode[String, FollowOption])
-    wfs <- TcsEpics.instance.oiwfsOn.map(decode[BinaryYesNo, GuiderSensorOption])
-  } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
-
-  import ScienceFoldPositionCodex._
-
-  private def getScienceFoldPosition: IO[Option[ScienceFold]] = for {
-    sfPos    <- TcsEpics.instance.sfName
-    sfParked <- TcsEpics.instance.sfParked.map(_ =!= 0)
-  } yield if (sfParked) ScienceFold.Parked.some
-          else decode[String, Option[ScienceFold]](sfPos)
-
-  implicit val decodeHwrsPickupPosition: DecodeEpicsValue[String, HrwfsPickupPosition] = DecodeEpicsValue((t: String)
-  => if (t.trim === "IN") HrwfsPickupPosition.IN
-    else HrwfsPickupPosition.OUT)
-
-  private def getHrwfsPickupPosition: IO[HrwfsPickupPosition] = for {
-    hwPos    <- TcsEpics.instance.agHwName.map(decode[String, HrwfsPickupPosition])
-    hwParked <- TcsEpics.instance.agHwParked.map(_ =!= 0)
-  } yield if (hwParked) HrwfsPickupPosition.Parked
-          else hwPos
-
-  private def getIAA: IO[Angle] = TcsEpics.instance.instrAA.map(Degrees(_))
-
-  private def getOffsetX: IO[Length] = TcsEpics.instance.xoffsetPoA1.map(Millimeters(_))
-
-  private def getOffsetY: IO[Length] = TcsEpics.instance.yoffsetPoA1.map(Millimeters(_))
-
-  private def getWavelength: IO[Wavelength] = TcsEpics.instance.sourceAWavelength.map(v => Wavelength(Angstroms(v)))
-
-  private def getGemsMap: IO[Map[GemsSource, VirtualGemsTelescope]] = for {
-    v1 <- TcsEpics.instance.g1MapName
-    v2 <- TcsEpics.instance.g2MapName
-    v3 <- TcsEpics.instance.g3MapName
-    v4 <- TcsEpics.instance.g4MapName
-  } yield List(
-    v1 -> VirtualGemsTelescope.G1,
-    v2 -> VirtualGemsTelescope.G2,
-    v3 -> VirtualGemsTelescope.G3,
-    v4 -> VirtualGemsTelescope.G4
-  ).mapFilter{ case (s, v) => s.map((_, v))}.toMap
-
-  private def getCwfs[T: DetectorStateOps: Eq](getFollow: IO[Boolean])
-                                             (g: VirtualGemsTelescope, active: IO[T])
-  : IO[GuiderConfig] = for {
-    trk <- getNodChopTrackingConfig(TcsEpics.instance.gemsGuideConfig(g))
-    fol <- getFollow.map{if(_) FollowOption.FollowOn else FollowOption.FollowOff}
-    wfs <- active.map{x => if(DetectorStateOps.isActive(x)) GuiderSensorOn else GuiderSensorOff}
-  } yield GuiderConfig(calcProbeTrackingConfig(fol, trk), wfs)
-
-  private val getCwfs1: (VirtualGemsTelescope, IO[Cwfs1DetectorState]) => IO[GuiderConfig] =
-    getCwfs(TcsEpics.instance.cwfs1Follow)
-
-  private val getCwfs2: (VirtualGemsTelescope, IO[Cwfs2DetectorState]) => IO[GuiderConfig] =
-    getCwfs(TcsEpics.instance.cwfs1Follow)
-
-  private val getCwfs3: (VirtualGemsTelescope, IO[Cwfs3DetectorState]) => IO[GuiderConfig] =
-    getCwfs(TcsEpics.instance.cwfs1Follow)
-
-  private def getOdgw[T: DetectorStateOps: Eq](getParked: IO[Boolean], getFollow: IO[Boolean])
-                                          (g: VirtualGemsTelescope, active: IO[T])
-  : IO[GuiderConfig] = for {
-    prk <- getParked
-    trk <- getNodChopTrackingConfig(TcsEpics.instance.gemsGuideConfig(g))
-    fol <- getFollow.map{ if(_) FollowOption.FollowOn else FollowOption.FollowOff}
-    wfs <- active.map{x => if(DetectorStateOps.isActive[T](x)) GuiderSensorOn else GuiderSensorOff}
-  } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
-
-  private val getOdgw1: (VirtualGemsTelescope, IO[Odgw1DetectorState]) => IO[GuiderConfig] =
-    getOdgw(TcsEpics.instance.odgw1Parked, TcsEpics.instance.odgw1Follow)
-
-  private val getOdgw2: (VirtualGemsTelescope, IO[Odgw2DetectorState]) => IO[GuiderConfig] =
-    getOdgw(TcsEpics.instance.odgw2Parked, TcsEpics.instance.odgw2Follow)
-
-  private val getOdgw3: (VirtualGemsTelescope, IO[Odgw3DetectorState]) => IO[GuiderConfig] =
-    getOdgw(TcsEpics.instance.odgw3Parked, TcsEpics.instance.odgw3Follow)
-
-  private val getOdgw4: (VirtualGemsTelescope, IO[Odgw4DetectorState]) => IO[GuiderConfig] =
-    getOdgw(TcsEpics.instance.odgw4Parked, TcsEpics.instance.odgw4Follow)
-
-  private def getInstrumentPorts: IO[InstrumentPorts] = for {
-    f2    <- TcsEpics.instance.f2Port.recover{case NullEpicsError(_) => InvalidPort}
-    ghost <- TcsEpics.instance.ghostPort.recover{case NullEpicsError(_) => InvalidPort}
-    gmos  <- TcsEpics.instance.gmosPort.recover{case NullEpicsError(_) => InvalidPort}
-    gnirs <- TcsEpics.instance.gnirsPort.recover{case NullEpicsError(_) => InvalidPort}
-    gpi   <- TcsEpics.instance.gpiPort.recover{case NullEpicsError(_) => InvalidPort}
-    gsaoi <- TcsEpics.instance.gsaoiPort.recover{case NullEpicsError(_) => InvalidPort}
-    nifs  <- TcsEpics.instance.nifsPort.recover{case NullEpicsError(_) => InvalidPort}
-    niri  <- TcsEpics.instance.niriPort.recover{case NullEpicsError(_) => InvalidPort}
-  } yield InstrumentPorts(
-    f2,
-    ghost,
-    gmos,
-    gnirs,
-    gpi,
-    gsaoi,
-    nifs,
-    niri
-  )
-
-  def retrieveConfigurationNorth(getAoFollow: IO[Boolean]): IO[TcsNorthControllerEpicsAo.EpicsTcsAoConfig] =
-    for {
-      base <- retrieveBaseConfiguration
-      ao   <- getAowfs(getAoFollow)
-    } yield TcsNorthControllerEpicsAo.EpicsTcsAoConfig(base, ao)
-
-  private def retrieveGemsGuider(mapping: Map[GemsSource, VirtualGemsTelescope],
-                                 gemsSource: GemsSource,
-                                 getGuide: VirtualGemsTelescope => IO[GuiderConfig]): IO[GuiderConfig] =
-    mapping.get(gemsSource).map(getGuide).getOrElse(IO(GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)))
-
-  def retrieveConfigurationSouth(gemsSt: GemsWfsState[IO]): IO[TcsSouthControllerEpicsAo.EpicsTcsAoConfig] =
-    for {
-      base    <- retrieveBaseConfiguration
-      mapping <- getGemsMap
-      cwfs1   <- retrieveGemsGuider(mapping, Cwfs1, getCwfs1(_, gemsSt.cwfs1))
-      cwfs2   <- retrieveGemsGuider(mapping, Cwfs2, getCwfs2(_, gemsSt.cwfs2))
-      cwfs3   <- retrieveGemsGuider(mapping, Cwfs3, getCwfs3(_, gemsSt.cwfs3))
-      odgw1   <- retrieveGemsGuider(mapping, Odgw1, getOdgw1(_, gemsSt.odgw1))
-      odgw2   <- retrieveGemsGuider(mapping, Odgw2, getOdgw2(_, gemsSt.odgw2))
-      odgw3   <- retrieveGemsGuider(mapping, Odgw3, getOdgw3(_, gemsSt.odgw3))
-      odgw4   <- retrieveGemsGuider(mapping, Odgw4, getOdgw4(_, gemsSt.odgw4))
-    } yield TcsSouthControllerEpicsAo.EpicsTcsAoConfig(
-      base,
-      mapping,
-      cwfs1,
-      cwfs2,
-      cwfs3,
-      odgw1,
-      odgw2,
-      odgw3,
-      odgw4
-    )
-
-  def retrieveBaseConfiguration: IO[TcsControllerEpicsCommon.BaseEpicsTcsConfig] =
-    for {
-      iaa   <- getIAA
-      offX  <- getOffsetX
-      offY  <- getOffsetY
-      wl    <- getWavelength
-      p1    <- getPwfs1
-      p2    <- getPwfs2
-      oi    <- getOiwfs
-      tgc   <- getGuideConfig
-      aof   <- getAoFold
-      useAo <- getUseAo
-      sf    <- getScienceFoldPosition
-      hr    <- getHrwfsPickupPosition
-      ports <- getInstrumentPorts
-    } yield TcsControllerEpicsCommon.BaseEpicsTcsConfig(
-      iaa,
-      FocalPlaneOffset(tag[OffsetX](offX), tag[OffsetY](offY)),
-      wl,
-      p1,
-      p2,
-      oi,
-      tgc,
-      aof,
-      useAo,
-      sf,
-      hr,
-      ports
-    )
-
+  def apply[F[_]: MonadError[?[_], Throwable]](epicsSys: TcsEpics[F]): TcsConfigRetriever[F] =
+    new TcsConfigRetrieverImpl(epicsSys)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEncoders.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEncoders.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import seqexec.model.enum.{ComaOption, MountGuideOption}
+import seqexec.model.M2GuideConfig
+import seqexec.model.M1GuideConfig
+import seqexec.server.EpicsCodex.EncodeEpicsValue
+import seqexec.server.tcs.TcsController._
+
+trait TcsControllerEncoders {
+  // Encoders
+  implicit val encodeMountGuideConfig: EncodeEpicsValue[MountGuideOption, String] =
+    EncodeEpicsValue{
+      case MountGuideOption.MountGuideOn  => "on"
+      case MountGuideOption.MountGuideOff => "off"
+    }
+
+  implicit val encodeM1GuideConfig: EncodeEpicsValue[M1GuideConfig, String] =
+    EncodeEpicsValue {
+      case M1GuideConfig.M1GuideOn(_) => "on"
+      case M1GuideConfig.M1GuideOff   => "off"
+    }
+
+  val encodeM2Guide: EncodeEpicsValue[M2GuideConfig, String] =
+    EncodeEpicsValue {
+      case M2GuideConfig.M2GuideOn(_, _) => "on"
+      case M2GuideConfig.M2GuideOff      => "off"
+    }
+
+  val encodeM2Coma: EncodeEpicsValue[M2GuideConfig, String] =
+    EncodeEpicsValue {
+      case M2GuideConfig.M2GuideOn(ComaOption.ComaOn, _) => "on"
+      case _                                             => "off"
+    }
+
+  val encodeM2GuideReset: EncodeEpicsValue[M2GuideConfig, String] =
+    EncodeEpicsValue {
+      case M2GuideConfig.M2GuideOn(_, _) => "off"
+      case M2GuideConfig.M2GuideOff      => "on"
+    }
+
+  implicit val encodeNodChopOption: EncodeEpicsValue[NodChopTrackingOption, String] =
+    EncodeEpicsValue {
+      case NodChopTrackingOption.NodChopTrackingOn  => "On"
+      case NodChopTrackingOption.NodChopTrackingOff => "Off"
+    }
+
+  implicit val encodeFollowOption: EncodeEpicsValue[FollowOption, String] =
+    EncodeEpicsValue {
+      case FollowOption.FollowOn  => "On"
+      case FollowOption.FollowOff => "Off"
+    }
+
+  implicit val encodeHrwfsPickupPosition: EncodeEpicsValue[HrwfsPickupPosition, String] =
+    EncodeEpicsValue{
+      case HrwfsPickupPosition.IN     => "IN"
+      case HrwfsPickupPosition.OUT    => "OUT"
+      case HrwfsPickupPosition.Parked => "park-pos."
+    }
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpicsCommon.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerEpicsCommon.scala
@@ -3,498 +3,137 @@
 
 package seqexec.server.tcs
 
+import cats._
 import cats.data._
-import cats.effect.{Async, IO, Sync}
+import cats.effect.{Async, Sync}
 import cats.implicits._
 import edu.gemini.spModel.core.Wavelength
+import io.chrisdavenport.log4cats.Logger
 import gem.enum.LightSinkName
-import squants.time.Seconds
 import mouse.boolean._
-import cats.{Applicative, Endo, Eq}
-import monocle.macros.Lenses
-import monocle.{Iso, Lens}
-import org.log4s.{Logger, getLogger}
-import squants.{Angle, Length, Time}
+import monocle.Lens
 import seqexec.model.enum.{ComaOption, M1Source, MountGuideOption, TipTiltSource}
 import seqexec.model.M2GuideConfig
 import seqexec.model.M1GuideConfig
 import seqexec.model.TelescopeGuideConfig
-import seqexec.server.EpicsCodex.{EncodeEpicsValue, encode}
+import seqexec.server.EpicsCodex.encode
 import seqexec.server.tcs.TcsController._
 import seqexec.server.{EpicsCommand, SeqexecFailure}
-import seqexec.server.tcs.TcsEpics.{ProbeFollowCmd, ProbeGuideCmd}
-import seqexec.server.tcs.ScienceFoldPositionCodex._
-import shapeless.tag
-import shapeless.tag.@@
-import squants.space.Arcseconds
+
+/**
+ * Base implementation of an Epics TcsController
+ * Type parameter BaseEpicsTcsConfig is the class used to hold the current configuration
+ */
+sealed trait TcsControllerEpicsCommon[F[_]] {
+
+  def applyBasicConfig(
+    subsystems: NonEmptySet[Subsystem],
+    tcs: BasicTcsConfig
+  ): F[Unit]
+
+  def notifyObserveStart: F[Unit]
+
+  def notifyObserveEnd: F[Unit]
+
+  def nod(
+    subsystems: NonEmptySet[Subsystem],
+    offset: InstrumentOffset,
+    guided: Boolean,
+    tcs: BasicTcsConfig
+  ): F[Unit]
+
+  def setMountGuide[C](l: Lens[C, BaseEpicsTcsConfig])(
+    subsystems: NonEmptySet[Subsystem],
+    c: MountGuideOption,
+    d: MountGuideOption
+  ): Option[C => F[C]]
+
+  def setM1Guide[C](l: Lens[C, BaseEpicsTcsConfig])(
+    subsystems: NonEmptySet[Subsystem],
+    c: M1GuideConfig,
+    d: M1GuideConfig
+  ): Option[C => F[C]]
+
+  def setM2Guide[C](l: Lens[C, BaseEpicsTcsConfig])(
+    subsystems: NonEmptySet[Subsystem],
+    c: M2GuideConfig,
+    d: M2GuideConfig
+  ): Option[C => F[C]]
+
+  def setPwfs1[C](l: Lens[C, BaseEpicsTcsConfig])(
+    subsystems: NonEmptySet[Subsystem],
+    c: GuiderSensorOption,
+    d: GuiderSensorOption
+  ): Option[C => F[C]]
+
+  def setOiwfs[C](l: Lens[C, BaseEpicsTcsConfig])(
+    subsystems: NonEmptySet[Subsystem],
+    c: GuiderSensorOption,
+    d: GuiderSensorOption
+  ): Option[C => F[C]]
+
+  def setScienceFold[C](l: Lens[C, BaseEpicsTcsConfig])(
+    subsystems: NonEmptySet[Subsystem],
+    c: C,
+    d: LightPath
+  ): Option[C => F[C]]
+
+  def setHrPickup[C](l: Lens[C, BaseEpicsTcsConfig])(
+    subsystems: NonEmptySet[Subsystem],
+    current: C,
+    d: AGConfig
+  ): Option[C => F[C]]
+
+  def setTelescopeOffset(c: FocalPlaneOffset): F[Unit]
+
+  def setWavelength(w: Wavelength): F[Unit]
+
+  def setPwfs1Probe[C](l: Lens[C, BaseEpicsTcsConfig])(
+    a: NonEmptySet[Subsystem],
+    b: ProbeTrackingConfig,
+    c: ProbeTrackingConfig
+  ): Option[C => F[C]]
+
+  def setOiwfsProbe[C](l: Lens[C, BaseEpicsTcsConfig])(
+    a: NonEmptySet[Subsystem],
+    b: ProbeTrackingConfig,
+    c: ProbeTrackingConfig
+  ): Option[C => F[C]]
+
+  def setNodChopProbeTrackingConfig(s: TcsEpics.ProbeGuideCmd[F])(
+    c: NodChopTrackingConfig
+  ): F[Unit]
+
+  def setGuideProbe[C](
+    guideControl: GuideControl[F],
+    trkSet: ProbeTrackingConfig => C => C)(
+    subsystems: NonEmptySet[Subsystem],
+    c: ProbeTrackingConfig,
+    d: ProbeTrackingConfig
+  ): Option[C => F[C]]
+}
 
 /*
  * Base implementation of an Epics TcsController
  * Type parameter BaseEpicsTcsConfig is the class used to hold the current configuration
  */
 object TcsControllerEpicsCommon {
+  private def mustPauseWhileOffsetting(current: BaseEpicsTcsConfig, demand: BasicTcsConfig): Boolean = {
+    val distanceSquared = demand.tc.offsetA.map(_.toFocalPlaneOffset(current.iaa))
+      .map { o => (o.x - current.offset.x, o.y - current.offset.y) }
+      .map(d => d._1 * d._1 + d._2 * d._2)
 
-  val logger: Logger = getLogger
-
-  def applyBasicConfig(subsystems: NonEmptySet[Subsystem], tcs: BasicTcsConfig): IO[Unit] = {
-
-    def sysConfig(current: BaseEpicsTcsConfig): IO[BaseEpicsTcsConfig] = {
-      val params = configBaseParams(subsystems, current, tcs)
-
-      if(params.nonEmpty)
-        for {
-          s <- params.foldLeft(IO(current)){ case (c, p) => c.flatMap(p) }
-          _ <- TcsEpics.instance.post
-          _ <- IO(logger.debug("TCS configuration command post"))
-          _ <- if(subsystems.contains(Subsystem.Mount))
-            TcsEpics.instance.waitInPosition(tcsTimeout) *> IO.apply(logger.info("TCS inposition"))
-          else if(Set(Subsystem.PWFS1, Subsystem.PWFS2, Subsystem.AGUnit).exists(subsystems.contains))
-            TcsEpics.instance.waitAGInPosition(agTimeout) *> IO.apply(logger.debug("AG inposition"))
-          else IO.unit
-        } yield s
-      else
-        IO(logger.debug("Skipping TCS configuration")) *> IO(current)
-    }
-
-    for {
-      s0 <- TcsConfigRetriever.retrieveBaseConfiguration
-      _  <- if(s0.useAo) SeqexecFailure.Execution("Found useAo set for non AO step.").raiseError[IO, Unit] else IO.unit
-      s1 <- guideOff(subsystems, s0, tcs)
-      s2 <- sysConfig(s1)
-      _  <- guideOn(subsystems, s2, tcs)
-    } yield ()
-  }
-
-  // To nod the telescope is just like applying a TCS configuration, but always with an offset
-  def nod(subsystems: NonEmptySet[Subsystem], offset: InstrumentOffset, guided: Boolean, tcs: BasicTcsConfig): IO[Unit] = {
-
-    val offsetConfig: BasicTcsConfig = (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(offset.some)(tcs)
-    val noddedConfig: BasicTcsConfig =
-      if(guided) offsetConfig
-      else BasicTcsConfig.gds.modify(
-        (BasicGuidersConfig.pwfs1 ^<-> tagIso).modify(
-          GuiderConfig.tracking.modify{ tr => if(tr.isActive) ProbeTrackingConfig.Frozen else tr} >>>
-          GuiderConfig.detector.set(GuiderSensorOff)
-        ) >>>
-          (BasicGuidersConfig.pwfs2 ^<-> tagIso).modify(
-            GuiderConfig.tracking.modify{ tr => if(tr.isActive) ProbeTrackingConfig.Frozen else tr} >>>
-            GuiderConfig.detector.set(GuiderSensorOff)
-          ) >>>
-          (BasicGuidersConfig.oiwfs ^<-> tagIso).modify(
-            GuiderConfig.tracking.modify{ tr => if(tr.isActive) ProbeTrackingConfig.Frozen else tr} >>>
-            GuiderConfig.detector.set(GuiderSensorOff)
-          )
-      )(offsetConfig)
-
-    applyBasicConfig(subsystems, noddedConfig)
-  }
-
-  def guideOff(subsystems: NonEmptySet[Subsystem], current: BaseEpicsTcsConfig, demand: BasicTcsConfig)
-  : IO[BaseEpicsTcsConfig] = {
-    val params = guideParams(subsystems, current, calcGuideOff(current, demand) )
-
-    if(params.nonEmpty)
-      for {
-        s <- params.foldLeft(IO(current)){ case (c, p) => c.flatMap(p)}
-        _ <- TcsEpics.instance.post
-        _ <- IO(logger.info("Turning guide off"))
-      } yield s
-    else
-      IO(logger.info("Skipping guide off")) *> IO(current)
-  }
-
-  def guideOn(subsystems: NonEmptySet[Subsystem], current: BaseEpicsTcsConfig, demand: BasicTcsConfig)
-  : IO[BaseEpicsTcsConfig] = {
-
-    // If the demand turned off any WFS, normalize will turn off the corresponding processing
-    val normalizedGuiding = (normalizeM1Guiding(false) >>> normalizeM2Guiding(false) >>>
-      normalizeMountGuiding)(demand)
-
-    val params = guideParams(subsystems, current, normalizedGuiding)
-
-    if(params.nonEmpty)
-      for {
-        s <- params.foldLeft(IO(current)){ case (c, p) => c.flatMap(p)}
-        _ <- TcsEpics.instance.post
-        _ <- IO(logger.info("Turning guide on"))
-      } yield s
-    else
-      IO(logger.info("Skipping guide on")) *> IO(current)
-  }
-
-  def tagIso[B, T]: Iso[B@@T, B] = Iso.apply[B@@T, B](x => x)(tag[T](_))
-
-  def notifyObserveStart: IO[Unit] =
-    TcsEpics.instance.observe.mark[IO] *> TcsEpics.instance.post.void
-
-  def notifyObserveEnd: IO[Unit] = TcsEpics.instance.endObserve.mark[IO] *> TcsEpics.instance.post.void
-
-  /* AO fold position */
-  sealed trait AoFold {
-    val active: Boolean
-  }
-  object AoFold {
-    object In extends AoFold {
-      override val active: Boolean = true
-    }
-    object Out extends AoFold {
-      override val active: Boolean = false
-    }
-  }
-
-  final case class InstrumentPorts(
-    flamingos2Port: Int,
-    ghostPort: Int,
-    gmosPort: Int,
-    gnirsPort: Int,
-    gpiPort: Int,
-    gsaoiPort: Int,
-    nifsPort: Int,
-    niriPort: Int
-  )
-
-  val BottomPort: Int = 1
-  val InvalidPort: Int = 0
-
-  sealed trait ScienceFold
-
-  object ScienceFold {
-    case object Parked extends ScienceFold
-    final case class Position(source: LightSource, sink: LightSinkName, port: Int) extends ScienceFold
-
-    implicit val positionEq: Eq[Position] = Eq.by(x => (x.source, x.sink, x.port))
-
-    implicit val eq: Eq[ScienceFold] = Eq.instance{
-      case (Parked, Parked)           => true
-      case (a: Position, b: Position) => a === b
-      case _                          => false
-    }
-  }
-
-  final case class GuideControl[F[_]: Async](subs: Subsystem,
-                                             parkCmd: EpicsCommand,
-                                             nodChopGuideCmd: ProbeGuideCmd[F],
-                                             followCmd: ProbeFollowCmd[F]
-                                            )
-
-  val pwfs1OffsetThreshold: Length = Arcseconds(0.01)/FOCAL_PLANE_SCALE
-  val pwfs2OffsetThreshold: Length = Arcseconds(0.01)/FOCAL_PLANE_SCALE
-
-  @Lenses
-  final case class BaseEpicsTcsConfig(
-    iaa: Angle,
-    offset: FocalPlaneOffset,
-    wavelA: Wavelength,
-    pwfs1: GuiderConfig,
-    pwfs2: GuiderConfig,
-    oiwfs: GuiderConfig,
-    telescopeGuideConfig: TelescopeGuideConfig,
-    aoFold: AoFold,
-    useAo: Boolean,
-    scienceFoldPosition: Option[ScienceFold],
-    hrwfsPickupPosition: HrwfsPickupPosition,
-    instPorts: InstrumentPorts
-  ) {
-    val instrumentOffset: InstrumentOffset = offset.toInstrumentOffset(iaa)
-  }
-
-  // Same offset is applied to all the beams
-  def setTelescopeOffset(c: FocalPlaneOffset): IO[Unit] =
-    TcsEpics.instance.offsetACmd.setX(c.x.toMillimeters) *>
-      TcsEpics.instance.offsetACmd.setY(c.y.toMillimeters) *>
-      TcsEpics.instance.offsetBCmd.setX(c.x.toMillimeters) *>
-      TcsEpics.instance.offsetBCmd.setY(c.y.toMillimeters) *>
-      TcsEpics.instance.offsetCCmd.setX(c.x.toMillimeters) *>
-      TcsEpics.instance.offsetCCmd.setY(c.y.toMillimeters)
-
-  // Same wavelength is applied to all the beams
-  def setWavelength(w: Wavelength): IO[Unit] =
-    TcsEpics.instance.wavelSourceA.setWavel(w.toMicrons) *>
-      TcsEpics.instance.wavelSourceB.setWavel(w.toMicrons) *>
-      TcsEpics.instance.wavelSourceC.setWavel(w.toMicrons)
-
-  implicit val encodeNodChopOption: EncodeEpicsValue[NodChopTrackingOption, String] =
-    EncodeEpicsValue {
-      case NodChopTrackingOption.NodChopTrackingOn  => "On"
-      case NodChopTrackingOption.NodChopTrackingOff => "Off"
-    }
-
-  implicit val encodeFollowOption: EncodeEpicsValue[FollowOption, String] =
-    EncodeEpicsValue {
-      case FollowOption.FollowOn  => "On"
-      case FollowOption.FollowOff => "Off"
-    }
-
-  def setNodChopProbeTrackingConfig[F[_] : Async](s: TcsEpics.ProbeGuideCmd[F])(c: NodChopTrackingConfig): F[Unit] =
-    s.setNodachopa(encode(c.get(NodChop(Beam.A, Beam.A)))) *>
-      s.setNodachopb(encode(c.get(NodChop(Beam.A, Beam.B)))) *>
-      s.setNodachopc(encode(c.get(NodChop(Beam.A, Beam.C)))) *>
-      s.setNodbchopa(encode(c.get(NodChop(Beam.B, Beam.A)))) *>
-      s.setNodbchopb(encode(c.get(NodChop(Beam.B, Beam.B)))) *>
-      s.setNodbchopc(encode(c.get(NodChop(Beam.B, Beam.C)))) *>
-      s.setNodcchopa(encode(c.get(NodChop(Beam.C, Beam.A)))) *>
-      s.setNodcchopb(encode(c.get(NodChop(Beam.C, Beam.B)))) *>
-      s.setNodcchopc(encode(c.get(NodChop(Beam.C, Beam.C))))
-
-  def setGuideProbe[F[_] : Async, C](guideControl: GuideControl[F],
-                                     trkSet: ProbeTrackingConfig => C => C)(
-                                      subsystems: NonEmptySet[Subsystem], c: ProbeTrackingConfig, d: ProbeTrackingConfig
-                                    ): Option[C => F[C]] =
-    if (subsystems.contains(guideControl.subs)) {
-      val actions = List(
-        (c.getNodChop =!= d.getNodChop)
-          .option(setNodChopProbeTrackingConfig(guideControl.nodChopGuideCmd)(d.getNodChop)),
-        d match {
-          case ProbeTrackingConfig.Parked => (c =!= ProbeTrackingConfig.Parked).option(guideControl.parkCmd.mark)
-          case ProbeTrackingConfig.On(_) |
-               ProbeTrackingConfig.Off |
-               ProbeTrackingConfig.Frozen => (c.follow =!= d.follow)
-            .option(guideControl.followCmd.setFollowState(encode(d.follow)))
-        }
-      ).flattenOption
-
-      actions.nonEmpty.option { x =>
-        actions.sequence *>
-          trkSet(d)(x).pure[F]
-      }
-    }
-    else none
-
-  private def pwfs1GuiderControl: GuideControl[IO] = GuideControl(Subsystem.PWFS1, TcsEpics.instance.pwfs1Park,
-    TcsEpics.instance.pwfs1ProbeGuideCmd, TcsEpics.instance.pwfs1ProbeFollowCmd)
-
-  def setPwfs1Probe[C](l: Lens[C, BaseEpicsTcsConfig])(
-    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
-  ): Option[C => IO[C]] =
-    setGuideProbe(pwfs1GuiderControl, (l ^|-> BaseEpicsTcsConfig.pwfs1 ^|-> GuiderConfig.tracking).set)(a, b, c)
-
-  private def pwfs2GuiderControl: GuideControl[IO] = GuideControl(Subsystem.PWFS2, TcsEpics.instance.pwfs2Park,
-    TcsEpics.instance.pwfs2ProbeGuideCmd, TcsEpics.instance.pwfs2ProbeFollowCmd)
-
-  def setPwfs2Probe[C](l: Lens[C, BaseEpicsTcsConfig])(
-    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
-  ): Option[C => IO[C]] =
-    setGuideProbe(pwfs2GuiderControl, (l ^|-> BaseEpicsTcsConfig.pwfs2 ^|-> GuiderConfig.tracking).set)(a, b, c)
-
-  private def oiwfsGuiderControl: GuideControl[IO] = GuideControl(Subsystem.OIWFS, TcsEpics.instance.oiwfsPark,
-    TcsEpics.instance.oiwfsProbeGuideCmd, TcsEpics.instance.oiwfsProbeFollowCmd)
-
-  def setOiwfsProbe[C](l: Lens[C, BaseEpicsTcsConfig])(
-    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
-  ): Option[C => IO[C]] =
-    setGuideProbe(oiwfsGuiderControl, (l ^|-> BaseEpicsTcsConfig.oiwfs ^|-> GuiderConfig.tracking).set)(a, b, c)
-
-  private def setGuiderWfs[F[_] : Sync](on: TcsEpics.WfsObserveCmd[F], off: EpicsCommand)(c: GuiderSensorOption)
-  : F[Unit] = {
-    val NonStopExposures = -1
-    c match {
-      case GuiderSensorOff => off.mark
-      case GuiderSensorOn => on.setNoexp(NonStopExposures) // Set number of exposures to non-stop (-1)
-    }
-  }
-
-  def setPwfs1[C](l: Lens[C, BaseEpicsTcsConfig])(
-    subsystems: NonEmptySet[Subsystem], c: GuiderSensorOption, d: GuiderSensorOption
-  ): Option[C => IO[C]] = applyParam(subsystems.contains(Subsystem.PWFS1), c, d,
-    setGuiderWfs(TcsEpics.instance.pwfs1ObserveCmd, TcsEpics.instance.pwfs1StopObserveCmd)(_: GuiderSensorOption),
-    l ^|-> BaseEpicsTcsConfig.pwfs1 ^|-> GuiderConfig.detector
-  )
-
-  def setPwfs2[C](l: Lens[C, BaseEpicsTcsConfig])(
-    subsystems: NonEmptySet[Subsystem], c: GuiderSensorOption, d: GuiderSensorOption
-  ): Option[C => IO[C]] = applyParam(subsystems.contains(Subsystem.PWFS2), c, d,
-    setGuiderWfs(TcsEpics.instance.pwfs2ObserveCmd, TcsEpics.instance.pwfs2StopObserveCmd)(_: GuiderSensorOption),
-    l ^|-> BaseEpicsTcsConfig.pwfs2 ^|-> GuiderConfig.detector
-  )
-
-  def setOiwfs[C](l: Lens[C, BaseEpicsTcsConfig])(
-    subsystems: NonEmptySet[Subsystem], c: GuiderSensorOption, d: GuiderSensorOption
-  ): Option[C => IO[C]] = applyParam(subsystems.contains(Subsystem.OIWFS), c, d,
-    setGuiderWfs(TcsEpics.instance.oiwfsObserveCmd, TcsEpics.instance.oiwfsStopObserveCmd)(_: GuiderSensorOption),
-    l ^|-> BaseEpicsTcsConfig.oiwfs ^|-> GuiderConfig.detector
-  )
-
-  def portFromSinkName(ports: InstrumentPorts)(n: LightSinkName): Option[Int] = {
-    import LightSinkName._
-    val port = n match {
-      case Gmos |
-           Gmos_Ifu => ports.gmosPort
-      case Niri_f6 |
-           Niri_f14 |
-           Niri_f32 => ports.niriPort
-      case Nifs     => ports.nifsPort
-      case Gnirs    => ports.gnirsPort
-      case F2       => ports.flamingos2Port
-      case Gpi      => ports.gpiPort
-      case Ghost    => ports.ghostPort
-      case Gsaoi    => ports.gsaoiPort
-      case Ac |
-           Hr       => BottomPort
-      case Phoenix |
-           Visitor  => InvalidPort
-    }
-    (port =!= InvalidPort).option(port)
-  }
-
-  def scienceFoldFromRequested(ports: InstrumentPorts)(r: LightPath): Option[ScienceFold] =
-    portFromSinkName(ports)(r.sink).map { p =>
-      if (p === BottomPort && r.source === LightSource.Sky) ScienceFold.Parked
-      else ScienceFold.Position(r.source, r.sink, p)
-    }
-
-  def setScienceFoldConfig(sfPos: ScienceFold): IO[Unit] = sfPos match {
-    case ScienceFold.Parked => TcsEpics.instance.scienceFoldParkCmd.mark[IO]
-    case p: ScienceFold.Position => TcsEpics.instance.scienceFoldPosCmd.setScfold(encode(p))
-  }
-
-  implicit private val encodeHrwfsPickupPosition: EncodeEpicsValue[HrwfsPickupPosition, String] =
-    EncodeEpicsValue{
-      case HrwfsPickupPosition.IN     => "IN"
-      case HrwfsPickupPosition.OUT    => "OUT"
-      case HrwfsPickupPosition.Parked => "park-pos."
-    }
-
-  def setHRPickupConfig(hrwfsPos: HrwfsPickupPosition): IO[Unit] = hrwfsPos match {
-    case HrwfsPickupPosition.Parked => TcsEpics.instance.hrwfsParkCmd.mark[IO]
-    case _ => TcsEpics.instance.hrwfsPosCmd.setHrwfsPos(encode(hrwfsPos))
-  }
-
-  private def calcHrPickupPosition(c: AGConfig, ports: InstrumentPorts): Option[HrwfsPickupPosition] = c.hrwfs.flatMap {
-    case HrwfsConfig.Manual(h) => h.some
-    case HrwfsConfig.Auto      => scienceFoldFromRequested(ports)(c.sfPos).flatMap {
-      case ScienceFold.Parked |
-           ScienceFold.Position(_, _, BottomPort) => HrwfsPickupPosition.Parked.some
-      case ScienceFold.Position(_, _, _)          => none
-    }
-  }
-
-  implicit private val encodeMountGuideConfig: EncodeEpicsValue[MountGuideOption, String] =
-    EncodeEpicsValue{
-      case MountGuideOption.MountGuideOn  => "on"
-      case MountGuideOption.MountGuideOff => "off"
-    }
-
-  def setMountGuide[C](l: Lens[C, BaseEpicsTcsConfig])(
-    subsystems: NonEmptySet[Subsystem], c: MountGuideOption, d: MountGuideOption
-  ): Option[C => IO[C]] = applyParam(subsystems.contains(Subsystem.Mount), c, d,
-    (x: MountGuideOption) => TcsEpics.instance.mountGuideCmd.setMode(encode(x)),
-    l ^|-> BaseEpicsTcsConfig.telescopeGuideConfig ^|-> TelescopeGuideConfig.mountGuide
-  )
-
-  implicit private val encodeM1GuideConfig: EncodeEpicsValue[M1GuideConfig, String] =
-    EncodeEpicsValue {
-      case M1GuideConfig.M1GuideOn(_) => "on"
-      case M1GuideConfig.M1GuideOff   => "off"
-    }
-
-  def setM1Guide[C](l: Lens[C, BaseEpicsTcsConfig])(
-    subsystems: NonEmptySet[Subsystem], c: M1GuideConfig, d: M1GuideConfig
-  ): Option[C => IO[C]] = applyParam(subsystems.contains(Subsystem.M1), c, d,
-    (x: M1GuideConfig) => TcsEpics.instance.m1GuideCmd.setState(encode(x)),
-    l ^|-> BaseEpicsTcsConfig.telescopeGuideConfig ^|-> TelescopeGuideConfig.m1Guide
-  )
-
-  private val encodeM2Guide: EncodeEpicsValue[M2GuideConfig, String] =
-    EncodeEpicsValue {
-      case M2GuideConfig.M2GuideOn(_, _) => "on"
-      case M2GuideConfig.M2GuideOff      => "off"
-    }
-
-  private val encodeM2Coma: EncodeEpicsValue[M2GuideConfig, String] =
-    EncodeEpicsValue {
-      case M2GuideConfig.M2GuideOn(ComaOption.ComaOn, _) => "on"
-      case _                                             => "off"
-    }
-
-  private val encodeM2GuideReset: EncodeEpicsValue[M2GuideConfig, String] =
-    EncodeEpicsValue {
-      case M2GuideConfig.M2GuideOn(_, _) => "off"
-      case M2GuideConfig.M2GuideOff      => "on"
-    }
-
-  def setM2Guide[C](l: Lens[C, BaseEpicsTcsConfig])(
-    subsystems: NonEmptySet[Subsystem], c: M2GuideConfig, d: M2GuideConfig
-  ): Option[C => IO[C]] = {
-    val actions = List(
-      TcsEpics.instance.m2GuideModeCmd.setComa(encodeM2Coma.encode(d))
-        .whenA(encodeM2Coma.encode(d) =!= encodeM2Coma.encode(c)),
-      TcsEpics.instance.m2GuideCmd.setState(encodeM2Guide.encode(d))
-        .whenA(encodeM2Guide.encode(d) =!= encodeM2Guide.encode(c)),
-      TcsEpics.instance.m2GuideConfigCmd.setReset(encodeM2GuideReset.encode(d))
-        .whenA(encodeM2GuideReset.encode(d) =!= encodeM2GuideReset.encode(c))
+    val thresholds = List(
+      (Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS1, M1Source.PWFS1) && demand.gds.pwfs1.isActive)
+        .option(pwfs1OffsetThreshold),
+      (Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS2, M1Source.PWFS2) && demand.gds.pwfs2.isActive)
+        .option(pwfs2OffsetThreshold),
+      demand.inst.oiOffsetGuideThreshold
+        .filter(_ => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.OIWFS, M1Source.OIWFS) && demand.gds.oiwfs.isActive)
     )
-
-    (subsystems.contains(Subsystem.M2) && actions.nonEmpty).option( x =>
-      actions.sequence *> IO(
-        (l ^|-> BaseEpicsTcsConfig.telescopeGuideConfig ^|-> TelescopeGuideConfig.m2Guide).set(d)(x)
-      )
-    )
+    // Does the offset movement surpass any of the existing thresholds ?
+    distanceSquared.exists(dd => thresholds.exists(_.exists(t => t*t < dd)))
   }
-
-  def setScienceFold[C](l: Lens[C, BaseEpicsTcsConfig])(subsystems: NonEmptySet[Subsystem], c: C, d: LightPath)
-  : Option[C => IO[C]] = {
-    val base = l.get(c)
-    scienceFoldFromRequested(base.instPorts)(d).flatMap { sf =>
-      (subsystems.contains(Subsystem.AGUnit) && base.scienceFoldPosition.forall(_ =!= sf)).option { x =>
-        setScienceFoldConfig(sf) *> IO((l ^|-> BaseEpicsTcsConfig.scienceFoldPosition).set(sf.some)(x))
-      }
-    }
-  }
-
-  /*
-   * Positions Parked and OUT are equivalent for practical purposes. Therefore, if the current position is Parked and
-   * requested position is OUT (or the other way around), then it is not necessary to move the HR pickup mirror.
-   */
-  def setHrPickup[C](l: Lens[C, BaseEpicsTcsConfig])(
-    subsystems: NonEmptySet[Subsystem], current: C, d: AGConfig
-  ): Option[C => IO[C]] = {
-    val base = l.get(current)
-    subsystems.contains(Subsystem.AGUnit).fold(
-      calcHrPickupPosition(d, base.instPorts).flatMap { a =>
-        val b = base.hrwfsPickupPosition
-        (a =!= b && (HrwfsPickupPosition.isInTheWay(a) || HrwfsPickupPosition.isInTheWay(b))).option { x =>
-          setHRPickupConfig(a) *> IO((l ^|-> BaseEpicsTcsConfig.hrwfsPickupPosition).set(a)(x))
-        }
-      },
-      none
-    )
-  }
-
-  val tcsTimeout: Time = Seconds(60)
-  val agTimeout: Time = Seconds(60)
-
-  private def configBaseParams(subsystems: NonEmptySet[Subsystem], current: BaseEpicsTcsConfig, tcs: BasicTcsConfig)
-  : List[BaseEpicsTcsConfig => IO[BaseEpicsTcsConfig]] = List(
-    setPwfs1Probe(Lens.id)(subsystems, current.pwfs1.tracking, tcs.gds.pwfs1.tracking),
-    setPwfs2Probe(Lens.id)(subsystems, current.pwfs2.tracking, tcs.gds.pwfs2.tracking),
-    setOiwfsProbe(Lens.id)(subsystems, current.oiwfs.tracking, tcs.gds.oiwfs.tracking),
-    tcs.tc.offsetA.flatMap(o => applyParam(subsystems.contains(Subsystem.Mount), current.offset,
-      o.toFocalPlaneOffset(current.iaa), setTelescopeOffset, BaseEpicsTcsConfig.offset
-    )),
-    tcs.tc.wavelA.flatMap(applyParam(subsystems.contains(Subsystem.Mount), current.wavelA, _, setWavelength,
-      BaseEpicsTcsConfig.wavelA
-    )),
-    setScienceFold(Lens.id)(subsystems, current, tcs.agc.sfPos),
-    setHrPickup(Lens.id)(subsystems, current, tcs.agc)
-  ).flattenOption
-
-  def applyParam[F[_] : Applicative, T: Eq, C](used: Boolean,
-                                            current: T,
-                                            demand: T,
-                                            act: T => F[Unit],
-                                            lens: Lens[C, T])
-  : Option[C => F[C]] =
-    (used && current =!= demand).option(c => act(demand) *> lens.set(demand)(c).pure[F])
-
-  private def guideParams(subsystems: NonEmptySet[Subsystem], current: BaseEpicsTcsConfig, demand: BasicTcsConfig)
-  : List[BaseEpicsTcsConfig => IO[BaseEpicsTcsConfig]] = List(
-    setMountGuide(Lens.id)(subsystems, current.telescopeGuideConfig.mountGuide, demand.gc.mountGuide),
-    setM1Guide(Lens.id)(subsystems, current.telescopeGuideConfig.m1Guide, demand.gc.m1Guide),
-    setM2Guide(Lens.id)(subsystems, current.telescopeGuideConfig.m2Guide, demand.gc.m2Guide),
-    setPwfs1(Lens.id)(subsystems, current.pwfs1.detector, demand.gds.pwfs1.detector),
-    setPwfs2(Lens.id)(subsystems, current.pwfs2.detector, demand.gds.pwfs2.detector),
-    setOiwfs(Lens.id)(subsystems, current.oiwfs.detector, demand.gds.oiwfs.detector)
-  ).flattenOption
 
   // Disable M1 guiding if source is off
   private def normalizeM1Guiding(gaosEnabled: Boolean): Endo[BasicTcsConfig] = cfg =>
@@ -557,21 +196,356 @@ object TcsControllerEpicsCommon {
     ) >>> normalizeM1Guiding(false) >>> normalizeM2Guiding(false) >>> normalizeMountGuiding)(demand)
   }
 
-  private def mustPauseWhileOffsetting(current: BaseEpicsTcsConfig, demand: BasicTcsConfig): Boolean = {
-    val distanceSquared = demand.tc.offsetA.map(_.toFocalPlaneOffset(current.iaa))
-      .map { o => (o.x - current.offset.x, o.y - current.offset.y) }
-      .map(d => d._1 * d._1 + d._2 * d._2)
+  def applyParam[F[_]: Applicative, T: Eq, C](
+    used: Boolean,
+    current: T,
+    demand: T,
+    act: T => F[Unit],
+    lens: Lens[C, T]
+  ): Option[C => F[C]] =
+    (used && current =!= demand).option(c => act(demand) *> lens.set(demand)(c).pure[F])
 
-    val thresholds = List(
-      (Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS1, M1Source.PWFS1) && demand.gds.pwfs1.isActive)
-        .option(pwfs1OffsetThreshold),
-      (Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS2, M1Source.PWFS2) && demand.gds.pwfs2.isActive)
-        .option(pwfs2OffsetThreshold),
-      demand.inst.oiOffsetGuideThreshold
-        .filter(_ => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.OIWFS, M1Source.OIWFS) && demand.gds.oiwfs.isActive)
+  private class TcsControllerEpicsCommonImpl[F[_]: Async](epicsSys: TcsEpics[F])(implicit L: Logger[F]) extends TcsControllerEpicsCommon[F] with TcsControllerEncoders with ScienceFoldPositionCodex {
+    private val tcsConfigRetriever = TcsConfigRetriever[F](epicsSys)
+
+    override def setMountGuide[C](l: Lens[C, BaseEpicsTcsConfig])(
+      subsystems: NonEmptySet[Subsystem], c: MountGuideOption, d: MountGuideOption
+    ): Option[C => F[C]] = applyParam(subsystems.contains(Subsystem.Mount), c, d,
+      (x: MountGuideOption) => epicsSys.mountGuideCmd.setMode(encode(x)),
+      l ^|-> BaseEpicsTcsConfig.telescopeGuideConfig ^|-> TelescopeGuideConfig.mountGuide
     )
-    // Does the offset movement surpass any of the existing thresholds ?
-    distanceSquared.exists(dd => thresholds.exists(_.exists(t => t*t < dd)))
+
+    override def setM1Guide[C](l: Lens[C, BaseEpicsTcsConfig])(
+      subsystems: NonEmptySet[Subsystem], c: M1GuideConfig, d: M1GuideConfig
+    ): Option[C => F[C]] = applyParam(subsystems.contains(Subsystem.M1), c, d,
+      (x: M1GuideConfig) => epicsSys.m1GuideCmd.setState(encode(x)),
+      l ^|-> BaseEpicsTcsConfig.telescopeGuideConfig ^|-> TelescopeGuideConfig.m1Guide
+    )
+
+    override def setM2Guide[C](l: Lens[C, BaseEpicsTcsConfig])(
+      subsystems: NonEmptySet[Subsystem], c: M2GuideConfig, d: M2GuideConfig
+    ): Option[C => F[C]] = {
+      val actions = List(
+        epicsSys.m2GuideModeCmd.setComa(encodeM2Coma.encode(d))
+          .whenA(encodeM2Coma.encode(d) =!= encodeM2Coma.encode(c)),
+        epicsSys.m2GuideCmd.setState(encodeM2Guide.encode(d))
+          .whenA(encodeM2Guide.encode(d) =!= encodeM2Guide.encode(c)),
+        epicsSys.m2GuideConfigCmd.setReset(encodeM2GuideReset.encode(d))
+          .whenA(encodeM2GuideReset.encode(d) =!= encodeM2GuideReset.encode(c))
+      )
+
+      (subsystems.contains(Subsystem.M2) && actions.nonEmpty).option( x =>
+        actions.sequence *> Sync[F].delay(
+          (l ^|-> BaseEpicsTcsConfig.telescopeGuideConfig ^|-> TelescopeGuideConfig.m2Guide).set(d)(x)
+        )
+      )
+    }
+
+    val NonStopExposures = -1
+
+    private def setGuiderWfs(on: TcsEpics.WfsObserveCmd[F], off: EpicsCommand)(c: GuiderSensorOption)
+    : F[Unit] =
+      c match {
+        case GuiderSensorOff => off.mark[F]
+        case GuiderSensorOn  => on.setNoexp(NonStopExposures) // Set number of exposures to non-stop (-1)
+      }
+
+    override def setPwfs1[C](l: Lens[C, BaseEpicsTcsConfig])(
+      subsystems: NonEmptySet[Subsystem], c: GuiderSensorOption, d: GuiderSensorOption
+    ): Option[C => F[C]] = applyParam(subsystems.contains(Subsystem.PWFS1), c, d,
+      setGuiderWfs(epicsSys.pwfs1ObserveCmd, epicsSys.pwfs1StopObserveCmd)(_: GuiderSensorOption),
+      l ^|-> BaseEpicsTcsConfig.pwfs1 ^|-> GuiderConfig.detector
+    )
+
+    private def setPwfs2[C](l: Lens[C, BaseEpicsTcsConfig])(
+      subsystems: NonEmptySet[Subsystem], c: GuiderSensorOption, d: GuiderSensorOption
+    ): Option[C => F[C]] = applyParam(subsystems.contains(Subsystem.PWFS2), c, d,
+      setGuiderWfs(epicsSys.pwfs2ObserveCmd, epicsSys.pwfs2StopObserveCmd)(_: GuiderSensorOption),
+      l ^|-> BaseEpicsTcsConfig.pwfs2 ^|-> GuiderConfig.detector
+    )
+
+    override def setOiwfs[C](l: Lens[C, BaseEpicsTcsConfig])(
+      subsystems: NonEmptySet[Subsystem], c: GuiderSensorOption, d: GuiderSensorOption
+    ): Option[C => F[C]] = applyParam(subsystems.contains(Subsystem.OIWFS), c, d,
+      setGuiderWfs(epicsSys.oiwfsObserveCmd, epicsSys.oiwfsStopObserveCmd)(_: GuiderSensorOption),
+      l ^|-> BaseEpicsTcsConfig.oiwfs ^|-> GuiderConfig.detector
+    )
+
+    private def guideParams(subsystems: NonEmptySet[Subsystem], current: BaseEpicsTcsConfig, demand: BasicTcsConfig)
+    : List[BaseEpicsTcsConfig => F[BaseEpicsTcsConfig]] = List(
+      setMountGuide(Lens.id)(subsystems, current.telescopeGuideConfig.mountGuide, demand.gc.mountGuide),
+      setM1Guide(Lens.id)(subsystems, current.telescopeGuideConfig.m1Guide, demand.gc.m1Guide),
+      setM2Guide(Lens.id)(subsystems, current.telescopeGuideConfig.m2Guide, demand.gc.m2Guide),
+      setPwfs1(Lens.id)(subsystems, current.pwfs1.detector, demand.gds.pwfs1.detector),
+      setPwfs2(Lens.id)(subsystems, current.pwfs2.detector, demand.gds.pwfs2.detector),
+      setOiwfs(Lens.id)(subsystems, current.oiwfs.detector, demand.gds.oiwfs.detector)
+    ).flattenOption
+
+    def setHRPickupConfig(hrwfsPos: HrwfsPickupPosition): F[Unit] = hrwfsPos match {
+      case HrwfsPickupPosition.Parked => epicsSys.hrwfsParkCmd.mark[F]
+      case _                          => epicsSys.hrwfsPosCmd.setHrwfsPos(encode(hrwfsPos))
+    }
+
+    private def calcHrPickupPosition(c: AGConfig, ports: InstrumentPorts): Option[HrwfsPickupPosition] = c.hrwfs.flatMap {
+      case HrwfsConfig.Manual(h) => h.some
+      case HrwfsConfig.Auto      => scienceFoldFromRequested(ports)(c.sfPos).flatMap {
+        case ScienceFold.Parked |
+             ScienceFold.Position(_, _, BottomPort) => HrwfsPickupPosition.Parked.some
+        case ScienceFold.Position(_, _, _)          => none
+      }
+    }
+
+    override def setScienceFold[C](l: Lens[C, BaseEpicsTcsConfig])(subsystems: NonEmptySet[Subsystem], c: C, d: LightPath)
+    : Option[C => F[C]] = {
+      val base = l.get(c)
+      scienceFoldFromRequested(base.instPorts)(d).flatMap { sf =>
+        (subsystems.contains(Subsystem.AGUnit) && base.scienceFoldPosition.forall(_ =!= sf)).option { x =>
+          setScienceFoldConfig(sf) *> Sync[F].delay((l ^|-> BaseEpicsTcsConfig.scienceFoldPosition).set(sf.some)(x))
+        }
+      }
+    }
+
+    /**
+     * Positions Parked and OUT are equivalent for practical purposes. Therefore, if the current position is Parked and
+     * requested position is OUT (or the other way around), then it is not necessary to move the HR pickup mirror.
+     */
+    override def setHrPickup[C](l: Lens[C, BaseEpicsTcsConfig])(
+      subsystems: NonEmptySet[Subsystem], current: C, d: AGConfig
+    ): Option[C => F[C]] = {
+      val base = l.get(current)
+      subsystems.contains(Subsystem.AGUnit).fold(
+        calcHrPickupPosition(d, base.instPorts).flatMap { a =>
+          val b = base.hrwfsPickupPosition
+          (a =!= b && (HrwfsPickupPosition.isInTheWay(a) || HrwfsPickupPosition.isInTheWay(b))).option { x =>
+            setHRPickupConfig(a) *> Sync[F].delay((l ^|-> BaseEpicsTcsConfig.hrwfsPickupPosition).set(a)(x))
+          }
+        },
+        none
+      )
+    }
+
+    private def guideOff(subsystems: NonEmptySet[Subsystem], current: BaseEpicsTcsConfig, demand: BasicTcsConfig): F[BaseEpicsTcsConfig] = {
+      val params = guideParams(subsystems, current, calcGuideOff(current, demand) )
+
+      if(params.nonEmpty)
+        for {
+          s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p)}
+          _ <- epicsSys.post
+          _ <- L.info("Turning guide off")
+        } yield s
+      else
+        L.info("Skipping guide off") *> current.pure[F]
+    }
+
+    override def setNodChopProbeTrackingConfig(s: TcsEpics.ProbeGuideCmd[F])(c: NodChopTrackingConfig): F[Unit] =
+      s.setNodachopa(encode(c.get(NodChop(Beam.A, Beam.A)))) *>
+        s.setNodachopb(encode(c.get(NodChop(Beam.A, Beam.B)))) *>
+        s.setNodachopc(encode(c.get(NodChop(Beam.A, Beam.C)))) *>
+        s.setNodbchopa(encode(c.get(NodChop(Beam.B, Beam.A)))) *>
+        s.setNodbchopb(encode(c.get(NodChop(Beam.B, Beam.B)))) *>
+        s.setNodbchopc(encode(c.get(NodChop(Beam.B, Beam.C)))) *>
+        s.setNodcchopa(encode(c.get(NodChop(Beam.C, Beam.A)))) *>
+        s.setNodcchopb(encode(c.get(NodChop(Beam.C, Beam.B)))) *>
+        s.setNodcchopc(encode(c.get(NodChop(Beam.C, Beam.C))))
+
+    private def portFromSinkName(ports: InstrumentPorts)(n: LightSinkName): Option[Int] = {
+      import LightSinkName._
+      val port = n match {
+        case Gmos |
+             Gmos_Ifu => ports.gmosPort
+        case Niri_f6 |
+             Niri_f14 |
+             Niri_f32 => ports.niriPort
+        case Nifs     => ports.nifsPort
+        case Gnirs    => ports.gnirsPort
+        case F2       => ports.flamingos2Port
+        case Gpi      => ports.gpiPort
+        case Ghost    => ports.ghostPort
+        case Gsaoi    => ports.gsaoiPort
+        case Ac |
+             Hr       => BottomPort
+        case Phoenix |
+             Visitor  => InvalidPort
+      }
+      (port =!= InvalidPort).option(port)
+    }
+
+    override def setGuideProbe[C](
+      guideControl: GuideControl[F],
+      trkSet: ProbeTrackingConfig => C => C)(
+      subsystems: NonEmptySet[Subsystem],
+      c: ProbeTrackingConfig,
+      d: ProbeTrackingConfig): Option[C => F[C]] =
+      if (subsystems.contains(guideControl.subs)) {
+        val actions = List(
+          (c.getNodChop =!= d.getNodChop)
+            .option(setNodChopProbeTrackingConfig(guideControl.nodChopGuideCmd)(d.getNodChop)),
+          d match {
+            case ProbeTrackingConfig.Parked => (c =!= ProbeTrackingConfig.Parked).option(guideControl.parkCmd.mark[F])
+            case ProbeTrackingConfig.On(_) |
+                 ProbeTrackingConfig.Off |
+                 ProbeTrackingConfig.Frozen => (c.follow =!= d.follow)
+              .option(guideControl.followCmd.setFollowState(encode(d.follow)))
+          }
+        ).flattenOption
+
+        actions.nonEmpty.option { x =>
+          actions.sequence *>
+            trkSet(d)(x).pure[F]
+        }
+      }
+      else none
+
+    private def pwfs1GuiderControl: GuideControl[F] =
+      GuideControl(Subsystem.PWFS1, epicsSys.pwfs1Park,
+        epicsSys.pwfs1ProbeGuideCmd, epicsSys.pwfs1ProbeFollowCmd)
+
+    override def setPwfs1Probe[C](l: Lens[C, BaseEpicsTcsConfig])(
+      a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+    ): Option[C => F[C]] =
+      setGuideProbe(pwfs1GuiderControl, (l ^|-> BaseEpicsTcsConfig.pwfs1 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+    private def pwfs2GuiderControl: GuideControl[F] =
+      GuideControl(Subsystem.PWFS2, epicsSys.pwfs2Park,
+        epicsSys.pwfs2ProbeGuideCmd, epicsSys.pwfs2ProbeFollowCmd)
+
+    def setPwfs2Probe[C](l: Lens[C, BaseEpicsTcsConfig])(
+      a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+    ): Option[C => F[C]] =
+      setGuideProbe(pwfs2GuiderControl, (l ^|-> BaseEpicsTcsConfig.pwfs2 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+    private def oiwfsGuiderControl: GuideControl[F] =
+      GuideControl(Subsystem.OIWFS, epicsSys.oiwfsPark,
+        epicsSys.oiwfsProbeGuideCmd, epicsSys.oiwfsProbeFollowCmd)
+
+    override def setOiwfsProbe[C](l: Lens[C, BaseEpicsTcsConfig])(
+      a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+    ): Option[C => F[C]] =
+      setGuideProbe(oiwfsGuiderControl, (l ^|-> BaseEpicsTcsConfig.oiwfs ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+    // Same offset is applied to all the beams
+    override def setTelescopeOffset(c: FocalPlaneOffset): F[Unit] =
+      epicsSys.offsetACmd.setX(c.x.toMillimeters) *>
+        epicsSys.offsetACmd.setY(c.y.toMillimeters) *>
+        epicsSys.offsetBCmd.setX(c.x.toMillimeters) *>
+        epicsSys.offsetBCmd.setY(c.y.toMillimeters) *>
+        epicsSys.offsetCCmd.setX(c.x.toMillimeters) *>
+        epicsSys.offsetCCmd.setY(c.y.toMillimeters)
+
+    // Same wavelength is applied to all the beams
+    override def setWavelength(w: Wavelength): F[Unit] =
+      epicsSys.wavelSourceA.setWavel(w.toMicrons) *>
+        epicsSys.wavelSourceB.setWavel(w.toMicrons) *>
+        epicsSys.wavelSourceC.setWavel(w.toMicrons)
+
+    def scienceFoldFromRequested(ports: InstrumentPorts)(r: LightPath): Option[ScienceFold] =
+      portFromSinkName(ports)(r.sink).map { p =>
+        if (p === BottomPort && r.source === LightSource.Sky) ScienceFold.Parked
+        else ScienceFold.Position(r.source, r.sink, p)
+      }
+
+    def setScienceFoldConfig(sfPos: ScienceFold): F[Unit] = sfPos match {
+      case ScienceFold.Parked => epicsSys.scienceFoldParkCmd.mark[F]
+      case p: ScienceFold.Position => epicsSys.scienceFoldPosCmd.setScfold(encode(p))
+    }
+
+    private def configBaseParams(subsystems: NonEmptySet[Subsystem], current: BaseEpicsTcsConfig, tcs: BasicTcsConfig)
+    : List[BaseEpicsTcsConfig => F[BaseEpicsTcsConfig]] = List(
+      setPwfs1Probe(Lens.id)(subsystems, current.pwfs1.tracking, tcs.gds.pwfs1.tracking),
+      setPwfs2Probe(Lens.id)(subsystems, current.pwfs2.tracking, tcs.gds.pwfs2.tracking),
+      setOiwfsProbe(Lens.id)(subsystems, current.oiwfs.tracking, tcs.gds.oiwfs.tracking),
+      tcs.tc.offsetA.flatMap(o => applyParam(subsystems.contains(Subsystem.Mount), current.offset,
+        o.toFocalPlaneOffset(current.iaa), setTelescopeOffset, BaseEpicsTcsConfig.offset
+      )),
+      tcs.tc.wavelA.flatMap(applyParam(subsystems.contains(Subsystem.Mount), current.wavelA, _, setWavelength,
+        BaseEpicsTcsConfig.wavelA
+      )),
+      setScienceFold(Lens.id)(subsystems, current, tcs.agc.sfPos),
+      setHrPickup(Lens.id)(subsystems, current, tcs.agc)
+    ).flattenOption
+
+  def guideOn(subsystems: NonEmptySet[Subsystem], current: BaseEpicsTcsConfig, demand: BasicTcsConfig)
+  : F[BaseEpicsTcsConfig] = {
+
+    // If the demand turned off any WFS, normalize will turn off the corresponding processing
+    val normalizedGuiding = (normalizeM1Guiding(false) >>> normalizeM2Guiding(false) >>>
+      normalizeMountGuiding)(demand)
+
+    val params = guideParams(subsystems, current, normalizedGuiding)
+
+    if(params.nonEmpty)
+      for {
+        s <- params.foldLeft(Sync[F].delay(current)){ case (c, p) => c.flatMap(p)}
+        _ <- epicsSys.post
+        _ <- L.info("Turning guide on")
+      } yield s
+    else
+      L.info("Skipping guide on") *> Sync[F].delay(current)
   }
+
+
+    override def applyBasicConfig(subsystems: NonEmptySet[Subsystem], tcs: BasicTcsConfig): F[Unit] = {
+      def sysConfig(current: BaseEpicsTcsConfig): F[BaseEpicsTcsConfig] = {
+        val params = configBaseParams(subsystems, current, tcs)
+
+        if(params.nonEmpty)
+          for {
+            s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p) }
+            _ <- epicsSys.post
+            _ <- L.debug("TCS configuration command post")
+            _ <- if(subsystems.contains(Subsystem.Mount))
+              epicsSys.waitInPosition(tcsTimeout) *> L.info("TCS inposition")
+            else if(Set(Subsystem.PWFS1, Subsystem.PWFS2, Subsystem.AGUnit).exists(subsystems.contains))
+              epicsSys.waitAGInPosition(agTimeout) *> L.debug("AG inposition")
+            else Sync[F].unit
+          } yield s
+        else
+          L.debug("Skipping TCS configuration") *> current.pure[F]
+      }
+
+      for {
+        s0 <- tcsConfigRetriever.retrieveBaseConfiguration
+        _  <- SeqexecFailure.Execution("Found useAo set for non AO step.").raiseError[F, Unit].whenA(s0.useAo)
+        s1 <- guideOff(subsystems, s0, tcs)
+        s2 <- sysConfig(s1)
+        _  <- guideOn(subsystems, s2, tcs)
+      } yield ()
+    }
+    override def notifyObserveStart: F[Unit] =
+      epicsSys.observe.mark[F] *>
+        epicsSys.post.void
+
+    override def notifyObserveEnd: F[Unit] =
+      epicsSys.endObserve.mark[F] *>
+        epicsSys.post.void
+
+    // To nod the telescope is just like applying a TCS configuration, but always with an offset
+    override def nod(subsystems: NonEmptySet[Subsystem], offset: InstrumentOffset, guided: Boolean, tcs: BasicTcsConfig): F[Unit] = {
+
+      val offsetConfig: BasicTcsConfig = (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(offset.some)(tcs)
+      val noddedConfig: BasicTcsConfig =
+        if(guided) offsetConfig
+        else BasicTcsConfig.gds.modify(
+          (BasicGuidersConfig.pwfs1 ^<-> tagIso).modify(
+            GuiderConfig.tracking.modify{ tr => if(tr.isActive) ProbeTrackingConfig.Frozen else tr} >>>
+            GuiderConfig.detector.set(GuiderSensorOff)
+          ) >>>
+            (BasicGuidersConfig.pwfs2 ^<-> tagIso).modify(
+              GuiderConfig.tracking.modify{ tr => if(tr.isActive) ProbeTrackingConfig.Frozen else tr} >>>
+              GuiderConfig.detector.set(GuiderSensorOff)
+            ) >>>
+            (BasicGuidersConfig.oiwfs ^<-> tagIso).modify(
+              GuiderConfig.tracking.modify{ tr => if(tr.isActive) ProbeTrackingConfig.Frozen else tr} >>>
+              GuiderConfig.detector.set(GuiderSensorOff)
+            )
+        )(offsetConfig)
+
+      applyBasicConfig(subsystems, noddedConfig)
+    }
+
+  }
+
+  def apply[F[_]: Async: Logger](epicsSys: TcsEpics[F]): TcsControllerEpicsCommon[F] =
+    new TcsControllerEpicsCommonImpl(epicsSys)
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsControllerSim.scala
@@ -10,7 +10,6 @@ import io.chrisdavenport.log4cats.Logger
 import seqexec.server.tcs.TcsController._
 import seqexec.model.enum.NodAndShuffleStage
 
-
 class TcsControllerSim[F[_]: Applicative: Logger] {
 
   def info(msg: String): F[Unit] = Logger[F].info(msg)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpics.scala
@@ -4,40 +4,37 @@
 package seqexec.server.tcs
 
 import cats.data._
-import cats.effect.IO
+import cats.effect.Async
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.NodAndShuffleStage
 import seqexec.server.altair.Altair
 import seqexec.server.tcs.TcsController._
 import seqexec.server.SeqexecFailure
 import seqexec.server.tcs.TcsNorthController.{TcsNorthAoConfig, TcsNorthConfig}
 
-class TcsNorthControllerEpics private extends TcsNorthController[IO] {
+final case class TcsNorthControllerEpics[F[_]: Async: Logger](epicsSys: TcsEpics[F]) extends TcsNorthController[F] {
+  private val commonController = TcsControllerEpicsCommon(epicsSys)
+  private val aoController = TcsNorthControllerEpicsAo(epicsSys)
 
   override def applyConfig(subsystems: NonEmptySet[Subsystem],
-                           gaos: Option[Altair[IO]],
-                           tcs: TcsNorthConfig): IO[Unit] = {
+                           gaos: Option[Altair[F]],
+                           tcs: TcsNorthConfig): F[Unit] = {
     tcs match {
-      case c: BasicTcsConfig   => TcsControllerEpicsCommon.applyBasicConfig(subsystems, c)
-      case d: TcsNorthAoConfig => gaos.map(TcsNorthControllerEpicsAo.applyAoConfig(subsystems, _, d))
-        .getOrElse(SeqexecFailure.Execution("No Altair object defined for Altair step").raiseError[IO, Unit])
+      case c: BasicTcsConfig   => commonController.applyBasicConfig(subsystems, c)
+      case d: TcsNorthAoConfig => gaos.map(aoController.applyAoConfig(subsystems, _, d))
+        .getOrElse(SeqexecFailure.Execution("No Altair object defined for Altair step").raiseError[F, Unit])
     }
   }
 
-  override def notifyObserveStart: IO[Unit] = TcsControllerEpicsCommon.notifyObserveStart
+  override def notifyObserveStart: F[Unit] = commonController.notifyObserveStart
 
-  override def notifyObserveEnd: IO[Unit] = TcsControllerEpicsCommon.notifyObserveEnd
+  override def notifyObserveEnd: F[Unit] = commonController.notifyObserveEnd
 
   override def nod(subsystems: NonEmptySet[Subsystem], tcsConfig: TcsNorthConfig)
                   (stage: NodAndShuffleStage, offset: InstrumentOffset, guided: Boolean)
-  : IO[Unit] = tcsConfig match {
-    case c: BasicTcsConfig => TcsControllerEpicsCommon.nod(subsystems, offset, guided, c)
-    case _: TcsNorthAoConfig => SeqexecFailure.Execution("N&S not supported when using Altair").raiseError[IO, Unit]
+  : F[Unit] = tcsConfig match {
+    case c: BasicTcsConfig => commonController.nod(subsystems, offset, guided, c)
+    case _: TcsNorthAoConfig => SeqexecFailure.Execution("N&S not supported when using Altair").raiseError[F, Unit]
   }
-}
-
-object TcsNorthControllerEpics {
-
-  def apply(): TcsNorthController[IO] = new TcsNorthControllerEpics
-
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpics.scala
@@ -4,8 +4,9 @@
 package seqexec.server.tcs
 
 import cats.data._
-import cats.effect.IO
+import cats.effect._
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.NodAndShuffleStage
 import seqexec.server.SeqexecFailure
 import seqexec.server.gems.Gems
@@ -13,37 +14,34 @@ import seqexec.server.gems.GemsController.GemsConfig
 import seqexec.server.tcs.TcsController._
 import seqexec.server.tcs.TcsSouthController._
 
-class TcsSouthControllerEpics private (guideConfigDb: GuideConfigDb[IO]) extends TcsSouthController[IO] {
+final case class TcsSouthControllerEpics[F[_]: Async: Logger](epicsSys: TcsEpics[F], guideConfigDb: GuideConfigDb[F]) extends TcsSouthController[F] {
+  private val commonController = TcsControllerEpicsCommon(epicsSys)
+  private val aoController = TcsSouthControllerEpicsAo(epicsSys)
+
   override def applyConfig(subsystems: NonEmptySet[Subsystem],
-                           gaos: Option[Gems[IO]],
-                           tcs: TcsSouthConfig): IO[Unit] = {
+                           gaos: Option[Gems[F]],
+                           tcs: TcsSouthConfig): F[Unit] = {
     tcs match {
-      case c: BasicTcsConfig   => TcsControllerEpicsCommon.applyBasicConfig(subsystems, c)
+      case c: BasicTcsConfig   => commonController.applyBasicConfig(subsystems, c)
       case d: TcsSouthAoConfig => for {
         oc <- guideConfigDb.value
-        gc <- oc.gaosGuide.flatMap(_.toOption).map(_.pure[IO])
-          .getOrElse(SeqexecFailure.Execution("Attemp to run GeMS step before the operator configured GeMS").raiseError[IO, GemsConfig])
-        ob <- gaos.map(_.pure[IO])
-          .getOrElse(SeqexecFailure.Execution("No GeMS object defined for GeMS step").raiseError[IO, Gems[IO]])
-        r  <- TcsSouthControllerEpicsAo.applyAoConfig(subsystems, ob, gc, d)
+        gc <- oc.gaosGuide.flatMap(_.toOption).map(_.pure[F])
+          .getOrElse(SeqexecFailure.Execution("Attemp to run GeMS step before the operator configured GeMS").raiseError[F, GemsConfig])
+        ob <- gaos.map(_.pure[F])
+          .getOrElse(SeqexecFailure.Execution("No GeMS object defined for GeMS step").raiseError[F, Gems[F]])
+        r  <- aoController.applyAoConfig(subsystems, ob, gc, d)
       } yield r
     }
   }
 
-  override def notifyObserveStart: IO[Unit] = TcsControllerEpicsCommon.notifyObserveStart
+  override def notifyObserveStart: F[Unit] = commonController.notifyObserveStart
 
-  override def notifyObserveEnd: IO[Unit] = TcsControllerEpicsCommon.notifyObserveEnd
+  override def notifyObserveEnd: F[Unit] = commonController.notifyObserveEnd
 
   override def nod(subsystems: NonEmptySet[Subsystem], tcsConfig: TcsSouthConfig)
                   (stage: NodAndShuffleStage, offset: InstrumentOffset, guided: Boolean)
-  : IO[Unit] = tcsConfig match {
-    case c: BasicTcsConfig => TcsControllerEpicsCommon.nod(subsystems, offset, guided, c)
-    case _: TcsSouthAoConfig => SeqexecFailure.Execution("N&S not supported when using GeMS").raiseError[IO, Unit]
+  : F[Unit] = tcsConfig match {
+    case c: BasicTcsConfig => commonController.nod(subsystems, offset, guided, c)
+    case _: TcsSouthAoConfig => SeqexecFailure.Execution("N&S not supported when using GeMS").raiseError[F, Unit]
   }
-}
-
-object TcsSouthControllerEpics {
-
-  def apply(guideConfigDb: GuideConfigDb[IO]): TcsSouthController[IO] = new TcsSouthControllerEpics(guideConfigDb)
-
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -3,14 +3,14 @@
 
 package seqexec.server.tcs
 
-import cats.Endo
+import cats._
 import cats.implicits._
 import cats.data.NonEmptySet
-import cats.effect.IO
+import cats.effect.{Async, Sync}
+import io.chrisdavenport.log4cats.Logger
 import monocle.Lens
 import mouse.boolean._
 import monocle.macros.Lenses
-import org.log4s.{Logger, getLogger}
 import seqexec.model.M1GuideConfig.M1GuideOn
 import seqexec.model.{M1GuideConfig, M2GuideConfig, TelescopeGuideConfig}
 import seqexec.model.enum.{ComaOption, M1Source, MountGuideOption, TipTiltSource}
@@ -21,333 +21,22 @@ import seqexec.server.gems.GemsController.GemsConfig
 import seqexec.server.tcs.Gaos.{PauseCondition, PauseConditionSet, ResumeCondition, ResumeConditionSet}
 import seqexec.server.tcs.GemsSource._
 import seqexec.server.tcs.TcsController.{AoGuidersConfig, AoTcsConfig, GuiderConfig, GuiderSensorOff, GuiderSensorOption, ProbeTrackingConfig, Subsystem, wavelengthEq}
-import seqexec.server.tcs.TcsControllerEpicsCommon.{BaseEpicsTcsConfig, GuideControl, agTimeout, applyParam, encodeFollowOption, pwfs1OffsetThreshold, setGuideProbe, setHrPickup, setM1Guide, setM2Guide, setMountGuide, setNodChopProbeTrackingConfig, setOiwfs, setOiwfsProbe, setPwfs1, setPwfs1Probe, setScienceFold, setTelescopeOffset, setWavelength, tcsTimeout}
 import seqexec.server.tcs.TcsEpics.{ProbeFollowCmd, VirtualGemsTelescope}
 import seqexec.server.tcs.TcsSouthController.{GemsGuiders, TcsSouthAoConfig}
-import squants.space.{Arcseconds, Length}
+
+/**
+ * Controller of Gemini's South AO system over epics
+ */
+sealed trait TcsSouthControllerEpicsAo[F[_]] {
+  def applyAoConfig(
+    subsystems: NonEmptySet[Subsystem],
+    gaos: Gems[F],
+    baseAoConfig: GemsConfig,
+    tcs: TcsSouthAoConfig
+  ): F[Unit]
+}
 
 object TcsSouthControllerEpicsAo {
-
-  val Log: Logger = getLogger
-
-  def setNgsGuide(followCmd: ProbeFollowCmd[IO], l: Lens[EpicsTcsAoConfig, GuiderConfig])(
-    g: VirtualGemsTelescope,
-    subsystems: NonEmptySet[Subsystem],
-    current: ProbeTrackingConfig,
-    demand: ProbeTrackingConfig
-  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-    if (subsystems.contains(Subsystem.Gaos)) {
-      val actions = List(
-        (current.getNodChop =!= demand.getNodChop)
-          .option(setNodChopProbeTrackingConfig(TcsEpics.instance.gemsProbeGuideCmd(g))(demand.getNodChop)),
-        (current.follow =!= demand.follow).option(followCmd.setFollowState(encode(demand.follow)))
-      ).flattenOption
-
-      actions.nonEmpty.option { x =>
-        actions.sequence *>
-          IO((l ^|-> GuiderConfig.tracking).set(demand)(x))
-      }
-    }
-    else none
-
-  val setCwfs1Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
-    Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-    setNgsGuide(TcsEpics.instance.cwfs1ProbeFollowCmd, EpicsTcsAoConfig.cwfs1)
-
-  val setCwfs2Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
-    Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-    setNgsGuide(TcsEpics.instance.cwfs2ProbeFollowCmd, EpicsTcsAoConfig.cwfs2)
-
-  val setCwfs3Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
-    Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-    setNgsGuide(TcsEpics.instance.cwfs3ProbeFollowCmd, EpicsTcsAoConfig.cwfs3)
-
-  private def odgw1GuiderControl(g: VirtualGemsTelescope): GuideControl[IO] = GuideControl(Subsystem.Gaos, TcsEpics.instance.odgw1ParkCmd,
-    TcsEpics.instance.gemsProbeGuideCmd(g), TcsEpics.instance.odgw1FollowCmd)
-
-  def setOdgw1Probe(g: VirtualGemsTelescope)(
-    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
-  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-    setGuideProbe(odgw1GuiderControl(g), (EpicsTcsAoConfig.odgw1 ^|-> GuiderConfig.tracking).set)(a, b, c)
-
-  private def odgw2GuiderControl(g: VirtualGemsTelescope): GuideControl[IO] = GuideControl(Subsystem.Gaos, TcsEpics.instance.odgw2ParkCmd,
-    TcsEpics.instance.gemsProbeGuideCmd(g), TcsEpics.instance.odgw2FollowCmd)
-
-  def setOdgw2Probe(g: VirtualGemsTelescope)(
-    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
-  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-    setGuideProbe(odgw2GuiderControl(g), (EpicsTcsAoConfig.odgw2 ^|-> GuiderConfig.tracking).set)(a, b, c)
-
-  private def odgw3GuiderControl(g: VirtualGemsTelescope): GuideControl[IO] = GuideControl(Subsystem.Gaos, TcsEpics.instance.odgw3ParkCmd,
-    TcsEpics.instance.gemsProbeGuideCmd(g), TcsEpics.instance.odgw3FollowCmd)
-
-  def setOdgw3Probe(g: VirtualGemsTelescope)(
-    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
-  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-    setGuideProbe(odgw3GuiderControl(g), (EpicsTcsAoConfig.odgw3 ^|-> GuiderConfig.tracking).set)(a, b, c)
-
-  private def odgw4GuiderControl(g: VirtualGemsTelescope): GuideControl[IO] = GuideControl(Subsystem.Gaos, TcsEpics.instance.odgw4ParkCmd,
-    TcsEpics.instance.gemsProbeGuideCmd(g), TcsEpics.instance.odgw4FollowCmd)
-
-  def setOdgw4Probe(g: VirtualGemsTelescope)(
-    a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
-  ): Option[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-    setGuideProbe(odgw4GuiderControl(g), (EpicsTcsAoConfig.odgw4 ^|-> GuiderConfig.tracking).set)(a, b, c)
-
-  def setGemsProbes(subsystems: NonEmptySet[Subsystem], current: EpicsTcsAoConfig, demand: GemsGuiders)
-  : List[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] = List(
-      current.mapping.get(Cwfs1).flatMap(setCwfs1Guide(_, subsystems, current.cwfs1.tracking, demand.cwfs1.tracking)),
-      current.mapping.get(Cwfs2).flatMap(setCwfs1Guide(_, subsystems, current.cwfs2.tracking, demand.cwfs2.tracking)),
-      current.mapping.get(Cwfs3).flatMap(setCwfs1Guide(_, subsystems, current.cwfs3.tracking, demand.cwfs3.tracking)),
-      current.mapping.get(Odgw1).flatMap(setOdgw1Probe(_)(subsystems, current.odgw1.tracking, demand.odgw1.tracking)),
-      current.mapping.get(Odgw2).flatMap(setOdgw1Probe(_)(subsystems, current.odgw2.tracking, demand.odgw2.tracking)),
-      current.mapping.get(Odgw3).flatMap(setOdgw1Probe(_)(subsystems, current.odgw3.tracking, demand.odgw3.tracking)),
-      current.mapping.get(Odgw4).flatMap(setOdgw1Probe(_)(subsystems, current.odgw4.tracking, demand.odgw4.tracking))
-    ).flattenOption
-
-  // It will be a GeMS guided step only if all GeMS sources used in the base configuration are active
-  private def isAoGuidedStep(baseAoCfg: GemsConfig, demand: TcsSouthAoConfig): Boolean =
-    (!baseAoCfg.isCwfs1Used || demand.gds.aoguide.cwfs1.isActive) &&
-      (!baseAoCfg.isCwfs2Used || demand.gds.aoguide.cwfs2.isActive) &&
-      (!baseAoCfg.isCwfs3Used || demand.gds.aoguide.cwfs3.isActive) &&
-      (!baseAoCfg.isOdgw1Used || demand.gds.aoguide.odgw1.isActive) &&
-      (!baseAoCfg.isOdgw2Used || demand.gds.aoguide.odgw2.isActive) &&
-      (!baseAoCfg.isOdgw3Used || demand.gds.aoguide.odgw3.isActive) &&
-      (!baseAoCfg.isOdgw4Used || demand.gds.aoguide.odgw4.isActive) &&
-      (!baseAoCfg.isOIUsed || demand.gds.oiwfs.isActive) &&
-      (!baseAoCfg.isP1Used || demand.gds.pwfs1.isActive)
-
-  // GeMS is guiding if all sources used in the GeMS base configuration are active
-  private def isCurrentlyGuiding(current: EpicsTcsAoConfig, baseAoCfg: GemsConfig): Boolean =
-    (!baseAoCfg.isCwfs1Used || current.cwfs1.isActive) &&
-      (!baseAoCfg.isCwfs2Used || current.cwfs2.isActive) &&
-      (!baseAoCfg.isCwfs3Used || current.cwfs3.isActive) &&
-      (!baseAoCfg.isOdgw1Used || current.odgw1.isActive) &&
-      (!baseAoCfg.isOdgw2Used || current.odgw2.isActive) &&
-      (!baseAoCfg.isOdgw3Used || current.odgw3.isActive) &&
-      (!baseAoCfg.isOdgw4Used || current.odgw4.isActive) &&
-      (!baseAoCfg.isOIUsed || current.base.oiwfs.isActive) &&
-      (!baseAoCfg.isP1Used || current.base.pwfs1.isActive)
-
-  private def isStartingUnguidedStep(current: EpicsTcsAoConfig, baseAoCfg: GemsConfig, demand: TcsSouthAoConfig)
-  : Boolean = isCurrentlyGuiding(current, baseAoCfg) && !isAoGuidedStep(baseAoCfg, demand)
-
-  private def isComingBackFromUnguidedStep(current: EpicsTcsAoConfig, baseAoCfg: GemsConfig, demand: TcsSouthAoConfig)
-  : Boolean = !isCurrentlyGuiding(current, baseAoCfg) && isAoGuidedStep(baseAoCfg, demand)
-
-  private def mustPauseAoWhileOffseting(current: EpicsTcsAoConfig, demand: TcsSouthAoConfig): Boolean = {
-    val distanceSquared = demand.tc.offsetA.map(_.toFocalPlaneOffset(current.base.iaa))
-      .map { o => (o.x - current.base.offset.x, o.y - current.base.offset.y) }
-      .map(d => d._1 * d._1 + d._2 * d._2)
-
-    val isAnyGemsSourceUsed = (demand.gaos.isCwfs1Used && current.cwfs1.isActive) ||
-      (demand.gaos.isCwfs2Used && !current.cwfs2.isActive) ||
-      (demand.gaos.isCwfs3Used && !current.cwfs3.isActive) ||
-      (demand.gaos.isOdgw1Used && !current.odgw1.isActive) ||
-      (demand.gaos.isOdgw2Used && !current.odgw2.isActive) ||
-      (demand.gaos.isOdgw3Used && !current.odgw3.isActive) ||
-      (demand.gaos.isOdgw4Used && !current.odgw4.isActive)
-
-    distanceSquared.exists(dd =>
-      (isAnyGemsSourceUsed && dd > AoOffsetThreshold * AoOffsetThreshold) ||
-        (demand.gaos.isP1Used && dd > pwfs1OffsetThreshold * pwfs1OffsetThreshold) ||
-        (demand.gaos.isOIUsed && demand.inst.oiOffsetGuideThreshold.exists(t => dd > t * t))
-    )
-
-  }
-
-  private def mustPauseWhileOffsetting(current: EpicsTcsAoConfig, demand: TcsSouthAoConfig): Boolean = {
-    val distanceSquared = demand.tc.offsetA.map(_.toFocalPlaneOffset(current.base.iaa))
-      .map { o => (o.x - current.base.offset.x, o.y - current.base.offset.y) }
-      .map(d => d._1 * d._1 + d._2 * d._2)
-
-    val becauseP1 = distanceSquared.exists(dd => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS1, M1Source.PWFS1)
-      && dd > pwfs1OffsetThreshold * pwfs1OffsetThreshold )
-
-    val beacauseOi = demand.inst.oiOffsetGuideThreshold.exists(t =>
-      Tcs.calcGuiderInUse(demand.gc, TipTiltSource.OIWFS, M1Source.OIWFS) && distanceSquared.exists(_ > t*t ))
-
-    val becauseAo = demand.gc.m1Guide match {
-      case M1GuideOn(M1Source.GAOS) => mustPauseAoWhileOffseting(current, demand)
-      case _                        => false
-    }
-
-    beacauseOi || becauseP1 || becauseAo
-  }
-
-  def calcAoPauseConditions(current: EpicsTcsAoConfig, baseAoConfig: GemsConfig, demand: TcsSouthAoConfig): PauseConditionSet =
-    PauseConditionSet.fromList(List(
-      isStartingUnguidedStep(current, baseAoConfig, demand).option(PauseCondition.GaosGuideOff),
-      demand.tc.offsetA.flatMap(o =>
-        (!isStartingUnguidedStep(current, baseAoConfig, demand) && mustPauseAoWhileOffseting(current, demand))
-          .option(PauseCondition.OffsetMove(o.toFocalPlaneOffset(current.base.iaa))))
-    ).flattenOption)
-
-  def calcAoResumeConditions(current: EpicsTcsAoConfig, baseAoConfig: GemsConfig, demand: TcsSouthAoConfig): ResumeConditionSet =
-    ResumeConditionSet.fromList(List(
-      isComingBackFromUnguidedStep(current, baseAoConfig, demand).option(ResumeCondition.GaosGuideOn),
-      demand.tc.offsetA.flatMap(o =>
-        (!isComingBackFromUnguidedStep(current, baseAoConfig, demand) && mustPauseAoWhileOffseting(current, demand))
-          .option(ResumeCondition.OffsetReached(o.toFocalPlaneOffset(current.base.iaa))))
-    ).flattenOption)
-
-  def pauseResumeGaos(gaos: Gems[IO], current: EpicsTcsAoConfig, baseAoConfig: GemsConfig, demand: TcsSouthAoConfig)
-  : IO[Gaos.PauseResume[IO]] =
-    gaos.pauseResume(
-      calcAoPauseConditions(current, baseAoConfig, demand),
-      calcAoResumeConditions(current, baseAoConfig, demand)
-    )
-
-  def calcGuideOff(current: EpicsTcsAoConfig, demand: TcsSouthAoConfig, gaosEnabled: Boolean): TcsSouthAoConfig = {
-    val mustOff = mustPauseWhileOffsetting(current, demand)
-    // Only turn things off here. Things that must be turned on will be turned on in GuideOn.
-    def calc(c: GuiderSensorOption, d: GuiderSensorOption) = (mustOff || d === GuiderSensorOff).fold(GuiderSensorOff, c)
-
-    (AoTcsConfig.gds[GemsGuiders, GemsConfig].modify(
-      (AoGuidersConfig.pwfs1[GemsGuiders] ^<-> tagIso ^|-> GuiderConfig.detector)
-        .set(calc(current.base.pwfs1.detector, demand.gds.pwfs1.detector)) >>>
-        (AoGuidersConfig.oiwfs[GemsGuiders] ^<-> tagIso ^|-> GuiderConfig.detector)
-          .set(calc(current.base.oiwfs.detector, demand.gds.oiwfs.detector))
-    ) >>>
-      AoTcsConfig.gc[GemsGuiders, GemsConfig].modify(
-      TelescopeGuideConfig.mountGuide.set(
-        (mustOff || demand.gc.mountGuide === MountGuideOption.MountGuideOff).fold(MountGuideOption.MountGuideOff, current.base.telescopeGuideConfig.mountGuide)
-      ) >>>
-        TelescopeGuideConfig.m1Guide.set(
-          (mustOff || demand.gc.m1Guide === M1GuideConfig.M1GuideOff).fold(M1GuideConfig.M1GuideOff, current.base.telescopeGuideConfig.m1Guide)
-        ) >>>
-        TelescopeGuideConfig.m2Guide.set(
-          (mustOff || demand.gc.m2Guide === M2GuideConfig.M2GuideOff).fold(M2GuideConfig.M2GuideOff, current.base.telescopeGuideConfig.m2Guide)
-        )
-    ) >>> normalizeM1Guiding >>> normalizeM2Guiding(gaosEnabled) >>> normalizeMountGuiding)(demand)
-
-  }
-
-  def guideParams(subsystems: NonEmptySet[Subsystem], current: EpicsTcsAoConfig, demand: TcsSouthAoConfig)
-  : List[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] = List(
-    setMountGuide(EpicsTcsAoConfig.base)(subsystems, current.base.telescopeGuideConfig.mountGuide, demand.gc.mountGuide),
-    setM1Guide(EpicsTcsAoConfig.base)(subsystems, current.base.telescopeGuideConfig.m1Guide, demand.gc.m1Guide),
-    setM2Guide(EpicsTcsAoConfig.base)(subsystems, current.base.telescopeGuideConfig.m2Guide, demand.gc.m2Guide),
-    setPwfs1(EpicsTcsAoConfig.base)(subsystems, current.base.pwfs1.detector, demand.gds.pwfs1.detector),
-    setOiwfs(EpicsTcsAoConfig.base)(subsystems, current.base.oiwfs.detector, demand.gds.oiwfs.detector)
-  ).flattenOption
-
-
-  def guideOff(subsystems: NonEmptySet[Subsystem], current: EpicsTcsAoConfig, demand: TcsSouthAoConfig, pauseGaos: Boolean)
-  : IO[EpicsTcsAoConfig]= {
-    val params = guideParams(subsystems, current, calcGuideOff(current, demand, pauseGaos) )
-
-    if(params.nonEmpty)
-      for {
-        s <- params.foldLeft(IO(current)){ case (c, p) => c.flatMap(p)}
-        _ <- TcsEpics.instance.post
-        _ <- IO(Log.info("Turning guide off"))
-      } yield s
-    else
-      IO(Log.info("Skipping guide off")) *> IO(current)
-
-  }
-
-  def guideOn(subsystems: NonEmptySet[Subsystem], current: EpicsTcsAoConfig, demand: TcsSouthAoConfig,
-              gaosEnabled: Boolean): IO[EpicsTcsAoConfig] = {
-    // If the demand turned off any WFS, normalize will turn off the corresponding processing
-    val normalizedGuiding = (normalizeM1Guiding >>> normalizeM2Guiding(gaosEnabled) >>>
-      normalizeMountGuiding)(demand)
-
-    val params = guideParams(subsystems, current, normalizedGuiding)
-
-    if(params.nonEmpty)
-      for {
-        s <- params.foldLeft(IO(current)){ case (c, p) => c.flatMap(p)}
-        _ <- TcsEpics.instance.post
-        _ <- IO(Log.info("Turning guide on"))
-      } yield s
-    else
-      IO(Log.info("Skipping guide on")) *> IO(current)
-  }
-
-  def applyAoConfig(subsystems: NonEmptySet[Subsystem],
-                    gaos: Gems[IO],
-                    baseAoConfig: GemsConfig,
-                    tcs: TcsSouthAoConfig): IO[Unit] = {
-    def configParams(current: EpicsTcsAoConfig): List[EpicsTcsAoConfig => IO[EpicsTcsAoConfig]] =
-      List(
-        setPwfs1Probe(EpicsTcsAoConfig.base)(subsystems, current.base.pwfs1.tracking, tcs.gds.pwfs1.tracking),
-        setOiwfsProbe(EpicsTcsAoConfig.base)(subsystems, current.base.oiwfs.tracking, tcs.gds.oiwfs.tracking),
-        tcs.tc.offsetA.flatMap(o => applyParam(subsystems.contains(Subsystem.Mount), current.base.offset,
-          o.toFocalPlaneOffset(current.base.iaa), setTelescopeOffset, EpicsTcsAoConfig.base ^|-> BaseEpicsTcsConfig.offset
-        )),
-        tcs.tc.wavelA.flatMap(applyParam(subsystems.contains(Subsystem.Mount), current.base.wavelA, _, setWavelength,
-          EpicsTcsAoConfig.base ^|-> BaseEpicsTcsConfig.wavelA
-        )),
-        setScienceFold(EpicsTcsAoConfig.base)(subsystems, current, tcs.agc.sfPos),
-        setHrPickup(EpicsTcsAoConfig.base)(subsystems, current, tcs.agc)
-      ).flattenOption ++ setGemsProbes(subsystems, current, tcs.gds.aoguide)
-
-    def sysConfig(current: EpicsTcsAoConfig): IO[EpicsTcsAoConfig] = {
-      val params = configParams(current)
-
-      if(params.nonEmpty)
-        for {
-          s <- params.foldLeft(IO(current)){ case (c, p) => c.flatMap(p) }
-          _ <- TcsEpics.instance.post
-          _ <- IO(Log.debug("TCS configuration command post"))
-          _ <- if(subsystems.contains(Subsystem.Mount))
-            TcsEpics.instance.waitInPosition(tcsTimeout) *> IO.apply(Log.info("TCS inposition"))
-          else if(Set(Subsystem.PWFS1, Subsystem.PWFS2, Subsystem.AGUnit).exists(subsystems.contains))
-            TcsEpics.instance.waitAGInPosition(agTimeout) *> IO.apply(Log.debug("AG inposition"))
-          else IO.unit
-        } yield s
-      else
-        IO(Log.debug("Skipping TCS configuration")) *> IO(current)
-    }
-
-    for {
-      s0 <- TcsConfigRetriever.retrieveConfigurationSouth(gaos.stateGetter)
-      _  <- if(s0.base.useAo) IO.unit
-            else SeqexecFailure.Execution("Found useAo not set for GeMS step.").raiseError[IO, Unit]
-      pr <- pauseResumeGaos(gaos, s0, baseAoConfig, tcs)
-      _  <- pr.pause.getOrElse(IO.unit)
-      s1 <- guideOff(subsystems, s0, tcs, pr.pause.isEmpty)
-      s2 <- sysConfig(s1)
-      _  <- guideOn(subsystems, s2, tcs, pr.resume.isDefined)
-      _  <- pr.resume.getOrElse(IO.unit)
-    } yield ()
-  }
-
-  // Disable M1 guiding if source is off
-  def normalizeM1Guiding: Endo[TcsSouthAoConfig] = cfg =>
-    (AoTcsConfig.gc ^|-> TelescopeGuideConfig.m1Guide).modify{
-      case g @ M1GuideConfig.M1GuideOn(src) => src match {
-        case M1Source.PWFS1 => if(cfg.gds.pwfs1.isActive) g else M1GuideConfig.M1GuideOff
-        case M1Source.OIWFS => if(cfg.gds.oiwfs.isActive) g else M1GuideConfig.M1GuideOff
-        case _              => g
-      }
-      case x                => x
-    }(cfg)
-
-  // Disable M2 sources if they are off, disable M2 guiding if all are off
-  def normalizeM2Guiding(gaosEnabled: Boolean): Endo[TcsSouthAoConfig] = cfg =>
-    (AoTcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).modify{
-      case M2GuideConfig.M2GuideOn(coma, srcs) =>
-        val ss = srcs.filter{
-          case TipTiltSource.PWFS1 => cfg.gds.pwfs1.isActive
-          case TipTiltSource.OIWFS => cfg.gds.oiwfs.isActive
-          case TipTiltSource.GAOS  => gaosEnabled
-          case _                   => true
-        }
-        if(ss.isEmpty) M2GuideConfig.M2GuideOff
-        else M2GuideConfig.M2GuideOn(if(cfg.gc.m1Guide =!= M1GuideConfig.M1GuideOff) coma else ComaOption.ComaOff, ss)
-      case x                     => x
-    }(cfg)
-
-  // Disable Mount guiding if M2 guiding is disabled
-  val normalizeMountGuiding: Endo[TcsSouthAoConfig] = cfg =>
-    (AoTcsConfig.gc ^|-> TelescopeGuideConfig.mountGuide).modify{ m => (m, cfg.gc.m2Guide) match {
-      case (MountGuideOption.MountGuideOn, M2GuideConfig.M2GuideOn(_, _)) => MountGuideOption.MountGuideOn
-      case _                                                              => MountGuideOption.MountGuideOff
-    } }(cfg)
-
   @Lenses
   final case class EpicsTcsAoConfig(
     base: BaseEpicsTcsConfig,
@@ -361,5 +50,349 @@ object TcsSouthControllerEpicsAo {
     odgw4: GuiderConfig
   )
 
-  val AoOffsetThreshold: Length = Arcseconds(0.01)/FOCAL_PLANE_SCALE
+  private final class TcsSouthControllerEpicsAoImpl[F[_]: Async](epicsSys: TcsEpics[F])(
+    implicit L: Logger[F]) extends TcsSouthControllerEpicsAo[F] with TcsControllerEncoders {
+    private val tcsConfigRetriever = TcsConfigRetriever[F](epicsSys)
+    private val commonController = TcsControllerEpicsCommon[F](epicsSys)
+
+    def setNgsGuide(followCmd: ProbeFollowCmd[F], l: Lens[EpicsTcsAoConfig, GuiderConfig])(
+      g: VirtualGemsTelescope,
+      subsystems: NonEmptySet[Subsystem],
+      current: ProbeTrackingConfig,
+      demand: ProbeTrackingConfig
+    ): Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+      if (subsystems.contains(Subsystem.Gaos)) {
+        val actions = List(
+          (current.getNodChop =!= demand.getNodChop)
+            .option(
+              commonController
+                .setNodChopProbeTrackingConfig(epicsSys.gemsProbeGuideCmd(g))(demand.getNodChop)),
+          (current.follow =!= demand.follow).option(followCmd.setFollowState(encode(demand.follow)))
+        ).flattenOption
+
+        actions.nonEmpty.option { x =>
+          actions.sequence *>
+            Sync[F].delay((l ^|-> GuiderConfig.tracking).set(demand)(x))
+        }
+      }
+      else none
+
+    val setCwfs1Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
+      Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+      setNgsGuide(epicsSys.cwfs1ProbeFollowCmd, EpicsTcsAoConfig.cwfs1)
+
+    val setCwfs2Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
+      Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+      setNgsGuide(epicsSys.cwfs2ProbeFollowCmd, EpicsTcsAoConfig.cwfs2)
+
+    val setCwfs3Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
+      Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+      setNgsGuide(epicsSys.cwfs3ProbeFollowCmd, EpicsTcsAoConfig.cwfs3)
+
+    private def odgw1GuiderControl(g: VirtualGemsTelescope): GuideControl[F] =
+      GuideControl(Subsystem.Gaos, epicsSys.odgw1ParkCmd,
+        epicsSys.gemsProbeGuideCmd(g), epicsSys.odgw1FollowCmd)
+
+    def setOdgw1Probe(g: VirtualGemsTelescope)(
+      a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+    ): Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+      commonController.setGuideProbe(odgw1GuiderControl(g), (EpicsTcsAoConfig.odgw1 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+    private def odgw2GuiderControl(g: VirtualGemsTelescope): GuideControl[F] =
+      GuideControl(Subsystem.Gaos, epicsSys.odgw2ParkCmd,
+        epicsSys.gemsProbeGuideCmd(g), epicsSys.odgw2FollowCmd)
+
+    def setOdgw2Probe(g: VirtualGemsTelescope)(
+      a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+    ): Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+      commonController.setGuideProbe(odgw2GuiderControl(g), (EpicsTcsAoConfig.odgw2 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+    private def odgw3GuiderControl(g: VirtualGemsTelescope): GuideControl[F] =
+      GuideControl(Subsystem.Gaos, epicsSys.odgw3ParkCmd,
+        epicsSys.gemsProbeGuideCmd(g), epicsSys.odgw3FollowCmd)
+
+    def setOdgw3Probe(g: VirtualGemsTelescope)(
+      a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+    ): Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+      commonController.setGuideProbe(odgw3GuiderControl(g), (EpicsTcsAoConfig.odgw3 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+    private def odgw4GuiderControl(g: VirtualGemsTelescope): GuideControl[F] =
+      GuideControl(Subsystem.Gaos, epicsSys.odgw4ParkCmd,
+        epicsSys.gemsProbeGuideCmd(g), epicsSys.odgw4FollowCmd)
+
+    def setOdgw4Probe(g: VirtualGemsTelescope)(
+      a: NonEmptySet[Subsystem], b: ProbeTrackingConfig, c: ProbeTrackingConfig
+    ): Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+      commonController.setGuideProbe(odgw4GuiderControl(g), (EpicsTcsAoConfig.odgw4 ^|-> GuiderConfig.tracking).set)(a, b, c)
+
+    def setGemsProbes(subsystems: NonEmptySet[Subsystem], current: EpicsTcsAoConfig, demand: GemsGuiders)
+    : List[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] = List(
+        current.mapping.get(Cwfs1).flatMap(setCwfs1Guide(_, subsystems, current.cwfs1.tracking, demand.cwfs1.tracking)),
+        current.mapping.get(Cwfs2).flatMap(setCwfs1Guide(_, subsystems, current.cwfs2.tracking, demand.cwfs2.tracking)),
+        current.mapping.get(Cwfs3).flatMap(setCwfs1Guide(_, subsystems, current.cwfs3.tracking, demand.cwfs3.tracking)),
+        current.mapping.get(Odgw1).flatMap(setOdgw1Probe(_)(subsystems, current.odgw1.tracking, demand.odgw1.tracking)),
+        current.mapping.get(Odgw2).flatMap(setOdgw1Probe(_)(subsystems, current.odgw2.tracking, demand.odgw2.tracking)),
+        current.mapping.get(Odgw3).flatMap(setOdgw1Probe(_)(subsystems, current.odgw3.tracking, demand.odgw3.tracking)),
+        current.mapping.get(Odgw4).flatMap(setOdgw1Probe(_)(subsystems, current.odgw4.tracking, demand.odgw4.tracking))
+      ).flattenOption
+
+    // It will be a GeMS guided step only if all GeMS sources used in the base configuration are active
+    private def isAoGuidedStep(baseAoCfg: GemsConfig, demand: TcsSouthAoConfig): Boolean =
+      (!baseAoCfg.isCwfs1Used || demand.gds.aoguide.cwfs1.isActive) &&
+        (!baseAoCfg.isCwfs2Used || demand.gds.aoguide.cwfs2.isActive) &&
+        (!baseAoCfg.isCwfs3Used || demand.gds.aoguide.cwfs3.isActive) &&
+        (!baseAoCfg.isOdgw1Used || demand.gds.aoguide.odgw1.isActive) &&
+        (!baseAoCfg.isOdgw2Used || demand.gds.aoguide.odgw2.isActive) &&
+        (!baseAoCfg.isOdgw3Used || demand.gds.aoguide.odgw3.isActive) &&
+        (!baseAoCfg.isOdgw4Used || demand.gds.aoguide.odgw4.isActive) &&
+        (!baseAoCfg.isOIUsed || demand.gds.oiwfs.isActive) &&
+        (!baseAoCfg.isP1Used || demand.gds.pwfs1.isActive)
+
+    // GeMS is guiding if all sources used in the GeMS base configuration are active
+    private def isCurrentlyGuiding(current: EpicsTcsAoConfig, baseAoCfg: GemsConfig): Boolean =
+      (!baseAoCfg.isCwfs1Used || current.cwfs1.isActive) &&
+        (!baseAoCfg.isCwfs2Used || current.cwfs2.isActive) &&
+        (!baseAoCfg.isCwfs3Used || current.cwfs3.isActive) &&
+        (!baseAoCfg.isOdgw1Used || current.odgw1.isActive) &&
+        (!baseAoCfg.isOdgw2Used || current.odgw2.isActive) &&
+        (!baseAoCfg.isOdgw3Used || current.odgw3.isActive) &&
+        (!baseAoCfg.isOdgw4Used || current.odgw4.isActive) &&
+        (!baseAoCfg.isOIUsed || current.base.oiwfs.isActive) &&
+        (!baseAoCfg.isP1Used || current.base.pwfs1.isActive)
+
+    private def isStartingUnguidedStep(current: EpicsTcsAoConfig, baseAoCfg: GemsConfig, demand: TcsSouthAoConfig): Boolean =
+      isCurrentlyGuiding(current, baseAoCfg) && !isAoGuidedStep(baseAoCfg, demand)
+
+    private def isComingBackFromUnguidedStep(current: EpicsTcsAoConfig, baseAoCfg: GemsConfig, demand: TcsSouthAoConfig): Boolean =
+      !isCurrentlyGuiding(current, baseAoCfg) && isAoGuidedStep(baseAoCfg, demand)
+
+    private def mustPauseAoWhileOffseting(current: EpicsTcsAoConfig, demand: TcsSouthAoConfig): Boolean = {
+      val distanceSquared = demand.tc.offsetA.map(_.toFocalPlaneOffset(current.base.iaa))
+        .map { o => (o.x - current.base.offset.x, o.y - current.base.offset.y) }
+        .map(d => d._1 * d._1 + d._2 * d._2)
+
+      val isAnyGemsSourceUsed = (demand.gaos.isCwfs1Used && current.cwfs1.isActive) ||
+        (demand.gaos.isCwfs2Used && !current.cwfs2.isActive) ||
+        (demand.gaos.isCwfs3Used && !current.cwfs3.isActive) ||
+        (demand.gaos.isOdgw1Used && !current.odgw1.isActive) ||
+        (demand.gaos.isOdgw2Used && !current.odgw2.isActive) ||
+        (demand.gaos.isOdgw3Used && !current.odgw3.isActive) ||
+        (demand.gaos.isOdgw4Used && !current.odgw4.isActive)
+
+      distanceSquared.exists(dd =>
+        (isAnyGemsSourceUsed && dd > AoOffsetThreshold * AoOffsetThreshold) ||
+          (demand.gaos.isP1Used && dd > pwfs1OffsetThreshold * pwfs1OffsetThreshold) ||
+          (demand.gaos.isOIUsed && demand.inst.oiOffsetGuideThreshold.exists(t => dd > t * t))
+      )
+
+    }
+
+    private def mustPauseWhileOffsetting(current: EpicsTcsAoConfig, demand: TcsSouthAoConfig): Boolean = {
+      val distanceSquared = demand.tc.offsetA.map(_.toFocalPlaneOffset(current.base.iaa))
+        .map { o => (o.x - current.base.offset.x, o.y - current.base.offset.y) }
+        .map(d => d._1 * d._1 + d._2 * d._2)
+
+      val becauseP1 = distanceSquared.exists(dd => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS1, M1Source.PWFS1)
+        && dd > pwfs1OffsetThreshold * pwfs1OffsetThreshold )
+
+      val beacauseOi = demand.inst.oiOffsetGuideThreshold.exists(t =>
+        Tcs.calcGuiderInUse(demand.gc, TipTiltSource.OIWFS, M1Source.OIWFS) && distanceSquared.exists(_ > t*t ))
+
+      val becauseAo = demand.gc.m1Guide match {
+        case M1GuideOn(M1Source.GAOS) => mustPauseAoWhileOffseting(current, demand)
+        case _                        => false
+      }
+
+      beacauseOi || becauseP1 || becauseAo
+    }
+
+    def calcAoPauseConditions(current: EpicsTcsAoConfig, baseAoConfig: GemsConfig, demand: TcsSouthAoConfig): PauseConditionSet =
+      PauseConditionSet.fromList(List(
+        isStartingUnguidedStep(current, baseAoConfig, demand).option(PauseCondition.GaosGuideOff),
+        demand.tc.offsetA.flatMap(o =>
+          (!isStartingUnguidedStep(current, baseAoConfig, demand) && mustPauseAoWhileOffseting(current, demand))
+            .option(PauseCondition.OffsetMove(o.toFocalPlaneOffset(current.base.iaa))))
+      ).flattenOption)
+
+    def calcAoResumeConditions(current: EpicsTcsAoConfig, baseAoConfig: GemsConfig, demand: TcsSouthAoConfig): ResumeConditionSet =
+      ResumeConditionSet.fromList(List(
+        isComingBackFromUnguidedStep(current, baseAoConfig, demand).option(ResumeCondition.GaosGuideOn),
+        demand.tc.offsetA.flatMap(o =>
+          (!isComingBackFromUnguidedStep(current, baseAoConfig, demand) && mustPauseAoWhileOffseting(current, demand))
+            .option(ResumeCondition.OffsetReached(o.toFocalPlaneOffset(current.base.iaa))))
+      ).flattenOption)
+
+    def pauseResumeGaos(gaos: Gems[F], current: EpicsTcsAoConfig, baseAoConfig: GemsConfig, demand: TcsSouthAoConfig)
+    : F[Gaos.PauseResume[F]] =
+      gaos.pauseResume(
+        calcAoPauseConditions(current, baseAoConfig, demand),
+        calcAoResumeConditions(current, baseAoConfig, demand)
+      )
+
+    def calcGuideOff(current: EpicsTcsAoConfig, demand: TcsSouthAoConfig, gaosEnabled: Boolean): TcsSouthAoConfig = {
+      val mustOff = mustPauseWhileOffsetting(current, demand)
+      // Only turn things off here. Things that must be turned on will be turned on in GuideOn.
+      def calc(c: GuiderSensorOption, d: GuiderSensorOption) = (mustOff || d === GuiderSensorOff).fold(GuiderSensorOff, c)
+
+      (AoTcsConfig.gds[GemsGuiders, GemsConfig].modify(
+        (AoGuidersConfig.pwfs1[GemsGuiders] ^<-> tagIso ^|-> GuiderConfig.detector)
+          .set(calc(current.base.pwfs1.detector, demand.gds.pwfs1.detector)) >>>
+          (AoGuidersConfig.oiwfs[GemsGuiders] ^<-> tagIso ^|-> GuiderConfig.detector)
+            .set(calc(current.base.oiwfs.detector, demand.gds.oiwfs.detector))
+      ) >>>
+        AoTcsConfig.gc[GemsGuiders, GemsConfig].modify(
+        TelescopeGuideConfig.mountGuide.set(
+          (mustOff || demand.gc.mountGuide === MountGuideOption.MountGuideOff).fold(MountGuideOption.MountGuideOff, current.base.telescopeGuideConfig.mountGuide)
+        ) >>>
+          TelescopeGuideConfig.m1Guide.set(
+            (mustOff || demand.gc.m1Guide === M1GuideConfig.M1GuideOff).fold(M1GuideConfig.M1GuideOff, current.base.telescopeGuideConfig.m1Guide)
+          ) >>>
+          TelescopeGuideConfig.m2Guide.set(
+            (mustOff || demand.gc.m2Guide === M2GuideConfig.M2GuideOff).fold(M2GuideConfig.M2GuideOff, current.base.telescopeGuideConfig.m2Guide)
+          )
+      ) >>> normalizeM1Guiding >>> normalizeM2Guiding(gaosEnabled) >>> normalizeMountGuiding)(demand)
+
+    }
+
+    def guideParams(
+      subsystems: NonEmptySet[Subsystem],
+      current: EpicsTcsAoConfig,
+      demand: TcsSouthAoConfig
+    ): List[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] = List(
+      commonController.setMountGuide(EpicsTcsAoConfig.base)(subsystems, current.base.telescopeGuideConfig.mountGuide, demand.gc.mountGuide),
+      commonController.setM1Guide(EpicsTcsAoConfig.base)(subsystems, current.base.telescopeGuideConfig.m1Guide, demand.gc.m1Guide),
+      commonController.setM2Guide(EpicsTcsAoConfig.base)(subsystems, current.base.telescopeGuideConfig.m2Guide, demand.gc.m2Guide),
+      commonController.setPwfs1(EpicsTcsAoConfig.base)(subsystems, current.base.pwfs1.detector, demand.gds.pwfs1.detector),
+      commonController.setOiwfs(EpicsTcsAoConfig.base)(subsystems, current.base.oiwfs.detector, demand.gds.oiwfs.detector)
+    ).flattenOption
+
+
+    def guideOff(
+      subsystems: NonEmptySet[Subsystem],
+      current: EpicsTcsAoConfig,
+      demand: TcsSouthAoConfig,
+      pauseGaos: Boolean
+    ): F[EpicsTcsAoConfig]= {
+      val params = guideParams(subsystems, current, calcGuideOff(current, demand, pauseGaos) )
+
+      if(params.nonEmpty)
+        for {
+          s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p)}
+          _ <- epicsSys.post
+          _ <- L.info("Turning guide off")
+        } yield s
+      else
+        L.info("Skipping guide off") *> current.pure[F]
+
+    }
+
+    def guideOn(
+      subsystems: NonEmptySet[Subsystem],
+      current: EpicsTcsAoConfig,
+      demand: TcsSouthAoConfig,
+      gaosEnabled: Boolean
+    ): F[EpicsTcsAoConfig] = {
+      // If the demand turned off any WFS, normalize will turn off the corresponding processing
+      val normalizedGuiding = (normalizeM1Guiding >>> normalizeM2Guiding(gaosEnabled) >>>
+        normalizeMountGuiding)(demand)
+
+      val params = guideParams(subsystems, current, normalizedGuiding)
+
+      if(params.nonEmpty)
+        for {
+          s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p)}
+          _ <- epicsSys.post
+          _ <- L.info("Turning guide on")
+        } yield s
+      else
+        L.info("Skipping guide on") *> current.pure[F]
+    }
+
+    def applyAoConfig(
+      subsystems: NonEmptySet[Subsystem],
+      gaos: Gems[F],
+      baseAoConfig: GemsConfig,
+      tcs: TcsSouthAoConfig
+    ): F[Unit] = {
+      def configParams(current: EpicsTcsAoConfig): List[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
+        List(
+          commonController.setPwfs1Probe(EpicsTcsAoConfig.base)(subsystems, current.base.pwfs1.tracking, tcs.gds.pwfs1.tracking),
+          commonController.setOiwfsProbe(EpicsTcsAoConfig.base)(subsystems, current.base.oiwfs.tracking, tcs.gds.oiwfs.tracking),
+          tcs.tc.offsetA.flatMap(o => TcsControllerEpicsCommon.applyParam(subsystems.contains(Subsystem.Mount), current.base.offset,
+            o.toFocalPlaneOffset(current.base.iaa), commonController.setTelescopeOffset, EpicsTcsAoConfig.base ^|-> BaseEpicsTcsConfig.offset
+          )),
+          tcs.tc.wavelA.flatMap(TcsControllerEpicsCommon.applyParam(subsystems.contains(Subsystem.Mount), current.base.wavelA, _, commonController.setWavelength,
+            EpicsTcsAoConfig.base ^|-> BaseEpicsTcsConfig.wavelA
+          )),
+          commonController.setScienceFold(EpicsTcsAoConfig.base)(subsystems, current, tcs.agc.sfPos),
+          commonController.setHrPickup(EpicsTcsAoConfig.base)(subsystems, current, tcs.agc)
+        ).flattenOption ++ setGemsProbes(subsystems, current, tcs.gds.aoguide)
+
+      def sysConfig(current: EpicsTcsAoConfig): F[EpicsTcsAoConfig] = {
+        val params = configParams(current)
+
+        if(params.nonEmpty)
+          for {
+            s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p) }
+            _ <- epicsSys.post
+            _ <- L.debug("TCS configuration command post")
+            _ <- if(subsystems.contains(Subsystem.Mount))
+              epicsSys.waitInPosition(tcsTimeout) *> L.info("TCS inposition")
+            else if(Set(Subsystem.PWFS1, Subsystem.PWFS2, Subsystem.AGUnit).exists(subsystems.contains))
+              epicsSys.waitAGInPosition(agTimeout) *> L.debug("AG inposition")
+            else Applicative[F].unit
+          } yield s
+        else
+          L.debug("Skipping TCS configuration") *> current.pure[F]
+      }
+
+      for {
+        s0 <- tcsConfigRetriever.retrieveConfigurationSouth(gaos.stateGetter)
+        _  <- SeqexecFailure.Execution("Found useAo not set for GeMS step.").raiseError[F, Unit].whenA(s0.base.useAo)
+        pr <- pauseResumeGaos(gaos, s0, baseAoConfig, tcs)
+        _  <- pr.pause.getOrElse(Applicative[F].unit)
+        s1 <- guideOff(subsystems, s0, tcs, pr.pause.isEmpty)
+        s2 <- sysConfig(s1)
+        _  <- guideOn(subsystems, s2, tcs, pr.resume.isDefined)
+        _  <- pr.resume.getOrElse(Applicative[F].unit)
+      } yield ()
+    }
+
+    // Disable M1 guiding if source is off
+    def normalizeM1Guiding: Endo[TcsSouthAoConfig] = cfg =>
+      (AoTcsConfig.gc ^|-> TelescopeGuideConfig.m1Guide).modify{
+        case g @ M1GuideConfig.M1GuideOn(src) => src match {
+          case M1Source.PWFS1 => if(cfg.gds.pwfs1.isActive) g else M1GuideConfig.M1GuideOff
+          case M1Source.OIWFS => if(cfg.gds.oiwfs.isActive) g else M1GuideConfig.M1GuideOff
+          case _              => g
+        }
+        case x                => x
+      }(cfg)
+
+    // Disable M2 sources if they are off, disable M2 guiding if all are off
+    def normalizeM2Guiding(gaosEnabled: Boolean): Endo[TcsSouthAoConfig] = cfg =>
+      (AoTcsConfig.gc ^|-> TelescopeGuideConfig.m2Guide).modify{
+        case M2GuideConfig.M2GuideOn(coma, srcs) =>
+          val ss = srcs.filter{
+            case TipTiltSource.PWFS1 => cfg.gds.pwfs1.isActive
+            case TipTiltSource.OIWFS => cfg.gds.oiwfs.isActive
+            case TipTiltSource.GAOS  => gaosEnabled
+            case _                   => true
+          }
+          if(ss.isEmpty) M2GuideConfig.M2GuideOff
+          else M2GuideConfig.M2GuideOn(if(cfg.gc.m1Guide =!= M1GuideConfig.M1GuideOff) coma else ComaOption.ComaOff, ss)
+        case x                     => x
+      }(cfg)
+
+    // Disable Mount guiding if M2 guiding is disabled
+    val normalizeMountGuiding: Endo[TcsSouthAoConfig] = cfg =>
+      (AoTcsConfig.gc ^|-> TelescopeGuideConfig.mountGuide).modify{ m => (m, cfg.gc.m2Guide) match {
+        case (MountGuideOption.MountGuideOn, M2GuideConfig.M2GuideOn(_, _)) => MountGuideOption.MountGuideOn
+        case _                                                              => MountGuideOption.MountGuideOff
+      } }(cfg)
+  }
+
+  def apply[F[_]: Async: Logger](epicsSys: TcsEpics[F]): TcsSouthControllerEpicsAo[F] =
+    new TcsSouthControllerEpicsAoImpl(epicsSys)
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/package.scala
@@ -11,6 +11,8 @@ import shapeless.tag
 import shapeless.tag.@@
 import squants.{Angle, Length, Ratio}
 import squants.space.{Arcseconds, Millimeters}
+import squants.Time
+import squants.time._
 
 package tcs {
 
@@ -43,9 +45,21 @@ package tcs {
 }
 
 package object tcs {
+  val BottomPort: Int = 1
+  val InvalidPort: Int = 0
+
+  val tcsTimeout: Time = Seconds(60)
+  val agTimeout: Time = Seconds(60)
+
+  val NonStopExposures = -1
 
   // Focal plane scale, expressed with squants quantities.
   val FOCAL_PLANE_SCALE = new FocalPlaneScale(Arcseconds(1.61144), Millimeters(1))
+
+  val pwfs1OffsetThreshold: Length = Arcseconds(0.01)/FOCAL_PLANE_SCALE
+  val pwfs2OffsetThreshold: Length = Arcseconds(0.01)/FOCAL_PLANE_SCALE
+
+  val AoOffsetThreshold: Length = Arcseconds(0.01)/FOCAL_PLANE_SCALE
 
   implicit val ooEq: Eq[BinaryOnOff] =
     Eq[Int].contramap(_.ordinal())

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/ScienceFoldPositionCodexSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/ScienceFoldPositionCodexSpec.scala
@@ -8,7 +8,6 @@ import ScienceFoldPositionCodex._
 import seqexec.server.EpicsCodex._
 import gem.enum.LightSinkName.{Gmos, Gsaoi, Nifs, Niri_f32, F2}
 import seqexec.server.tcs.TcsController.LightSource.{AO, GCAL, Sky}
-import seqexec.server.tcs.TcsControllerEpicsCommon.ScienceFold
 import org.scalatest.flatspec.AnyFlatSpec
 
 class ScienceFoldPositionCodexSpec extends AnyFlatSpec {

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/TcsControllerEpicsCommonSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/TcsControllerEpicsCommonSpec.scala
@@ -13,7 +13,6 @@ import seqexec.model.enum.{ComaOption, Instrument, M1Source, MountGuideOption, T
 import seqexec.server.InstrumentGuide
 import seqexec.server.tcs.TcsController.LightSource.Sky
 import seqexec.server.tcs.TcsController.{AGConfig, BasicGuidersConfig, BasicTcsConfig, FocalPlaneOffset, GuiderConfig, GuiderSensorOff, GuiderSensorOn, HrwfsPickupPosition, InstrumentOffset, LightPath, NodChopTrackingConfig, OIConfig, OffsetP, OffsetQ, OffsetX, OffsetY, P1Config, P2Config, ProbeTrackingConfig, TelescopeConfig}
-import seqexec.server.tcs.TcsControllerEpicsCommon.{AoFold, BaseEpicsTcsConfig, InstrumentPorts}
 import shapeless.tag
 import squants.space.{Arcseconds, Length, Microns, Millimeters}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -72,7 +71,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
       baseCurrentStatus,
       (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
         InstrumentOffset(
-          tag[OffsetP](TcsControllerEpicsCommon.pwfs1OffsetThreshold * 2 * FOCAL_PLANE_SCALE),
+          tag[OffsetP](pwfs1OffsetThreshold * 2 * FOCAL_PLANE_SCALE),
           tag[OffsetQ](Arcseconds(0.0))
         ).some
       )(baseConfig)
@@ -86,7 +85,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
       (
         (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
           InstrumentOffset(
-            tag[OffsetP](TcsControllerEpicsCommon.pwfs1OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetP](pwfs1OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
             tag[OffsetQ](Arcseconds(0.0))
           ).some
         ) >>>
@@ -106,7 +105,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
       (
         (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
           InstrumentOffset(
-            tag[OffsetP](TcsControllerEpicsCommon.pwfs1OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetP](pwfs1OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
             tag[OffsetQ](Arcseconds(0.0))
           ).some
         ) >>>
@@ -127,7 +126,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
       (
         (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
           InstrumentOffset(
-            tag[OffsetP](TcsControllerEpicsCommon.pwfs1OffsetThreshold / 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetP](pwfs1OffsetThreshold / 2.0 * FOCAL_PLANE_SCALE),
             tag[OffsetQ](Arcseconds(0.0))
           ).some
         ) >>>
@@ -150,7 +149,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
       (
         (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
           InstrumentOffset(
-            tag[OffsetP](TcsControllerEpicsCommon.pwfs2OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetP](pwfs2OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
             tag[OffsetQ](Arcseconds(0.0))
           ).some
         ) >>>
@@ -170,7 +169,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
       (
         (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
           InstrumentOffset(
-            tag[OffsetP](TcsControllerEpicsCommon.pwfs2OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetP](pwfs2OffsetThreshold * 2.0 * FOCAL_PLANE_SCALE),
             tag[OffsetQ](Arcseconds(0.0))
           ).some
         ) >>>
@@ -191,7 +190,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
       (
         (BasicTcsConfig.tc ^|-> TelescopeConfig.offsetA).set(
           InstrumentOffset(
-            tag[OffsetP](TcsControllerEpicsCommon.pwfs2OffsetThreshold / 2.0 * FOCAL_PLANE_SCALE),
+            tag[OffsetP](pwfs2OffsetThreshold / 2.0 * FOCAL_PLANE_SCALE),
             tag[OffsetQ](Arcseconds(0.0))
           ).some
         ) >>>

--- a/modules/seqexec/server/src/test/scala/seqexec/server/tcs/TcsNorthControllerEpicsAoSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/tcs/TcsNorthControllerEpicsAoSpec.scala
@@ -17,7 +17,6 @@ import seqexec.server.altair.AltairController
 import seqexec.server.altair.AltairController.AltairOff
 import seqexec.server.tcs.TcsController.LightSource.Sky
 import seqexec.server.tcs.TcsController._
-import seqexec.server.tcs.TcsControllerEpicsCommon.{AoFold, BaseEpicsTcsConfig, InstrumentPorts}
 import seqexec.server.tcs.TcsNorthControllerEpicsAo.EpicsTcsAoConfig
 import shapeless.tag
 import shapeless.tag.@@


### PR DESCRIPTION
We have an objective to redo some of the Epics connections to make them more robust and reduce the need for restarts in cases where instruments are not available when booting.

This is hampered by the use of global variables like `TcsEpics.instance`. We have already ported some instrument code to instead have the epics instance passed as a variable and this PR does the same for the TCS

The PR is fairly large but the changes are mostly mechanical
* Move inner classes to top level
* Put al epics encoders/decoders on separate traits
* Make algebras for TcsConfigRetriever, TcsCommonEpicsController, TcsSouthControllerEpicsAo and TcsNorthControllerEpicsAo
* Abstract the effect type on tagless final style
* Use log4cats where appropriate

A next PR will do the same for the remaining instruments