### PR TITLE
Prevent calls to epics subsystems before initalization

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerEpics.scala
@@ -3,156 +3,154 @@
 
 package seqexec.server.gems
 
-import cats.ApplicativeError
 import cats.effect.Async
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import monocle.macros.Lenses
 import mouse.boolean._
 import seqexec.server.gems.GemsController.GemsConfig
 import seqexec.server.gems.Gems._
-import org.log4s.getLogger
 import seqexec.server.gsaoi.GsaoiGuider
 import seqexec.server.tcs.Gaos.{PauseCondition, PauseConditionSet, PauseResume, ResumeCondition, ResumeConditionSet}
 import squants.Time
 import squants.time.TimeConversions._
 
-class GemsControllerEpics[F[_]: Async: ApplicativeError[?[_], Throwable]](epicsSys: GemsEpics[F],
-                                                                          gsaoiGuider: GsaoiGuider[F]
-                                                                         ) extends GemsController[F] {
-  import GemsControllerEpics._
-
-  override def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
-                          (cfg: GemsConfig)
-  : F[PauseResume[F]] = retrieveConfig.map{ c =>
-
-    // For pausing, pause loops in GeMS and then stop sensors
-    val (s1, stop) = stopCwfs(c, cfg)
-    val r1 = List(pause(pauseReasons), stop).flattenOption
-    // And the other way around for resuming, passing s1 (the state after stopping detectors) to startTtsg
-    val r2 = List(startCwfs(s1, cfg), resume(resumeReasons)).flattenOption
-
-    PauseResume(
-      r1.nonEmpty.option(r1.sequence.void),
-      r2.nonEmpty.option(r2.sequence.void)
-    )
-  }
-
-  import GsaoiGuider.OdgwId._
-  override val stateGetter: GemsWfsState[F] = GemsWfsState(
-      epicsSys.apd1Active.map(DetectorStateOps.fromBoolean[Cwfs1DetectorState]),
-      epicsSys.apd2Active.map(DetectorStateOps.fromBoolean[Cwfs2DetectorState]),
-      epicsSys.apd3Active.map(DetectorStateOps.fromBoolean[Cwfs3DetectorState]),
-      gsaoiGuider.currentState.map(x => DetectorStateOps.fromBoolean[Odgw1DetectorState](x.isOdgwGuiding(Odgw1))),
-      gsaoiGuider.currentState.map(x => DetectorStateOps.fromBoolean[Odgw2DetectorState](x.isOdgwGuiding(Odgw2))),
-      gsaoiGuider.currentState.map(x => DetectorStateOps.fromBoolean[Odgw3DetectorState](x.isOdgwGuiding(Odgw3))),
-      gsaoiGuider.currentState.map(x => DetectorStateOps.fromBoolean[Odgw4DetectorState](x.isOdgwGuiding(Odgw4)))
-    )
-
-  private val retrieveConfig: F[EpicsGems] = for{
-    cwfs1 <- stateGetter.cwfs1
-    cwfs2 <- stateGetter.cwfs2
-    cwfs3 <- stateGetter.cwfs3
-    odgw1 <- stateGetter.odgw1
-    odgw2 <- stateGetter.odgw2
-    odgw3 <- stateGetter.odgw3
-    odgw4 <- stateGetter.odgw4
-  } yield EpicsGems(
-    cwfs1,
-    cwfs2,
-    cwfs3,
-    odgw1,
-    odgw2,
-    odgw3,
-    odgw4
-  )
-
-  private def pause(pauseConditions: PauseConditionSet)
-  : Option[F[Unit]] = {
-    val unguided = pauseConditions.contains(PauseCondition.GaosGuideOff).option(UnguidedCondition)
-    val offset = pauseConditions.offsetO.as(OffsetCondition)
-    val instMove = pauseConditions.contains(PauseCondition.InstConfigMove).option(InstrumentCondition)
-
-    val reasons = List(unguided, offset, instMove).flattenOption
-
-    reasons.nonEmpty.option {
-      epicsSys.LoopControl.setCommand(PauseCmd) *>
-        epicsSys.LoopControl.setReasons(reasons.mkString("|")) *>
-        epicsSys.LoopControl.setTimeout(CmdTimeout) *>
-        epicsSys.LoopControl.post.void
-    }
-
-  }
-
-  private def resume(resumeConditions: ResumeConditionSet)
-  : Option[F[Unit]] = {
-    val unguided = resumeConditions.contains(ResumeCondition.GaosGuideOn).option(UnguidedCondition)
-    val offset = resumeConditions.offsetO.as(OffsetCondition)
-    val instMove = resumeConditions.contains(ResumeCondition.InstConfigCompleted).option(InstrumentCondition)
-
-    val reasons = List(unguided, offset, instMove).flattenOption
-
-    reasons.nonEmpty.option {
-      epicsSys.LoopControl.setCommand(ResumeCmd) *>
-        epicsSys.LoopControl.setReasons(reasons.mkString("|")) *>
-        epicsSys.LoopControl.setTimeout(CmdTimeout) *>
-        epicsSys.LoopControl.post *>
-        epicsSys.waitForStableLoops(LoopStabilizationTimeout)
-    }
-  }
-
-  import Gems.Cwfs1DetectorState.cwfs1DetectorStateDetectorStateOps
-  import Gems.Cwfs2DetectorState.cwfs2DetectorStateDetectorStateOps
-  import Gems.Cwfs3DetectorState.cwfs3DetectorStateDetectorStateOps
-
-  private def stopCwfs(current: EpicsGems, demand: GemsConfig): (EpicsGems, Option[F[Unit]]) = {
-    val p = List(
-      (DetectorStateOps.isActive(current.cwfs1) && !demand.isCwfs1Used).option(
-        (EpicsGems.cwfs1.set(Cwfs1DetectorState.Off), epicsSys.ApdControl.setApd1Cmd(ApdStop))
-      ),
-      (DetectorStateOps.isActive(current.cwfs2) && !demand.isCwfs2Used).option(
-        (EpicsGems.cwfs2.set(Cwfs2DetectorState.Off), epicsSys.ApdControl.setApd2Cmd(ApdStop))
-      ),
-      (DetectorStateOps.isActive(current.cwfs3) && !demand.isCwfs3Used).option(
-        (EpicsGems.cwfs3.set(Cwfs3DetectorState.Off), epicsSys.ApdControl.setApd3Cmd(ApdStop))
-      )
-    ).flattenOption
-
-    (
-      p.map(_._1).foldLeft(current){case (a, b) => b(a)},
-      p.nonEmpty.option{
-        p.traverse(_._2) *>
-        epicsSys.ApdControl.setTimeout(CmdTimeout) *>
-        epicsSys.ApdControl.post.void
-      }
-    )
-  }
-
-  private def startCwfs(current: EpicsGems, demand: GemsConfig): Option[F[Unit]] = {
-    val p = List(
-      (!DetectorStateOps.isActive(current.cwfs1) && demand.isCwfs1Used).option(
-        epicsSys.ApdControl.setApd1Cmd(ApdStart)
-      ),
-      (!DetectorStateOps.isActive(current.cwfs2) && demand.isCwfs2Used).option(
-        epicsSys.ApdControl.setApd2Cmd(ApdStart)
-      ),
-      (!DetectorStateOps.isActive(current.cwfs3) && demand.isCwfs3Used).option(
-        epicsSys.ApdControl.setApd3Cmd(ApdStart)
-      )
-    ).flattenOption
-
-    p.nonEmpty.option{
-      p.sequence *>
-        epicsSys.ApdControl.setTimeout(CmdTimeout) *>
-        epicsSys.ApdControl.post.void
-    }
-  }
-
-}
-
 object GemsControllerEpics {
-  val Log = getLogger
 
-  def apply[F[_]: Async](epicsSys: => GemsEpics[F],
+  private class GemsControllerEpics[F[_]: Async: Logger](
+    epicsSys: => GemsEpics[F],
+    gsaoiGuider: GsaoiGuider[F]
+  ) extends GemsController[F] {
+
+    override def pauseResume(pauseReasons: PauseConditionSet, resumeReasons: ResumeConditionSet)
+                            (cfg: GemsConfig)
+    : F[PauseResume[F]] = retrieveConfig.map{ c =>
+
+      // For pausing, pause loops in GeMS and then stop sensors
+      val (s1, stop) = stopCwfs(c, cfg)
+      val r1 = List(pause(pauseReasons), stop).flattenOption
+      // And the other way around for resuming, passing s1 (the state after stopping detectors) to startTtsg
+      val r2 = List(startCwfs(s1, cfg), resume(resumeReasons)).flattenOption
+
+      PauseResume(
+        r1.nonEmpty.option(r1.sequence.void),
+        r2.nonEmpty.option(r2.sequence.void)
+      )
+    }
+
+    import GsaoiGuider.OdgwId._
+    override lazy val stateGetter: GemsWfsState[F] = GemsWfsState(
+        epicsSys.apd1Active.map(DetectorStateOps.fromBoolean[Cwfs1DetectorState]),
+        epicsSys.apd2Active.map(DetectorStateOps.fromBoolean[Cwfs2DetectorState]),
+        epicsSys.apd3Active.map(DetectorStateOps.fromBoolean[Cwfs3DetectorState]),
+        gsaoiGuider.currentState.map(x => DetectorStateOps.fromBoolean[Odgw1DetectorState](x.isOdgwGuiding(Odgw1))),
+        gsaoiGuider.currentState.map(x => DetectorStateOps.fromBoolean[Odgw2DetectorState](x.isOdgwGuiding(Odgw2))),
+        gsaoiGuider.currentState.map(x => DetectorStateOps.fromBoolean[Odgw3DetectorState](x.isOdgwGuiding(Odgw3))),
+        gsaoiGuider.currentState.map(x => DetectorStateOps.fromBoolean[Odgw4DetectorState](x.isOdgwGuiding(Odgw4)))
+      )
+
+    private lazy val retrieveConfig: F[EpicsGems] = for{
+      cwfs1 <- stateGetter.cwfs1
+      cwfs2 <- stateGetter.cwfs2
+      cwfs3 <- stateGetter.cwfs3
+      odgw1 <- stateGetter.odgw1
+      odgw2 <- stateGetter.odgw2
+      odgw3 <- stateGetter.odgw3
+      odgw4 <- stateGetter.odgw4
+    } yield EpicsGems(
+      cwfs1,
+      cwfs2,
+      cwfs3,
+      odgw1,
+      odgw2,
+      odgw3,
+      odgw4
+    )
+
+    private def pause(pauseConditions: PauseConditionSet)
+    : Option[F[Unit]] = {
+      val unguided = pauseConditions.contains(PauseCondition.GaosGuideOff).option(UnguidedCondition)
+      val offset = pauseConditions.offsetO.as(OffsetCondition)
+      val instMove = pauseConditions.contains(PauseCondition.InstConfigMove).option(InstrumentCondition)
+
+      val reasons = List(unguided, offset, instMove).flattenOption
+
+      reasons.nonEmpty.option {
+        epicsSys.LoopControl.setCommand(PauseCmd) *>
+          epicsSys.LoopControl.setReasons(reasons.mkString("|")) *>
+          epicsSys.LoopControl.setTimeout(CmdTimeout) *>
+          epicsSys.LoopControl.post.void
+      }
+
+    }
+
+    private def resume(resumeConditions: ResumeConditionSet)
+    : Option[F[Unit]] = {
+      val unguided = resumeConditions.contains(ResumeCondition.GaosGuideOn).option(UnguidedCondition)
+      val offset = resumeConditions.offsetO.as(OffsetCondition)
+      val instMove = resumeConditions.contains(ResumeCondition.InstConfigCompleted).option(InstrumentCondition)
+
+      val reasons = List(unguided, offset, instMove).flattenOption
+
+      reasons.nonEmpty.option {
+        epicsSys.LoopControl.setCommand(ResumeCmd) *>
+          epicsSys.LoopControl.setReasons(reasons.mkString("|")) *>
+          epicsSys.LoopControl.setTimeout(CmdTimeout) *>
+          epicsSys.LoopControl.post *>
+          epicsSys.waitForStableLoops(LoopStabilizationTimeout)
+      }
+    }
+
+    import Gems.Cwfs1DetectorState.cwfs1DetectorStateDetectorStateOps
+    import Gems.Cwfs2DetectorState.cwfs2DetectorStateDetectorStateOps
+    import Gems.Cwfs3DetectorState.cwfs3DetectorStateDetectorStateOps
+
+    private def stopCwfs(current: EpicsGems, demand: GemsConfig): (EpicsGems, Option[F[Unit]]) = {
+      val p = List(
+        (DetectorStateOps.isActive(current.cwfs1) && !demand.isCwfs1Used).option(
+          (EpicsGems.cwfs1.set(Cwfs1DetectorState.Off), epicsSys.ApdControl.setApd1Cmd(ApdStop))
+        ),
+        (DetectorStateOps.isActive(current.cwfs2) && !demand.isCwfs2Used).option(
+          (EpicsGems.cwfs2.set(Cwfs2DetectorState.Off), epicsSys.ApdControl.setApd2Cmd(ApdStop))
+        ),
+        (DetectorStateOps.isActive(current.cwfs3) && !demand.isCwfs3Used).option(
+          (EpicsGems.cwfs3.set(Cwfs3DetectorState.Off), epicsSys.ApdControl.setApd3Cmd(ApdStop))
+        )
+      ).flattenOption
+
+      (
+        p.map(_._1).foldLeft(current){case (a, b) => b(a)},
+        p.nonEmpty.option{
+          p.traverse(_._2) *>
+          epicsSys.ApdControl.setTimeout(CmdTimeout) *>
+          epicsSys.ApdControl.post.void
+        }
+      )
+    }
+
+    private def startCwfs(current: EpicsGems, demand: GemsConfig): Option[F[Unit]] = {
+      val p = List(
+        (!DetectorStateOps.isActive(current.cwfs1) && demand.isCwfs1Used).option(
+          epicsSys.ApdControl.setApd1Cmd(ApdStart)
+        ),
+        (!DetectorStateOps.isActive(current.cwfs2) && demand.isCwfs2Used).option(
+          epicsSys.ApdControl.setApd2Cmd(ApdStart)
+        ),
+        (!DetectorStateOps.isActive(current.cwfs3) && demand.isCwfs3Used).option(
+          epicsSys.ApdControl.setApd3Cmd(ApdStart)
+        )
+      ).flattenOption
+
+      p.nonEmpty.option{
+        p.sequence *>
+          epicsSys.ApdControl.setTimeout(CmdTimeout) *>
+          epicsSys.ApdControl.post.void
+      }
+    }
+
+  }
+
+  def apply[F[_]: Async: Logger](epicsSys: => GemsEpics[F],
                          gsaoiGuider: GsaoiGuider[F]
                         )
   : GemsController[F] = new GemsControllerEpics[F](epicsSys, gsaoiGuider)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -149,8 +149,8 @@ object GmosControllerEpics extends GmosEncoders {
              T: Timer[F]
   ): GmosController[F, T] =
     new GmosController[F, T] {
-      private val CC = sys.configCmd
-      private val DC = sys.configDCCmd
+      private lazy val CC = sys.configCmd
+      private lazy val DC = sys.configDCCmd
 
       // Read the current state of the
       private def retrieveState: F[GmosEpicsState] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -111,17 +111,17 @@ object GnirsControllerEpics extends GnirsEncoders {
   def apply[F[_]: Async: Timer](epicsSys: => GnirsEpics[F])(implicit L: Logger[F]): GnirsController[F] =
     new GnirsController[F] {
 
-      private val ccCmd = epicsSys.configCCCmd
-      private val dcCmd = epicsSys.configDCCmd
+      private lazy val ccCmd = epicsSys.configCCCmd
+      private lazy val dcCmd = epicsSys.configDCCmd
 
-      private val warnOnDhs = epicsSys.dhsConnected.flatMap(L.warn("GNIRS is not connected to DHS").unlessA)
+      private lazy val warnOnDhs = epicsSys.dhsConnected.flatMap(L.warn("GNIRS is not connected to DHS").unlessA)
 
-      private val warnOnArray =
+      private lazy val warnOnArray =
         epicsSys.arrayActive.flatMap(L.warn("GNIRS detector array is not active").unlessA)
 
-      private val checkDhs = failUnlessM(epicsSys.dhsConnected, SeqexecFailure.Execution("GNIRS is not connected to DHS"))
+      private lazy val checkDhs = failUnlessM(epicsSys.dhsConnected, SeqexecFailure.Execution("GNIRS is not connected to DHS"))
 
-      private val checkArray =
+      private lazy val checkArray =
         failUnlessM(epicsSys.arrayActive, SeqexecFailure.Execution("GNIRS detector array is not active"))
 
       private def setAcquisitionMirror(mode: Mode): F[Option[F[Unit]]] = {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
@@ -99,7 +99,6 @@ object NifsControllerEpics extends NifsEncoders {
   private val ConfigTimeout: Time  = Seconds(400)
   private val DefaultTimeout: Time = Seconds(60)
 
-
   import NifsController._
   import NifsLookupTables._
 
@@ -318,7 +317,7 @@ object NifsControllerEpics extends NifsEncoders {
           }
       }
 
-    private val postCcConfig =
+    private lazy val postCcConfig =
       epicsSys.ccConfigCmd.setTimeout[F](ConfigTimeout) *>
         epicsSys.ccConfigCmd.post[F]
 
@@ -349,7 +348,7 @@ object NifsControllerEpics extends NifsEncoders {
     override def applyConfig(config: NifsController.NifsConfig): F[Unit] =
       configCC(config.cc) *> configDC(config.dc)
 
-    private val checkDhs =
+    private lazy val checkDhs =
       failUnlessM(
         epicsSys.dhsConnected.map(_ === DhsConnected.Yes),
                   SeqexecFailure.Execution("NIFS is not connected to DHS"))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
@@ -43,7 +43,7 @@ sealed trait TcsConfigRetriever[F[_]] {
 
 object TcsConfigRetriever {
   private class TcsConfigRetrieverImpl[F[_]: MonadError[?[_], Throwable]](
-    epicsSys: TcsEpics[F]) extends TcsConfigRetriever[F]
+    epicsSys: => TcsEpics[F]) extends TcsConfigRetriever[F]
                            with    TcsConfigDecoders
                            with    ScienceFoldPositionCodex {
 
@@ -174,13 +174,13 @@ object TcsConfigRetriever {
       wfs <- active.map{x => if(DetectorStateOps.isActive(x)) GuiderSensorOn else GuiderSensorOff}
     } yield GuiderConfig(calcProbeTrackingConfig(fol, trk), wfs)
 
-    private val getCwfs1: (VirtualGemsTelescope, F[Cwfs1DetectorState]) => F[GuiderConfig] =
+    private lazy val getCwfs1: (VirtualGemsTelescope, F[Cwfs1DetectorState]) => F[GuiderConfig] =
       getCwfs(epicsSys.cwfs1Follow)
 
-    private val getCwfs2: (VirtualGemsTelescope, F[Cwfs2DetectorState]) => F[GuiderConfig] =
+    private lazy val getCwfs2: (VirtualGemsTelescope, F[Cwfs2DetectorState]) => F[GuiderConfig] =
       getCwfs(epicsSys.cwfs1Follow)
 
-    private val getCwfs3: (VirtualGemsTelescope, F[Cwfs3DetectorState]) => F[GuiderConfig] =
+    private lazy val getCwfs3: (VirtualGemsTelescope, F[Cwfs3DetectorState]) => F[GuiderConfig] =
       getCwfs(epicsSys.cwfs1Follow)
 
     private def getOdgw[T: DetectorStateOps: Eq](getParked: F[Boolean], getFollow: F[Boolean])
@@ -192,16 +192,16 @@ object TcsConfigRetriever {
       wfs <- active.map{x => if(DetectorStateOps.isActive[T](x)) GuiderSensorOn else GuiderSensorOff}
     } yield GuiderConfig(prk.fold(ProbeTrackingConfig.Parked, calcProbeTrackingConfig(fol, trk)), wfs)
 
-    private val getOdgw1: (VirtualGemsTelescope, F[Odgw1DetectorState]) => F[GuiderConfig] =
+    private lazy val getOdgw1: (VirtualGemsTelescope, F[Odgw1DetectorState]) => F[GuiderConfig] =
       getOdgw(epicsSys.odgw1Parked, epicsSys.odgw1Follow)
 
-    private val getOdgw2: (VirtualGemsTelescope, F[Odgw2DetectorState]) => F[GuiderConfig] =
+    private lazy val getOdgw2: (VirtualGemsTelescope, F[Odgw2DetectorState]) => F[GuiderConfig] =
       getOdgw(epicsSys.odgw2Parked, epicsSys.odgw2Follow)
 
-    private val getOdgw3: (VirtualGemsTelescope, F[Odgw3DetectorState]) => F[GuiderConfig] =
+    private lazy val getOdgw3: (VirtualGemsTelescope, F[Odgw3DetectorState]) => F[GuiderConfig] =
       getOdgw(epicsSys.odgw3Parked, epicsSys.odgw3Follow)
 
-    private val getOdgw4: (VirtualGemsTelescope, F[Odgw4DetectorState]) => F[GuiderConfig] =
+    private lazy val getOdgw4: (VirtualGemsTelescope, F[Odgw4DetectorState]) => F[GuiderConfig] =
       getOdgw(epicsSys.odgw4Parked, epicsSys.odgw4Follow)
 
     private def getInstrumentPorts: F[InstrumentPorts] = for {
@@ -290,6 +290,6 @@ object TcsConfigRetriever {
 
   }
 
-  def apply[F[_]: MonadError[?[_], Throwable]](epicsSys: TcsEpics[F]): TcsConfigRetriever[F] =
+  def apply[F[_]: MonadError[?[_], Throwable]](epicsSys: => TcsEpics[F]): TcsConfigRetriever[F] =
     new TcsConfigRetrieverImpl(epicsSys)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpics.scala
@@ -13,28 +13,33 @@ import seqexec.server.tcs.TcsController._
 import seqexec.server.SeqexecFailure
 import seqexec.server.tcs.TcsNorthController.{TcsNorthAoConfig, TcsNorthConfig}
 
-final case class TcsNorthControllerEpics[F[_]: Async: Logger](epicsSys: TcsEpics[F]) extends TcsNorthController[F] {
-  private val commonController = TcsControllerEpicsCommon(epicsSys)
-  private val aoController = TcsNorthControllerEpicsAo(epicsSys)
+object TcsNorthControllerEpics {
+  private class TcsNorthControllerEpicsImpl[F[_]: Async: Logger](epicsSys: => TcsEpics[F]) extends TcsNorthController[F] {
+    private val commonController = TcsControllerEpicsCommon(epicsSys)
+    private val aoController = TcsNorthControllerEpicsAo(epicsSys)
 
-  override def applyConfig(subsystems: NonEmptySet[Subsystem],
-                           gaos: Option[Altair[F]],
-                           tcs: TcsNorthConfig): F[Unit] = {
-    tcs match {
-      case c: BasicTcsConfig   => commonController.applyBasicConfig(subsystems, c)
-      case d: TcsNorthAoConfig => gaos.map(aoController.applyAoConfig(subsystems, _, d))
-        .getOrElse(SeqexecFailure.Execution("No Altair object defined for Altair step").raiseError[F, Unit])
+    override def applyConfig(subsystems: NonEmptySet[Subsystem],
+                             gaos: Option[Altair[F]],
+                             tcs: TcsNorthConfig): F[Unit] = {
+      tcs match {
+        case c: BasicTcsConfig   => commonController.applyBasicConfig(subsystems, c)
+        case d: TcsNorthAoConfig => gaos.map(aoController.applyAoConfig(subsystems, _, d))
+          .getOrElse(SeqexecFailure.Execution("No Altair object defined for Altair step").raiseError[F, Unit])
+      }
+    }
+
+    override def notifyObserveStart: F[Unit] = commonController.notifyObserveStart
+
+    override def notifyObserveEnd: F[Unit] = commonController.notifyObserveEnd
+
+    override def nod(subsystems: NonEmptySet[Subsystem], tcsConfig: TcsNorthConfig)
+                    (stage: NodAndShuffleStage, offset: InstrumentOffset, guided: Boolean)
+    : F[Unit] = tcsConfig match {
+      case c: BasicTcsConfig => commonController.nod(subsystems, offset, guided, c)
+      case _: TcsNorthAoConfig => SeqexecFailure.Execution("N&S not supported when using Altair").raiseError[F, Unit]
     }
   }
 
-  override def notifyObserveStart: F[Unit] = commonController.notifyObserveStart
-
-  override def notifyObserveEnd: F[Unit] = commonController.notifyObserveEnd
-
-  override def nod(subsystems: NonEmptySet[Subsystem], tcsConfig: TcsNorthConfig)
-                  (stage: NodAndShuffleStage, offset: InstrumentOffset, guided: Boolean)
-  : F[Unit] = tcsConfig match {
-    case c: BasicTcsConfig => commonController.nod(subsystems, offset, guided, c)
-    case _: TcsNorthAoConfig => SeqexecFailure.Execution("N&S not supported when using Altair").raiseError[F, Unit]
-  }
+  def apply[F[_]: Async: Logger](epicsSys: => TcsEpics[F]): TcsNorthController[F] =
+    new TcsNorthControllerEpicsImpl(epicsSys)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
@@ -62,7 +62,7 @@ object TcsNorthControllerEpicsAo {
       distanceSquared.exists(dd => thresholds.exists(_.exists(t => t*t < dd)))
     }
 
-  private final class TcsNorthControllerEpicsAoImpl[F[_]: Async](epicsSys: TcsEpics[F])(implicit L: Logger[F]) extends TcsNorthControllerEpicsAo[F] with TcsControllerEncoders {
+  private final class TcsNorthControllerEpicsAoImpl[F[_]: Async](epicsSys: => TcsEpics[F])(implicit L: Logger[F]) extends TcsNorthControllerEpicsAo[F] with TcsControllerEncoders {
     private val tcsConfigRetriever = TcsConfigRetriever[F](epicsSys)
     private val commonController = TcsControllerEpicsCommon[F](epicsSys)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpics.scala
@@ -14,34 +14,43 @@ import seqexec.server.gems.GemsController.GemsConfig
 import seqexec.server.tcs.TcsController._
 import seqexec.server.tcs.TcsSouthController._
 
-final case class TcsSouthControllerEpics[F[_]: Async: Logger](epicsSys: TcsEpics[F], guideConfigDb: GuideConfigDb[F]) extends TcsSouthController[F] {
-  private val commonController = TcsControllerEpicsCommon(epicsSys)
-  private val aoController = TcsSouthControllerEpicsAo(epicsSys)
+object TcsSouthControllerEpics {
+  private class TcsSouthControllerEpicsImpl[F[_]: Async: Logger](
+    epicsSys: => TcsEpics[F],
+    guideConfigDb: GuideConfigDb[F]
+  ) extends TcsSouthController[F] {
+    private val commonController = TcsControllerEpicsCommon(epicsSys)
+    private val aoController = TcsSouthControllerEpicsAo(epicsSys)
 
-  override def applyConfig(subsystems: NonEmptySet[Subsystem],
-                           gaos: Option[Gems[F]],
-                           tcs: TcsSouthConfig): F[Unit] = {
-    tcs match {
-      case c: BasicTcsConfig   => commonController.applyBasicConfig(subsystems, c)
-      case d: TcsSouthAoConfig => for {
-        oc <- guideConfigDb.value
-        gc <- oc.gaosGuide.flatMap(_.toOption).map(_.pure[F])
-          .getOrElse(SeqexecFailure.Execution("Attemp to run GeMS step before the operator configured GeMS").raiseError[F, GemsConfig])
-        ob <- gaos.map(_.pure[F])
-          .getOrElse(SeqexecFailure.Execution("No GeMS object defined for GeMS step").raiseError[F, Gems[F]])
-        r  <- aoController.applyAoConfig(subsystems, ob, gc, d)
-      } yield r
+    override def applyConfig(subsystems: NonEmptySet[Subsystem],
+                             gaos: Option[Gems[F]],
+                             tcs: TcsSouthConfig): F[Unit] = {
+      tcs match {
+        case c: BasicTcsConfig   => commonController.applyBasicConfig(subsystems, c)
+        case d: TcsSouthAoConfig => for {
+          oc <- guideConfigDb.value
+          gc <- oc.gaosGuide.flatMap(_.toOption).map(_.pure[F])
+            .getOrElse(SeqexecFailure.Execution("Attemp to run GeMS step before the operator configured GeMS").raiseError[F, GemsConfig])
+          ob <- gaos.map(_.pure[F])
+            .getOrElse(SeqexecFailure.Execution("No GeMS object defined for GeMS step").raiseError[F, Gems[F]])
+          r  <- aoController.applyAoConfig(subsystems, ob, gc, d)
+        } yield r
+      }
+    }
+
+    override def notifyObserveStart: F[Unit] = commonController.notifyObserveStart
+
+    override def notifyObserveEnd: F[Unit] = commonController.notifyObserveEnd
+
+    override def nod(subsystems: NonEmptySet[Subsystem], tcsConfig: TcsSouthConfig)
+                    (stage: NodAndShuffleStage, offset: InstrumentOffset, guided: Boolean)
+    : F[Unit] = tcsConfig match {
+      case c: BasicTcsConfig => commonController.nod(subsystems, offset, guided, c)
+      case _: TcsSouthAoConfig => SeqexecFailure.Execution("N&S not supported when using GeMS").raiseError[F, Unit]
     }
   }
 
-  override def notifyObserveStart: F[Unit] = commonController.notifyObserveStart
+  def apply[F[_]: Async: Logger](epicsSys: => TcsEpics[F], guideConfigDb: GuideConfigDb[F]): TcsSouthController[F] =
+    new TcsSouthControllerEpicsImpl(epicsSys, guideConfigDb)
 
-  override def notifyObserveEnd: F[Unit] = commonController.notifyObserveEnd
-
-  override def nod(subsystems: NonEmptySet[Subsystem], tcsConfig: TcsSouthConfig)
-                  (stage: NodAndShuffleStage, offset: InstrumentOffset, guided: Boolean)
-  : F[Unit] = tcsConfig match {
-    case c: BasicTcsConfig => commonController.nod(subsystems, offset, guided, c)
-    case _: TcsSouthAoConfig => SeqexecFailure.Execution("N&S not supported when using GeMS").raiseError[F, Unit]
-  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -50,7 +50,7 @@ object TcsSouthControllerEpicsAo {
     odgw4: GuiderConfig
   )
 
-  private final class TcsSouthControllerEpicsAoImpl[F[_]: Async](epicsSys: TcsEpics[F])(
+  private final class TcsSouthControllerEpicsAoImpl[F[_]: Async](epicsSys: => TcsEpics[F])(
     implicit L: Logger[F]) extends TcsSouthControllerEpicsAo[F] with TcsControllerEncoders {
     private val tcsConfigRetriever = TcsConfigRetriever[F](epicsSys)
     private val commonController = TcsControllerEpicsCommon[F](epicsSys)
@@ -77,15 +77,15 @@ object TcsSouthControllerEpicsAo {
       }
       else none
 
-    val setCwfs1Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
+    lazy val setCwfs1Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
       Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
       setNgsGuide(epicsSys.cwfs1ProbeFollowCmd, EpicsTcsAoConfig.cwfs1)
 
-    val setCwfs2Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
+    lazy val setCwfs2Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
       Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
       setNgsGuide(epicsSys.cwfs2ProbeFollowCmd, EpicsTcsAoConfig.cwfs2)
 
-    val setCwfs3Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
+    lazy val setCwfs3Guide: (VirtualGemsTelescope, NonEmptySet[Subsystem], ProbeTrackingConfig, ProbeTrackingConfig) =>
       Option[EpicsTcsAoConfig => F[EpicsTcsAoConfig]] =
       setNgsGuide(epicsSys.cwfs3ProbeFollowCmd, EpicsTcsAoConfig.cwfs3)
 
@@ -392,7 +392,7 @@ object TcsSouthControllerEpicsAo {
       case _                                                              => MountGuideOption.MountGuideOff
     } }(cfg)
 
-  def apply[F[_]: Async: Logger](epicsSys: TcsEpics[F]): TcsSouthControllerEpicsAo[F] =
+  def apply[F[_]: Async: Logger](epicsSys: => TcsEpics[F]): TcsSouthControllerEpicsAo[F] =
     new TcsSouthControllerEpicsAoImpl(epicsSys)
 
 }


### PR DESCRIPTION
While testing the new config I noted we have a bug about the initialization of epics systems
This PR should fix it