### PR TITLE
[SEQNG-1123] Remember user-edited Observer name

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -421,6 +421,16 @@ body {
   padding-right: 0 !important;
 }
 
+.SeqexecStyles-defaultObserverEditField {
+  width: 10em !important;
+  margin-left: 1em !important;
+
+  input {
+    background-color: #555555 !important;
+    color: white !important;
+  }
+}
+
 .SeqexecStyles-shorterFields {
   margin-bottom: 0.2em !important;
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/HeaderSideBarFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/HeaderSideBarFocus.scala
@@ -45,7 +45,7 @@ object HeaderSideBarFocus {
 
   val headerSideBarG: Getter[SeqexecAppRootModel, HeaderSideBarFocus] =
     Getter[SeqexecAppRootModel, HeaderSideBarFocus] { c =>
-      val clientStatus = ClientStatus(c.uiModel.user, c.ws)
+      val clientStatus = ClientStatus(c.uiModel.user, c.uiModel.defaultObserver, c.ws)
       val obs = c.uiModel.sequencesOnDisplay.selectedObserver
         .toRight(c.uiModel.defaultObserver)
       HeaderSideBarFocus(clientStatus,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/ControlMenu.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/ControlMenu.scala
@@ -3,8 +3,7 @@
 
 package seqexec.web.client.components
 
-import seqexec.web.client.actions.Logout
-import seqexec.web.client.actions.OpenLoginBox
+import seqexec.web.client.actions.{Logout, OpenLoginBox, UpdateDefaultObserver}
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.semanticui.Size
@@ -14,7 +13,11 @@ import react.common.implicits._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.extra.StateSnapshot
 import japgolly.scalajs.react.vdom.html_<^._
+import seqexec.model.Observer
+import seqexec.web.client.semanticui.elements.input.InputEV
+import seqexec.web.client.semanticui.elements.label.FormLabel
 
 /**
   * Menu with options
@@ -44,14 +47,31 @@ object ControlMenu {
            disabled = !enabled,
            inverted = true)(text)
 
+
+  // Ideally we'd do this with css text-overflow but it is not
+  // working properly inside a header item, let's abbreviate in code
+  private def overflowText(text: String): String =
+    text
+      .split("\\s")
+      .headOption
+      .map(_.substring(0, 10) + "...")
+      .getOrElse[String]("")
+
   private val component = ScalaComponent
     .builder[Props]("SeqexecTopMenu")
     .stateless
     .render_P { p =>
       val status = p.status
+
+      val enabled = p.status.canOperate
+      def updateStateOb(value: Option[String], cb: Callback): Callback =
+        SeqexecCircuit.dispatchCB(UpdateDefaultObserver(value.fold(Observer.Zero)(Observer.apply))) >> cb
+      val observerEV =
+        StateSnapshot(p.status.defaultObserver.value)(updateStateOb)
+
       <.div(
         ^.cls := "ui secondary right menu",
-        status.u.fold(
+        status.userDetails.fold(
           <.div(
             ^.cls := "ui item",
             soundConnect(x => SoundControl(SoundControl.Props(x()))),
@@ -62,20 +82,35 @@ object ControlMenu {
             <.div(
               ^.cls := "ui secondary right menu",
               <.div(
+                ^.cls := "ui form item",
+                SeqexecStyles.notInMobile,
+                FormLabel(FormLabel.Props("Observer:", Some("observer"))),
+                <.div(
+                  ^.cls := "ui input",
+                  SeqexecStyles.defaultObserverEditField,
+                  InputEV(
+                    InputEV.Props("observer",
+                                  "observer",
+                                  observerEV,
+                                  placeholder = "Observer...",
+                                  disabled    = !enabled)
+                  )
+                )
+              ),
+              <.div(
+                ^.cls := "ui item",
+                SeqexecStyles.onlyMobile,
+                s"Observer: ${overflowText(status.defaultObserver.value)}"
+              ),
+              <.div(
                 ^.cls := "ui header item",
                 SeqexecStyles.notInMobile,
-                u.displayName
+                s"User: ${u.displayName}"
               ),
               <.div(
                 ^.cls := "ui header item",
                 SeqexecStyles.onlyMobile,
-                // Ideally we'd do this with css text-overflow but it is not
-                // working properly inside a header item, let's abbreviate in code
-                u.displayName
-                  .split("\\s")
-                  .headOption
-                  .map(_.substring(0, 10) + "...")
-                  .getOrElse[String]("")
+                s"User: ${overflowText(u.displayName)}"
               ),
               <.div(
                 ^.cls := "ui item",

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/HeadersSideBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/HeadersSideBar.scala
@@ -153,6 +153,7 @@ object HeadersSideBar {
       val obsCompleted =
         p.selectedObserver.map(_.fold(_ => false, _.completed)).getOrElse(false)
       val observerField = s"Observer - $instrument"
+      val isDefaultObserver =  p.selectedObserver.isLeft
       <.div(
         ^.cls := "ui secondary segment",
         SeqexecStyles.headerSideBarStyle,
@@ -181,7 +182,7 @@ object HeadersSideBar {
                               "observer",
                               observerEV,
                               placeholder = "Observer...",
-                              disabled    = !enabled || obsCompleted,
+                              disabled    = !enabled || obsCompleted || isDefaultObserver,
                               onBlur      = _ => submitIfChangedOb)
               )
             )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -166,6 +166,8 @@ object SeqexecStyles {
 
   val observerField: Css = Css("SeqexecStyles-observerField")
 
+  val defaultObserverEditField: Css = Css("SeqexecStyles-defaultObserverEditField")
+
   val shorterFields: Css = Css("SeqexecStyles-shorterFields")
 
   val configLabel: Css = Css("SeqexecStyles-configLabel")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -212,7 +212,7 @@ object SessionQueueTable extends Columns {
 
     val loggedIn: Boolean = sequences.status.isLogged
 
-    val user: Option[UserDetails] = sequences.status.u
+    val user: Option[UserDetails] = sequences.status.userDetails
 
     val extractors = List[(TableColumn, SequenceInSessionQueue => String)](
       (ObsIdColumn, _.id.format),

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -261,12 +261,13 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
     Arbitrary {
       for {
         u <- arbitrary[Option[UserDetails]]
+        o <- arbitrary[Observer]
         w <- arbitrary[WebSocketConnection]
-      } yield ClientStatus(u, w)
+      } yield ClientStatus(u, o, w)
     }
 
   implicit val cssCogen: Cogen[ClientStatus] =
-    Cogen[(Option[UserDetails], WebSocketConnection)].contramap(x => (x.u, x.w))
+    Cogen[(Option[UserDetails], Observer, WebSocketConnection)].contramap(x => (x.userDetails, x.defaultObserver, x.webSocket))
 
   implicit val arbTableType: Arbitrary[StepsTableTypeSelection] =
     Arbitrary(


### PR DESCRIPTION
The user-edited was being remembered but it seems the current interfaced proved a bit confusing.

This is how it is looking now:

![defaultObserver](https://user-images.githubusercontent.com/1895643/69010857-ae00c900-0942-11ea-8005-319ffd797220.gif)

As always, I accept suggestions regarding UI in general: fonts, colors, behavior, etc.