### PR TITLE
Add systemd launcher scripts

### DIFF
--- a/app/seqexec-server/src/main/resources/seqexec-server.env
+++ b/app/seqexec-server/src/main/resources/seqexec-server.env
@@ -1,0 +1,38 @@
+# #####################################
+# ##### Environment Configuration #####
+# #####################################
+
+# To use your own template create
+#   src/templates/etc-default-systemv
+# see http://www.scala-sbt.org/sbt-native-packager/archetypes/cheatsheet.html#server-app-config-src-templates-etc-default-systemv-systemd
+
+# This file is parsed by systemd. You can modify it to specify environment
+# variables for your application.
+#
+# For a description of the format, see: `man systemd.exec`, section
+# `EnvironmentFile`.
+
+# Available replacements
+# see http://www.scala-sbt.org/sbt-native-packager/archetypes/systemloaders.html#override-start-script
+# --------------------------------------------------------------------
+# Name                   Contains                     Current value
+# (remove space)
+# $ {{author}}           debian author                Software Group
+# $ {{descr}}            debian package description   app_seqexec_server_gs_test
+# $ {{exec}}             startup script name          seqexec-server
+# $ {{chdir}}            app directory                /usr/share/app_seqexec_server_gs_test
+# $ {{retries}}          retries for startup          0
+# $ {{retryTimeout}}     retry timeout                60
+# $ {{app_name}}         normalized app name          app_seqexec_server_gs_test
+# $ {{app_main_class}}   main class/entry point       ${{app_main_class}}
+# $ {{daemon_user}}      daemon user                  software
+# $ {{daemon_group}}     daemon group                 software
+# --------------------------------------------------------------------
+
+# Setting JAVA_OPTS
+# -----------------
+# JAVA_OPTS="-Dpidfile.path=/var/run/app_seqexec_server_gs_test/play.pid"
+
+# Setting PIDFILE
+# ---------------
+# PIDFILE="/var/run/app_seqexec_server_gs_test/play.pid"

--- a/app/seqexec-server/src/main/resources/seqexec-server.service
+++ b/app/seqexec-server/src/main/resources/seqexec-server.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Seqexec Server
+Requires=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/software/seqexec_server/
+EnvironmentFile=/etc/default/seqexec-server.env
+ExecStart=/home/software/seqexec_server/bin/seqexec-server
+Restart=always
+RestartSec=60
+# IOApp returns 128+15 on a regular cancellation, 15 being SIGTERM
+SuccessExitStatus=143
+TimeoutStopSec=5
+User=software
+ExecStartPre=/bin/mkdir -p /run/seqexec_server
+ExecStartPre=/bin/chown software:software /run/seqexec_server
+ExecStartPre=/bin/chmod 755 /run/seqexec_server
+PermissionsStartOnly=true
+LimitNOFILE=1024
+
+[Install]
+WantedBy=multi-user.target

--- a/build.sbt
+++ b/build.sbt
@@ -543,23 +543,17 @@ lazy val seqexecCommonSettings = Seq(
 ) ++ commonSettings
 
 /**
-  * Settings for Seqexec RPMs
+  * Settings for Seqexec in Linux
   */
-lazy val seqexecRPMSettings = Seq(
-  // RPM properties
-  rpmVendor := "Gemini",
-  rpmLicense := Some("BSD-3"),
-  rpmGroup := Some("Gemini"),
-  rpmChangelogFile := None,
-  packageDescription in Rpm := "Seqexec Server",
-  rpmPrefix in Rpm := Some("/gemsoft/opt"),
-  packageName in Rpm := "seqexec-server",
+lazy val seqexecLinux = Seq(
   // User/Group for execution
-  daemonUser in Linux := "telops",
-  daemonGroup in Linux := "telops",
+  daemonUser in Linux := "software",
+  daemonGroup in Linux := "software",
+  maintainer in Universal := "Software Group <software@gemini.edu>",
   // This lets us build RPMs from snapshot versions
-  version in Rpm := {
-    (version in ThisBuild).value.replace("-SNAPSHOT", "")
+  name in Linux := "Seqexec Server",
+  version in Linux := {
+    (version in ThisBuild).value.replace("-SNAPSHOT", "").replace("-", "_").replace(" ", "")
   }
 )
 
@@ -590,6 +584,14 @@ lazy val app_seqexec_server = preventPublication(project.in(file("app/seqexec-se
     mappings in Universal += {
       val f = (resourceDirectory in Compile).value / "update_smartgcal"
       f -> ("bin/" + f.getName)
+    },
+    mappings in Universal += {
+      val f = (resourceDirectory in Compile).value / "seqexec-server.env"
+      f -> ("systemd/" + f.getName)
+    },
+    mappings in Universal += {
+      val f = (resourceDirectory in Compile).value / "seqexec-server.service"
+      f -> ("systemd/" + f.getName)
     }
   )
 
@@ -599,11 +601,12 @@ lazy val app_seqexec_server = preventPublication(project.in(file("app/seqexec-se
 lazy val app_seqexec_server_gs_test = preventPublication(project.in(file("app/seqexec-server-gs-test")))
   .dependsOn(seqexec_web_server, seqexec_web_client)
   .aggregate(seqexec_web_server, seqexec_web_client)
-  .enablePlugins(LinuxPlugin, RpmPlugin)
+  .enablePlugins(LinuxPlugin)
   .enablePlugins(JavaServerAppPackaging)
+  .enablePlugins(SystemdPlugin)
   .enablePlugins(GitBranchPrompt)
   .settings(seqexecCommonSettings: _*)
-  .settings(seqexecRPMSettings: _*)
+  .settings(seqexecLinux: _*)
   .settings(deployedAppMappings: _*)
   .settings(
     description := "Seqexec GS test deployment",
@@ -631,7 +634,7 @@ lazy val app_seqexec_server_gn_test = preventPublication(project.in(file("app/se
   .enablePlugins(JavaServerAppPackaging)
   .enablePlugins(GitBranchPrompt)
   .settings(seqexecCommonSettings: _*)
-  .settings(seqexecRPMSettings: _*)
+  .settings(seqexecLinux: _*)
   .settings(deployedAppMappings: _*)
   .settings(
     description := "Seqexec GN test deployment",
@@ -659,7 +662,7 @@ lazy val app_seqexec_server_gs = preventPublication(project.in(file("app/seqexec
   .enablePlugins(JavaServerAppPackaging)
   .enablePlugins(GitBranchPrompt)
   .settings(seqexecCommonSettings: _*)
-  .settings(seqexecRPMSettings: _*)
+  .settings(seqexecLinux: _*)
   .settings(deployedAppMappings: _*)
   .settings(
     description := "Seqexec Gemini South server production",
@@ -687,7 +690,7 @@ lazy val app_seqexec_server_gn = preventPublication(project.in(file("app/seqexec
   .enablePlugins(JavaServerAppPackaging)
   .enablePlugins(GitBranchPrompt)
   .settings(seqexecCommonSettings: _*)
-  .settings(seqexecRPMSettings: _*)
+  .settings(seqexecLinux: _*)
   .settings(deployedAppMappings: _*)
   .settings(
     description := "Seqexec Gemini North server production",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,7 +27,7 @@ addSbtPlugin("io.spray"           % "sbt-revolver"             % "0.9.1")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.9.0")
 
 // Support making distributions
-addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager"      % "1.4.1")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager"      % "1.5.0")
 
 // Check the style with scalastyle
 addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin"    % "1.0.0")


### PR DESCRIPTION
This PR adds scripts to launch the seqexec via systemd. Note that we install the scripts manually rather than using e.g rpms.
The scripts are designed to keep the current location of the seqexec so they should work with new deployments.
I'm not an expert on this an apparently `systemd` would allow much finer grained control but this suffice for our needs
This seems a bit of an arcane art, I expect we'll be iterating about it for a while