### PR TITLE
[SEQENG-1125] & [SEQNG-1116] (partial)

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/ObservationProgressBar.scala
@@ -32,7 +32,7 @@ trait ProgressLabel {
     val durationStr = if (remainingSecs > 1) s"$remainingSecs seconds" else "1 second"
 
     if (paused) s"$fileId - Paused - $durationStr left"
-      else if (stopping) s"$fileId - Stopping - $durationStr left"
+      else if (stopping) s"$fileId - Stopping - Reading out..."
       else if (remainingSecs > 0) s"$fileId - $durationStr left"
       else s"$fileId - Reading out..."
   }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsControlButtons.scala
@@ -146,7 +146,7 @@ object ControlButtons {
                  icon     = Some(IconStop),
                  color    = Some("orange"),
                  onClick  = requestGracefulStop(p.id, p.stepId),
-                 disabled = p.requestInFlight
+                 disabled = p.requestInFlight || p.isObservePaused
                )
              )
          }


### PR DESCRIPTION
[SEQNG-1125]: Disable GMOS N&S "Stop at end of cycle" button while paused

Regarding [SEQNG-1116]: Indicate detector is reading out after Stop
*  I'm changing the message to "Stopping - Reading Out" whenever a stop is requested in any kind of observation. I just need confirmation that a "Reading Out" always takes place whenever a Stop is requested in any kind of step.

* Also, @jluhrs @cquiroz  we seem to be missing an event that should happen whenever a graceful stop starts. Without that, we have no way to display the "Reading Out" message when the end of the cycle is reached. (At least without knowing that a graceful stop has been requested).