### PR TITLE
[SEQNG-1116] Indicate detector is reading out after stop.

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -214,7 +214,7 @@ object actions {
 
   private val stepInfo: PartialFunction[Step, Product] = {
     case i: StandardStep => (i.id, i.status, i.configStatus)
-    case i: NodAndShuffleStep => (i.id, i.status, i.configStatus, i.nsStatus)
+    case i: NodAndShuffleStep => (i.id, i.status, i.configStatus, i.nsStatus, i.pendingObserveCmd)
   }
 
   implicit val show: Show[Action] = Show.show {

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -16,7 +16,7 @@ import seqexec.web.client.model.StepItems.StepStateSummary
 import seqexec.model.enum.NodAndShuffleStage
 import seqexec.web.client.components.{DividedProgress, SeqexecStyles}
 import seqexec.model.dhs.ImageFileId
-import seqexec.model.{NSObservationProgress, NodAndShuffleStatus, StepId}
+import seqexec.model.{NSObservationProgress, NodAndShuffleStatus, ObserveStage, StepId}
 import seqexec.model.operations._
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.model.{ClientStatus, StopOperation}
@@ -65,7 +65,8 @@ object NodAndShuffleProgressMessage extends ProgressLabel {
             val remainingNods = nodCount - nsState.sub.stageIndex - 1
             val remainingNodMillis = proxy().foldMap(_.remaining.toMilliseconds.toInt)
             val remainingMillis = remainingCycles * cycleMillis + remainingNods * nodMillis + remainingNodMillis
-            <.span(label(p.fileId, remainingMillis, p.stopping, p.paused))
+            val stage = proxy().map(_.stage).getOrElse(ObserveStage.Idle)
+            <.span(label(p.fileId, remainingMillis, p.stopping, p.paused, stage))
           }
         } getOrElse <.span(p.fileId)
         )


### PR DESCRIPTION
I'm detecting a number of cases where the UI is not receiving the `ReadingOut` status:
  - Regular observation stopped early.
  - N&S graceful stop reached.
  - N&S observation completes normally.

Consulting with @jluhrs it seems this is a simulation issue. However, I'm keeping some heuristic logic to show "Reading Out" when the observation is stopping or the remaining time is 0, just in case.