### PR TITLE
Tagless auth

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -281,8 +281,14 @@ lazy val seqexec_web_server = project.in(file("modules/seqexec/web/server"))
   .settings(commonSettings: _*)
   .settings(
     addCompilerPlugin(Plugins.kindProjectorPlugin),
-    libraryDependencies ++= Seq(UnboundId, JwtCore, Http4sPrometheus, Argonaut, CommonsHttp) ++
-      Http4sClient ++ Http4s ++ PureConfig ++ Logging.value,
+    libraryDependencies ++= Seq(
+      UnboundId,
+      JwtCore,
+      JwtCirce,
+      Http4sPrometheus,
+      CommonsHttp,
+      Log4CatsNoop.value) ++
+      Http4sClient ++ Http4s ++ PureConfig ++ Logging.value ,
     // Supports launching the server in the background
     javaOptions in reStart += s"-javaagent:${(baseDirectory in ThisBuild).value}/app/seqexec-server/src/universal/bin/jmx_prometheus_javaagent-0.3.1.jar=6060:${(baseDirectory in ThisBuild).value}/app/seqexec-server/src/universal/bin/prometheus.yaml",
     mainClass in reStart := Some("seqexec.web.server.http4s.WebServerLauncher"),

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -24,7 +24,7 @@ import seqexec.web.server.security.TokenRefresher
 /**
   * Rest Endpoints under the /api route
   */
-class SeqexecCommandRoutes(auth:       AuthenticationService,
+class SeqexecCommandRoutes(auth:       AuthenticationService[IO],
                            inputQueue: server.EventQueue[IO],
                            se:         SeqexecEngine)
     extends BooEncoders {

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -16,7 +16,7 @@ import giapi.client.StatusValue
 import gem.enum.GiapiStatus
 import gem.enum.Site
 import org.http4s._
-import org.http4s.dsl.io._
+import org.http4s.dsl._
 import org.http4s.server.middleware.GZip
 import org.http4s.server.websocket.WebSocketBuilder
 import org.http4s.websocket.WebSocketFrame
@@ -45,13 +45,13 @@ import seqexec.web.common.LogMessage
   */
 class SeqexecUIApiRoutes(site: Site,
                          mode: Mode,
-                         auth: AuthenticationService,
+                         auth: AuthenticationService[IO],
                          guideConfigS: GuideConfigDb[IO],
                          giapiDB: GiapiStatusDb[IO],
                          engineOutput: Topic[IO, SeqexecEvent])(
   implicit cio: Concurrent[IO],
            tio: Timer[IO]
-) extends BooEncoders with ModelLenses {
+) extends BooEncoders with ModelLenses with Http4sDsl[IO] {
 
   // Logger for client messages
   private val clientLog = getLogger

--- a/modules/seqexec/web/server/src/test/scala/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
+++ b/modules/seqexec/web/server/src/test/scala/seqexec/web/server/http4s/SeqexecUIApiRoutesSpec.scala
@@ -9,6 +9,7 @@ import fs2.concurrent.Topic
 import fs2.Stream
 import gem.enum.Site
 import giapi.client.GiapiStatusDb
+import io.chrisdavenport.log4cats.noop.NoOpLogger
 import org.http4s._
 import org.http4s.Uri.uri
 import seqexec.model.events._
@@ -19,6 +20,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 class SeqexecUIApiRoutesSpec extends CatsSuite {
+  private implicit def logger = NoOpLogger.impl[IO]
 
   implicit val ioContextShift: ContextShift[IO] =
     IO.contextShift(ExecutionContext.global)
@@ -29,7 +31,7 @@ class SeqexecUIApiRoutesSpec extends CatsSuite {
   val statusDb = GiapiStatusDb.simulatedDb[IO]
 
   private val config = AuthenticationConfig(FiniteDuration(8, HOURS), "token", "abc", useSSL = false, Nil)
-  private val authService = AuthenticationService(Mode.Production, config)
+  private val authService = AuthenticationService[IO](Mode.Production, config)
   val out: Stream[IO, Topic[IO, SeqexecEvent]] = Stream.eval(Topic[IO, SeqexecEvent](NullEvent))
 
   private val service =

--- a/modules/seqexec/web/server/src/test/scala/seqexec/web/server/security/JWTTokensSpec.scala
+++ b/modules/seqexec/web/server/src/test/scala/seqexec/web/server/security/JWTTokensSpec.scala
@@ -3,14 +3,22 @@
 
 package seqexec.web.server.security
 
+import cats.effect.IO
+import cats.effect.Timer
 import cats.tests.CatsSuite
+import io.chrisdavenport.log4cats.noop.NoOpLogger
 import seqexec.model.config._
 import seqexec.model.UserDetails
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 
 class JWTTokensSpec extends CatsSuite {
+  private implicit def logger = NoOpLogger.impl[IO]
+  implicit val ioTimer: Timer[IO] =
+    IO.timer(ExecutionContext.global)
+
   private val config = AuthenticationConfig(FiniteDuration(8, HOURS), "token", "key", useSSL = false, Nil)
-  private val authService = AuthenticationService(Mode.Production, config)
+  private val authService = AuthenticationService[IO](Mode.Production, config)
 
   test("JWT Tokens: encode/decode") {
     forAll { (u: String, p: String) =>

--- a/modules/shared/web/server/src/main/scala/web/server/common/RedirectToHttpsRoutes.scala
+++ b/modules/shared/web/server/src/main/scala/web/server/common/RedirectToHttpsRoutes.scala
@@ -3,15 +3,15 @@
 
 package web.server.common
 
-import cats.effect.IO
-import org.http4s.dsl.io._
+import cats.effect.Sync
+import org.http4s.dsl._
 import org.http4s.headers.Location
 import org.http4s.{HttpRoutes, Uri}
 
-class RedirectToHttpsRoutes(toPort: Int, externalName: String) {
+class RedirectToHttpsRoutes[F[_]: Sync](toPort: Int, externalName: String) extends Http4sDsl[F] {
   val baseUri: Uri = Uri.fromString(s"https://$externalName:$toPort").getOrElse(Uri.uri("/"))
 
-  val service: HttpRoutes[IO] = HttpRoutes.of {
+  val service: HttpRoutes[F] = HttpRoutes.of[F] {
     case request =>
       MovedPermanently(Location(baseUri.withPath(request.uri.path)))
   }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -45,10 +45,9 @@ object Settings {
 
     val http4sVersion           = "0.20.11"
     val squants                 = "1.5.0"
-    val argonaut                = "6.2.3"
     val commonsHttp             = "2.0.2"
     val unboundId               = "3.2.1"
-    val jwt                     = "2.1.0"
+    val jwt                     = "4.1.0"
     val slf4j                   = "1.7.28"
     val log4s                   = "1.8.2"
     val log4cats                = "1.0.1"
@@ -112,10 +111,10 @@ object Settings {
     val Fs2IO                  = "co.fs2"                    %%  "fs2-io"                            % LibraryVersions.fs2Version % "test"
     val Mouse                  = Def.setting("org.typelevel" %%% "mouse"                             % LibraryVersions.mouseVersion)
     val Shapeless              = Def.setting("com.chuusai"   %%% "shapeless"                         % LibraryVersions.shapelessVersion)
-    val Argonaut               = "io.argonaut"               %%  "argonaut"                          % LibraryVersions.argonaut
     val CommonsHttp            = "commons-httpclient"        %   "commons-httpclient"                % LibraryVersions.commonsHttp
     val UnboundId              = "com.unboundid"             %   "unboundid-ldapsdk-minimal-edition" % LibraryVersions.unboundId
     val JwtCore                = "com.pauldijou"             %%  "jwt-core"                          % LibraryVersions.jwt
+    val JwtCirce               = "com.pauldijou"             %%  "jwt-circe"                         % LibraryVersions.jwt
     val Slf4j                  = "org.slf4j"                 %   "slf4j-api"                         % LibraryVersions.slf4j
     val JuliSlf4j              = "org.slf4j"                 %   "jul-to-slf4j"                      % LibraryVersions.slf4j
     val NopSlf4j               = "org.slf4j"                 %   "slf4j-nop"                         % LibraryVersions.slf4j


### PR DESCRIPTION
This PR revamps the auth code with the following improvements:
* Update to the latest jwt library
* Replace argonaut for circe
* Use tagless style

The code could have used a bit more improvements (Some bits were use to learn about free monads) but given time constraints I'll leave it as is