### PR TITLE
Remove the concept of graceful abort

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -43,7 +43,7 @@ trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
 object InstrumentSystem {
 
   final case class StopObserveCmd[F[_]](self: Boolean => F[Unit])
-  final case class AbortObserveCmd[F[_]](self: Boolean => F[Unit])
+  final case class AbortObserveCmd[F[_]](self: F[Unit])
   final case class PauseObserveCmd[F[_]](self: Boolean => F[Unit])
 
   final case class ContinuePausedCmd[F[_]](self: Time => F[ObserveCommandResult])

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -224,8 +224,8 @@ object SeqTranslate {
                tio: Timer[F]
     ): EngineState[F] => Option[Stream[F, EventType[F]]] = st => {
       def f(oc: ObserveControl[F]): F[Unit] = oc match {
-        case CompleteControl(_, AbortObserveCmd(abort), _, _, _, _) => abort(graceful)
-        case UnpausableControl(_, AbortObserveCmd(abort))           => abort(graceful)
+        case CompleteControl(_, AbortObserveCmd(abort), _, _, _, _) => abort
+        case UnpausableControl(_, AbortObserveCmd(abort))           => abort
         case _                                                      => Applicative[F].unit
       }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -72,7 +72,7 @@ abstract class Gmos[F[_]: Concurrent: Logger, T <: GmosController.SiteDependentT
     else
       CompleteControl(
         StopObserveCmd(_ => controller.stopObserve),
-        AbortObserveCmd(_ => controller.abortObserve),
+        AbortObserveCmd(controller.abortObserve),
         PauseObserveCmd(_ => controller.pauseObserve),
         ContinuePausedCmd(controller.resumePaused),
         StopPausedCmd(controller.stopPaused),
@@ -85,11 +85,8 @@ abstract class Gmos[F[_]: Concurrent: Logger, T <: GmosController.SiteDependentT
     else
       nsCmdRef.set(NSObserveCommand.StopImmediately.some) *> controller.stopObserve
 
-  private def abortNS(gracefully: Boolean): F[Unit] =
-    if (gracefully)
-      nsCmdRef.set(NSObserveCommand.AbortGracefully.some)
-    else
-      nsCmdRef.set(NSObserveCommand.AbortImmediately.some) *> controller.abortObserve
+  private def abortNS: F[Unit] =
+    nsCmdRef.set(NSObserveCommand.AbortImmediately.some) *> controller.abortObserve
 
   private def pauseNS(gracefully: Boolean): F[Unit] =
     if (gracefully)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -40,7 +40,7 @@ final case class Gnirs[F[_]: Logger: Concurrent](controller: GnirsController[F],
   override def observeControl(config: CleanConfig): ObserveControl[F] =
     UnpausableControl(
       StopObserveCmd(_ => controller.stopObserve),
-      AbortObserveCmd(_ => controller.abortObserve)
+      AbortObserveCmd(controller.abortObserve)
     )
 
   override def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -46,9 +46,9 @@ final case class Gsaoi[F[_]: Logger: Concurrent](
   override val contributorName: String = "GSAOI"
 
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
-    UnpausableControl[F](
-      StopObserveCmd[F](_ => controller.stopObserve),
-      AbortObserveCmd[F](_ => controller.abortObserve)
+    UnpausableControl(
+      StopObserveCmd(_ => controller.stopObserve),
+      AbortObserveCmd(controller.abortObserve)
     )
 
   override def observe(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -52,7 +52,7 @@ final case class Nifs[F[_]: Logger: Concurrent](
 
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
     UnpausableControl(StopObserveCmd(_ => controller.stopObserve),
-      AbortObserveCmd(_ => controller.abortObserve))
+      AbortObserveCmd(controller.abortObserve))
 
   override def observe(
     config: CleanConfig

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -48,7 +48,7 @@ final case class Niri[F[_]: Timer: Logger: Concurrent](controller: NiriControlle
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
     UnpausableControl(
       StopObserveCmd(_ => controller.stopObserve),
-      AbortObserveCmd(_ => controller.abortObserve)
+      AbortObserveCmd(controller.abortObserve)
     )
 
   override def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult] =


### PR DESCRIPTION
It seems to me the concept of graceful abort is not used and could be removed. @jluhrs Why did we have it in the first place?