### PR TITLE
SEQNG-551 Remove duplicate log lines

### DIFF
--- a/.github/workflows/packtracker.yml
+++ b/.github/workflows/packtracker.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2-beta
+      - uses: actions/checkout@v1
       - name: Set up Scala
         uses: olafurpg/setup-scala@v2
         with:

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/common/FixedLengthBuffer.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/common/FixedLengthBuffer.scala
@@ -3,44 +3,44 @@
 
 package seqexec.common
 
-import cats.{Applicative, Eq, Eval, Show, Traverse}
+import cats.{Applicative, Eq, Eval, Traverse, Order}
+import cats.data.Chain
+import cats.data.Chain._
 import cats.implicits._
 import mouse.all._
 
 object FixedLengthBuffer {
-  private final case class FixedLengthBufferImpl[A](maxLength: Int, data: Vector[A]) extends FixedLengthBuffer[A] {
+  private final case class FixedLengthBufferImpl[A](maxLength: Int, data: Chain[A]) extends FixedLengthBuffer[A] {
     // Sanity check
     require(maxLength >= data.length)
     require(maxLength >= 0)
 
-    def append(element: A): FixedLengthBuffer[A] = {
-      if (data.length === maxLength && data.length >= 0) {
+    def append(element: A)(implicit ev: Order[A]): FixedLengthBuffer[A] = {
+      if (data.length === maxLength.toLong && data.length >= 0) {
         data match {
-          case _ +: tail => FixedLengthBufferImpl[A](maxLength, tail :+ element)
-          case _         => FixedLengthBufferImpl[A](maxLength, Vector(element))
+          case _ ==: tail => FixedLengthBufferImpl[A](maxLength, tail :+ element)
+          case _          => FixedLengthBufferImpl[A](maxLength, Chain(element))
         }
       } else {
-        FixedLengthBufferImpl[A](maxLength, data :+ element)
+        FixedLengthBufferImpl[A](maxLength, (data :+ element).distinct)
       }
     }
 
-    def toVector: Vector[A] =
+    def toChain: Chain[A] =
       data
-
-    def size: Int = data.size
 
     def isEmpty: Boolean = data.isEmpty
 
     def reverse: FixedLengthBuffer[A] = FixedLengthBufferImpl(maxLength, data.reverse)
 
     def flatMap[B](f: A => FixedLengthBuffer[B]): FixedLengthBuffer[B] =
-      FixedLengthBufferImpl(maxLength, this.toVector.flatMap(f(_).toVector))
+      FixedLengthBufferImpl(maxLength, this.data.flatMap(f(_).toChain))
 
   }
 
   def apply[A](maxLength: Int, initial: A*): Option[FixedLengthBuffer[A]] = {
     (maxLength > 0 && maxLength >= initial.length) option
-      FixedLengthBufferImpl[A](maxLength, Vector(initial: _*))
+      FixedLengthBufferImpl[A](maxLength, Chain(initial: _*))
   }
 
   def fromInt[A](maxLength: Int, initial: A*): Option[FixedLengthBuffer[A]] =
@@ -49,12 +49,10 @@ object FixedLengthBuffer {
   def unsafeFromInt[A](maxLength: Int, initial: A*): FixedLengthBuffer[A] =
     fromInt[A](maxLength, initial: _*).getOrElse(sys.error(s"Invalid max length $maxLength, data length ${initial.length}"))
 
-  def Zero[A]: FixedLengthBuffer[A] = FixedLengthBufferImpl[A](0, Vector.empty[A])
-
-  implicit def show[A]: Show[FixedLengthBuffer[A]] = Show.fromToString
+  def Zero[A]: FixedLengthBuffer[A] = FixedLengthBufferImpl[A](0, Chain.empty[A])
 
   implicit def equal[A: Eq]: Eq[FixedLengthBuffer[A]] =
-    Eq.by(x => (x.maxLength, x.toVector))
+    Eq.by(x => (x.maxLength, x.toChain))
 
   /**
    * @typeclass Traverse
@@ -62,19 +60,19 @@ object FixedLengthBuffer {
    */
   implicit val instance: Traverse[FixedLengthBuffer] = new Traverse[FixedLengthBuffer] {
     override def traverse[G[_], A, B](fa: FixedLengthBuffer[A])(f: A => G[B])(implicit G: Applicative[G]): G[FixedLengthBuffer[B]] =
-      fa.toVector.traverse(f).map(FixedLengthBuffer.unsafeFromInt(fa.maxLength, _: _*))
+      fa.toChain.traverse(f).map(FixedLengthBufferImpl(fa.maxLength, _))
 
     override def foldLeft[A, B](fa: FixedLengthBuffer[A], b: B)(f: (B, A) => B): B =
-      fa.toVector.foldLeft(b)(f)
+      fa.toChain.foldLeft(b)(f)
 
     override def foldRight[A, B](fa: FixedLengthBuffer[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = {
-      def loop(as: Vector[A]): Eval[B] =
+      def loop(as: Chain[A]): Eval[B] =
         as match {
-          case h +: t => f(h, Eval.defer(loop(t)))
-          case _ => lb
+          case h ==: t => f(h, Eval.defer(loop(t)))
+          case _       => lb
         }
 
-      Eval.defer(loop(fa.toVector))
+      Eval.defer(loop(fa.toChain))
     }
   }
 
@@ -88,7 +86,7 @@ sealed trait FixedLengthBuffer[A] {
   /**
    * Append elements to the buffer
    */
-  def append(element: A): FixedLengthBuffer[A]
+  def append(element: A)(implicit ev: Order[A]): FixedLengthBuffer[A]
 
   /**
    * Max length of the list
@@ -98,12 +96,7 @@ sealed trait FixedLengthBuffer[A] {
   /**
    * Converts the buffer to a list
    */
-  def toVector: Vector[A]
-
-  /**
-   * Size of the data
-   */
-  def size: Int
+  def toChain: Chain[A]
 
   /**
    * Indicates if the buffer is empty

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/events.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/events.scala
@@ -4,6 +4,7 @@
 package seqexec.model
 
 import cats.Eq
+import cats.Order
 import cats.implicits._
 import dhs.ImageFileId
 import gem.Observation
@@ -38,8 +39,10 @@ object events {
                                     msg:       String)
       extends SeqexecEvent
   object ServerLogMessage {
-    implicit lazy val equal: Eq[ServerLogMessage] =
-      Eq.by(x => (x.level, x.timestamp, x.msg))
+    private implicit val instantOrder: Order[Instant] =
+      Order.by(_.getNano)
+    implicit val serverLogMessageOrder: Order[ServerLogMessage] =
+      Order.by(x => (x.level, x.timestamp, x.msg))
   }
 
   case object NullEvent extends SeqexecEvent

--- a/modules/seqexec/model/shared/src/test/scala/seqexec/common/ArbitrariesCommon.scala
+++ b/modules/seqexec/model/shared/src/test/scala/seqexec/common/ArbitrariesCommon.scala
@@ -20,7 +20,7 @@ trait ArbitrariesCommon {
     }
 
   implicit def fixedLengthBufferCogen[A: Cogen]: Cogen[FixedLengthBuffer[A]] =
-    Cogen[(Int, Vector[A])].contramap(x => (x.maxLength, x.toVector))
+    Cogen[(Int, Vector[A])].contramap(x => (x.maxLength, x.toChain.toVector))
 
   implicit def arbZipper[A: Arbitrary]: Arbitrary[Zipper[A]] =
     Arbitrary {

--- a/modules/seqexec/model/shared/src/test/scala/seqexec/model/SeqexecEventSpec.scala
+++ b/modules/seqexec/model/shared/src/test/scala/seqexec/model/SeqexecEventSpec.scala
@@ -36,4 +36,5 @@ final class SeqexecEventSpec extends CatsSuite with SequenceEventsArbitraries {
   checkAll("Eq[SequenceStopped]", EqTests[SequenceStopped].eqv)
   checkAll("Eq[SequenceAborted]", EqTests[SequenceAborted].eqv)
   checkAll("Eq[GuideConfigUpdate]", EqTests[GuideConfigUpdate].eqv)
+  checkAll("Order[ServerLogMessage]", OrderTests[ServerLogMessage].order)
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -169,7 +169,7 @@ object LogArea {
       State(SortedMap(ServerLogLevel.ServerLogLevelEnumerated.all.map(_ -> true): _*), DefaultTableState)
   }
 
-  private val ClipboardWidth    = 37.0
+  private val ClipboardWidth    = 41.0
   private val TimestampMinWidth = 90.1667 + SeqexecStyles.TableBorderWidth
   private val LevelMinWidth     = 59.3333 + SeqexecStyles.TableBorderWidth
   private val MessageMinWidth   = 89.35 + SeqexecStyles.TableBorderWidth

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/reusability/package.scala
@@ -17,18 +17,12 @@ import seqexec.model.dhs._
 import seqexec.model.{M1GuideConfig, M2GuideConfig, NSRunningState, NSSubexposure, NodAndShuffleStatus, NodAndShuffleStep, Observer, QueueId, SequenceState, StandardStep, Step, StepConfig, StepState, TelescopeGuideConfig, UserDetails}
 import seqexec.web.client.model.AvailableTab
 import seqexec.web.client.model.ClientStatus
-import seqexec.web.client.model.SectionVisibilityState
 import seqexec.web.client.model.UserNotificationState
 import seqexec.web.client.model.WebSocketConnection
-import seqexec.web.client.model.PauseOperation
 import seqexec.web.client.model.QueueOperations
-import seqexec.web.client.model.RunOperation
-import seqexec.web.client.model.SyncOperation
 import seqexec.web.client.model.TabOperations
 import seqexec.web.client.model.ResourceRunOperation
-import seqexec.web.client.model.StartFromOperation
 import seqexec.web.client.model.TabSelected
-import seqexec.web.client.model.SoundSelection
 import seqexec.web.client.model.GlobalLog
 import seqexec.web.client.circuit._
 import seqexec.web.client.model.StepItems.StepStateSummary
@@ -74,18 +68,10 @@ package object reusability {
   implicit val sCFocusReuse: Reusability[SequenceControlFocus] =
     Reusability.byEq
   implicit val tabSelReuse: Reusability[TabSelected] = Reusability.byRef
-  implicit val sectReuse: Reusability[SectionVisibilityState] =
-    Reusability.byRef
   implicit val potStateReuse: Reusability[PotState] = Reusability.byRef
   implicit val webSCeuse: Reusability[WebSocketConnection] =
     Reusability.by(_.ws.state)
-  implicit val runOperationReuse: Reusability[RunOperation] = Reusability.byRef
-  implicit val syncOperationReuse: Reusability[SyncOperation] =
-    Reusability.byRef
-  implicit val psOperationReuse: Reusability[PauseOperation] = Reusability.byRef
   implicit val rrOperationReuse: Reusability[ResourceRunOperation] =
-    Reusability.byRef
-  implicit val rfOperationReuse: Reusability[StartFromOperation] =
     Reusability.byRef
   implicit val availableTabsReuse: Reusability[AvailableTab] = Reusability.byEq
   implicit val userDetailsReuse: Reusability[UserDetails]    = Reusability.byEq
@@ -95,7 +81,6 @@ package object reusability {
   implicit val qfReuse: Reusability[CalQueueControlFocus]  = Reusability.byEq
   implicit val cqfReuse: Reusability[CalQueueFocus]        = Reusability.byEq
   implicit val qidReuse: Reusability[QueueId]              = Reusability.byEq
-  implicit val soundReuse: Reusability[SoundSelection]     = Reusability.byRef
   implicit val globalLogReuse: Reusability[GlobalLog]      = Reusability.byEq
   implicit val resMap: Reusability[Map[Resource, ResourceRunOperation]] =
     Reusability.map


### PR DESCRIPTION
Sometimes we show log lines duplicated on the client. I tracked this to multiple subscriptions on the client when you do login/logout. Fixing the root maybe complicated due to the asynchronous nature of the events so I'll simply filter duplicates on the UI