### PR TITLE
SEQNG-1155 Put some order in the real system log messages.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/Systems.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/Systems.scala
@@ -194,7 +194,7 @@ object Systems {
       instObjects(
         settings.systemControl.niri,
         NiriEpics.instance[IO],
-        NiriControllerEpics.apply,
+        NiriControllerEpics.apply[IO],
         NiriControllerSim.apply[IO],
         NiriKeywordReaderEpics[IO],
         NiriKeywordReaderDummy[IO]
@@ -246,7 +246,7 @@ object Systems {
       (gpiClient, gpiGDS(httpClient)).mapN(GpiController(_, _))
     }
 
-    def ghost[F[_] : ConcurrentEffect : Timer](httpClient: Client[F]): Resource[F, GhostController[F]] = {
+    def ghost[F[_] : ConcurrentEffect : Timer: Logger](httpClient: Client[F]): Resource[F, GhostController[F]] = {
       def ghostClient: Resource[F, GhostClient[F]] =
         if (settings.systemControl.ghost.command) GhostClient.ghostClient[F](settings.ghostUrl.renderString)
         else GhostClient.simulatedGhostClient

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostController.scala
@@ -11,6 +11,8 @@ import giapi.client.commands.Configuration
 import giapi.client.ghost.GhostClient
 import giapi.client.GiapiConfig
 import giapi.client.syntax.giapiconfig._
+import io.chrisdavenport.log4cats.Logger
+
 import scala.concurrent.duration._
 import seqexec.server.ConfigUtilOps.ContentError
 import seqexec.server.ConfigUtilOps.ExtractFailure
@@ -292,7 +294,7 @@ trait GhostController[F[_]] extends GiapiInstrumentController[F, GhostConfig] {
 }
 
 object GhostController {
-  def apply[F[_]: Sync](client: GhostClient[F], gds: GdsClient[F]): GhostController[F] =
+  def apply[F[_]: Sync: Logger](client: GhostClient[F], gds: GdsClient[F]): GhostController[F] =
     new AbstractGiapiInstrumentController[F, GhostConfig, GhostClient[F]](client) with GhostController[F] {
       override val gdsClient: GdsClient[F] = gds
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -375,14 +375,14 @@ object GmosControllerEpics extends GmosEncoders {
                      ccParams(state.cc, config.cc) ++
                      nsParams(state.ns, config.ns)
 
-        L.info("Start Gmos configuration") *>
+        L.debug("Start Gmos configuration") *>
           L.debug(s"Gmos configuration: ${config.show}") *>
           warnOnDHSNotConected *>
           (params.sequence *>
             sys.configCmd.setTimeout[F](ConfigTimeout) *>
             sys.post
           ).unlessA(params.isEmpty) *>
-          L.info("Completed Gmos configuration")
+          L.debug("Completed Gmos configuration")
       }
 
       override def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult] =
@@ -400,11 +400,11 @@ object GmosControllerEpics extends GmosEncoders {
 
         (sys.dcIsAcquiring, sys.countdown).mapN { case (isAcq, timeLeft) =>
           if(!isAcq)
-            L.info(s"Gmos $name Observe canceled because it is not acquiring.")
+            L.debug(s"Gmos $name Observe canceled because it is not acquiring.")
           else if(timeLeft <= safetyCutoffAsDouble)
-            L.info(s"Gmos $name Observe canceled because there is less than $safetyCutoffAsDouble seconds left.")
+            L.debug(s"Gmos $name Observe canceled because there is less than $safetyCutoffAsDouble seconds left.")
           else
-            L.info(s"$name Gmos exposure") *>
+            L.debug(s"$name Gmos exposure") *>
               cmd.setTimeout[F](DefaultTimeout) *>
               cmd.mark[F] *>
               cmd.post[F].void
@@ -432,19 +432,19 @@ object GmosControllerEpics extends GmosEncoders {
       } yield ret
 
       override def stopPaused: F[ObserveCommandResult] = for {
-        _   <- L.info("Stop Gmos paused observation")
+        _   <- L.debug("Stop Gmos paused observation")
         _   <- sys.pauseCmd.setTimeout[F](DefaultTimeout)
         _   <- sys.stopAndWaitCmd.mark[F]
         ret <- sys.stopAndWaitCmd.post[F]
-        _   <- L.info("Completed stopping Gmos observation")
+        _   <- L.debug("Completed stopping Gmos observation")
       } yield if(ret === ObserveCommandResult.Success) ObserveCommandResult.Stopped else ret
 
       override def abortPaused: F[ObserveCommandResult] = for {
-        _   <- L.info("Abort Gmos paused observation")
+        _   <- L.debug("Abort Gmos paused observation")
         _   <- sys.abortAndWait.setTimeout[F](DefaultTimeout)
         _   <- sys.abortAndWait.mark[F]
         ret <- sys.abortAndWait.post[F]
-        _   <- L.info("Completed aborting Gmos observation")
+        _   <- L.debug("Completed aborting Gmos observation")
       } yield if(ret === ObserveCommandResult.Success) ObserveCommandResult.Aborted else ret
 
       // Calculate the current subexposure

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -281,12 +281,14 @@ object GnirsControllerEpics extends GnirsEncoders {
           L.debug("Completed GNIRS configuration")
 
       override def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult] =
-        L.info("Start GNIRS observe") *>
+        L.debug(s"Start GNIRS observe, file id $fileId") *>
           checkDhs *>
           checkArray *>
           epicsSys.observeCmd.setLabel(fileId) *>
           epicsSys.observeCmd.setTimeout[F](expTime + ReadoutTimeout) *>
-          epicsSys.observeCmd.post[F]
+          epicsSys.observeCmd.post[F].flatMap{ r =>
+            L.debug("Completed GNITS observe").as(r)
+          }
 
       override def endObserve: F[Unit] =
         L.debug("Send endObserve to GNIRS") *>
@@ -295,13 +297,13 @@ object GnirsControllerEpics extends GnirsEncoders {
           epicsSys.endObserveCmd.post[F].void
 
       override def stopObserve: F[Unit] =
-        L.info("Stop GNIRS exposure") *>
+        L.debug("Stop GNIRS exposure") *>
           epicsSys.stopCmd.setTimeout[F](DefaultTimeout) *>
           epicsSys.stopCmd.mark[F] *>
           epicsSys.stopCmd.post[F].void
 
       override def abortObserve: F[Unit] =
-        L.info("Abort GNIRS exposure") *>
+        L.debug("Abort GNIRS exposure") *>
           epicsSys.abortCmd.setTimeout[F](DefaultTimeout) *>
           epicsSys.abortCmd.mark[F] *>
           epicsSys.abortCmd.post[F].void

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -286,9 +286,7 @@ object GnirsControllerEpics extends GnirsEncoders {
           checkArray *>
           epicsSys.observeCmd.setLabel(fileId) *>
           epicsSys.observeCmd.setTimeout[F](expTime + ReadoutTimeout) *>
-          epicsSys.observeCmd.post[F].flatMap{ r =>
-            L.debug("Completed GNITS observe").as(r)
-          }
+          epicsSys.observeCmd.post[F].flatTap{ _ => L.debug("Completed GNITS observe") }
 
       override def endObserve: F[Unit] =
         L.debug("Send endObserve to GNIRS") *>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerEpics.scala
@@ -153,9 +153,7 @@ object GsaoiControllerEpics {
         checkDhs *>
         epicsSys.observeCmd.setLabel(fileId) *>
         epicsSys.observeCmd.setTimeout[F](calcObserveTimeout(cfg)) *>
-        epicsSys.observeCmd.post[F].flatMap{ r =>
-          L.debug("Completed GSAOI observe").as(r)
-        }
+        epicsSys.observeCmd.post[F].flatTap{ _ => L.debug("Completed GSAOI observe") }
     }
 
     // GSAOI endObserve is a NOP with no CAR associated

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerEpics.scala
@@ -128,7 +128,7 @@ object GsaoiControllerEpics {
           epicsSys.waitForGuideOn
       ).whenA(current.guiding)
 
-      L.info("Start Gsaoi configuration") *>
+      L.debug("Start Gsaoi configuration") *>
         L.debug(s"Gsaoi configuration: ${config.show}") *>
         guideOff.whenA(ccParams.nonEmpty || dcParams.nonEmpty) *>
         ( ccParams.sequence *>
@@ -140,7 +140,7 @@ object GsaoiControllerEpics {
           epicsSys.dcConfigCmd.post[F].void
         ).unlessA(dcParams.isEmpty) *>
         guideOn.whenA(ccParams.nonEmpty || dcParams.nonEmpty) *>
-        L.info("Completed Gsaoi configuration")
+        L.debug("Completed Gsaoi configuration")
     }
 
     override def observe(fileId: ImageFileId, cfg: GsaoiController.DCConfig): F[ObserveCommandResult] = {
@@ -149,25 +149,27 @@ object GsaoiControllerEpics {
         SeqexecFailure.Execution("GSAOI is not connected to DHS")
       )
 
-      L.info("Start GSAOI observe") *>
+      L.debug(s"Start GSAOI observe, file id $fileId") *>
         checkDhs *>
         epicsSys.observeCmd.setLabel(fileId) *>
         epicsSys.observeCmd.setTimeout[F](calcObserveTimeout(cfg)) *>
-        epicsSys.observeCmd.post[F]
+        epicsSys.observeCmd.post[F].flatMap{ r =>
+          L.debug("Completed GSAOI observe").as(r)
+        }
     }
 
     // GSAOI endObserve is a NOP with no CAR associated
     override def endObserve: F[Unit] =
-      L.info("endObserve for GSAOI skipped")
+      L.debug("endObserve for GSAOI skipped")
 
     override def stopObserve: F[Unit] =
-      L.info("Stop GSAOI exposure") *>
+      L.debug("Stop GSAOI exposure") *>
         epicsSys.stopCmd.setTimeout[F](DefaultTimeout) *>
         epicsSys.stopCmd.mark[F] *>
         epicsSys.stopCmd.post[F].void
 
     override def abortObserve: F[Unit] =
-      L.info("Stop GSAOI exposure") *>
+      L.debug("Abort GSAOI exposure") *>
         epicsSys.abortCmd.setTimeout[F](DefaultTimeout) *>
         epicsSys.abortCmd.mark[F] *>
         epicsSys.abortCmd.post[F].void

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
@@ -349,7 +349,9 @@ object NifsControllerEpics extends NifsEncoders {
         secondCCPass(cfg)
 
     override def applyConfig(config: NifsController.NifsConfig): F[Unit] =
-      configCC(config.cc) *> configDC(config.dc)
+      L.debug("Start NIFS configuration") *>
+        configCC(config.cc) *> configDC(config.dc) *>
+        L.debug("Completed NIFS configuration")
 
     private val checkDhs =
       failUnlessM(
@@ -358,27 +360,29 @@ object NifsControllerEpics extends NifsEncoders {
 
     override def observe(fileId: ImageFileId,
                          cfg:    DCConfig): F[ObserveCommandResult] = {
-      L.info("Start NIFS observe") *>
+      L.debug(s"Start NIFS observe, file id $fileId") *>
         checkDhs *>
         epicsSys.observeCmd.setLabel(fileId) *>
         epicsSys.observeCmd.setTimeout[F](calcObserveTimeout(cfg)) *>
-        epicsSys.observeCmd.post[F]
+        epicsSys.observeCmd.post[F].flatMap{ r =>
+          L.debug("Completed NIFS observe").as(r)
+        }
     }
 
     override def endObserve: F[Unit] =
-      L.info("Send endObserve to NIFS") *>
+      L.debug("Send endObserve to NIFS") *>
         epicsSys.endObserveCmd.setTimeout[F](DefaultTimeout) *>
         epicsSys.endObserveCmd.mark[F] *>
         epicsSys.endObserveCmd.post[F].void
 
     override def stopObserve: F[Unit] =
-      L.info("Stop NIFS exposure") *>
+      L.debug("Stop NIFS exposure") *>
         epicsSys.stopCmd.setTimeout[F](DefaultTimeout) *>
         epicsSys.stopCmd.mark[F] *>
         epicsSys.stopCmd.post[F].void
 
     override def abortObserve: F[Unit] =
-      L.info("Abort NIFS exposure") *>
+      L.debug("Abort NIFS exposure") *>
         epicsSys.abortCmd.setTimeout[F](DefaultTimeout) *>
         epicsSys.abortCmd.mark[F] *>
         epicsSys.abortCmd.post[F].void

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
@@ -364,9 +364,7 @@ object NifsControllerEpics extends NifsEncoders {
         checkDhs *>
         epicsSys.observeCmd.setLabel(fileId) *>
         epicsSys.observeCmd.setTimeout[F](calcObserveTimeout(cfg)) *>
-        epicsSys.observeCmd.post[F].flatMap{ r =>
-          L.debug("Completed NIFS observe").as(r)
-        }
+        epicsSys.observeCmd.post[F].flatTap{ _ => L.debug("Completed NIFS observe") }
     }
 
     override def endObserve: F[Unit] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
@@ -3,7 +3,8 @@
 
 package seqexec.server.niri
 
-import cats.effect.{IO, Timer}
+import cats.Applicative
+import cats.effect.{Async, Timer}
 import cats.implicits._
 import edu.gemini.seqexec.server.niri.{Camera => JCamera}
 import edu.gemini.seqexec.server.niri.{BeamSplitter => JBeamSplitter}
@@ -16,10 +17,9 @@ import edu.gemini.spModel.gemini.niri.Niri.Filter
 import edu.gemini.spModel.gemini.niri.Niri.Camera
 import edu.gemini.spModel.gemini.niri.Niri.BeamSplitter
 import edu.gemini.spModel.gemini.niri.Niri.BuiltinROI
-import org.log4s.getLogger
+import io.chrisdavenport.log4cats.Logger
 import seqexec.model.ObserveStage
 
-import scala.concurrent.ExecutionContext
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.model.enum.ApplyCommandResult
@@ -129,11 +129,6 @@ trait NiriEncoders {
 }
 
 object NiriControllerEpics extends NiriEncoders {
-  private val Log = getLogger
-
-  implicit val ioTimer: Timer[IO] =
-    IO.timer(ExecutionContext.global)
-
   import EpicsCodex._
 
   val WindowOpen = "open"
@@ -142,214 +137,217 @@ object NiriControllerEpics extends NiriEncoders {
   private val ConfigTimeout: Time = Seconds(180)
   private val DefaultTimeout: Time = Seconds(60)
 
-  def apply(epicsSys: => NiriEpics[IO]): NiriController[IO] = new NiriController[IO] {
-    /**
-     * The instrument has three filter wheels with a status channel for each one. But it does not have
-     * a status channel for the virtual filter, so I have to calculate it. The assumption is that only
-     * one wheel can be in a not open position at a given time.
-     */
-    private def currentFilter: IO[Option[String]] = {
-      val filter1 = epicsSys.filter1
-      val filter2 = epicsSys.filter2
-      val filter3 = epicsSys.filter3
-      val Open = "open"
+  def apply[F[_]: Timer: Async](epicsSys: => NiriEpics[F])(implicit L: Logger[F]): NiriController[F] =
+      new NiriController[F] {
+      /**
+       * The instrument has three filter wheels with a status channel for each one. But it does not have
+       * a status channel for the virtual filter, so I have to calculate it. The assumption is that only
+       * one wheel can be in a not open position at a given time.
+       */
+      private def currentFilter: F[Option[String]] = {
+        val filter1 = epicsSys.filter1
+        val filter2 = epicsSys.filter2
+        val filter3 = epicsSys.filter3
+        val Open = "open"
 
-      for {
-        iof1 <- filter1
-        iof2 <- filter2
-        iof3 <- filter3
-      } yield {
-        val l = List(iof1, iof2, iof3).filterNot(_ === Open)
-        if(l.length === 1) l.headOption
-        else none
-      }.map(removePartName)
-    }
-
-    private def setFocus(f: Focus): IO[Option[IO[Unit]]] = {
-      val encoded = encode(f)
-      smartSetParamF(encoded, epicsSys.focus, epicsSys.configCmd.setFocus(encoded))
-    }
-
-    private def setCamera(c: Camera): IO[Option[IO[Unit]]] = {
-      val encoded = encode(c)
-      smartSetParamF(encoded.toString, epicsSys.camera, epicsSys.configCmd.setCamera(encoded))
-    }
-
-    private def setBeamSplitter(b: BeamSplitter): IO[Option[IO[Unit]]] = {
-      val encoded = encode(b)
-      smartSetParamF(encoded.toString, epicsSys.beamSplitter,
-        epicsSys.configCmd.setBeamSplitter(encoded))
-    }
-
-    private def setFilter(f: Filter): IO[Option[IO[Unit]]] = {
-      val encoded = encode(f)
-
-      smartSetParamF(encoded.some, currentFilter, epicsSys.configCmd.setFilter(encoded))
-    }
-
-    private def setBlankFilter: IO[Option[IO[Unit]]] = {
-      val BlankFilter = "blank"
-
-      smartSetParamF(BlankFilter.some, currentFilter, epicsSys.configCmd.setFilter(BlankFilter))
-    }
-
-    private def setMask(m: Mask): IO[Option[IO[Unit]]] = {
-      val encoded = encode(m)
-
-      smartSetParamF(encoded.toString, epicsSys.mask, epicsSys.configCmd.setMask(encoded))
-    }
-
-    private def setDisperser(d: Disperser): IO[Unit] = {
-      val encoded = encode(d)
-
-      // There is no status for the disperser
-      epicsSys.configCmd.setDisperser(encoded)
-    }
-
-    private def configCommonCC(cfg: Common): List[IO[Option[IO[Unit]]]] =
-      List(
-        setBeamSplitter(cfg.beamSplitter),
-        setCamera(cfg.camera),
-        setDisperser(cfg.disperser).wrapped,
-        setFocus(cfg.focus),
-        setMask(cfg.mask))
-
-    private def configDarkCC(cfg: Dark): List[IO[Option[IO[Unit]]]] =
-      List(
-        setWindowCover(WindowClosed),
-        setBlankFilter) ++
-        configCommonCC(cfg.common)
-
-    private def configCC(cfg: CCConfig): List[IO[Option[IO[Unit]]]] = cfg match {
-      case d@Dark(_)           => configDarkCC(d)
-      case i@Illuminated(_, _) => configIlluminatedCC(i)
-    }
-
-    private def configIlluminatedCC(cfg: Illuminated): List[IO[Option[IO[Unit]]]] =
-      List(
-        setWindowCover(WindowOpen),
-        setFilter(cfg.filter)) ++
-        configCommonCC(cfg.common)
-
-    private def setWindowCover(pos: String): IO[Option[IO[Unit]]] =
-      smartSetParamF(pos, epicsSys.windowCover, epicsSys.windowCoverConfig.setWindowCover(pos))
-
-    private def setExposureTime(t: ExposureTime): IO[Option[IO[Unit]]] = {
-      val ExposureTimeTolerance = 0.001
-      smartSetDoubleParamF[IO](ExposureTimeTolerance)(t.toSeconds, epicsSys.integrationTime,
-        epicsSys.configCmd.setExposureTime(t.toSeconds)
-      )
-    }
-
-    private def configDC(cfg: DCConfig): List[IO[Option[IO[Unit]]]] =
-      List(
-        setExposureTime(cfg.exposureTime),
-          setCoadds(cfg.coadds),
-          setReadMode(cfg.readMode).wrapped,
-          setROI(cfg.builtInROI).wrapped)
-
-    private def setCoadds(n: Coadds): IO[Option[IO[Unit]]] =
-      smartSetParamF(n, epicsSys.coadds, epicsSys.configCmd.setCoadds(n))
-
-    private def setROI(r: BuiltInROI): IO[Unit] = {
-      val encoded = encode(r)
-
-      // There is no status for the builtin ROI
-      epicsSys.configCmd.setBuiltInROI(encoded)
-    }
-
-    // There is no status for the read mode
-    private def setReadMode(rm: ReadMode): IO[Unit] =
-      epicsSys.configCmd.setReadMode(rm)
-
-    private def calcObserveTimeout(cfg: DCConfig): IO[Time] = {
-      epicsSys.minIntegration.map { t =>
-        val MinIntTime = t.seconds
-        val CoaddOverhead = 2.5
-        val TotalOverhead = 30.seconds
-
-        (cfg.exposureTime + MinIntTime) * cfg.coadds.toDouble * CoaddOverhead + TotalOverhead
+        for {
+          iof1 <- filter1
+          iof2 <- filter2
+          iof3 <- filter3
+        } yield {
+          val l = List(iof1, iof2, iof3).filterNot(_ === Open)
+          if(l.length === 1) l.headOption
+          else none
+        }.map(removePartName)
       }
-    }
 
-    private def actOnDHSNotConected(act: IO[Unit]): IO[Unit] =
-      epicsSys.dhsConnected.ifM(IO.unit, act)
-
-    private def actOnArrayNotActive(act: IO[Unit]): IO[Unit] =
-      epicsSys.arrayActive.ifM(IO.unit, act)
-
-    private def failOnDHSNotConected: IO[Unit] =
-      actOnDHSNotConected(IO.raiseError(SeqexecFailure.Execution("NIRI is not connected to DHS")))
-
-    private def failOnArrayNotActive: IO[Unit] =
-      actOnArrayNotActive(IO.raiseError(SeqexecFailure.Execution("NIRI detector array is not active")))
-
-    private def warnOnDHSNotConected: IO[Unit] =
-      actOnDHSNotConected(IO(Log.warn("NIRI is not connected to DHS")))
-
-    private def warnOnArrayNotActive: IO[Unit] =
-      actOnArrayNotActive(IO(Log.warn("NIRI detector array is not active")))
-
-    override def applyConfig(config: NiriController.NiriConfig): IO[Unit] = {
-      val paramsDC = configDC(config.dc)
-      val params =  paramsDC ++ configCC(config.cc)
-
-      val cfgActions1 = if(params.isEmpty) IO.pure(ApplyCommandResult.Completed)
-                        else executeIfNeeded(params,
-                          epicsSys.configCmd.setTimeout[IO](ConfigTimeout) *>
-                          epicsSys.configCmd.post[IO])
-      // Weird NIRI behavior. The main IS apply is nor connected to the DC apply, but triggering the
-      // IS apply writes the DC parameters. So to configure the DC, we need to set the DC parameters
-      // in the IS, trigger the IS apply, and then trigger the DC apply.
-      val cfgActions = if(paramsDC.isEmpty) cfgActions1
-                       else cfgActions1 *>
-                         epicsSys.configDCCmd.setTimeout[IO](DefaultTimeout) *>
-                         epicsSys.configDCCmd.post[IO]
-
-      IO(Log.debug("Starting NIRI configuration")) *>
-        warnOnDHSNotConected *>
-        warnOnArrayNotActive *>
-        cfgActions *>
-        IO(Log.debug("Completed NIRI configuration"))
-    }
-
-    override def observe(fileId: ImageFileId, cfg: DCConfig): IO[ObserveCommandResult] =
-      IO(Log.info("Start NIRI observe")) *>
-        failOnDHSNotConected *>
-        failOnArrayNotActive *>
-        epicsSys.observeCmd.setLabel(fileId) *>
-        calcObserveTimeout(cfg).flatMap(epicsSys.observeCmd.setTimeout[IO]) *>
-        epicsSys.observeCmd.post[IO]
-
-    override def endObserve: IO[Unit] =
-      IO(Log.debug("Send endObserve to NIRI")) *>
-        epicsSys.endObserveCmd.setTimeout[IO](DefaultTimeout) *>
-        epicsSys.endObserveCmd.mark[IO] *>
-        epicsSys.endObserveCmd.post[IO].void
-
-    override def stopObserve: IO[Unit] =
-      IO(Log.info("Stop NIRI exposure")) *>
-        epicsSys.stopCmd.setTimeout[IO](DefaultTimeout) *>
-        epicsSys.stopCmd.mark[IO] *>
-        epicsSys.stopCmd.post[IO].void
-
-    override def abortObserve: IO[Unit] =
-      IO(Log.info("Abort NIRI exposure")) *>
-        epicsSys.abortCmd.setTimeout[IO](DefaultTimeout) *>
-        epicsSys.abortCmd.mark[IO] *>
-        epicsSys.abortCmd.post[IO].void
-
-    override def observeProgress(total: Time): fs2.Stream[IO, Progress] =
-      ProgressUtil.obsCountdownWithObsStage[IO](total, 0.seconds,
-        (epicsSys.dcIsPreparing, epicsSys.dcIsAcquiring, epicsSys.dcIsReadingOut).mapN(ObserveStage.fromBooleans)
-      )
-
-    override def calcTotalExposureTime(cfg: DCConfig): IO[Time] =
-      epicsSys.minIntegration.map { f =>
-        val MinIntTime = f.seconds
-
-        (cfg.exposureTime + MinIntTime) * cfg.coadds.toDouble
+      private def setFocus(f: Focus): F[Option[F[Unit]]] = {
+        val encoded = encode(f)
+        smartSetParamF(encoded, epicsSys.focus, epicsSys.configCmd.setFocus(encoded))
       }
+
+      private def setCamera(c: Camera): F[Option[F[Unit]]] = {
+        val encoded = encode(c)
+        smartSetParamF(encoded.toString, epicsSys.camera, epicsSys.configCmd.setCamera(encoded))
+      }
+
+      private def setBeamSplitter(b: BeamSplitter): F[Option[F[Unit]]] = {
+        val encoded = encode(b)
+        smartSetParamF(encoded.toString, epicsSys.beamSplitter,
+          epicsSys.configCmd.setBeamSplitter(encoded))
+      }
+
+      private def setFilter(f: Filter): F[Option[F[Unit]]] = {
+        val encoded = encode(f)
+
+        smartSetParamF(encoded.some, currentFilter, epicsSys.configCmd.setFilter(encoded))
+      }
+
+      private def setBlankFilter: F[Option[F[Unit]]] = {
+        val BlankFilter = "blank"
+
+        smartSetParamF(BlankFilter.some, currentFilter, epicsSys.configCmd.setFilter(BlankFilter))
+      }
+
+      private def setMask(m: Mask): F[Option[F[Unit]]] = {
+        val encoded = encode(m)
+
+        smartSetParamF(encoded.toString, epicsSys.mask, epicsSys.configCmd.setMask(encoded))
+      }
+
+      private def setDisperser(d: Disperser): F[Unit] = {
+        val encoded = encode(d)
+
+        // There is no status for the disperser
+        epicsSys.configCmd.setDisperser(encoded)
+      }
+
+      private def configCommonCC(cfg: Common): List[F[Option[F[Unit]]]] =
+        List(
+          setBeamSplitter(cfg.beamSplitter),
+          setCamera(cfg.camera),
+          setDisperser(cfg.disperser).wrapped,
+          setFocus(cfg.focus),
+          setMask(cfg.mask))
+
+      private def configDarkCC(cfg: Dark): List[F[Option[F[Unit]]]] =
+        List(
+          setWindowCover(WindowClosed),
+          setBlankFilter) ++
+          configCommonCC(cfg.common)
+
+      private def configCC(cfg: CCConfig): List[F[Option[F[Unit]]]] = cfg match {
+        case d@Dark(_)           => configDarkCC(d)
+        case i@Illuminated(_, _) => configIlluminatedCC(i)
+      }
+
+      private def configIlluminatedCC(cfg: Illuminated): List[F[Option[F[Unit]]]] =
+        List(
+          setWindowCover(WindowOpen),
+          setFilter(cfg.filter)) ++
+          configCommonCC(cfg.common)
+
+      private def setWindowCover(pos: String): F[Option[F[Unit]]] =
+        smartSetParamF(pos, epicsSys.windowCover, epicsSys.windowCoverConfig.setWindowCover(pos))
+
+      private def setExposureTime(t: ExposureTime): F[Option[F[Unit]]] = {
+        val ExposureTimeTolerance = 0.001
+        smartSetDoubleParamF[F](ExposureTimeTolerance)(t.toSeconds, epicsSys.integrationTime,
+          epicsSys.configCmd.setExposureTime(t.toSeconds)
+        )
+      }
+
+      private def configDC(cfg: DCConfig): List[F[Option[F[Unit]]]] =
+        List(
+          setExposureTime(cfg.exposureTime),
+            setCoadds(cfg.coadds),
+            setReadMode(cfg.readMode).wrapped,
+            setROI(cfg.builtInROI).wrapped)
+
+      private def setCoadds(n: Coadds): F[Option[F[Unit]]] =
+        smartSetParamF(n, epicsSys.coadds, epicsSys.configCmd.setCoadds(n))
+
+      private def setROI(r: BuiltInROI): F[Unit] = {
+        val encoded = encode(r)
+
+        // There is no status for the builtin ROI
+        epicsSys.configCmd.setBuiltInROI(encoded)
+      }
+
+      // There is no status for the read mode
+      private def setReadMode(rm: ReadMode): F[Unit] =
+        epicsSys.configCmd.setReadMode(rm)
+
+      private def calcObserveTimeout(cfg: DCConfig): F[Time] = {
+        epicsSys.minIntegration.map { t =>
+          val MinIntTime = t.seconds
+          val CoaddOverhead = 2.5
+          val TotalOverhead = 30.seconds
+
+          (cfg.exposureTime + MinIntTime) * cfg.coadds.toDouble * CoaddOverhead + TotalOverhead
+        }
+      }
+
+      private def actOnDHSNotConected(act: F[Unit]): F[Unit] =
+        epicsSys.dhsConnected.ifM(Applicative[F].unit, act)
+
+      private def actOnArrayNotActive(act: F[Unit]): F[Unit] =
+        epicsSys.arrayActive.ifM(Applicative[F].unit, act)
+
+      private def failOnDHSNotConected: F[Unit] =
+        actOnDHSNotConected(SeqexecFailure.Execution("NIRI is not connected to DHS").raiseError[F, Unit])
+
+      private def failOnArrayNotActive: F[Unit] =
+        actOnArrayNotActive(SeqexecFailure.Execution("NIRI detector array is not active").raiseError[F, Unit])
+
+      private def warnOnDHSNotConected: F[Unit] =
+        actOnDHSNotConected(L.warn("NIRI is not connected to DHS"))
+
+      private def warnOnArrayNotActive: F[Unit] =
+        actOnArrayNotActive(L.warn("NIRI detector array is not active"))
+
+      override def applyConfig(config: NiriController.NiriConfig): F[Unit] = {
+        val paramsDC = configDC(config.dc)
+        val params =  paramsDC ++ configCC(config.cc)
+
+        val cfgActions1 = if(params.isEmpty) ApplyCommandResult.Completed.pure[F]
+                          else executeIfNeeded(params,
+                            epicsSys.configCmd.setTimeout[F](ConfigTimeout) *>
+                            epicsSys.configCmd.post[F])
+        // Weird NIRI behavior. The main IS apply is nor connected to the DC apply, but triggering the
+        // IS apply writes the DC parameters. So to configure the DC, we need to set the DC parameters
+        // in the IS, trigger the IS apply, and then trigger the DC apply.
+        val cfgActions = if(paramsDC.isEmpty) cfgActions1
+                         else cfgActions1 *>
+                           epicsSys.configDCCmd.setTimeout[F](DefaultTimeout) *>
+                           epicsSys.configDCCmd.post[F]
+
+        L.debug("Starting NIRI configuration") *>
+          warnOnDHSNotConected *>
+          warnOnArrayNotActive *>
+          cfgActions *>
+          L.debug("Completed NIRI configuration")
+      }
+
+      override def observe(fileId: ImageFileId, cfg: DCConfig): F[ObserveCommandResult] =
+        L.debug(s"Start NIRI observe, file id $fileId") *>
+          failOnDHSNotConected *>
+          failOnArrayNotActive *>
+          epicsSys.observeCmd.setLabel(fileId) *>
+          calcObserveTimeout(cfg).flatMap(epicsSys.observeCmd.setTimeout[F]) *>
+          epicsSys.observeCmd.post[F].flatMap{ r =>
+            L.debug("Completed NIFS observe").as(r)
+          }
+
+      override def endObserve: F[Unit] =
+        L.debug("Send endObserve to NIRI") *>
+          epicsSys.endObserveCmd.setTimeout[F](DefaultTimeout) *>
+          epicsSys.endObserveCmd.mark[F] *>
+          epicsSys.endObserveCmd.post[F].void
+
+      override def stopObserve: F[Unit] =
+        L.debug("Stop NIRI exposure") *>
+          epicsSys.stopCmd.setTimeout[F](DefaultTimeout) *>
+          epicsSys.stopCmd.mark[F] *>
+          epicsSys.stopCmd.post[F].void
+
+      override def abortObserve: F[Unit] =
+        L.debug("Abort NIRI exposure") *>
+          epicsSys.abortCmd.setTimeout[F](DefaultTimeout) *>
+          epicsSys.abortCmd.mark[F] *>
+          epicsSys.abortCmd.post[F].void
+
+      override def observeProgress(total: Time): fs2.Stream[F, Progress] =
+        ProgressUtil.obsCountdownWithObsStage[F](total, 0.seconds,
+          (epicsSys.dcIsPreparing, epicsSys.dcIsAcquiring, epicsSys.dcIsReadingOut).mapN(ObserveStage.fromBooleans)
+        )
+
+      override def calcTotalExposureTime(cfg: DCConfig): F[Time] =
+        epicsSys.minIntegration.map { f =>
+          val MinIntTime = f.seconds
+
+          (cfg.exposureTime + MinIntTime) * cfg.coadds.toDouble
+        }
 
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
@@ -315,9 +315,7 @@ object NiriControllerEpics extends NiriEncoders {
           failOnArrayNotActive *>
           epicsSys.observeCmd.setLabel(fileId) *>
           calcObserveTimeout(cfg).flatMap(epicsSys.observeCmd.setTimeout[F]) *>
-          epicsSys.observeCmd.post[F].flatMap{ r =>
-            L.debug("Completed NIFS observe").as(r)
-          }
+          epicsSys.observeCmd.post[F].flatTap{ _ => L.debug("Completed NIFS observe") }
 
       override def endObserve: F[Unit] =
         L.debug("Send endObserve to NIRI") *>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
@@ -112,7 +112,7 @@ object TcsNorthControllerEpicsAo {
             _ <- epicsSys.post
             _ <- L.debug("TCS configuration command post")
             _ <- if(subsystems.contains(Subsystem.Mount))
-              epicsSys.waitInPosition(stabilizationTime, tcsTimeout) *> L.info("TCS inposition")
+              epicsSys.waitInPosition(stabilizationTime, tcsTimeout) *> L.debug("TCS inposition")
             else if(Set(Subsystem.PWFS1, Subsystem.PWFS2, Subsystem.AGUnit).exists(subsystems.contains))
               epicsSys.waitAGInPosition(agTimeout) *> L.debug("AG inposition")
             else Applicative[F].unit
@@ -204,10 +204,10 @@ object TcsNorthControllerEpicsAo {
         for {
           s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p)}
           _ <- epicsSys.post
-          _ <- L.info("Turning guide off")
+          _ <- L.debug("Turning guide off")
         } yield s
       else
-        L.info("Skipping guide off") *> current.pure[F]
+        L.debug("Skipping guide off") *> current.pure[F]
     }
 
     def guideOn(subsystems: NonEmptySet[Subsystem], current: EpicsTcsAoConfig, demand: TcsNorthAoConfig,
@@ -222,10 +222,10 @@ object TcsNorthControllerEpicsAo {
         for {
           s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p)}
           _ <- epicsSys.post
-          _ <- L.info("Turning guide on")
+          _ <- L.debug("Turning guide on")
         } yield s
       else
-        L.info("Skipping guide on") *> current.pure[F]
+        L.debug("Skipping guide on") *> current.pure[F]
     }
 
     // Disable M1 guiding if source is off

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -280,10 +280,10 @@ object TcsSouthControllerEpicsAo {
         for {
           s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p)}
           _ <- epicsSys.post
-          _ <- L.info("Turning guide off")
+          _ <- L.debug("Turning guide off")
         } yield s
       else
-        L.info("Skipping guide off") *> current.pure[F]
+        L.debug("Skipping guide off") *> current.pure[F]
 
     }
 
@@ -303,10 +303,10 @@ object TcsSouthControllerEpicsAo {
         for {
           s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p)}
           _ <- epicsSys.post
-          _ <- L.info("Turning guide on")
+          _ <- L.debug("Turning guide on")
         } yield s
       else
-        L.info("Skipping guide on") *> current.pure[F]
+        L.debug("Skipping guide on") *> current.pure[F]
     }
 
     def applyAoConfig(
@@ -341,7 +341,7 @@ object TcsSouthControllerEpicsAo {
             _ <- epicsSys.post
             _ <- L.debug("TCS configuration command post")
             _ <- if(subsystems.contains(Subsystem.Mount))
-              epicsSys.waitInPosition(stabilizationTime , tcsTimeout) *> L.info("TCS inposition")
+              epicsSys.waitInPosition(stabilizationTime , tcsTimeout) *> L.debug("TCS inposition")
             else if(Set(Subsystem.PWFS1, Subsystem.PWFS2, Subsystem.AGUnit).exists(subsystems.contains))
               epicsSys.waitAGInPosition(agTimeout) *> L.debug("AG inposition")
             else Applicative[F].unit


### PR DESCRIPTION
Added some missing log messages when interacting with external systems, and gave some uniformity to them. For example:
* Now every "start observe" message includes the file id.
* All long commands have a "start" and "completed" message
* All log messages related to interactions with external systems are at the DEBUG level.