### PR TITLE
Use github actions instead of buildkite

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Changes in this Release:
+            * First Change
+            * Second Change
+          draft: false
+          prerelease: false

--- a/.github/workflows/packtracker.yml
+++ b/.github/workflows/packtracker.yml
@@ -1,0 +1,29 @@
+name: packtracker
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - develop
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Scala
+        uses: olafurpg/setup-scala@v2
+        with:
+          java-version: 1.8
+      - name: Export assets to packtracker
+        run: |
+          sbt seqexec_web_client/fullOptJS::webpack
+          cd modules/seqexec/web/client/target/scala-2.12/scalajs-bundler/main/
+          node node_modules/webpack/bin/webpack --bail --profile --json --config packtracker.webpack.config.js
+        env:
+          SBT_OPTS: "-Xmx4096M -Xss2M -XX:ReservedCodeCacheSize=256M -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+          PT_PROJECT_TOKEN: ${{ secrets.PT_PROJECT_TOKEN }}

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,0 +1,18 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Scala
+        uses: olafurpg/setup-scala@v2
+        with:
+          java-version: 1.8
+      - name: Run tests
+        run: sbt headerCheck test:headerCheck scalastyle compile seqexec_modelJVM/test seqexec_modelJS/test seqexec_engine/test seqexec_server/test seqexec_web_sharedJVM/test seqexec_web_sharedJS/test seqexec_web_server/test seqexec_web_client/test seqexec_web_client/fastOptJS::webpack
+        env:
+          SBT_OPTS: "-Xmx4096M -Xss2M -XX:ReservedCodeCacheSize=256M -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"

--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,8 @@ lazy val seqexec_web_client = project.in(file("modules/seqexec/web/client"))
       "html-webpack-plugin"                -> "3.2.0",
       "optimize-css-assets-webpack-plugin" -> "5.0.3",
       "favicons-webpack-plugin"            -> "1.0.2",
-      "why-did-you-update"                 -> "1.0.6"
+      "why-did-you-update"                 -> "1.0.6",
+      "@packtracker/webpack-plugin"        -> "2.2.0"
     ),
     libraryDependencies ++= Seq(
       JQuery.value,

--- a/modules/seqexec/web/client/src/webpack/packtracker.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/packtracker.webpack.config.js
@@ -1,0 +1,19 @@
+const Merge = require("webpack-merge");
+const Web = require("./prod.webpack.config");
+const PacktrackerPlugin = require("@packtracker/webpack-plugin");
+
+console.log(process.env);
+
+const PackTracker = Merge(Web, {
+  plugins: [
+    new PacktrackerPlugin({
+      project_token: process.env.PT_PROJECT_TOKEN,
+      upload: true,
+      fail_build: true,
+      branch: process.env.GITHUB_REF.split("/")[2],
+      excludeAssets: ["seqexec_web_client-opt.js"]
+    })
+  ]
+});
+
+module.exports = PackTracker;

--- a/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/prod.webpack.config.js
@@ -4,7 +4,6 @@ const Webpack = require("webpack");
 const parts = require("./webpack.parts");
 const ScalaJSConfig = require("./scalajs.webpack.config");
 const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
-
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 const ci = process.env.CI; // When on CI don't add hashes

--- a/modules/seqexec/web/client/src/webpack/test.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/test.webpack.config.js
@@ -1,5 +1,3 @@
-const path = require("path");
-const Webpack = require("webpack");
 const Merge = require("webpack-merge");
 const parts = require("./webpack.parts");
 


### PR DESCRIPTION
Buildkite has become very unstable. I propose we switch to github actions

This PR sets it up running tests only for the seqexec part. This is because we are going to split the repo and I don't want to setup postgress yet

On buildkite we measure the asset sizes. I added another action that would do something equivalent using https://app.packtracker.io/organizations/422/projects/321. The latter task would only run on merge thus making the build faster