### PR TITLE
Revert "Switch to app-manifest-webpack-plugin"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -358,7 +358,7 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
       "uglifyjs-webpack-plugin"            -> "2.2.0",
       "html-webpack-plugin"                -> "3.2.0",
       "optimize-css-assets-webpack-plugin" -> "5.0.3",
-      "app-manifest-webpack-plugin"        -> "1.1.0",
+      "favicons-webpack-plugin"            -> "1.0.2",
       "why-did-you-update"                 -> "1.0.6"
     ),
     libraryDependencies ++= Seq(

--- a/modules/seqexec/web/client/src/webpack/dev.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/dev.webpack.config.js
@@ -4,7 +4,7 @@ const Merge = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const parts = require("./webpack.parts");
 const ScalaJSConfig = require("./scalajs.webpack.config");
-const AppManifestWebpackPlugin = require("app-manifest-webpack-plugin");
+const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
 
 const isDevServer = process.argv.some(s => s.match(/webpack-dev-server\.js$/));
 
@@ -76,10 +76,9 @@ const Web = Merge(
         title: "Seqexec",
         chunks: ["seqexec"]
       }),
-      new AppManifestWebpackPlugin({
-        logo: path.resolve(parts.resourcesDir, "images/launcher.png"),
-        output: "icons-[hash:8]/"
-      })
+      new FaviconsWebpackPlugin(
+        path.resolve(parts.resourcesDir, "images/launcher.png")
+      )
     ]
   }
 );

--- a/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
@@ -3,7 +3,7 @@ const Merge = require("webpack-merge");
 const Webpack = require("webpack");
 const parts = require("./webpack.parts");
 const ScalaJSConfig = require("./scalajs.webpack.config");
-const AppManifestWebpackPlugin = require("app-manifest-webpack-plugin");
+const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
 
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
@@ -51,9 +51,9 @@ const Web = Merge(
         filename: "index.html",
         chunks: ["seqexec"]
       }),
-      new AppManifestWebpackPlugin({
+      new FaviconsWebpackPlugin({
         logo: path.resolve(parts.resourcesDir, "images/launcher.png"),
-        output: "icons-[hash:8]/"
+        persistentCache: false
       })
     ]
   }


### PR DESCRIPTION
This reverts commit 6fb87866bd92792211adf360ff76abaaebcce426. (https://github.com/gemini-hlsw/ocs3/pull/1219)

It is the right move but it seemed to break a clean build. I'm reverting for now to unlock other PRs and we can investigate later how to upgrade the library and eliminate the warnings from the old version.

Luckily, it was possible to revert without consequences.

