### PR TITLE
[SEQNG-1123] Remember user-edited Observer name

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -421,16 +421,6 @@ body {
   padding-right: 0 !important;
 }
 
-.SeqexecStyles-defaultObserverEditField {
-  width: 10em !important;
-  margin-left: 1em !important;
-
-  input {
-    background-color: #555555 !important;
-    color: white !important;
-  }
-}
-
 .SeqexecStyles-shorterFields {
   margin-bottom: 0.2em !important;
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/HeaderSideBarFocus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/HeaderSideBarFocus.scala
@@ -45,7 +45,7 @@ object HeaderSideBarFocus {
 
   val headerSideBarG: Getter[SeqexecAppRootModel, HeaderSideBarFocus] =
     Getter[SeqexecAppRootModel, HeaderSideBarFocus] { c =>
-      val clientStatus = ClientStatus(c.uiModel.user, c.uiModel.defaultObserver, c.ws)
+      val clientStatus = ClientStatus(c.uiModel.user, c.ws)
       val obs = c.uiModel.sequencesOnDisplay.selectedObserver
         .toRight(c.uiModel.defaultObserver)
       HeaderSideBarFocus(clientStatus,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/ControlMenu.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/ControlMenu.scala
@@ -3,7 +3,8 @@
 
 package seqexec.web.client.components
 
-import seqexec.web.client.actions.{Logout, OpenLoginBox, UpdateDefaultObserver}
+import seqexec.web.client.actions.Logout
+import seqexec.web.client.actions.OpenLoginBox
 import seqexec.web.client.model.ClientStatus
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.semanticui.Size
@@ -13,11 +14,7 @@ import react.common.implicits._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ScalaComponent
-import japgolly.scalajs.react.extra.StateSnapshot
 import japgolly.scalajs.react.vdom.html_<^._
-import seqexec.model.Observer
-import seqexec.web.client.semanticui.elements.input.InputEV
-import seqexec.web.client.semanticui.elements.label.FormLabel
 
 /**
   * Menu with options
@@ -47,31 +44,14 @@ object ControlMenu {
            disabled = !enabled,
            inverted = true)(text)
 
-
-  // Ideally we'd do this with css text-overflow but it is not
-  // working properly inside a header item, let's abbreviate in code
-  private def overflowText(text: String): String =
-    text
-      .split("\\s")
-      .headOption
-      .map(_.substring(0, 10) + "...")
-      .getOrElse[String]("")
-
   private val component = ScalaComponent
     .builder[Props]("SeqexecTopMenu")
     .stateless
     .render_P { p =>
       val status = p.status
-
-      val enabled = p.status.canOperate
-      def updateStateOb(value: Option[String], cb: Callback): Callback =
-        SeqexecCircuit.dispatchCB(UpdateDefaultObserver(value.fold(Observer.Zero)(Observer.apply))) >> cb
-      val observerEV =
-        StateSnapshot(p.status.defaultObserver.value)(updateStateOb)
-
       <.div(
         ^.cls := "ui secondary right menu",
-        status.userDetails.fold(
+        status.u.fold(
           <.div(
             ^.cls := "ui item",
             soundConnect(x => SoundControl(SoundControl.Props(x()))),
@@ -82,35 +62,20 @@ object ControlMenu {
             <.div(
               ^.cls := "ui secondary right menu",
               <.div(
-                ^.cls := "ui form item",
-                SeqexecStyles.notInMobile,
-                FormLabel(FormLabel.Props("Observer:", Some("observer"))),
-                <.div(
-                  ^.cls := "ui input",
-                  SeqexecStyles.defaultObserverEditField,
-                  InputEV(
-                    InputEV.Props("observer",
-                                  "observer",
-                                  observerEV,
-                                  placeholder = "Observer...",
-                                  disabled    = !enabled)
-                  )
-                )
-              ),
-              <.div(
-                ^.cls := "ui item",
-                SeqexecStyles.onlyMobile,
-                s"Observer: ${overflowText(status.defaultObserver.value)}"
-              ),
-              <.div(
                 ^.cls := "ui header item",
                 SeqexecStyles.notInMobile,
-                s"User: ${u.displayName}"
+                u.displayName
               ),
               <.div(
                 ^.cls := "ui header item",
                 SeqexecStyles.onlyMobile,
-                s"User: ${overflowText(u.displayName)}"
+                // Ideally we'd do this with css text-overflow but it is not
+                // working properly inside a header item, let's abbreviate in code
+                u.displayName
+                  .split("\\s")
+                  .headOption
+                  .map(_.substring(0, 10) + "...")
+                  .getOrElse[String]("")
               ),
               <.div(
                 ^.cls := "ui item",

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/HeadersSideBar.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/HeadersSideBar.scala
@@ -153,7 +153,6 @@ object HeadersSideBar {
       val obsCompleted =
         p.selectedObserver.map(_.fold(_ => false, _.completed)).getOrElse(false)
       val observerField = s"Observer - $instrument"
-      val isDefaultObserver =  p.selectedObserver.isLeft
       <.div(
         ^.cls := "ui secondary segment",
         SeqexecStyles.headerSideBarStyle,
@@ -182,7 +181,7 @@ object HeadersSideBar {
                               "observer",
                               observerEV,
                               placeholder = "Observer...",
-                              disabled    = !enabled || obsCompleted || isDefaultObserver,
+                              disabled    = !enabled || obsCompleted,
                               onBlur      = _ => submitIfChangedOb)
               )
             )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -166,8 +166,6 @@ object SeqexecStyles {
 
   val observerField: Css = Css("SeqexecStyles-observerField")
 
-  val defaultObserverEditField: Css = Css("SeqexecStyles-defaultObserverEditField")
-
   val shorterFields: Css = Css("SeqexecStyles-shorterFields")
 
   val configLabel: Css = Css("SeqexecStyles-configLabel")

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SessionQueueTable.scala
@@ -212,7 +212,7 @@ object SessionQueueTable extends Columns {
 
     val loggedIn: Boolean = sequences.status.isLogged
 
-    val user: Option[UserDetails] = sequences.status.userDetails
+    val user: Option[UserDetails] = sequences.status.u
 
     val extractors = List[(TableColumn, SequenceInSessionQueue => String)](
       (ObsIdColumn, _.id.format),

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/SequenceExecutionHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/SequenceExecutionHandler.scala
@@ -26,7 +26,8 @@ class SequenceExecutionHandler[M](
   def handleUpdateObserver: PartialFunction[Any, ActionResult[M]] = {
     case UpdateObserver(sequenceId, name) =>
       val updateObserverE = Effect(
-        SeqexecWebClient.setObserver(sequenceId, name.value).as(NoAction))
+        SeqexecWebClient.setObserver(sequenceId, name.value).as(NoAction)
+        ) + Effect.action(UpdateDefaultObserver(name))
       val updatedSequences =
         value.copy(sessionQueue = value.sessionQueue.collect {
           case s if s.id === sequenceId =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ClientStatus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/ClientStatus.scala
@@ -7,29 +7,25 @@ import cats.Eq
 import cats.implicits._
 import monocle.Getter
 import monocle.Lens
-import seqexec.model.{Observer, UserDetails}
+import seqexec.model.UserDetails
 
 /**
   * Utility class to let components more easily switch parts of the UI depending on the user and connection state
   */
-final case class ClientStatus(
-  userDetails: Option[UserDetails],
-  defaultObserver: Observer,
-  webSocket: WebSocketConnection
-) {
-  def isLogged: Boolean    = userDetails.isDefined
-  def isConnected: Boolean = webSocket.ws.isReady
+final case class ClientStatus(u: Option[UserDetails], w: WebSocketConnection) {
+  def isLogged: Boolean    = u.isDefined
+  def isConnected: Boolean = w.ws.isReady
   def canOperate: Boolean  = isLogged && isConnected
 }
 
 object ClientStatus {
   implicit val eq: Eq[ClientStatus] =
-    Eq.by(x => (x.userDetails, x.defaultObserver, x.webSocket))
+    Eq.by(x => (x.u, x.w))
 
   val clientStatusFocusL: Lens[SeqexecAppRootModel, ClientStatus] =
     Lens[SeqexecAppRootModel, ClientStatus](m =>
-      ClientStatus(m.uiModel.user, m.uiModel.defaultObserver, m.ws))(v =>
-      m => m.copy(ws = v.webSocket, uiModel = m.uiModel.copy(user = v.userDetails, defaultObserver = v.defaultObserver)))
+      ClientStatus(m.uiModel.user, m.ws))(v =>
+      m => m.copy(ws = v.w, uiModel = m.uiModel.copy(user = v.u)))
 
   val canOperateG: Getter[SeqexecAppRootModel, Boolean] =
     clientStatusFocusL.composeGetter(

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -261,13 +261,12 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
     Arbitrary {
       for {
         u <- arbitrary[Option[UserDetails]]
-        o <- arbitrary[Observer]
         w <- arbitrary[WebSocketConnection]
-      } yield ClientStatus(u, o, w)
+      } yield ClientStatus(u, w)
     }
 
   implicit val cssCogen: Cogen[ClientStatus] =
-    Cogen[(Option[UserDetails], Observer, WebSocketConnection)].contramap(x => (x.userDetails, x.defaultObserver, x.webSocket))
+    Cogen[(Option[UserDetails], WebSocketConnection)].contramap(x => (x.u, x.w))
 
   implicit val arbTableType: Arbitrary[StepsTableTypeSelection] =
     Arbitrary(


### PR DESCRIPTION
We go back to the previous way observers were edited, but now we change the default observer for the session whenever the observer is changed for any sequence, thus remembering the change for future sequences previewed or loaded from that terminal.