### PR TITLE
SEQNG-1157 Add a timeout to observes

### DIFF
--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveTimeoutSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveTimeoutSpec.scala
@@ -1,0 +1,150 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.epics.acm
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+  * Tests of the observe state machine timeouts
+  */
+final class ObserveTimeoutSpec extends AnyFunSuite with NiriMocks with GsaoiMocks {
+
+  test("NIRI no response should timeout") {
+    val (epicsReader, epicsWriter) = niriMocks
+
+    val observe = new CaObserveSenderImpl(
+      "niri::observeCmd",
+      "niri:dc:apply",
+      "niri:dc:applyC",
+      "niri:dc:observeC",
+      "niri:dc:stop",
+      "niri:dc:abort",
+      "NIRI Observe",
+      classOf[CarState],
+      epicsReader,
+      epicsWriter)
+
+    observe.setTimeout(5, TimeUnit.SECONDS)
+    // Start idle
+    assert(observe.applyState().isIdle)
+    val observeErrorCount = new AtomicInteger()
+    val observePauseCount = new AtomicInteger()
+    val observeSuccessCount = new AtomicInteger()
+    // Post an observe
+    val l = observe.post()
+    l.setCallback(new CaCommandListener() {
+      def onFailure(ex: Exception): Unit = {
+        observeErrorCount.incrementAndGet()
+        ()
+      }
+      def onPause(): Unit = {
+        observePauseCount.incrementAndGet()
+        ()
+      }
+      def onSuccess(): Unit = {
+        observeSuccessCount.incrementAndGet()
+        ()
+      }
+    })
+
+    // OBSERVE
+    // OBSERVE goes BUSY
+    observe.onObserveCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(365)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+
+    // Apply VAL change
+    observe.onApplyValChange(365)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(365)
+    assert(!observe.applyState().isIdle)
+    // OBSERVE never completes
+    // observe.onObserveCarValChange(CarState.IDLE)
+    // And we are done and IDLE
+    assert(!observe.applyState().isIdle)
+    // wait for the timeout
+    l.waitDone(20, TimeUnit.SECONDS)
+    assert(l.isDone)
+    // Now we are idle
+    assert(observe.applyState().isIdle)
+
+    // Check that listener was called
+    assert(observeErrorCount.get() === 1)
+    assert(observePauseCount.get() === 0)
+    assert(observeSuccessCount.get() === 0)
+  }
+
+  test("GSAOI apply no response should timeout") {
+
+    val (epicsReader, epicsWriter) = gsaoiMocks
+    val observe = new CaSimpleObserveSenderImpl(
+      "gsaoi::observeCmd",
+      "gsaoi:dc:obsapply",
+      "gsaoi:dc:observeC",
+      "gsaoi:dc:stop",
+      "gsaoi:dc:abort",
+      "GSAOI Observe",
+      classOf[CarState],
+      epicsReader,
+      epicsWriter)
+    observe.setTimeout(5, TimeUnit.SECONDS)
+    // Start idle
+    assert(observe.applyState().isIdle)
+
+    val observeErrorCount = new AtomicInteger()
+    val observePauseCount = new AtomicInteger()
+    val observeSuccessCount = new AtomicInteger()
+    // Post an observe
+    val l = observe.post()
+    l.setCallback(new CaCommandListener() {
+      def onFailure(ex: Exception): Unit = {
+        observeErrorCount.incrementAndGet()
+        ()
+      }
+      def onPause(): Unit = {
+        observePauseCount.incrementAndGet()
+        ()
+      }
+      def onSuccess(): Unit = {
+        observeSuccessCount.incrementAndGet()
+        ()
+      }
+    })
+
+    // VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR VAL change
+    observe.onCarValChange(CarState.BUSY)
+    assert(!observe.applyState().isIdle)
+    // Another VAL change
+    observe.onApplyValChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR CLID change
+    observe.onCarClidChange(4167)
+    assert(!observe.applyState().isIdle)
+    // CAR never returs to IDLE
+    // observe.onCarValChange(CarState.IDLE)
+    // And we are done and IDLE
+    assert(!observe.applyState().isIdle)
+    l.waitDone(20, TimeUnit.SECONDS)
+    assert(l.isDone)
+
+    // Check that listener was called
+    assert(observeErrorCount.get() === 1)
+    assert(observePauseCount.get() === 0)
+    assert(observeSuccessCount.get() === 0)
+  }
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/CleanConfig.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/CleanConfig.scala
@@ -47,7 +47,8 @@ final case class CleanConfig(config: Config, overrides: Map[ItemKey, AnyRef]) {
 
 object CleanConfig {
 
-  implicit val extractItem: ExtractItem[CleanConfig] = (a: CleanConfig, key: ItemKey) => a.itemValue(key)
+  implicit val extractItem: ExtractItem[CleanConfig] =
+    (a: CleanConfig, key: ItemKey) => a.itemValue(key)
 
   type ConfigWiper = Config => Map[ItemKey, AnyRef]
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -142,9 +142,6 @@ trait ObserveCommand {
 
   def setTimeout[F[_]: Sync](t: Time): F[Unit] =
     Sync[F].delay {
-      cs.map(_.getApplySender).map(_.setTimeout(t.toMilliseconds.toLong, MILLISECONDS))
-    } *>
-    Sync[F].delay {
       os.map(_.setTimeout(t.toMilliseconds.toLong, MILLISECONDS))
     }.void
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -143,6 +143,9 @@ trait ObserveCommand {
   def setTimeout[F[_]: Sync](t: Time): F[Unit] =
     Sync[F].delay {
       cs.map(_.getApplySender).map(_.setTimeout(t.toMilliseconds.toLong, MILLISECONDS))
+    } *>
+    Sync[F].delay {
+      os.map(_.setTimeout(t.toMilliseconds.toLong, MILLISECONDS))
     }.void
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentActions.scala
@@ -6,6 +6,7 @@ package seqexec.server
 import cats.MonadError
 import cats.data.NonEmptyList
 import cats.effect.Concurrent
+import cats.effect.Timer
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.ActionType
@@ -78,7 +79,7 @@ object InstrumentActions {
   /**
     * Default Actions for most instruments it basically delegates to ObserveActions
     */
-  def defaultInstrumentActions[F[_]: Concurrent: Logger]
+  def defaultInstrumentActions[F[_]: Concurrent: Timer: Logger]
     : InstrumentActions[F] =
     new InstrumentActions[F] {
       def observationProgressStream(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -11,6 +11,7 @@ import seqexec.model.enum.Instrument
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.server.keywords.KeywordsClient
 import squants.{Length, Time}
+import scala.concurrent.duration._
 
 trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
   override val resource: Instrument
@@ -24,6 +25,8 @@ trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
 
   //Expected total observe lapse, used to calculate timeout
   def calcObserveTime(config: CleanConfig): F[Time]
+
+  def observeTimeout: FiniteDuration = 1.minute
 
   def keywordsClient: KeywordsClient[F]
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -44,6 +44,7 @@ trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
 }
 
 object InstrumentSystem {
+  val ObserveOperationsTimeout = 1.minute
 
   final case class StopObserveCmd[F[_]](self: Boolean => F[Unit])
   final case class AbortObserveCmd[F[_]](self: F[Unit])

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -13,7 +13,7 @@ import io.chrisdavenport.log4cats.Logger
 import seqexec.engine._
 import seqexec.model.dhs._
 import seqexec.model.enum.ObserveCommandResult
-import seqexec.server.InstrumentSystem.{CompleteControl, ElapsedTime}
+import seqexec.server.InstrumentSystem._
 import SeqTranslate.dataIdFromConfig
 import squants.time.Time
 import squants.time.TimeConversions._
@@ -124,7 +124,7 @@ trait ObserveActions {
     for {
       d <- dataId(env)
       _ <- sendDataStart(env.systems, env.obsId, fileId, d)
-      _ <- notifyObserveStart(env)
+      _ <- notifyObserveStart(env).timeoutTo(env.inst.observeTimeout, Concurrent[F].raiseError(SeqexecFailure.ObsSystemTimeout(fileId)))
       _ <- env.headers(env.ctx).traverse(_.sendBefore(env.obsId, fileId))
       _ <- info(s"Start ${env.inst.resource.show} observation ${env.obsId.format} with label $fileId")
       t <- env.inst.calcObserveTime(env.config).map(t => t + env.inst.observeTimeout)
@@ -137,14 +137,14 @@ trait ObserveActions {
     * It tells the odb and each subsystem and also sends the end
     * observation keywords
     */
-  def okTail[F[_]: MonadError[?[_], Throwable]](
+  def okTail[F[_]: Concurrent: Timer](
     fileId:  ImageFileId,
     dataId:  DataId,
     stopped: Boolean,
     env:     ObserveEnvironment[F]
   ): F[Result[F]] =
     for {
-      _ <- notifyObserveEnd(env)
+      _ <- notifyObserveEnd(env).timeoutTo(env.inst.observeTimeout, Concurrent[F].raiseError(SeqexecFailure.ObsSystemTimeout(fileId)))
       _ <- env.headers(env.ctx).reverseMap(_.sendAfter(fileId)).sequence.void
       _ <- closeImage(fileId, env)
       _ <- sendDataEnd[F](env.systems, env.obsId, fileId, dataId)
@@ -155,11 +155,11 @@ trait ObserveActions {
   /**
     * Method to process observe results and act accordingly to the response
     */
-  private def observeTail[F[_]: MonadError[?[_], Throwable]](
+  private def observeTail[F[_]: Timer](
     fileId: ImageFileId,
     dataId: DataId,
     env:    ObserveEnvironment[F]
-  )(r:      ObserveCommandResult): Stream[F, Result[F]] = {
+  )(r:      ObserveCommandResult)(implicit cio: Concurrent[F]): Stream[F, Result[F]] =
     Stream.eval(r match {
       case ObserveCommandResult.Success =>
         okTail(fileId, dataId, stopped = false, env)
@@ -168,13 +168,35 @@ trait ObserveActions {
       case ObserveCommandResult.Aborted =>
         abortTail(env.systems, env.obsId, fileId)
       case ObserveCommandResult.Paused =>
+        val timeout = env.inst.observeTimeout
         env.inst.calcObserveTime(env.config)
           .flatMap(totalTime => env.inst.observeControl(env.config) match {
-            case c: CompleteControl[F] => Result.Paused(
+            case c: CompleteControl[F] =>
+            val resumePaused: Time => Stream[F, Result[F]] =
+                (elapsed: Time) => Stream.eval{
+                  val resumeTimeout: FiniteDuration = new FiniteDuration((elapsed + timeout).millis, MILLISECONDS)
+                  c.continue
+                    .self(elapsed)
+                    .timeoutTo(resumeTimeout, cio.raiseError(SeqexecFailure.ObsTimeout(fileId)))
+                }.flatMap(observeTail(fileId, dataId, env))
+            val stopPaused: Stream[F, Result[F]] =
+                Stream.eval{
+                  c.stopPaused
+                    .self
+                    .timeoutTo(timeout, cio.raiseError(SeqexecFailure.ObsTimeout(fileId)))
+                }.flatMap(observeTail(fileId, dataId, env))
+            val abortPaused: Stream[F, Result[F]] =
+                Stream.eval{
+                  c.abortPaused
+                    .self
+                    .timeoutTo(timeout, cio.raiseError(SeqexecFailure.ObsTimeout(fileId)))
+                }.flatMap(observeTail(fileId, dataId, env))
+
+             Result.Paused(
               ObserveContext[F](
-                (elapsed: Time) => Stream.eval(c.continue.self(elapsed)).flatMap(observeTail(fileId, dataId, env)),
-                Stream.eval(c.stopPaused.self).flatMap(observeTail(fileId, dataId, env)),
-                Stream.eval(c.abortPaused.self).flatMap(observeTail(fileId, dataId, env)),
+                resumePaused,
+                stopPaused,
+                abortPaused,
                 totalTime
               )
             ).pure[F].widen[Result[F]]
@@ -183,7 +205,6 @@ trait ObserveActions {
                 .raiseError[F, Result[F]]
           })
     })
-  }
 
   /**
     * Observe for a typical instrument

--- a/modules/seqexec/server/src/main/scala/seqexec/server/OdbProxy.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/OdbProxy.scala
@@ -57,8 +57,8 @@ object OdbProxy {
     }
 
   final class DummyOdbCommands[F[_]: Applicative] extends OdbCommands[F] {
-    override def datasetStart(obsId: Observation.Id, dataId: DataId, fileId: ImageFileId): F[Boolean] = false.pure[F]
-    override def datasetComplete(obsId: Observation.Id, dataId: DataId, fileId: ImageFileId): F[Boolean] = false.pure[F]
+    override def datasetStart(obsId: Observation.Id, dataId: DataId, fileId: ImageFileId): F[Boolean] = true.pure[F]
+    override def datasetComplete(obsId: Observation.Id, dataId: DataId, fileId: ImageFileId): F[Boolean] = true.pure[F]
     override def obsAbort(obsId: Observation.Id, reason: String): F[Boolean] = false.pure[F]
     override def sequenceEnd(obsId: Observation.Id): F[Boolean] = false.pure[F]
     override def sequenceStart(obsId: Observation.Id, dataId: DataId): F[Boolean] = false.pure[F]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
@@ -53,8 +53,14 @@ object SeqexecFailure {
   /** Null epics read */
   final case class NullEpicsError(channel: String) extends SeqexecFailure
 
-  /** Observation command timeout */
+  /** Observation command timeout on instrument */
   final case class ObsTimeout(fileId: ImageFileId) extends SeqexecFailure
+
+  /** Observation system timeout, e.g. TCS/GCAL */
+  final case class ObsSystemTimeout(fileId: ImageFileId) extends SeqexecFailure
+
+  /** Observation command timeout */
+  final case class ObsCommandTimeout(obsId: Observation.Id) extends SeqexecFailure
 
   /** Failed simulation */
   case object FailedSimulation extends SeqexecFailure
@@ -78,6 +84,8 @@ object SeqexecFailure {
     case FailedSimulation             => s"Failed to simulate"
     case NullEpicsError(channel)      => s"Failed to read epics channel: $channel"
     case ObsTimeout(fileId)           => s"Observation of $fileId timed out"
+    case ObsSystemTimeout(fileId)     => s"Observation of $fileId timed out on a subsystem"
+    case ObsCommandTimeout(obsId)     => s"Observation command on ${obsId.format} timed out"
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecFailure.scala
@@ -6,6 +6,7 @@ package seqexec.server
 import edu.gemini.seqexec.odb.SeqFailure
 import gem.Observation
 import org.http4s.Uri
+import seqexec.model.dhs._
 
 sealed trait SeqexecFailure extends Exception with Product with Serializable
 
@@ -52,6 +53,9 @@ object SeqexecFailure {
   /** Null epics read */
   final case class NullEpicsError(channel: String) extends SeqexecFailure
 
+  /** Observation command timeout */
+  final case class ObsTimeout(fileId: ImageFileId) extends SeqexecFailure
+
   /** Failed simulation */
   case object FailedSimulation extends SeqexecFailure
 
@@ -73,6 +77,7 @@ object SeqexecFailure {
     case GdsXmlError(msg, url)        => s"XML RPC error with GDS at $url: $msg"
     case FailedSimulation             => s"Failed to simulate"
     case NullEpicsError(channel)      => s"Failed to read epics channel: $channel"
+    case ObsTimeout(fileId)           => s"Observation of $fileId timed out"
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -5,7 +5,7 @@ package seqexec.server.ghost
 
 import cats.data.Kleisli
 import cats.data.EitherT
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Concurrent, Sync, Timer}
 import cats.implicits._
 import fs2.Stream
 import edu.gemini.spModel.seqcomp.SeqConfigNames._
@@ -30,7 +30,7 @@ import squants.time.Time
 
 import scala.reflect.ClassTag
 
-final case class Ghost[F[_]: Logger: Concurrent](controller: GhostController[F])
+final case class Ghost[F[_]: Logger: Concurrent: Timer](controller: GhostController[F])
     extends GdsInstrument[F]
     with InstrumentSystem[F] {
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -7,7 +7,7 @@ import cats._
 import cats.data.Kleisli
 import cats.data.EitherT
 import cats.implicits._
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Concurrent, Sync, Timer}
 import cats.effect.concurrent.Ref
 import edu.gemini.spModel.config2.ItemKey
 import edu.gemini.spModel.gemini.gmos.GmosCommonType._
@@ -43,7 +43,7 @@ import squants.{Seconds, Time}
 import squants.space.LengthConversions._
 import shapeless.tag
 
-abstract class Gmos[F[_]: Concurrent: Logger, T <: GmosController.SiteDependentTypes]
+abstract class Gmos[F[_]: Concurrent: Timer: Logger, T <: GmosController.SiteDependentTypes]
 (val controller: GmosController[F, T], ss: SiteSpecifics[T], nsCmdR: Ref[F, Option[NSObserveCommand]])
 (configTypes: GmosController.Config[T]) extends DhsInstrument[F] with InstrumentSystem[F] {
   import Gmos._

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -5,6 +5,7 @@ package seqexec.server.gmos
 
 import cats.implicits._
 import cats.effect.Concurrent
+import cats.effect.Timer
 import cats.effect.concurrent.Ref
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
@@ -31,7 +32,7 @@ import squants.space.AngleConversions._
 /**
   * Gmos needs different actions for N&S
   */
-class GmosInstrumentActions[F[_]: Concurrent: Logger, A <: GmosController.SiteDependentTypes](
+class GmosInstrumentActions[F[_]: Concurrent: Timer: Logger, A <: GmosController.SiteDependentTypes](
   inst:   Gmos[F, A],
   config: CleanConfig
 ) extends InstrumentActions[F] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -5,6 +5,7 @@ package seqexec.server.gmos
 
 import cats.implicits._
 import cats.effect.Concurrent
+import cats.effect.Timer
 import cats.effect.concurrent.Ref
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
@@ -22,7 +23,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosNorth[F[_]: Concurrent: Logger](
+final case class GmosNorth[F[_]: Concurrent: Timer: Logger] private (
   c: GmosNorthController[F],
   dhsClient: DhsClient[F],
   nsCmdR: Ref[F, Option[NSObserveCommand]]
@@ -42,6 +43,7 @@ final case class GmosNorth[F[_]: Concurrent: Logger](
 )(northConfigTypes) {
   override val resource: Instrument = Instrument.GmosN
   override val dhsInstrumentName: String = "GMOS-N"
+
   // TODO Use different value if using electronic offsets
   override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 }
@@ -49,7 +51,7 @@ final case class GmosNorth[F[_]: Concurrent: Logger](
 object GmosNorth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: Concurrent: Logger](
+  def apply[F[_]: Concurrent: Timer: Logger](
     c: GmosController[F, NorthTypes],
     dhsClient: DhsClient[F],
     nsCmdR: Ref[F, Option[NSObserveCommand]]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -5,6 +5,7 @@ package seqexec.server.gmos
 
 import cats.implicits._
 import cats.effect.Concurrent
+import cats.effect.Timer
 import cats.effect.concurrent.Ref
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
@@ -22,7 +23,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
 import squants.Length
 import squants.space.Arcseconds
 
-final case class GmosSouth[F[_]: Concurrent: Logger](
+final case class GmosSouth[F[_]: Concurrent: Timer: Logger] private (
  c: GmosSouthController[F],
  dhsClient: DhsClient[F],
  nsCmdR: Ref[F, Option[NSObserveCommand]]
@@ -51,7 +52,7 @@ final case class GmosSouth[F[_]: Concurrent: Logger](
 object GmosSouth {
   val name: String = INSTRUMENT_NAME_PROP
 
-  def apply[F[_]: Concurrent: Logger](
+  def apply[F[_]: Concurrent: Timer: Logger](
     c: GmosController[F, SouthTypes],
     dhsClient: DhsClient[F],
     nsCmdR: Ref[F, Option[NSObserveCommand]]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -6,7 +6,7 @@ package seqexec.server.gnirs
 import cats.data.Kleisli
 import cats.data.EitherT
 import cats.implicits._
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Concurrent, Sync, Timer}
 import edu.gemini.spModel.gemini.gnirs.GNIRSConstants.{INSTRUMENT_NAME_PROP, WOLLASTON_PRISM_PROP}
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams._
 import edu.gemini.spModel.gemini.gnirs.InstGNIRS._
@@ -28,7 +28,7 @@ import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
-final case class Gnirs[F[_]: Logger: Concurrent](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
+final case class Gnirs[F[_]: Logger: Concurrent: Timer](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
   override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gnirs
   override val contributorName: String = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiInstrumentActions.scala
@@ -4,6 +4,7 @@
 package seqexec.server.gpi
 
 import cats.effect.Concurrent
+import cats.effect.Timer
 import cats.implicits._
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
@@ -17,7 +18,7 @@ import seqexec.server.ObserveEnvironment
 /**
   * Gpi needs different actions for A&C
   */
-class GpiInstrumentActions[F[_]: Logger: Concurrent]
+class GpiInstrumentActions[F[_]: Logger: Concurrent: Timer]
     extends InstrumentActions[F] {
 
   override def observationProgressStream(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -5,7 +5,7 @@ package seqexec.server.gsaoi
 
 import cats.data.Kleisli
 import cats.data.EitherT
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Concurrent, Sync, Timer}
 import cats.implicits._
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi._
 import edu.gemini.spModel.obscomp.InstConstants.DARK_OBSERVE_TYPE
@@ -33,7 +33,7 @@ import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Gsaoi[F[_]: Logger: Concurrent](
+final case class Gsaoi[F[_]: Logger: Concurrent: Timer](
   controller: GsaoiController[F],
   dhsClient:  DhsClient[F])
     extends DhsInstrument[F]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -5,7 +5,7 @@ package seqexec.server.nifs
 
 import cats.data.Kleisli
 import cats.data.EitherT
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Concurrent, Timer, Sync}
 import cats.implicits._
 import edu.gemini.spModel.gemini.nifs.InstNIFS._
 import edu.gemini.spModel.gemini.nifs.InstEngNifs._
@@ -38,7 +38,7 @@ import squants.space.Arcseconds
 import squants.{Length, Time}
 import squants.time.TimeConversions._
 
-final case class Nifs[F[_]: Logger: Concurrent](
+final case class Nifs[F[_]: Logger: Concurrent: Timer](
   controller: NifsController[F],
   dhsClient:  DhsClient[F])
     extends DhsInstrument[F]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerSim.scala
@@ -40,4 +40,5 @@ object NiriControllerSim {
         }.pure[F]
       }
     }
+
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/ObserveActionsSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/ObserveActionsSpec.scala
@@ -83,7 +83,6 @@ final class ObserveActionsSpec extends CatsSuite {
     config.putItem(INSTRUMENT_KEY / READ_MODE_PROP, ReadMode.DEFAULT)
     config.putItem(INSTRUMENT_KEY / WELL_DEPTH_PROP, WellDepth.DEFAULT)
     config.putItem(INSTRUMENT_KEY / BUILTIN_ROI_PROP, BuiltinROI.DEFAULT)
-    println(config)
     val httpClient: Client[IO] = GdsClient.alwaysOkClient[IO]
     val control = SystemsControlConfiguration(
       altair   = ControlStrategy.Simulated,
@@ -119,28 +118,26 @@ final class ObserveActionsSpec extends CatsSuite {
       None,
       30.seconds
     )
-    println(
-      Systems
-        .build(Site.GS, httpClient, conf, null)
-        .use { s =>
-          noObserve.flatMap { c =>
-            val niri = Niri(c, s.dhs)
-            val env = ObserveEnvironment[IO](
-              s,
-              CleanConfig(config),
-              StepType.CelestialObject(inst),
-              Observation.Id.unsafeFromString("GS-2019-Q-0-1"),
-              niri,
-              Nil,
-              _ => Nil,
-              null
-            )
-            ObserveActions.observePreamble[IO](toImageFileId("S001"), env)
-          }
+    Systems
+      .build(Site.GS, httpClient, conf, null)
+      .use { s =>
+        noObserve.flatMap { c =>
+          val niri = Niri(c, s.dhs)
+          val env = ObserveEnvironment[IO](
+            s,
+            CleanConfig(config),
+            StepType.CelestialObject(inst),
+            Observation.Id.unsafeFromString("GS-2019-Q-0-1"),
+            niri,
+            Nil,
+            _ => Nil,
+            null
+          )
+          ObserveActions.observePreamble[IO](toImageFileId("S001"), env)
         }
-        .attempt
-        .unsafeRunSync
-        .isLeft shouldBe true
-    )
+      }
+      .attempt
+      .unsafeRunSync
+      .isLeft shouldBe true
   }
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/ObserveActionsSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/ObserveActionsSpec.scala
@@ -1,0 +1,146 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server
+
+import cats.tests.CatsSuite
+import cats.effect._
+import edu.gemini.spModel.config2.DefaultConfig
+import edu.gemini.spModel.gemini.niri.InstNIRI._
+import edu.gemini.spModel.gemini.niri.Niri.ReadMode
+import edu.gemini.spModel.gemini.niri.Niri.WellDepth
+import edu.gemini.spModel.gemini.niri.Niri.BuiltinROI
+import edu.gemini.spModel.obscomp.InstConstants.DATA_LABEL_PROP
+import edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_KEY
+import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+import gem.Observation
+import gem.enum.Site
+import io.chrisdavenport.log4cats.noop.NoOpLogger
+import org.http4s.client.Client
+import org.http4s.Uri
+import org.http4s.Uri._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+import shapeless.tag
+import seqexec.server.InstrumentSystem.ElapsedTime
+import seqexec.server.niri.NiriController.DCConfig
+import seqexec.server.niri.NiriController.NiriConfig
+import seqexec.server.keywords.GdsClient
+import seqexec.model.dhs._
+import seqexec.model.enum._
+import seqexec.model.config._
+import seqexec.server.ConfigUtilOps._
+import seqexec.server.niri._
+import squants.Time
+import squants.time.TimeConversions._
+
+final class ObserveActionsSpec extends CatsSuite {
+  private implicit def unsafeLogger = NoOpLogger.impl[IO]
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  implicit val noWaitTio: Timer[IO] = new Timer[IO] {
+    override def clock: Clock[IO] = Clock.create[IO]
+    override def sleep(duration: FiniteDuration): IO[Unit] =
+      IO.unit
+  }
+
+  // This is a simulator for NIRI that never completes an obs
+  // The engine should timeout and produce an error
+  def noObserve: IO[NiriController[IO]] =
+    InstrumentControllerSim[IO](s"NIRI").map { sim =>
+      new NiriController[IO] {
+        override def observe(
+          fileId: ImageFileId,
+          cfg:    DCConfig
+        ): IO[ObserveCommandResult] =
+          IO.never // obs neither fails nor completes
+
+        override def applyConfig(config: NiriConfig): IO[Unit] =
+          sim.applyConfig(config)
+
+        override def stopObserve: IO[Unit] = sim.stopObserve
+
+        override def abortObserve: IO[Unit] = sim.abortObserve
+
+        override def endObserve: IO[Unit] = sim.endObserve
+
+        override def observeProgress(total: Time): fs2.Stream[IO, Progress] =
+          sim.observeCountdown(total, ElapsedTime(0.seconds))
+
+        override def calcTotalExposureTime(cfg: DCConfig): IO[Time] = {
+          val MinIntTime = 0.5.seconds
+
+          (cfg.exposureTime + MinIntTime) * cfg.coadds.toDouble
+        }.pure[IO]
+      }
+    }
+
+  test("Observe Actions do timeout") {
+    val inst   = Instrument.Niri
+    val config = new DefaultConfig()
+    config.putItem(OBSERVE_KEY / DATA_LABEL_PROP, "label")
+    config.putItem(OBSERVE_KEY / EXPOSURE_TIME_PROP, 1.0)
+    config.putItem(OBSERVE_KEY / COADDS_PROP, 1)
+    config.putItem(INSTRUMENT_KEY / READ_MODE_PROP, ReadMode.DEFAULT)
+    config.putItem(INSTRUMENT_KEY / WELL_DEPTH_PROP, WellDepth.DEFAULT)
+    config.putItem(INSTRUMENT_KEY / BUILTIN_ROI_PROP, BuiltinROI.DEFAULT)
+    println(config)
+    val httpClient: Client[IO] = GdsClient.alwaysOkClient[IO]
+    val control = SystemsControlConfiguration(
+      altair   = ControlStrategy.Simulated,
+      gems     = ControlStrategy.Simulated,
+      dhs      = ControlStrategy.Simulated,
+      f2       = ControlStrategy.Simulated,
+      gcal     = ControlStrategy.Simulated,
+      gmos     = ControlStrategy.Simulated,
+      gnirs    = ControlStrategy.Simulated,
+      gpi      = ControlStrategy.Simulated,
+      gpiGds   = ControlStrategy.Simulated,
+      ghost    = ControlStrategy.Simulated,
+      ghostGds = ControlStrategy.Simulated,
+      gsaoi    = ControlStrategy.Simulated,
+      gws      = ControlStrategy.Simulated,
+      nifs     = ControlStrategy.Simulated,
+      niri     = ControlStrategy.Simulated,
+      tcs      = ControlStrategy.Simulated
+    )
+    val conf = SeqexecEngineConfiguration(
+      uri("http://127.0.0.1"),
+      uri("http://127.0.0.1"),
+      control,
+      false,
+      false,
+      0,
+      30.seconds,
+      tag[GpiSettings][Uri](uri("http://127.0.0.1")),
+      tag[GpiSettings][Uri](uri("http://127.0.0.1")),
+      tag[GhostSettings][Uri](uri("http://127.0.0.1")),
+      tag[GhostSettings][Uri](uri("http://127.0.0.1")),
+      "",
+      None,
+      30.seconds
+    )
+    println(
+      Systems
+        .build(Site.GS, httpClient, conf, null)
+        .use { s =>
+          noObserve.flatMap { c =>
+            val niri = Niri(c, s.dhs)
+            val env = ObserveEnvironment[IO](
+              s,
+              CleanConfig(config),
+              StepType.CelestialObject(inst),
+              Observation.Id.unsafeFromString("GS-2019-Q-0-1"),
+              niri,
+              Nil,
+              _ => Nil,
+              null
+            )
+            ObserveActions.observePreamble[IO](toImageFileId("S001"), env)
+          }
+        }
+        .attempt
+        .unsafeRunSync
+        .isLeft shouldBe true
+    )
+  }
+}


### PR DESCRIPTION
If the instrument observe were to fail (e.g the instrument crashes) the seqexec waits for ever and becomes mostly non-operational
This PR adds a timeout to the observe. This is a bit hard to test but I managed to reproduce it on a simulated GPI and added a test
We should consider adding timeouts to other parts of the obs process