### PR TITLE
SEQNG-1170 Auto logout when the session expires

### DIFF
--- a/modules/seqexec/model/shared/src/main/scala/seqexec/common/HttpStatusCodes.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/common/HttpStatusCodes.scala
@@ -5,4 +5,5 @@ package seqexec.common
 
 object HttpStatusCodes {
   val NotFound: Int = 404
+  val Unauthorized: Int = 401
 }

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/actions.scala
@@ -36,6 +36,7 @@ object actions {
 
   final case class LoggedIn(u: UserDetails) extends Action
   case object Logout extends Action
+  case object VerifyLoggedStatus extends Action
 
   // Action to select a sequence for display
   final case class SelectIdToDisplay(i:    Instrument,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/circuit/SeqexecCircuit.scala
@@ -46,6 +46,7 @@ final class LoggingProcessor[M <: AnyRef] extends ActionProcessor[M] {
       case UpdateStepTableState(_, _)                 =>
       case UpdateCalTableState(_, _)                  =>
       case UpdateSelectedStep(_, _)                   =>
+      case VerifyLoggedStatus                         =>
       case a: Action                                  =>
         if(LinkingInfo.developmentMode) logger.info(s"Action: ${a.show}")
       case _                                          =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/SeqexecAppRootModel.scala
@@ -16,6 +16,7 @@ import monocle.function.At.atSortedMap
 import monocle.function.Each.each
 import monocle.function.FilterIndex.filterIndex
 import scala.collection.immutable.SortedMap
+import scala.scalajs.js.timers._
 import seqexec.model.enum.MountGuideOption._
 import seqexec.model.M1GuideConfig._
 import seqexec.model.M2GuideConfig._
@@ -44,7 +45,8 @@ final case class SeqexecAppRootModel(
   uiModel:       SeqexecUIModel,
   serverVersion: Option[String],
   guideConfig:   TelescopeGuideConfig,
-  alignAndCalib: AlignAndCalibStep
+  alignAndCalib: AlignAndCalibStep,
+  pingInterval:  Option[SetTimeoutHandle]
 )
 
 object SeqexecAppRootModel {
@@ -63,7 +65,8 @@ object SeqexecAppRootModel {
     SeqexecUIModel.Initial,
     none,
     TelescopeGuideConfig(MountGuideOff, M1GuideOff, M2GuideOff),
-    AlignAndCalibStep.NoAction
+    AlignAndCalibStep.NoAction,
+    None
   )
 
   val logDisplayL: Lens[SeqexecAppRootModel, SectionVisibilityState] =

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/WebSocketConnection.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/WebSocketConnection.scala
@@ -7,14 +7,16 @@ import cats._
 import cats.implicits._
 import diode.data.Pot
 import org.scalajs.dom.WebSocket
+import scala.scalajs.js.timers.SetIntervalHandle
 
 final case class WebSocketConnection(ws:            Pot[WebSocket],
                                      nextAttempt:   Int,
-                                     autoReconnect: Boolean)
+                                     autoReconnect: Boolean,
+                                     pingInterval:  Option[SetIntervalHandle])
 
 object WebSocketConnection {
   val Empty: WebSocketConnection =
-    WebSocketConnection(diode.data.Empty, 0, autoReconnect = true)
+    WebSocketConnection(diode.data.Empty, 0, autoReconnect = true, None)
 
   implicit val equal: Eq[WebSocketConnection] =
     Eq.by { x =>

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/services/SeqexecWebClient.scala
@@ -10,6 +10,7 @@ import cats.implicits._
 import gem.Observation
 import org.scalajs.dom.ext.Ajax
 import org.scalajs.dom.XMLHttpRequest
+import seqexec.common.HttpStatusCodes
 import seqexec.model.ClientId
 import seqexec.model.QueueId
 import seqexec.model.UserDetails
@@ -255,6 +256,17 @@ object SeqexecWebClient extends ModelBooPicklers {
         url = s"$baseUrl/logout"
       )
       .map(_.responseText)
+
+  /**
+    * Ping request
+    */
+  def ping(): Future[Int] =
+    Ajax
+      .get(
+        url = "/ping"
+      )
+      .map(_.status)
+      .handleError(_ => HttpStatusCodes.Unauthorized)
 
   /**
     * Load a sequence

--- a/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
+++ b/modules/seqexec/web/client/src/test/scala/seqexec/web/client/model/ArbitrariesWebClient.scala
@@ -246,7 +246,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         ws <- arbitrary[Pot[WebSocket]]
         a  <- arbitrary[Int]
         r  <- arbitrary[Boolean]
-      } yield WebSocketConnection(ws, a, r)
+      } yield WebSocketConnection(ws, a, r, None)
     }
 
   implicit val wssCogen: Cogen[WebSocketConnection] =
@@ -790,7 +790,7 @@ trait ArbitrariesWebClient extends ArbObservation with TableArbitraries with Arb
         version   <- arbitrary[Option[String]]
         guideConf <- arbitrary[TelescopeGuideConfig]
         acStep    <- arbitrary[AlignAndCalibStep]
-      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel, version, guideConf, acStep)
+      } yield SeqexecAppRootModel(sequences, ws, site, clientId, uiModel, version, guideConf, acStep, None)
     }
 
   implicit val seqexecAppRootModelCogen: Cogen[SeqexecAppRootModel] =

--- a/modules/seqexec/web/client/src/webpack/dev.webpack.config.js
+++ b/modules/seqexec/web/client/src/webpack/dev.webpack.config.js
@@ -46,6 +46,9 @@ const Web = Merge(
           changeOrigin: true,
           ws: true
         },
+        "/ping": {
+          target: "http://localhost:7070"
+        },
         "/api/**": {
           target: "http://localhost:7070",
           logLevel: "debug",

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/PingRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/PingRoutes.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.server.http4s
+
+import cats.effect.Sync
+import cats.implicits._
+import org.http4s._
+import org.http4s.dsl._
+import seqexec.web.server.security.AuthenticationService.AuthResult
+import seqexec.web.server.security.AuthenticationService
+import seqexec.web.server.security.Http4sAuthentication
+
+/**
+  * Rest Endpoints to ping the backend and detect when you're logged out
+  */
+class PingRoutes[F[_]: Sync](auth: AuthenticationService[F])
+    extends Http4sDsl[F] {
+
+  private val httpAuthentication = new Http4sAuthentication(auth)
+  val pingService: AuthedRoutes[AuthResult, F] =
+    AuthedRoutes.of {
+      case GET -> Root as user =>
+        user.fold(_ => Response[F](Status.Unauthorized).pure[F], _ => Ok(""))
+    }
+
+  def service: HttpRoutes[F] = httpAuthentication.optAuth(pingService)
+
+}

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -103,7 +103,11 @@ object WebServerLauncher extends IOApp with LogInitialization {
       "/smartgcal"            -> new SmartGcalRoutes[F](cal).service
     )
 
-    val loggedRoutes = Http4sLogger.httpRoutes(logHeaders = false, logBody = false)(router)
+    val pingRouter = Router[F](
+      "/ping" -> new PingRoutes(as).service
+    )
+
+    val loggedRoutes = pingRouter <+> Http4sLogger.httpRoutes(logHeaders = false, logBody = false)(router)
     val metricsMiddleware: Resource[F, HttpRoutes[F]] = Prometheus.metricsOps[F](cr, "seqexec").map(Metrics[F](_)(loggedRoutes))
 
     metricsMiddleware.flatMap(x => build(x.pure[F]))


### PR DESCRIPTION
The seqexec has a session of 2h which gets renewed when the user does something.
If the user leaves without logging out, after the TTL actions are rejected. That is working fine but the UI shows it like it still logged in

Detecting that your session expired is a bit tricky as if the user does nothing we can't tell and the websocket channel only checks auth at the start

The solution is to define a "ping" route that the client hits ever n minutes. If you are logged in and the ping returns unauthorized then the UI will log itself out