### PR TITLE
SEQNG-1038 Custom tolerance function for polarizer angle

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiController.scala
@@ -276,7 +276,8 @@ object GpiController extends GpiLookupTables with GpiConfigEq {
   ): F[Configuration] =
     for {
       b <- gpiConfiguration(config).pure[F]
-      q <- GpiStatusApply.foldConfig(client.statusDb, b)
+      c <- GpiStatusApply.overridePolAngle(client.statusDb, b)
+      q <- GpiStatusApply.foldConfig(client.statusDb, c)
       p <- GpiStatusApply.overrideObsMode(client.statusDb, config, q)
       _ <- Logger[F].info(s"Applied GPI config ${p.config}").unlessA(p.config.isEmpty)
     } yield p

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiStatusApply.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiStatusApply.scala
@@ -176,7 +176,7 @@ object GpiStatusApply extends GpiLookupTables {
           // "normalized" difference
           val δʹ= abs(if (δ < - π) δ + 2*π else if (δ >= π) δ - 2*π else δ)
           val ε: Option[Double] = GpiPolarizerAngle.tolerance.map(t => Angle.fromDoubleDegrees(t.toDouble).toSignedDoubleRadians)
-          ε.exists(abs(δʹ) <= _)
+          ε.exists(δʹ <= _)
         }.getOrElse(false)
       })
 


### PR DESCRIPTION
Turns out the original comparison function to decide if we should move GPI's polarizer angle was too naive not taking into account wraparounds on 360
This PR improves it calculating the shortest angle difference and fixes an additional bug on comparisons
This code was tested on instrument and surfaced an extra bug on GPI TLC code: REL-3752