### PR TITLE
Improvements to StepState

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -59,7 +59,7 @@ class Engine[F[_]: MonadError[?[_], Throwable]: Logger, S, U](stateL: Engine.Sta
   def startFrom(id: Observation.Id, step: StepId): HandleType[Unit] =
     getS(id).flatMap {
       case Some(seq) if (seq.status.isIdle || seq.status.isError) && seq.toSequence.steps.exists(_.id === step) =>
-        val steps = seq.toSequence.steps.takeWhile(_.id =!= step).mapFilter(p => Step.status(p).canRunFrom.option(p.id))
+        val steps = seq.toSequence.steps.takeWhile(_.id =!= step).mapFilter(p => p.status.canRunFrom.option(p.id))
         val withSkips = steps.foldLeft[Sequence.State[F]](seq){ case (s, i) => s.setSkipMark(i, v = true) }
         putS(id)(
           Sequence.State.status.set(SequenceState.Running.init)(withSkips.skips.getOrElse(withSkips).rollback)

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Sequence.scala
@@ -3,7 +3,7 @@
 
 package seqexec.engine
 
-import seqexec.model.{SequenceState, StepId, StepState}
+import seqexec.model.{SequenceState, StepId}
 import gem.Observation
 import cats.implicits._
 import monocle.Lens
@@ -134,11 +134,11 @@ object Sequence {
 
       seq.steps.foldLeftM[Option, (List[Step[F]], List[Step[F]])]((Nil, Nil))(
         (acc, step) =>
-        if (Step.status(step) === StepState.Pending)
-          Some(acc.leftMap(_ :+ step))
-        else if (Step.status(step) === StepState.Completed || Step.status(step) === StepState.Skipped)
-          Some(acc.map(_ :+ step))
-        else None
+        if (step.status.isPending)
+          acc.leftMap(_ :+ step).some
+        else if (step.status.isFinished)
+          acc.map(_ :+ step).some
+        else none
       )
 
     }

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Step.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Step.scala
@@ -46,7 +46,7 @@ object Step {
   /**
     * Calculate the `Step` `Status` based on the underlying `Action`s.
     */
-  def status[F[_]](step: Step[F]): StepState = {
+  private def status[F[_]](step: Step[F]): StepState = {
 
     if(step.skipped.self) StepState.Skipped
     else
@@ -63,6 +63,10 @@ object Step {
         else StepState.Running
       )
 
+  }
+
+  implicit class StepOps[F[_]](val s: Step[F]) extends AnyVal {
+    def status: StepState = Step.status(s)
   }
 
   /**

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/StepSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/StepSpec.scala
@@ -603,86 +603,76 @@ class StepSpec extends CatsSuite {
   }
 
   test("status should be completed when it doesn't have any executions") {
-    assert(Step.status(stepz0.toStep) === StepState.Completed)
+    assert(stepz0.toStep.status === StepState.Completed)
   }
 
   test("status should be Error when at least one Action failed") {
     assert(
-      Step.status(
-        Step.Zipper(
-          id = 1,
-          breakpoint = Step.BreakpointMark(false),
-          skipMark = Step.SkipMark(false),
-          pending = Nil,
-          focus = Execution(List(action, actionFailed, actionCompleted)),
-          done = Nil,
-          rolledback = (Execution(List(action, action, action)), Nil)
-        ).toStep
-      ) === StepState.Failed("Dummy error")
+      Step.Zipper(
+        id = 1,
+        breakpoint = Step.BreakpointMark(false),
+        skipMark = Step.SkipMark(false),
+        pending = Nil,
+        focus = Execution(List(action, actionFailed, actionCompleted)),
+        done = Nil,
+        rolledback = (Execution(List(action, action, action)), Nil)
+      ).toStep.status === StepState.Failed("Dummy error")
     )
   }
 
   test("status should be Completed when all actions succeeded") {
     assert(
-      Step.status(
-        Step.Zipper(
-          id = 1,
-          breakpoint = Step.BreakpointMark(false),
-          skipMark = Step.SkipMark(false),
-          pending = Nil,
-          focus = Execution(List(actionCompleted, actionCompleted, actionCompleted)),
-          done = Nil,
-          rolledback = (Execution(List(action, action, action)), Nil)
-        ).toStep
-      ) === StepState.Completed
+      Step.Zipper(
+        id = 1,
+        breakpoint = Step.BreakpointMark(false),
+        skipMark = Step.SkipMark(false),
+        pending = Nil,
+        focus = Execution(List(actionCompleted, actionCompleted, actionCompleted)),
+        done = Nil,
+        rolledback = (Execution(List(action, action, action)), Nil)
+      ).toStep.status === StepState.Completed
     )
   }
 
   test("status should be Running when there are both actions and results") {
     assert(
-      Step.status(
-        Step.Zipper(
-          id = 1,
-          breakpoint = Step.BreakpointMark(false),
-          skipMark = Step.SkipMark(false),
-          pending = Nil,
-          focus = Execution(List(actionCompleted, action, actionCompleted)),
-          done = Nil,
-          rolledback = (Execution(List(action, action, action)), Nil)
-        ).toStep
-      ) === StepState.Running
+      Step.Zipper(
+        id = 1,
+        breakpoint = Step.BreakpointMark(false),
+        skipMark = Step.SkipMark(false),
+        pending = Nil,
+        focus = Execution(List(actionCompleted, action, actionCompleted)),
+        done = Nil,
+        rolledback = (Execution(List(action, action, action)), Nil)
+      ).toStep.status === StepState.Running
     )
   }
 
   test("status should be Pending when there are only pending actions") {
     assert(
-      Step.status(
-        Step.Zipper(
-          id = 1,
-          breakpoint = Step.BreakpointMark(false),
-          skipMark = Step.SkipMark(false),
-          pending = Nil,
-          focus = Execution(List(action, action, action)),
-          done = Nil,
-          rolledback = (Execution(List(action, action, action)), Nil)
-        ).toStep
-      ) === StepState.Pending
+      Step.Zipper(
+        id = 1,
+        breakpoint = Step.BreakpointMark(false),
+        skipMark = Step.SkipMark(false),
+        pending = Nil,
+        focus = Execution(List(action, action, action)),
+        done = Nil,
+        rolledback = (Execution(List(action, action, action)), Nil)
+      ).toStep.status === StepState.Pending
     )
   }
 
   test("status should be Skipped if the Step was skipped") {
     assert(
-      Step.status(
-        Step.Zipper(
-          id = 1,
-          breakpoint = Step.BreakpointMark(false),
-          skipMark = Step.SkipMark(false),
-          pending = Nil,
-          focus = Execution(List(action, action, action)),
-          done = Nil,
-          rolledback = (Execution(List(action, action, action)), Nil)
-        ).toStep.copy(skipped = Step.Skipped(true))
-      ) === StepState.Skipped
+      Step.Zipper(
+        id = 1,
+        breakpoint = Step.BreakpointMark(false),
+        skipMark = Step.SkipMark(false),
+        pending = Nil,
+        focus = Execution(List(action, action, action)),
+        done = Nil,
+        rolledback = (Execution(List(action, action, action)), Nil)
+      ).toStep.copy(skipped = Step.Skipped(true)).status === StepState.Skipped
     )
   }
 

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
@@ -254,7 +254,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
     val sf = runToCompletion(s0)
 
-    inside (sf.map(_.sequences(seqId).done.map(Step.status))) {
+    inside (sf.map(_.sequences(seqId).done.map(_.status))) {
       case Some(stepSs) => assert(stepSs === List(StepState.Skipped, StepState.Completed, StepState.Completed))
     }
   }
@@ -273,7 +273,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
     val sf = runToCompletion(s0)
 
-    inside (sf.map(_.sequences(seqId).done.map(Step.status))) {
+    inside (sf.map(_.sequences(seqId).done.map(_.status))) {
       case Some(stepSs) => assert(stepSs === List(StepState.Completed, StepState.Skipped, StepState.Completed))
     }
   }
@@ -294,7 +294,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
     val sf = runToCompletion(s0)
 
-    inside (sf.map(_.sequences(seqId).done.map(Step.status))) {
+    inside (sf.map(_.sequences(seqId).done.map(_.status))) {
       case Some(stepSs) => assert(stepSs === List(StepState.Completed, StepState.Skipped, StepState.Skipped, StepState.Skipped, StepState.Completed))
     }
   }
@@ -315,7 +315,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
     inside (sf.map(_.sequences(seqId))) {
       case Some(s @ Final(_, SequenceState.Completed)) =>
-        assert(s.done.map(Step.status) === List(StepState.Completed, StepState.Completed, StepState.Skipped))
+        assert(s.done.map(_.status) === List(StepState.Completed, StepState.Completed, StepState.Skipped))
     }
   }
 
@@ -331,7 +331,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
     val sf = runToCompletion(s0)
 
-    inside (sf.map(_.sequences(seqId).done.map(Step.status))) {
+    inside (sf.map(_.sequences(seqId).done.map(_.status))) {
       case Some(stepSs) => assert(stepSs === List(StepState.Skipped))
     }
   }
@@ -351,7 +351,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
     val sf = runToCompletion(s0)
 
-    inside (sf.map(_.sequences(seqId).done.map(Step.status))) {
+    inside (sf.map(_.sequences(seqId).done.map(_.status))) {
       case Some(stepSs) => assert(stepSs === List(StepState.Skipped, StepState.Skipped, StepState.Completed))
     }
   }
@@ -374,7 +374,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
     inside (sf.map(_.sequences(seqId))) {
       case Some(s@Final(_, SequenceState.Completed)) =>
-        assert(s.done.map(Step.status) === List(StepState.Skipped, StepState.Skipped, StepState.Skipped))
+        assert(s.done.map(_.status) === List(StepState.Skipped, StepState.Skipped, StepState.Skipped))
     }
   }
 
@@ -394,7 +394,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
     val sf = runToCompletion(s0)
 
-    inside (sf.map(_.sequences(seqId).done.map(Step.status))) {
+    inside (sf.map(_.sequences(seqId).done.map(_.status))) {
       case Some(stepSs) => assert(stepSs === List(StepState.Completed, StepState.Skipped))
     }
   }
@@ -424,7 +424,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
     val sfs = executionEngine.process(PartialFunction.empty)(Stream.eval(IO.pure(event)))(s0)
       .map(_._2).take(2).compile.toList.unsafeRunSync
 
-    /*
+    /**
      * First state update must have the action started.
      * Second state update must have the action finished.
      * The value in `dummy` must change. That is prove that the `Action` run.
@@ -486,10 +486,10 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
     ).compile.last.unsafeRunSync.map(_._2)
 
     inside (sf.flatMap(_.sequences.get(seqId).map(_.toSequence))) {
-      case Some(seq) => assertResult(Some(StepState.Completed))(seq.steps.get(0).map(Step.status))
-        assertResult(Some(StepState.Skipped))(seq.steps.get(1).map(Step.status))
-        assertResult(Some(StepState.Completed))(seq.steps.get(2).map(Step.status))
-        assertResult(Some(StepState.Completed))(seq.steps.get(3).map(Step.status))
+      case Some(seq) => assertResult(Some(StepState.Completed))(seq.steps.get(0).map(_.status))
+        assertResult(Some(StepState.Skipped))(seq.steps.get(1).map(_.status))
+        assertResult(Some(StepState.Completed))(seq.steps.get(2).map(_.status))
+        assertResult(Some(StepState.Completed))(seq.steps.get(3).map(_.status))
     }
 
   }

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/Step.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/Step.scala
@@ -130,32 +130,16 @@ object Step {
 
     def file: Option[String] = None
 
-    def canSetBreakpoint(i: Int, firstRunnable: Int): Boolean = s.status match {
-      case StepState.Pending | StepState.Skipped | StepState.Paused |
-          StepState.Running => i > firstRunnable
-      case _ => false
-    }
+    def canSetBreakpoint(i: Int, firstRunnable: Int): Boolean =
+      s.status.canSetBreakpoint(i, firstRunnable)
 
-    def canSetSkipmark: Boolean = s.status match {
-      case StepState.Pending | StepState.Paused => true
-      case _ if hasError                        => true
-      case _                                    => false
-    }
+    def canSetSkipmark: Boolean = s.status.canSetSkipmark
 
-    def hasError: Boolean = s.status match {
-      case StepState.Failed(_) => true
-      case _                   => false
-    }
+    def hasError: Boolean = s.status.hasError
 
-    def isRunning: Boolean = s.status match {
-      case StepState.Running => true
-      case _                 => false
-    }
+    def isRunning: Boolean = s.status.isRunning
 
-    def runningOrComplete: Boolean = s.status match {
-      case StepState.Running | StepState.Completed => true
-      case _                                       => false
-    }
+    def runningOrComplete: Boolean = s.status.runningOrComplete
 
     def isObserving: Boolean = s match {
       case StandardStep(_, _, _, _, _, _, _, o)      => o === ActionStatus.Running
@@ -177,20 +161,13 @@ object Step {
       case _ => false
     }
 
-    def isFinished: Boolean =
-      s.status === StepState.Completed || s.status === StepState.Skipped
+    def isFinished: Boolean = s.status.isFinished
 
-    def wasSkipped: Boolean = s.status === StepState.Skipped
+    def wasSkipped: Boolean = s.status.wasSkipped
 
-    def canRunFrom: Boolean = s.status match {
-      case StepState.Pending | StepState.Failed(_) => true
-      case _                                       => false
-    }
+    def canRunFrom: Boolean = s.status.canRunFrom
 
-    def canConfigure: Boolean = s.status match {
-      case StepState.Pending | StepState.Paused | StepState.Failed(_) => true
-      case _                                                          => false
-    }
+    def canConfigure: Boolean = s.status.canConfigure
 
     def isMultiLevel: Boolean = s match {
       case _: NodAndShuffleStep => true

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/StepState.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/StepState.scala
@@ -29,4 +29,49 @@ object StepState {
       case _                      => false
     }
 
+    implicit class StepStateOps(val s: StepState) extends AnyVal {
+      def canSetBreakpoint(i: Int, firstRunnable: Int): Boolean = s match {
+        case StepState.Pending | StepState.Skipped | StepState.Paused |
+            StepState.Running => i > firstRunnable
+        case _ => false
+      }
+
+      def canSetSkipmark: Boolean = s match {
+        case StepState.Pending | StepState.Paused => true
+        case _ if hasError                        => true
+        case _                                    => false
+      }
+
+      def hasError: Boolean = s match {
+        case StepState.Failed(_) => true
+        case _                   => false
+      }
+
+      def isRunning: Boolean = s === StepState.Running
+
+      def isPending: Boolean = s === StepState.Pending
+
+      def runningOrComplete: Boolean = s match {
+        case StepState.Running | StepState.Completed => true
+        case _                                       => false
+      }
+
+      def isFinished: Boolean = s match {
+        case StepState.Completed | StepState.Skipped => true
+        case _                                       => false
+      }
+
+      def wasSkipped: Boolean = s === StepState.Skipped
+
+      def canRunFrom: Boolean = s match {
+        case StepState.Pending | StepState.Failed(_) => true
+        case _                                       => false
+      }
+
+      def canConfigure: Boolean = s match {
+        case StepState.Pending | StepState.Paused | StepState.Failed(_) => true
+        case _                                                          => false
+      }
+
+    }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -58,7 +58,7 @@ trait SeqTranslate[F[_]] extends ObserveActions {
     implicit cio: Concurrent[F], tio: Timer[F]
   ): EngineState[F] => Option[Stream[F, EventType[F]]]
 
-  def abortObserve(seqId: Observation.Id, graceful: Boolean)(
+  def abortObserve(seqId: Observation.Id)(
     implicit cio: Concurrent[F], tio: Timer[F]
   ): EngineState[F] => Option[Stream[F, EventType[F]]]
 
@@ -151,7 +151,7 @@ object SeqTranslate {
 
       val nextToRun = configs
         .map(extractStatus)
-        .lastIndexWhere(s => s === StepState.Completed || s === StepState.Skipped) + 1
+        .lastIndexWhere(_.isFinished) + 1
 
       val steps = configs.zipWithIndex.map {
         case (c, i) => step(obsId, i, c, nextToRun, sequence.datasets).attempt
@@ -219,7 +219,7 @@ object SeqTranslate {
       deliverObserveCmd(seqId, f)(st).orElse(stopPaused(seqId).apply(st))
     }
 
-    override def abortObserve(seqId: Observation.Id, graceful: Boolean)(
+    override def abortObserve(seqId: Observation.Id)(
       implicit cio: Concurrent[F],
                tio: Timer[F]
     ): EngineState[F] => Option[Stream[F, EventType[F]]] = st => {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -82,7 +82,7 @@ trait SeqexecEngine[F[_]] {
 
   def stopObserve(q: EventQueue[F], seqId: Observation.Id, graceful: Boolean): F[Unit]
 
-  def abortObserve(q: EventQueue[F], seqId: Observation.Id, graceful: Boolean): F[Unit]
+  def abortObserve(q: EventQueue[F], seqId: Observation.Id): F[Unit]
 
   def pauseObserve(q: EventQueue[F], seqId: Observation.Id, graceful: Boolean): F[Unit]
 
@@ -274,8 +274,8 @@ object SeqexecEngine {
       Event.actionStop[F, EngineState[F], SeqEvent](seqId, translator.stopObserve(seqId, graceful))
     )
 
-    override def abortObserve(q: EventQueue[F], seqId: Observation.Id, graceful: Boolean): F[Unit] = q.enqueue1(
-      Event.actionStop[F, EngineState[F], SeqEvent](seqId, translator.abortObserve(seqId, graceful))
+    override def abortObserve(q: EventQueue[F], seqId: Observation.Id): F[Unit] = q.enqueue1(
+      Event.actionStop[F, EngineState[F], SeqEvent](seqId, translator.abortObserve(seqId))
     )
 
     override def pauseObserve(q: EventQueue[F], seqId: Observation.Id, graceful: Boolean): F[Unit] = q.enqueue1(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosStepView.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosStepView.scala
@@ -8,6 +8,7 @@ import seqexec.model._
 import seqexec.model.enum._
 import seqexec.engine
 import seqexec.server._
+import seqexec.server.StepsView._
 import seqexec.server.gmos.GmosController.Config._
 import mouse.all._
 
@@ -19,10 +20,10 @@ final class GmosStepsView[F[_]] extends StepsView[F] {
   ): Step =
     Gmos.nsConfig(stepg.config) match {
       case Right(e @ NSConfig.NodAndShuffle(c, _, _, _)) =>
-        val status = engine.Step.status(step)
+        val status = step.status
         val configStatus =
-          if (StepsView.runningOrComplete(status)) {
-            StepsView.stepConfigStatus(step)
+          if (status.runningOrComplete) {
+            stepConfigStatus(step)
           } else {
             altCfgStatus
           }
@@ -49,7 +50,7 @@ final class GmosStepsView[F[_]] extends StepsView[F] {
           skip         = step.skipMark.self,
           configStatus = configStatus,
           nsStatus =
-            NodAndShuffleStatus(StepsView.observeStatus(step.executions),
+            NodAndShuffleStatus(observeStatus(step.executions),
                                 e.totalExposureTime,
                                 e.nodExposureTime,
                                 c,
@@ -61,7 +62,7 @@ final class GmosStepsView[F[_]] extends StepsView[F] {
             }.flatten)
         )
       case _ =>
-        StepsView.defaultStepsView.stepView(stepg, step, altCfgStatus)
+        defaultStepsView.stepView(stepg, step, altCfgStatus)
     }
 
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -87,12 +87,12 @@ class SeqTranslateSpec extends AnyFlatSpec {
   }
 
   "SeqTranslate" should "trigger abortObserve command only if exposure is in progress" in {
-    assert(translator.abortObserve(seqId, graceful = false).apply(s0).isDefined)
-    assert(translator.abortObserve(seqId, graceful = false).apply(s1).isEmpty)
-    assert(translator.abortObserve(seqId, graceful = false).apply(s2).isEmpty)
-    assert(translator.abortObserve(seqId, graceful = false).apply(s3).isDefined)
-    assert(translator.abortObserve(seqId, graceful = false).apply(s4).isDefined)
-    assert(translator.abortObserve(seqId, graceful = false).apply(s5).isEmpty)
+    assert(translator.abortObserve(seqId).apply(s0).isDefined)
+    assert(translator.abortObserve(seqId).apply(s1).isEmpty)
+    assert(translator.abortObserve(seqId).apply(s2).isEmpty)
+    assert(translator.abortObserve(seqId).apply(s3).isDefined)
+    assert(translator.abortObserve(seqId).apply(s4).isDefined)
+    assert(translator.abortObserve(seqId).apply(s5).isEmpty)
   }
 
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -222,9 +222,9 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
         .compile.last
     } yield {
       inside(sf.flatMap(EngineState.sequenceStateIndex[IO](seqObsId1).getOption).map(_.toSequence.steps)) {
-        case Some(steps) => assertResult(Some(StepState.Skipped))( steps.get(0).map(Step.status))
-                            assertResult(Some(StepState.Skipped))( steps.get(1).map(Step.status))
-                            assertResult(Some(StepState.Completed))( steps.get(2).map(Step.status))
+        case Some(steps) => assertResult(Some(StepState.Skipped))(steps.get(0).map(_.status))
+                            assertResult(Some(StepState.Skipped))(steps.get(1).map(_.status))
+                            assertResult(Some(StepState.Completed))(steps.get(2).map(_.status))
       }
     }).unsafeRunSync
   }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/StepsViewSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/StepsViewSpec.scala
@@ -329,9 +329,9 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
         .compile.last
     } yield {
       inside(sf.flatMap(EngineState.sequenceStateIndex(seqObsId1).getOption).map(_.toSequence.steps)) {
-        case Some(steps) => assertResult(Some(StepState.Skipped))( steps.get(0).map(Step.status))
-                            assertResult(Some(StepState.Skipped))( steps.get(1).map(Step.status))
-                            assertResult(Some(StepState.Completed))( steps.get(2).map(Step.status))
+        case Some(steps) => assertResult(Some(StepState.Skipped))(steps.get(0).map(_.status))
+                            assertResult(Some(StepState.Skipped))(steps.get(1).map(_.status))
+                            assertResult(Some(StepState.Completed))(steps.get(2).map(_.status))
       }
     }).unsafeRunSync
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -113,16 +113,6 @@ object SeqexecWebClient extends ModelBooPicklers {
       .void
 
   /**
-    * Requests the backend to abort this sequenece gracefully
-    */
-  def abortGracefully(sid: Observation.Id, step: StepId): Future[Unit] =
-    Ajax
-      .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/abortGracefully"
-        )
-      .void
-
-  /**
     * Requests the backend to hold the current exposure immediately
     */
   def pauseObs(sid: Observation.Id, step: StepId): Future[Unit] =

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -90,14 +90,8 @@ class SeqexecCommandRoutes[F[_]: Sync](auth:       AuthenticationService[F],
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "abort" as _ =>
       for {
-        _    <- se.abortObserve(inputQueue, obsId, graceful = false)
+        _    <- se.abortObserve(inputQueue, obsId)
         resp <- Ok(s"Abort requested for $obsId on step $stepId")
-      } yield resp
-
-    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "abortGracefully" as _ =>
-      for {
-        _    <- se.abortObserve(inputQueue, obsId, graceful = true)
-        resp <- Ok(s"Abort gracefully requested for $obsId on step $stepId")
       } yield resp
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "pauseObs" as _ =>


### PR DESCRIPTION
This is a small refactoring while I'm doing some changes to abort. It adds a syntax to find the status of an engine Step and removes some duplicated bits
It also removes some references to the deprecated graceful abort mode