### PR TITLE
Improve initalization of the ca service

### DIFF
--- a/modules/seqexec/model/jvm/src/main/scala/seqexec/model/config/SystemsControlConfiguration.scala
+++ b/modules/seqexec/model/jvm/src/main/scala/seqexec/model/config/SystemsControlConfiguration.scala
@@ -26,7 +26,10 @@ final case class SystemsControlConfiguration(
   nifs:     ControlStrategy,
   niri:     ControlStrategy,
   tcs:      ControlStrategy
-)
+) {
+  def connectEpics: Boolean =
+    (altair.connect || gems.connect || f2.connect || gcal.connect || gmos.connect || gnirs.connect || gsaoi.connect || gws.connect || nifs.connect || niri.connect || tcs.connect)
+}
 
 object SystemsControlConfiguration {
   implicit val eqSystemsControl: Eq[SystemsControlConfiguration] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/CaServiceInit.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/CaServiceInit.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import cats.effect.Sync
+import cats.implicits._
+import edu.gemini.epics.acm.CaService
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.config.SeqexecEngineConfiguration
+
+object CaServiceInit {
+  // Ensure there is a valid way to init CaService either from
+  // the configuration file or from the environment
+  def caInit[F[_]](conf: SeqexecEngineConfiguration)(implicit F: Sync[F], L: Logger[F]): F[CaService] =
+    L.info("Init EPICS but all subsystems in simulation").unlessA(conf.systemControl.connectEpics) *>
+    (conf.epicsCaAddrList.map(a => F.delay(CaService.setAddressList(a))).getOrElse {
+      F.delay(Option(System.getenv("EPICS_CA_ADDR_LIST"))).flatMap {
+        case Some(_) => F.unit
+        case _       => F.raiseError[Unit](new RuntimeException("Cannot initialize EPICS subsystem"))
+      }
+    } *>
+      F.delay(CaService.setIOTimeout(java.time.Duration.ofMillis(conf.ioTimeout.toMillis))) *>
+      F.delay(Option(CaService.getInstance())).flatMap {
+        case None    => F.raiseError[CaService](new Exception("Unable to start EPICS service."))
+        case Some(s) => s.pure[F]
+      })
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/CaServiceInit.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/CaServiceInit.scala
@@ -12,15 +12,19 @@ import seqexec.model.config.SeqexecEngineConfiguration
 object CaServiceInit {
   // Ensure there is a valid way to init CaService either from
   // the configuration file or from the environment
-  def caInit[F[_]](conf: SeqexecEngineConfiguration)(implicit F: Sync[F], L: Logger[F]): F[CaService] =
+  def caInit[F[_]](conf: SeqexecEngineConfiguration)(implicit F: Sync[F], L: Logger[F]): F[CaService] = {
+    def setAddressList(a: String) =
+      F.delay(CaService.setAddressList(a))
+
     L.info("Init EPICS but all subsystems in simulation").unlessA(conf.systemControl.connectEpics) *>
-    conf.epicsCaAddrList.map(a => F.delay(CaService.setAddressList(a))).getOrElse {
+    conf.epicsCaAddrList.map(setAddressList).getOrElse {
       F.delay(Option(System.getenv("EPICS_CA_ADDR_LIST"))).flatMap {
-        case Some(_) => F.unit
+        case Some(a) => setAddressList(a).void
         case _       => F.raiseError[Unit](new RuntimeException("Cannot initialize EPICS subsystem"))
       }
     } *>
       F.delay(CaService.setIOTimeout(java.time.Duration.ofMillis(conf.ioTimeout.toMillis))) *>
         F.delay(CaService.getInstance())
          .ensure(new Exception("Unable to start EPICS service."))(c => Option(c).isDefined)
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/Systems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Systems.scala
@@ -323,10 +323,10 @@ object Systems {
     }.toMap
 
   def build(
-             site: Site,
-             httpClient: Client[IO],
-             settings: SeqexecEngineConfiguration,
-             service: CaService
-           )(implicit T: Timer[IO], L: Logger[IO], C: ContextShift[IO]): Resource[IO, Systems[IO]] =
+     site: Site,
+     httpClient: Client[IO],
+     settings: SeqexecEngineConfiguration,
+     service: CaService
+   )(implicit T: Timer[IO], L: Logger[IO], C: ContextShift[IO]): Resource[IO, Systems[IO]] =
     Builder(settings, service, decodeTops(settings.tops)).build(site, httpClient)
 }

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -37,6 +37,7 @@ import seqexec.web.server.config._
 import seqexec.server.{SeqexecEngine, SeqexecMetrics, executeEngine}
 import seqexec.server.SeqexecFailure
 import seqexec.server.Systems
+import seqexec.server.CaServiceInit
 import seqexec.web.server.OcsBuildInfo
 import seqexec.web.server.config._
 import seqexec.web.server.logging.AppenderForClients
@@ -193,8 +194,7 @@ object WebServerLauncher extends IOApp with LogInitialization {
     ): Resource[IO, SeqexecEngine[IO]] =
       for {
         met  <- Resource.liftF(SeqexecMetrics.build[IO](conf.site, collector))
-        caS  <- Resource.liftF(SeqexecEngine.caInit[IO](conf.seqexecEngine.epicsCaAddrList,
-          conf.seqexecEngine.ioTimeout))
+        caS  <- Resource.liftF(CaServiceInit.caInit[IO](conf.seqexecEngine))
         sys  <- Systems.build(conf.site, httpClient, conf.seqexecEngine, caS)
         seqE <- Resource.liftF(SeqexecEngine.build(conf.site, sys, conf.seqexecEngine, met))
       } yield seqE


### PR DESCRIPTION
I was a bit surprised to see the CaService initalized even in full simulation, then I noted it was ok to do so but I want to add a log item just to make it clearer
This PR adds that and moves the init part out of SeqexecEngine