### PR TITLE
Switch to app-manifest-webpack-plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -358,7 +358,7 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
       "uglifyjs-webpack-plugin"            -> "2.2.0",
       "html-webpack-plugin"                -> "3.2.0",
       "optimize-css-assets-webpack-plugin" -> "5.0.3",
-      "favicons-webpack-plugin"            -> "1.0.2",
+      "app-manifest-webpack-plugin"        -> "1.1.0",
       "why-did-you-update"                 -> "1.0.6"
     ),
     libraryDependencies ++= Seq(

--- a/modules/seqexec/web/client/src/webpack/dev.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/dev.webpack.config.js
@@ -4,7 +4,7 @@ const Merge = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const parts = require("./webpack.parts");
 const ScalaJSConfig = require("./scalajs.webpack.config");
-const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
+const AppManifestWebpackPlugin = require("app-manifest-webpack-plugin");
 
 const isDevServer = process.argv.some(s => s.match(/webpack-dev-server\.js$/));
 
@@ -76,9 +76,10 @@ const Web = Merge(
         title: "Seqexec",
         chunks: ["seqexec"]
       }),
-      new FaviconsWebpackPlugin(
-        path.resolve(parts.resourcesDir, "images/launcher.png")
-      )
+      new AppManifestWebpackPlugin({
+        logo: path.resolve(parts.resourcesDir, "images/launcher.png"),
+        output: "icons-[hash:8]/"
+      })
     ]
   }
 );

--- a/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
@@ -3,7 +3,7 @@ const Merge = require("webpack-merge");
 const Webpack = require("webpack");
 const parts = require("./webpack.parts");
 const ScalaJSConfig = require("./scalajs.webpack.config");
-const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
+const AppManifestWebpackPlugin = require("app-manifest-webpack-plugin");
 
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
@@ -51,9 +51,9 @@ const Web = Merge(
         filename: "index.html",
         chunks: ["seqexec"]
       }),
-      new FaviconsWebpackPlugin({
+      new AppManifestWebpackPlugin({
         logo: path.resolve(parts.resourcesDir, "images/launcher.png"),
-        persistentCache: false
+        output: "icons-[hash:8]/"
       })
     ]
   }


### PR DESCRIPTION
We use `favicons-webpack-plugin` to generate favicons for the app. This plugin is now obsolete and throws a bunch of warnings. This PR switches to `app-manifest-webpack-plugin`