### PR TITLE
SEQNG-1145 Improve reusability of tables

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/dev.js
+++ b/modules/seqexec/web/client/src/main/resources/dev.js
@@ -6,7 +6,7 @@ import React from "react";
 if (process.env.NODE_ENV !== "production") {
   const { whyDidYouUpdate } = require("why-did-you-update");
   whyDidYouUpdate(React, {
-    exclude: ["Draggable", "DraggableCore", "AutoSizer"]
+    exclude: ["Draggable", "DraggableCore", "AutoSizer", "DiodeWrapper"]
   });
 }
 

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
@@ -3,14 +3,14 @@
 
 package seqexec.web.client.components
 
+import cats.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.implicits._
 import react.common.Css
-import cats.implicits._
 import seqexec.web.client.semanticui.elements.progress.Progress
-import web.client.ReactProps
 import seqexec.web.client.semanticui._
+import web.client.ReactProps
 
 /**
   * Progress bar divided in steps

--- a/modules/shared/web/client/src/main/scala/web/client/table/package.scala
+++ b/modules/shared/web/client/src/main/scala/web/client/table/package.scala
@@ -26,7 +26,7 @@ import web.client.utils._
 package object table {
   val DragHandleWidth: Int = 12
 
-  private implicit val doubleReuse: Reusability[Double] =
+  private[table] implicit val doubleReuse: Reusability[Double] =
     Reusability.double(0.01)
 
   implicit val sizeReuse: Reusability[Size] =


### PR DESCRIPTION
We have detected some unnecessary re renderings. I traced at least some of them to the calculations on tables. The original calculation was too naive and we should account for small changes
This PR seems to reduce the warnings of unneeded refreshes