### PR TITLE
SEQNG-1124: Avoid duplicated abort notifications to the odb

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/OdbProxy.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/OdbProxy.scala
@@ -92,37 +92,43 @@ object OdbProxy {
       )
 
     override def obsAbort(obsId: Observation.Id, reason: String): F[Boolean] =
+      L.debug(s"Aborted: ${obsId.format} reason: $reason") *>
       F.delay(
         xmlrpcClient.observationAbort(sessionName, obsId.format, reason)
       )
 
     override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
-      Sync[F].delay(
+      L.debug(s"${obsId.format} sequence ended") *>
+      F.delay(
         xmlrpcClient.sequenceEnd(sessionName, obsId.format)
       )
 
     override def sequenceStart(obsId: Observation.Id, dataId: DataId): F[Boolean] =
+      L.debug(s"${obsId.format} sequence started") *>
       F.delay(
         xmlrpcClient.sequenceStart(sessionName, obsId.format, dataId.toString)
       )
 
     override def obsContinue(obsId: Observation.Id): F[Boolean] =
-      Sync[F].delay(
+      L.debug(s"${obsId.format} sequence continues") *>
+      F.delay(
         xmlrpcClient.observationContinue(sessionName, obsId.format)
       )
 
     override def obsPause(obsId: Observation.Id, reason: String): F[Boolean] =
-      Sync[F].delay(
+      L.debug(s"${obsId.format} sequence paused: $reason") *>
+      F.delay(
         xmlrpcClient.observationPause(sessionName, obsId.format, reason)
       )
 
     override def obsStop(obsId: Observation.Id, reason: String): F[Boolean] =
-      Sync[F].delay(
+      L.debug(s"${obsId.format} sequence stopped: $reason") *>
+      F.delay(
         xmlrpcClient.observationStop(sessionName, obsId.format, reason)
       )
 
     override def queuedSequences: F[List[Observation.Id]] =
-      Sync[F].delay(
+      F.delay(
         xmlrpcClient.getObservations(sessionName).toList.flatMap(id => Observation.Id.fromString(id).toList)
       ).recoverWith {
         case e: ServiceException =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -56,7 +56,7 @@ class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDe
       case ObserveCommandResult.Stopped =>
         okTail(fileId, dataId, stopped = true, env)
       case ObserveCommandResult.Aborted =>
-        abortTail(env.systems, env.obsId, fileId)
+        abortTail(env.obsId)
       case ObserveCommandResult.Paused =>
         env.inst
           .calcObserveTime(env.config)
@@ -77,7 +77,7 @@ class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDe
   private def initialObserve(
     fileId: ImageFileId,
     env:    ObserveEnvironment[F],
-    nsCfg: NSConfig.NodAndShuffle,
+    nsCfg:  NSConfig.NodAndShuffle,
     subExp: NSSubexposure,
     nsObsCmd: Ref[F, Option[NSObserveCommand]]
   ): F[Result[F]] =
@@ -91,7 +91,7 @@ class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDe
   private def lastObserve(
     fileId: ImageFileId,
     env:    ObserveEnvironment[F],
-    nsCfg: NSConfig.NodAndShuffle
+    nsCfg:  NSConfig.NodAndShuffle
   ): F[Result[F]] =
     // the last step completes the observations doing an observeTail
     (for {
@@ -105,7 +105,7 @@ class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDe
     fileId: ImageFileId,
     dataId: DataId,
     env:    ObserveEnvironment[F],
-    nsCfg: NSConfig.NodAndShuffle,
+    nsCfg:  NSConfig.NodAndShuffle,
     subExp: NSSubexposure,
     nsObsCmd: Option[NSObserveCommand])(obsResult: ObserveCommandResult): F[Result[F]] =
     (nsObsCmd, obsResult) match {
@@ -144,7 +144,7 @@ class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDe
   private def continueObserve(
     fileId: ImageFileId,
     env:    ObserveEnvironment[F],
-    nsCfg: NSConfig.NodAndShuffle,
+    nsCfg:  NSConfig.NodAndShuffle,
     subExp: NSSubexposure,
     nsObsCmdRef: Ref[F, Option[NSObserveCommand]]
   ): F[Result[F]] = (
@@ -241,8 +241,8 @@ class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDe
       }
 
   def resumeObserve(
-    fileId: ImageFileId,
-    env:    ObserveEnvironment[F],
+    fileId:  ImageFileId,
+    env:     ObserveEnvironment[F],
     nsConfig: NSConfig.NodAndShuffle
   ): Stream[F, Result[F]] = {
 
@@ -271,7 +271,7 @@ class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDe
     fileId: ImageFileId,
     dataId: DataId,
     env:    ObserveEnvironment[F],
-    nsCfg: NSConfig.NodAndShuffle
+    nsCfg:  NSConfig.NodAndShuffle
   ): Stream[F, Result[F]] = Stream.eval(
     inst.controller.stopPaused.flatMap(observeTail(fileId, dataId, env, nsCfg))
   )
@@ -280,20 +280,20 @@ class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDe
     fileId: ImageFileId,
     dataId: DataId,
     env:    ObserveEnvironment[F],
-    nsCfg: NSConfig.NodAndShuffle
+    nsCfg:  NSConfig.NodAndShuffle
   ): Stream[F, Result[F]] = Stream.eval(
     inst.controller.abortPaused.flatMap(observeTail(fileId, dataId, env, nsCfg))
   )
 
   def launchObserve(
-    env:  ObserveEnvironment[F]
+    env: ObserveEnvironment[F]
   ): Stream[F, Result[F]] =
     Stream.eval(FileIdProvider.fileId(env)).flatMap { fileId =>
       Stream.emit(Result.Partial(FileIdAllocated(fileId))) ++ doObserve(fileId, env)
     }.handleErrorWith(catchObsErrors[F])
 
   override def observeActions(
-    env:  ObserveEnvironment[F]
+    env: ObserveEnvironment[F]
   ): List[ParallelActions[F]] =
     env.stepType match {
       case StepType.NodAndShuffle(i) if i === inst.resource =>


### PR DESCRIPTION
Some testing shows that on abort we get two abort events on the odb:
<img width="891" alt="image" src="https://user-images.githubusercontent.com/3615303/68347753-b18c8880-00d6-11ea-8d6b-93ca5e0c253e.png">

This is because the abort sends one, and we have a generic one for errors.
A future change will make abort act without using an error but in the meanwhile this PR fixes it