### PR TITLE
Always pass the epics instances as build params

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/Systems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Systems.scala
@@ -68,7 +68,7 @@ object Systems {
     else                                                          TcsNorthControllerSim[IO].pure[IO]
 
   def altair(settings: Settings)(implicit L: Logger[IO]): IO[AltairController[IO]] =
-    if (settings.altairControl.command && settings.tcsControl.command) AltairControllerEpics.pure[IO]
+    if (settings.altairControl.command && settings.tcsControl.command) AltairControllerEpics(AltairEpics.instance, TcsEpics.instance).pure[IO]
     else                                                               AltairControllerSim[IO].pure[IO]
 
   def gems(settings: Settings, gsaoiController: GsaoiGuider[IO])(implicit L: Logger[IO]): IO[GemsController[IO]] =
@@ -76,27 +76,27 @@ object Systems {
     else                                                             GemsControllerSim[IO].pure[IO]
 
   def gsaoi(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[GsaoiFullHandler[IO]] =
-    if (settings.gsaoiControl.command) GsaoiControllerEpics().pure[IO]
+    if (settings.gsaoiControl.command) GsaoiControllerEpics(GsaoiEpics.instance).pure[IO]
     else                               GsaoiControllerSim[IO]
 
   def gnirs(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[GnirsController[IO]] =
-    if (settings.gnirsControl.command) GnirsControllerEpics().pure[IO]
+    if (settings.gnirsControl.command) GnirsControllerEpics(GnirsEpics.instance).pure[IO]
     else                               GnirsControllerSim[IO]
 
   def niri(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[NiriController[IO]] =
-    if (settings.niriControl.command) NiriControllerEpics().pure[IO]
+    if (settings.niriControl.command) NiriControllerEpics(NiriEpics.instance).pure[IO]
     else                              NiriControllerSim[IO]
 
   def nifs(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[NifsController[IO]] =
-    if (settings.nifsControl.command) NifsControllerEpics().pure[IO]
+    if (settings.nifsControl.command) NifsControllerEpics(NifsEpics.instance).pure[IO]
     else                              NifsControllerSim[IO]
 
   def gmosSouth(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[GmosSouthController[IO]] =
-    if (settings.gmosControl.command) GmosSouthControllerEpics().pure[IO]
+    if (settings.gmosControl.command) GmosSouthControllerEpics(GmosEpics.instance).pure[IO]
     else                              GmosControllerSim.south[IO]
 
   def gmosNorth(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[GmosNorthController[IO]] =
-    if (settings.gmosControl.command) GmosNorthControllerEpics().pure[IO]
+    if (settings.gmosControl.command) GmosNorthControllerEpics(GmosEpics.instance).pure[IO]
     else                              GmosControllerSim.north[IO]
 
   def flamingos2(settings: Settings)(implicit T: Timer[IO], L: Logger[IO]): IO[Flamingos2Controller[IO]] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -3,17 +3,17 @@
 
 package seqexec.server.altair
 
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-
-import cats.Endo
-import cats.effect.IO
+import cats._
+import cats.effect.Async
+import cats.effect.Sync
 import cats.implicits._
 import cats.kernel.Eq
 import edu.gemini.epics.acm.CarStateGEM5
-import mouse.boolean._
 import edu.gemini.seqexec.server.altair.LgsSfoControl
 import edu.gemini.spModel.gemini.altair.AltairParams.FieldLens
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import mouse.boolean._
 import monocle.macros.Lenses
 import seqexec.server.{SeqexecFailure, TrySeq}
 import seqexec.server.altair.AltairController._
@@ -24,277 +24,7 @@ import squants.{Length, Time}
 import squants.time.TimeConversions._
 import squants.space.{Arcseconds, Millimeters}
 
-object AltairControllerEpics extends AltairController[IO] {
-
-  private val epicsAltair = AltairEpics.instance
-  private val epicsTcs = TcsEpics.instance
-
-  private def inRangeLinear[T <: Ordered[T]](vMin: T, vMax: T)(v: T): Boolean =
-    v > vMin && v < vMax
-
-  private def newPosition(starPos: (Length, Length))(next: FocalPlaneOffset): (Length, Length) =
-    starPos.bimap(_ + next.x, _ + next.y)
-
-  val CorrectionsOn: String = "ON"
-  val CorrectionsOff: String = "OFF"
-  val TargetFilterOpen: String = "Open"
-  val TargetFilterClosed: String = "Closed"
-
-  // The OT checks this, why do it again in Seqexec?
-  private def newPosInRange(newPos: (Length, Length)): Boolean = {
-    val minX = Millimeters(-37.2)
-    val maxX = Millimeters(37.2)
-    val minY = Millimeters(-37.2)
-    val maxY = Millimeters(37.2)
-
-    newPos match {
-      case (x, y) => inRangeLinear(minX, maxX)(x) && inRangeLinear(minY, maxY)(y)
-    }
-  }
-
-  private def validControlMatrix(mtxPos: (Length, Length))(newPos: (Length, Length)): Boolean = {
-    val limit = Arcseconds(5.0) / FOCAL_PLANE_SCALE
-
-    val diff = newPos.bimap(_ - mtxPos._1, _ - mtxPos._2)
-
-    diff._1 * diff._1 + diff._2 * diff._2 < limit * limit
-  }
-
-  private def validateCurrentControlMatrix(currCfg: EpicsAltairConfig, newPos: (Length, Length))
-  : Boolean = validControlMatrix(currCfg.currentMatrixCoords)(newPos)
-
-  private def validatePreparedControlMatrix(currCfg: EpicsAltairConfig, newPos: (Length, Length))
-  : Boolean = validControlMatrix(currCfg.preparedMatrixCoords)(newPos)
-
-  private def prepareMatrix(newPos: (Length, Length)): IO[Unit] =
-    epicsTcs.aoPrepareControlMatrix.setX(newPos._1.toMillimeters) *>
-      epicsTcs.aoPrepareControlMatrix.setY(newPos._2.toMillimeters)
-
-  implicit val fieldLensEq: Eq[FieldLens] = Eq.by(_.ordinal)
-
-  private def pauseNgsOrLgsMode(starPos: (Length, Length), fieldLens: FieldLens, currCfg: EpicsAltairConfig)(
-    reasons: PauseConditionSet)
-  : Option[(EpicsAltairConfig, IO[Unit])] = {
-    val newOffset = reasons.offsetO.map(_.newOffset)
-    val newPos = newOffset.map(newPosition(starPos))
-    val newPosOk = newPos.forall(newPosInRange)
-    val matrixOk = newPos.forall(validateCurrentControlMatrix(currCfg, _)) || fieldLens === FieldLens.IN
-    val prepMatrixOk = newPos.forall(validatePreparedControlMatrix(currCfg, _)) || fieldLens === FieldLens.IN
-    val guideOk = !reasons.contains(PauseCondition.GaosGuideOff) //It can follow the guide star on this step
-
-    val needsToStop = !(newPosOk && matrixOk && guideOk)
-
-    // How the current configuration changes if loops are stopped
-    val newCfg = (EpicsAltairConfig.preparedMatrixCoords.modify(v =>
-      newPos.filter(_ => newPosOk && !matrixOk && !prepMatrixOk).getOrElse(v)) >>>
-      EpicsAltairConfig.aoLoop.set(!needsToStop)
-    ) (currCfg)
-
-    // Actions to stop loops
-    val actions = List(
-      currCfg.aoLoop.option(epicsTcs.aoCorrect.setCorrections(CorrectionsOff) *>
-        epicsTcs.targetFilter.setShortCircuit(TargetFilterClosed)),
-      newPos.filter(_ => newPosOk && !matrixOk && !prepMatrixOk).map(prepareMatrix)
-    ).collect { case Some(x) => x }
-
-    val pause = (actions.sequence *> epicsTcs.targetFilter.post[IO].void).whenA(actions.nonEmpty)
-
-    needsToStop.option((newCfg, pause))
-  }
-
-  private def pauseResumeNgsMode(starPos: (Length, Length), fieldLens: FieldLens, currCfg: EpicsAltairConfig)(
-    pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
-  : PauseResume[IO] = {
-    val pause = pauseNgsOrLgsMode(starPos, fieldLens, currCfg)(pauseReasons)
-    val resume = resumeNgsOrLgsMode(starPos, pause.map(_._1).getOrElse(currCfg))(resumeReasons)
-
-    PauseResume(pause.map(_._2), resume)
-  }
-
-  val aoSettledTimeout: Time = 30.0.seconds
-  val matrixPrepTimeout: Time = 10.seconds
-
-  private def resumeNgsOrLgsMode(starPos: (Length, Length), currCfg: EpicsAltairConfig)(
-    reasons: ResumeConditionSet): Option[IO[Unit]] = {
-    val offsets = reasons.offsetO.map(_.newOffset)
-    val newPosOk = offsets.forall(v => newPosInRange(newPosition(starPos)(v)))
-    val guideOk = reasons.contains(ResumeCondition.GaosGuideOn)
-
-    (newPosOk && guideOk).option(
-      (epicsAltair.waitMatrixCalc(CarStateGEM5.IDLE, matrixPrepTimeout) *>
-        epicsTcs.aoCorrect.setCorrections(CorrectionsOn) *>
-        epicsTcs.aoFlatten.mark[IO] *>
-        epicsTcs.targetFilter.setShortCircuit(TargetFilterOpen) *>
-        epicsTcs.targetFilter.post[IO] *>
-        epicsAltair.waitAoSettled(aoSettledTimeout)
-      ).whenA(!currCfg.aoLoop)
-    )
-  }
-
-  private def checkStrapLoopState(currCfg: EpicsAltairConfig): TrySeq[Unit] =
-    currCfg.strapRTStatus.either(
-      SeqexecFailure.Unexpected("Cannot start Altair STRAP loop, RT Control status is bad."), ()
-    ) *>
-      currCfg.strapTempStatus.either(
-        SeqexecFailure.Unexpected("Cannot start Altair STRAP loop, Temperature Control status is bad."), ()
-      ) *>
-      currCfg.stapHVoltStatus.either(
-        SeqexecFailure.Unexpected("Cannot start Altair STRAP loop, HVolt status is bad."), ()
-      )
-
-  private val DefaultTimeout = 10.seconds
-
-  private def startStrapGate(currCfg: EpicsAltairConfig): IO[Unit] = (
-    epicsAltair.strapGateControl.setGate(1) *>
-      epicsAltair.strapGateControl.setTimeout[IO](DefaultTimeout) *>
-      epicsAltair.strapGateControl.post[IO] *>
-      epicsAltair.waitForStrapGate(100, 5.seconds)
-    ).unlessA(currCfg.strapGate =!= 0)
-
-  private def stopStrapGate(currCfg: EpicsAltairConfig): IO[Unit] = (
-    epicsAltair.strapGateControl.setGate(0) *>
-      epicsAltair.strapGateControl.setTimeout[IO](DefaultTimeout) *>
-      epicsAltair.strapGateControl.post[IO].void
-    ).whenA(currCfg.strapGate =!= 0)
-
-  private def startStrapLoop(currCfg: EpicsAltairConfig): IO[Unit] = (
-    epicsAltair.strapControl.setActive(1) *>
-      epicsAltair.strapControl.setTimeout[IO](DefaultTimeout) *>
-      epicsAltair.strapControl.post[IO] *>
-      epicsAltair.waitForStrapLoop(v = true, 10.seconds)
-    ).unlessA(currCfg.strapLoop)
-
-  private def stopStrapLoop(currCfg: EpicsAltairConfig): IO[Unit] = (
-    epicsAltair.strapControl.setActive(0) *>
-      epicsAltair.strapControl.setTimeout[IO](DefaultTimeout) *>
-      epicsAltair.strapControl.post[IO].void
-    ).whenA(currCfg.strapLoop)
-
-  implicit val sfoControlEq: Eq[LgsSfoControl] = Eq.by(_.ordinal)
-
-  private def startSfoLoop(currCfg: EpicsAltairConfig): IO[Unit] =
-    epicsAltair.sfoControl.setActive(LgsSfoControl.Enable).unlessA(currCfg.sfoLoop === LgsSfoControl.Enable)
-
-  private def pauseSfoLoop(currCfg: EpicsAltairConfig): IO[Unit] =
-    epicsAltair.sfoControl.setActive(LgsSfoControl.Pause).whenA(currCfg.sfoLoop === LgsSfoControl.Enable)
-
-  private def ttgsOn(strap: Boolean, sfo: Boolean, currCfg: EpicsAltairConfig): IO[Unit] =
-    checkStrapLoopState(currCfg).fold(IO.raiseError, IO(_)) *>
-      (startStrapGate(currCfg) *> startStrapLoop(currCfg)).whenA(strap) *>
-      startSfoLoop(currCfg).whenA(sfo)
-
-  private val ttgsOffEndo: Endo[EpicsAltairConfig] = EpicsAltairConfig.strapGate.set(0) >>>
-    EpicsAltairConfig.strapLoop.set(false) >>>
-    EpicsAltairConfig.sfoLoop.modify { v =>
-      (v === LgsSfoControl.Disable).fold(LgsSfoControl.Disable, LgsSfoControl.Pause)
-    }
-
-  private def ttgsOff(currCfg: EpicsAltairConfig): IO[Unit] =
-    stopStrapGate(currCfg) *>
-      stopStrapLoop(currCfg) *>
-      pauseSfoLoop(currCfg)
-
-  private def pauseResumeLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length), fieldLens: FieldLens,
-                           currCfg: EpicsAltairConfig)(
-    pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet): PauseResume[IO] = {
-    val pause = pauseLgsMode(strap, sfo, starPos, fieldLens, currCfg)(pauseReasons)
-    val resume = resumeLgsMode(strap, sfo, starPos)(pause.map(_._1).getOrElse(currCfg))(resumeReasons)
-
-    PauseResume(pause.map(_._2), resume)
-  }
-
-  private def pauseLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length), fieldLens: FieldLens,
-                           currCfg: EpicsAltairConfig)(reasons: PauseConditionSet)
-  : Option[(EpicsAltairConfig, IO[Unit])] =
-    pauseNgsOrLgsMode(starPos, fieldLens, currCfg)(reasons).filter(_ => strap || sfo)
-      .map(_.bimap(ttgsOffEndo, ttgsOff(currCfg) *> _))
-
-  private def resumeLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length))(currCfg: EpicsAltairConfig)(
-    reasons: ResumeConditionSet): Option[IO[Unit]] =
-    resumeNgsOrLgsMode(starPos, currCfg)(reasons).filter(_ => strap || sfo).map(_ *> ttgsOn(strap, sfo, currCfg))
-
-  /**
-   * Modes LgsWithP1 and LgsWithOi don't use an Altair target. The only action required is to start or stop corrections
-   */
-  private def pauseResumeLgsWithXX(currCfg: EpicsAltairConfig)(
-      pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
-  : PauseResume[IO] = {
-    val pause: Option[IO[Unit]] = (pauseReasons.contains(PauseCondition.GaosGuideOff) && currCfg.aoLoop).option{
-      epicsTcs.aoCorrect.setCorrections(CorrectionsOff) *>
-        epicsTcs.targetFilter.setShortCircuit(TargetFilterClosed) *>
-        epicsTcs.targetFilter.post[IO].void
-    }
-    val resume: Option[IO[Unit]] = (resumeReasons.contains(ResumeCondition.GaosGuideOn) &&
-      (pauseReasons.contains(PauseCondition.GaosGuideOff) || !currCfg.aoLoop)
-    ).option{
-      epicsTcs.aoCorrect.setCorrections(CorrectionsOn) *>
-        epicsTcs.aoFlatten.mark[IO] *>
-        epicsTcs.targetFilter.setShortCircuit(TargetFilterOpen) *>
-        epicsTcs.targetFilter.post[IO] *>
-        epicsAltair.waitAoSettled(aoSettledTimeout)
-    }
-
-    PauseResume(
-      pause,
-      resume
-    )
-  }
-
-  private def turnOff(c: EpicsAltairConfig): PauseResume[IO] = PauseResume(
-    (epicsTcs.aoCorrect.setCorrections(CorrectionsOff) *>
-      epicsTcs.targetFilter.post[IO]
-    ).whenA(c.aoLoop).some,
-    None
-  )
-
-  override def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet,
-                           fieldLens: FieldLens)(cfg: AltairConfig): IO[PauseResume[IO]] =
-    retrieveConfig.map{ currCfg =>
-      cfg match {
-        case Ngs(_, starPos)                      => pauseResumeNgsMode(starPos, fieldLens, currCfg)(pauseReasons,
-          resumeReasons)
-        case Lgs(str: Boolean, sfo: Boolean, pos) => pauseResumeLgsMode(str, sfo, pos, fieldLens, currCfg)(pauseReasons,
-          resumeReasons)
-        case LgsWithP1                            => pauseResumeLgsWithXX(currCfg)(pauseReasons, resumeReasons)
-        case LgsWithOi                            => pauseResumeLgsWithXX(currCfg)(pauseReasons, resumeReasons)
-        case AltairOff                            => turnOff(currCfg)
-      }
-    }
-
-  override def observe(expTime: Time)(cfg: AltairConfig): IO[Unit] = IO(LocalDate.now).flatMap( date =>
-    ( epicsTcs.aoStatistics.setTriggerTimeInterval(0.0) *>
-        epicsTcs.aoStatistics.setInterval(expTime.toSeconds) *>
-        epicsTcs.aoStatistics.setSamples(1) *>
-        epicsTcs.aoStatistics.setFileName("aostats" + date.format(DateTimeFormatter.ofPattern("yyyyMMdd")))
-    ).whenA(expTime > 5.seconds && cfg =!= AltairOff)
-  )
-
-  override def endObserve(cfg: AltairConfig): IO[Unit] = IO.unit
-
-  def retrieveConfig: IO[EpicsAltairConfig] = for {
-    cmtxx <- epicsAltair.matrixStartX.map(Millimeters(_))
-    cmtxy <- epicsAltair.matrixStartY.map(Millimeters(_))
-    pmtxx <- epicsTcs.aoPreparedCMX.map(Millimeters(_))
-    pmtxy <- epicsTcs.aoPreparedCMY.map(Millimeters(_))
-    strRT <- epicsAltair.strapRTStatus
-    strTm <- epicsAltair.strapTempStatus
-    strHV <- epicsAltair.strapHVStatus
-    strap <- epicsAltair.strapLoop
-    sfo   <- epicsAltair.sfoLoop
-    stGat <- epicsAltair.strapGate
-    aolp  <- epicsAltair.aoLoop
-  } yield EpicsAltairConfig(
-    (cmtxx, cmtxy),
-    (pmtxx, pmtxy),
-    strRT,
-    strTm,
-    strHV,
-    strap,
-    sfo,
-    stGat,
-    aolp
-  )
-
+object AltairControllerEpics {
   @Lenses
   final case class EpicsAltairConfig(
     currentMatrixCoords: (Length, Length),
@@ -308,6 +38,275 @@ object AltairControllerEpics extends AltairController[IO] {
     aoLoop: Boolean
   )
 
-  // This is a bit convoluted. AO follow state is read from Altair, but set as part of TCS configuration
-  override def isFollowing: IO[Boolean] = AltairEpics.instance.aoFollow
+  def apply[F[_]: Async](epicsAltair: => AltairEpics[F], epicsTcs: => TcsEpics[F]): AltairController[F] = new AltairController[F] {
+
+    private def inRangeLinear[T <: Ordered[T]](vMin: T, vMax: T)(v: T): Boolean =
+      v > vMin && v < vMax
+
+    private def newPosition(starPos: (Length, Length))(next: FocalPlaneOffset): (Length, Length) =
+      starPos.bimap(_ + next.x, _ + next.y)
+
+    val CorrectionsOn: String = "ON"
+    val CorrectionsOff: String = "OFF"
+    val TargetFilterOpen: String = "Open"
+    val TargetFilterClosed: String = "Closed"
+
+    // The OT checks this, why do it again in Seqexec?
+    private def newPosInRange(newPos: (Length, Length)): Boolean = {
+      val minX = Millimeters(-37.2)
+      val maxX = Millimeters(37.2)
+      val minY = Millimeters(-37.2)
+      val maxY = Millimeters(37.2)
+
+      newPos match {
+        case (x, y) => inRangeLinear(minX, maxX)(x) && inRangeLinear(minY, maxY)(y)
+      }
+    }
+
+    private def validControlMatrix(mtxPos: (Length, Length))(newPos: (Length, Length)): Boolean = {
+      val limit = Arcseconds(5.0) / FOCAL_PLANE_SCALE
+
+      val diff = newPos.bimap(_ - mtxPos._1, _ - mtxPos._2)
+
+      diff._1 * diff._1 + diff._2 * diff._2 < limit * limit
+    }
+
+    private def validateCurrentControlMatrix(currCfg: EpicsAltairConfig, newPos: (Length, Length))
+    : Boolean = validControlMatrix(currCfg.currentMatrixCoords)(newPos)
+
+    private def validatePreparedControlMatrix(currCfg: EpicsAltairConfig, newPos: (Length, Length))
+    : Boolean = validControlMatrix(currCfg.preparedMatrixCoords)(newPos)
+
+    private def prepareMatrix(newPos: (Length, Length)): F[Unit] =
+      epicsTcs.aoPrepareControlMatrix.setX(newPos._1.toMillimeters) *>
+        epicsTcs.aoPrepareControlMatrix.setY(newPos._2.toMillimeters)
+
+    implicit val fieldLensEq: Eq[FieldLens] = Eq.by(_.ordinal)
+
+    private def pauseNgsOrLgsMode(starPos: (Length, Length), fieldLens: FieldLens, currCfg: EpicsAltairConfig)(
+      reasons: PauseConditionSet)
+    : Option[(EpicsAltairConfig, F[Unit])] = {
+      val newOffset = reasons.offsetO.map(_.newOffset)
+      val newPos = newOffset.map(newPosition(starPos))
+      val newPosOk = newPos.forall(newPosInRange)
+      val matrixOk = newPos.forall(validateCurrentControlMatrix(currCfg, _)) || fieldLens === FieldLens.IN
+      val prepMatrixOk = newPos.forall(validatePreparedControlMatrix(currCfg, _)) || fieldLens === FieldLens.IN
+      val guideOk = !reasons.contains(PauseCondition.GaosGuideOff) //It can follow the guide star on this step
+
+      val needsToStop = !(newPosOk && matrixOk && guideOk)
+
+      // How the current configuration changes if loops are stopped
+      val newCfg = (EpicsAltairConfig.preparedMatrixCoords.modify(v =>
+        newPos.filter(_ => newPosOk && !matrixOk && !prepMatrixOk).getOrElse(v)) >>>
+        EpicsAltairConfig.aoLoop.set(!needsToStop)
+      ) (currCfg)
+
+      // Actions to stop loops
+      val actions = List(
+        currCfg.aoLoop.option(epicsTcs.aoCorrect.setCorrections(CorrectionsOff) *>
+          epicsTcs.targetFilter.setShortCircuit(TargetFilterClosed)),
+        newPos.filter(_ => newPosOk && !matrixOk && !prepMatrixOk).map(prepareMatrix)
+      ).collect { case Some(x) => x }
+
+      val pause = (actions.sequence *> epicsTcs.targetFilter.post[F].void).whenA(actions.nonEmpty)
+
+      needsToStop.option((newCfg, pause))
+    }
+
+    private def pauseResumeNgsMode(starPos: (Length, Length), fieldLens: FieldLens, currCfg: EpicsAltairConfig)(
+      pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
+    : PauseResume[F] = {
+      val pause = pauseNgsOrLgsMode(starPos, fieldLens, currCfg)(pauseReasons)
+      val resume = resumeNgsOrLgsMode(starPos, pause.map(_._1).getOrElse(currCfg))(resumeReasons)
+
+      PauseResume(pause.map(_._2), resume)
+    }
+
+    val aoSettledTimeout: Time = 30.0.seconds
+    val matrixPrepTimeout: Time = 10.seconds
+
+    private def resumeNgsOrLgsMode(starPos: (Length, Length), currCfg: EpicsAltairConfig)(
+      reasons: ResumeConditionSet): Option[F[Unit]] = {
+      val offsets = reasons.offsetO.map(_.newOffset)
+      val newPosOk = offsets.forall(v => newPosInRange(newPosition(starPos)(v)))
+      val guideOk = reasons.contains(ResumeCondition.GaosGuideOn)
+
+      (newPosOk && guideOk).option(
+        (epicsAltair.waitMatrixCalc(CarStateGEM5.IDLE, matrixPrepTimeout) *>
+          epicsTcs.aoCorrect.setCorrections(CorrectionsOn) *>
+          epicsTcs.aoFlatten.mark[F] *>
+          epicsTcs.targetFilter.setShortCircuit(TargetFilterOpen) *>
+          epicsTcs.targetFilter.post[F] *>
+          epicsAltair.waitAoSettled(aoSettledTimeout)
+        ).whenA(!currCfg.aoLoop)
+      )
+    }
+
+    private def checkStrapLoopState(currCfg: EpicsAltairConfig): TrySeq[Unit] =
+      currCfg.strapRTStatus.either(
+        SeqexecFailure.Unexpected("Cannot start Altair STRAP loop, RT Control status is bad."), ()
+      ) *>
+        currCfg.strapTempStatus.either(
+          SeqexecFailure.Unexpected("Cannot start Altair STRAP loop, Temperature Control status is bad."), ()
+        ) *>
+        currCfg.stapHVoltStatus.either(
+          SeqexecFailure.Unexpected("Cannot start Altair STRAP loop, HVolt status is bad."), ()
+        )
+
+    private val DefaultTimeout = 10.seconds
+
+    private def startStrapGate(currCfg: EpicsAltairConfig): F[Unit] = (
+      epicsAltair.strapGateControl.setGate(1) *>
+        epicsAltair.strapGateControl.setTimeout[F](DefaultTimeout) *>
+        epicsAltair.strapGateControl.post[F] *>
+        epicsAltair.waitForStrapGate(100, 5.seconds)
+      ).unlessA(currCfg.strapGate =!= 0)
+
+    private def stopStrapGate(currCfg: EpicsAltairConfig): F[Unit] = (
+      epicsAltair.strapGateControl.setGate(0) *>
+        epicsAltair.strapGateControl.setTimeout[F](DefaultTimeout) *>
+        epicsAltair.strapGateControl.post[F].void
+      ).whenA(currCfg.strapGate =!= 0)
+
+    private def startStrapLoop(currCfg: EpicsAltairConfig): F[Unit] = (
+      epicsAltair.strapControl.setActive(1) *>
+        epicsAltair.strapControl.setTimeout[F](DefaultTimeout) *>
+        epicsAltair.strapControl.post[F] *>
+        epicsAltair.waitForStrapLoop(v = true, 10.seconds)
+      ).unlessA(currCfg.strapLoop)
+
+    private def stopStrapLoop(currCfg: EpicsAltairConfig): F[Unit] = (
+      epicsAltair.strapControl.setActive(0) *>
+        epicsAltair.strapControl.setTimeout[F](DefaultTimeout) *>
+        epicsAltair.strapControl.post[F].void
+      ).whenA(currCfg.strapLoop)
+
+    implicit val sfoControlEq: Eq[LgsSfoControl] = Eq.by(_.ordinal)
+
+    private def startSfoLoop(currCfg: EpicsAltairConfig): F[Unit] =
+      epicsAltair.sfoControl.setActive(LgsSfoControl.Enable).unlessA(currCfg.sfoLoop === LgsSfoControl.Enable)
+
+    private def pauseSfoLoop(currCfg: EpicsAltairConfig): F[Unit] =
+      epicsAltair.sfoControl.setActive(LgsSfoControl.Pause).whenA(currCfg.sfoLoop === LgsSfoControl.Enable)
+
+    private def ttgsOn(strap: Boolean, sfo: Boolean, currCfg: EpicsAltairConfig): F[Unit] =
+      checkStrapLoopState(currCfg).fold(ApplicativeError[F, Throwable].raiseError, Sync[F].delay(_)) *>
+        (startStrapGate(currCfg) *> startStrapLoop(currCfg)).whenA(strap) *>
+        startSfoLoop(currCfg).whenA(sfo)
+
+    private val ttgsOffEndo: Endo[EpicsAltairConfig] = EpicsAltairConfig.strapGate.set(0) >>>
+      EpicsAltairConfig.strapLoop.set(false) >>>
+      EpicsAltairConfig.sfoLoop.modify { v =>
+        (v === LgsSfoControl.Disable).fold(LgsSfoControl.Disable, LgsSfoControl.Pause)
+      }
+
+    private def ttgsOff(currCfg: EpicsAltairConfig): F[Unit] =
+      stopStrapGate(currCfg) *>
+        stopStrapLoop(currCfg) *>
+        pauseSfoLoop(currCfg)
+
+    private def pauseResumeLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length), fieldLens: FieldLens,
+                             currCfg: EpicsAltairConfig)(
+      pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet): PauseResume[F] = {
+      val pause = pauseLgsMode(strap, sfo, starPos, fieldLens, currCfg)(pauseReasons)
+      val resume = resumeLgsMode(strap, sfo, starPos)(pause.map(_._1).getOrElse(currCfg))(resumeReasons)
+
+      PauseResume(pause.map(_._2), resume)
+    }
+
+    private def pauseLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length), fieldLens: FieldLens,
+                             currCfg: EpicsAltairConfig)(reasons: PauseConditionSet)
+    : Option[(EpicsAltairConfig, F[Unit])] =
+      pauseNgsOrLgsMode(starPos, fieldLens, currCfg)(reasons).filter(_ => strap || sfo)
+        .map(_.bimap(ttgsOffEndo, ttgsOff(currCfg) *> _))
+
+    private def resumeLgsMode(strap: Boolean, sfo: Boolean, starPos: (Length, Length))(currCfg: EpicsAltairConfig)(
+      reasons: ResumeConditionSet): Option[F[Unit]] =
+      resumeNgsOrLgsMode(starPos, currCfg)(reasons).filter(_ => strap || sfo).map(_ *> ttgsOn(strap, sfo, currCfg))
+
+    /**
+     * Modes LgsWithP1 and LgsWithOi don't use an Altair target. The only action required is to start or stop corrections
+     */
+    private def pauseResumeLgsWithXX(currCfg: EpicsAltairConfig)(
+        pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
+    : PauseResume[F] = {
+      val pause: Option[F[Unit]] = (pauseReasons.contains(PauseCondition.GaosGuideOff) && currCfg.aoLoop).option{
+        epicsTcs.aoCorrect.setCorrections(CorrectionsOff) *>
+          epicsTcs.targetFilter.setShortCircuit(TargetFilterClosed) *>
+          epicsTcs.targetFilter.post[F].void
+      }
+      val resume: Option[F[Unit]] = (resumeReasons.contains(ResumeCondition.GaosGuideOn) &&
+        (pauseReasons.contains(PauseCondition.GaosGuideOff) || !currCfg.aoLoop)
+      ).option{
+        epicsTcs.aoCorrect.setCorrections(CorrectionsOn) *>
+          epicsTcs.aoFlatten.mark[F] *>
+          epicsTcs.targetFilter.setShortCircuit(TargetFilterOpen) *>
+          epicsTcs.targetFilter.post[F] *>
+          epicsAltair.waitAoSettled(aoSettledTimeout)
+      }
+
+      PauseResume(
+        pause,
+        resume
+      )
+    }
+
+    private def turnOff(c: EpicsAltairConfig): PauseResume[F] = PauseResume(
+      (epicsTcs.aoCorrect.setCorrections(CorrectionsOff) *>
+        epicsTcs.targetFilter.post[F]
+      ).whenA(c.aoLoop).some,
+      None
+    )
+
+    override def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet,
+                             fieldLens: FieldLens)(cfg: AltairConfig): F[PauseResume[F]] =
+      retrieveConfig.map{ currCfg =>
+        cfg match {
+          case Ngs(_, starPos)                      => pauseResumeNgsMode(starPos, fieldLens, currCfg)(pauseReasons,
+            resumeReasons)
+          case Lgs(str: Boolean, sfo: Boolean, pos) => pauseResumeLgsMode(str, sfo, pos, fieldLens, currCfg)(pauseReasons,
+            resumeReasons)
+          case LgsWithP1                            => pauseResumeLgsWithXX(currCfg)(pauseReasons, resumeReasons)
+          case LgsWithOi                            => pauseResumeLgsWithXX(currCfg)(pauseReasons, resumeReasons)
+          case AltairOff                            => turnOff(currCfg)
+        }
+      }
+
+    override def observe(expTime: Time)(cfg: AltairConfig): F[Unit] = Sync[F].delay(LocalDate.now).flatMap( date =>
+      ( epicsTcs.aoStatistics.setTriggerTimeInterval(0.0) *>
+          epicsTcs.aoStatistics.setInterval(expTime.toSeconds) *>
+          epicsTcs.aoStatistics.setSamples(1) *>
+          epicsTcs.aoStatistics.setFileName("aostats" + date.format(DateTimeFormatter.ofPattern("yyyyMMdd")))
+      ).whenA(expTime > 5.seconds && cfg =!= AltairOff)
+    )
+
+    override def endObserve(cfg: AltairConfig): F[Unit] = Applicative[F].unit
+
+    def retrieveConfig: F[EpicsAltairConfig] = for {
+      cmtxx <- epicsAltair.matrixStartX.map(Millimeters(_))
+      cmtxy <- epicsAltair.matrixStartY.map(Millimeters(_))
+      pmtxx <- epicsTcs.aoPreparedCMX.map(Millimeters(_))
+      pmtxy <- epicsTcs.aoPreparedCMY.map(Millimeters(_))
+      strRT <- epicsAltair.strapRTStatus
+      strTm <- epicsAltair.strapTempStatus
+      strHV <- epicsAltair.strapHVStatus
+      strap <- epicsAltair.strapLoop
+      sfo   <- epicsAltair.sfoLoop
+      stGat <- epicsAltair.strapGate
+      aolp  <- epicsAltair.aoLoop
+    } yield EpicsAltairConfig(
+      (cmtxx, cmtxy),
+      (pmtxx, pmtxy),
+      strRT,
+      strTm,
+      strHV,
+      strap,
+      sfo,
+      stGat,
+      aolp
+    )
+
+    // This is a bit convoluted. AO follow state is read from Altair, but set as part of TCS configuration
+    override def isFollowing: F[Boolean] = epicsAltair.aoFollow
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerSim.scala
@@ -12,7 +12,7 @@ import squants.Time
 
 object AltairControllerSim {
   def apply[F[_]: Applicative: Logger]: AltairController[F] = new AltairController[F] {
-    private val L = Logger[F].withModifiedString(s => s"$s-altair-sim")
+    private val L = Logger[F]
 
     override def pauseResume(
       pauseReasons: PauseConditionSet,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
@@ -97,7 +97,7 @@ object Flamingos2ControllerEpics extends Flamingos2Encoders {
   val DefaultTimeout: Time = Seconds(60)
   val ConfigTimeout: Time = Seconds(400)
 
-  def apply[F[_]: Async](sys: Flamingos2Epics[F])(implicit tio: Timer[F]): Flamingos2Controller[F] = new Flamingos2Controller[F] {
+  def apply[F[_]: Async](sys: => Flamingos2Epics[F])(implicit tio: Timer[F]): Flamingos2Controller[F] = new Flamingos2Controller[F] {
     private val Log = getLogger
 
     private def setDCConfig(dc: DCConfig): F[Unit] = for {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorthControllerEpics.scala
@@ -3,7 +3,7 @@
 
 package seqexec.server.gmos
 
-import cats.effect.IO
+import cats.effect._
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import seqexec.server.EpicsCodex
@@ -113,6 +113,8 @@ object GmosNorthEncoders extends GmosControllerEpics.Encoders[NorthTypes] {
 }
 
 object GmosNorthControllerEpics {
-  def apply()(implicit L: Logger[IO]): GmosController[IO, NorthTypes] =
-    GmosControllerEpics[NorthTypes](northConfigTypes)(GmosNorthEncoders, L)
+  def apply[F[_]: Async: Timer: Logger](sys: => GmosEpics[F]): GmosController[F, NorthTypes] = {
+    implicit val encoders = GmosNorthEncoders
+    GmosControllerEpics[F, NorthTypes](sys, northConfigTypes)
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouthControllerEpics.scala
@@ -3,7 +3,7 @@
 
 package seqexec.server.gmos
 
-import cats.effect.IO
+import cats.effect._
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import seqexec.server.EpicsCodex.EncodeEpicsValue
@@ -111,6 +111,8 @@ object GmosSouthEncoders extends GmosControllerEpics.Encoders[SouthTypes] {
 }
 
 object GmosSouthControllerEpics {
-  def apply()(implicit L: Logger[IO]): GmosController[IO, SouthTypes] =
-    GmosControllerEpics[SouthTypes](southConfigTypes)(GmosSouthEncoders, L)
+  def apply[F[_]: Async: Timer: Logger](sys: => GmosEpics[F]): GmosController[F, SouthTypes] = {
+    implicit val encoders = GmosSouthEncoders
+    GmosControllerEpics[F, SouthTypes](sys, southConfigTypes)
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
@@ -43,24 +43,24 @@ object TcsNorthControllerEpicsAo {
     case _                => none
   }
 
-  private def mustPauseWhileOffsetting(current: EpicsTcsAoConfig, demand: TcsNorthAoConfig): Boolean = {
-    val distanceSquared = demand.tc.offsetA.map(_.toFocalPlaneOffset(current.base.iaa))
-      .map { o => (o.x - current.base.offset.x, o.y - current.base.offset.y) }
-      .map(d => d._1 * d._1 + d._2 * d._2)
+    private def mustPauseWhileOffsetting(current: EpicsTcsAoConfig, demand: TcsNorthAoConfig): Boolean = {
+      val distanceSquared = demand.tc.offsetA.map(_.toFocalPlaneOffset(current.base.iaa))
+        .map { o => (o.x - current.base.offset.x, o.y - current.base.offset.y) }
+        .map(d => d._1 * d._1 + d._2 * d._2)
 
-    val aoThreshold = aoOffsetThreshold(demand.inst.instrument)
-        .filter(_ => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.GAOS, M1Source.GAOS) && demand.gds.aoguide.isActive)
+      val aoThreshold = aoOffsetThreshold(demand.inst.instrument)
+          .filter(_ => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.GAOS, M1Source.GAOS) && demand.gds.aoguide.isActive)
 
-    val thresholds = List(
-      (Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS1, M1Source.PWFS1) && demand.gds.pwfs1.isActive)
-        .option(pwfs1OffsetThreshold),
-      aoThreshold,
-      demand.inst.oiOffsetGuideThreshold
-        .filter(_ => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.OIWFS, M1Source.OIWFS) && demand.gds.oiwfs.isActive)
-    )
-    // Does the offset movement surpass any of the existing thresholds ?
-    distanceSquared.exists(dd => thresholds.exists(_.exists(t => t*t < dd)))
-  }
+      val thresholds = List(
+        (Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS1, M1Source.PWFS1) && demand.gds.pwfs1.isActive)
+          .option(pwfs1OffsetThreshold),
+        aoThreshold,
+        demand.inst.oiOffsetGuideThreshold
+          .filter(_ => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.OIWFS, M1Source.OIWFS) && demand.gds.oiwfs.isActive)
+      )
+      // Does the offset movement surpass any of the existing thresholds ?
+      distanceSquared.exists(dd => thresholds.exists(_.exists(t => t*t < dd)))
+    }
 
   private final class TcsNorthControllerEpicsAoImpl[F[_]: Async](epicsSys: TcsEpics[F])(implicit L: Logger[F]) extends TcsNorthControllerEpicsAo[F] with TcsControllerEncoders {
     private val tcsConfigRetriever = TcsConfigRetriever[F](epicsSys)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -383,14 +383,14 @@ object TcsSouthControllerEpicsAo {
           else M2GuideConfig.M2GuideOn(if(cfg.gc.m1Guide =!= M1GuideConfig.M1GuideOff) coma else ComaOption.ComaOff, ss)
         case x                     => x
       }(cfg)
-
-    // Disable Mount guiding if M2 guiding is disabled
-    val normalizeMountGuiding: Endo[TcsSouthAoConfig] = cfg =>
-      (AoTcsConfig.gc ^|-> TelescopeGuideConfig.mountGuide).modify{ m => (m, cfg.gc.m2Guide) match {
-        case (MountGuideOption.MountGuideOn, M2GuideConfig.M2GuideOn(_, _)) => MountGuideOption.MountGuideOn
-        case _                                                              => MountGuideOption.MountGuideOff
-      } }(cfg)
   }
+
+  // Disable Mount guiding if M2 guiding is disabled
+  val normalizeMountGuiding: Endo[TcsSouthAoConfig] = cfg =>
+    (AoTcsConfig.gc ^|-> TelescopeGuideConfig.mountGuide).modify{ m => (m, cfg.gc.m2Guide) match {
+      case (MountGuideOption.MountGuideOn, M2GuideConfig.M2GuideOn(_, _)) => MountGuideOption.MountGuideOn
+      case _                                                              => MountGuideOption.MountGuideOff
+    } }(cfg)
 
   def apply[F[_]: Async: Logger](epicsSys: TcsEpics[F]): TcsSouthControllerEpicsAo[F] =
     new TcsSouthControllerEpicsAoImpl(epicsSys)


### PR DESCRIPTION
This is the continuation of #1152 applied to instruments.

Same set of changes:
* Remove static calls to epics systems
* Convert to a tagless final encoding
* Use Logger where appropriate