### PR TITLE
[SEQNG-1163] Display "Reading Out" in BIAS observations, disable control buttons during readout, fix N&S countdown

### DIFF
--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/ObservationProgress.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/ObservationProgress.scala
@@ -33,6 +33,9 @@ object Progress {
 
   implicit val nsProgressP: Prism[Progress, NSObservationProgress] =
     GenPrism[Progress, NSObservationProgress]
+
+  implicit val progressP: Prism[Progress, Progress] =
+    GenPrism[Progress, Progress]
 }
 
 final case class ObservationProgress(obsId:     Observation.Id,

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/ObservationProgress.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/ObservationProgress.scala
@@ -7,7 +7,7 @@ import cats.Eq
 import cats.implicits._
 import gem.Observation
 import gem.util.Enumerated
-import monocle.Prism
+import monocle.{Iso, Prism}
 import monocle.macros.GenPrism
 import squants.Time
 
@@ -35,7 +35,7 @@ object Progress {
     GenPrism[Progress, NSObservationProgress]
 
   implicit val progressP: Prism[Progress, Progress] =
-    GenPrism[Progress, Progress]
+    Iso.id[Progress].asPrism
 }
 
 final case class ObservationProgress(obsId:     Observation.Id,

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/BiasStatus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/BiasStatus.scala
@@ -3,28 +3,50 @@
 
 package seqexec.web.client.components.sequence.steps
 
+import gem.Observation
+import seqexec.model.{ObservationProgress, StepId}
+import seqexec.web.client.circuit.SeqexecCircuit
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
 import react.common.implicits._
 import seqexec.web.client.components.SeqexecStyles
+import seqexec.web.client.reusability._
 
-case class BiasStatus(fileId: String) extends ReactProps {
+case class BiasStatus(
+  obsId: Observation.Id,
+  stepId: StepId,
+  fileId: String,
+  stopping: Boolean,
+  paused: Boolean
+) extends ReactProps {
   @inline def render: VdomElement = BiasStatus.component(this)
+
+  protected[steps] val connect =
+    SeqexecCircuit.connect(SeqexecCircuit.obsProgressReader[ObservationProgress](obsId, stepId))
 }
 
-object BiasStatus {
+object BiasStatus extends ProgressLabel {
   type Props = BiasStatus
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   protected val component = ScalaComponent
-    .builder[Props]("ObservationProgressDisplay")
+    .builder[Props]("BiasStatus")
     .stateless
     .render_P(p =>
       <.div(
         SeqexecStyles.specialStateLabel,
-        p.fileId
+        p.connect(proxy =>
+          <.span(
+            proxy() match {
+              case Some(ObservationProgress(_, _, _, _, stage)) =>
+                label(p.fileId, None, p.stopping, p.paused, stage)
+              case _ =>
+                if (p.paused) s"${p.fileId} - Paused" else p.fileId
+            }
+          )
+        )
       )
     )
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -54,20 +54,21 @@ object NodAndShuffleProgressMessage extends ProgressLabel {
       <.div(
         SeqexecStyles.specialStateLabel,
         SeqexecStyles.progressMessage,
-        p.nsStatus.state.map[VdomElement] { nsState =>
+        p.nsStatus.state.map[VdomElement] { _ =>
           s.progressConnect { proxy =>
+            val nsProgress = proxy()
             val nodCount = NodAndShuffleStage.NsSequence.length
             val nodMillis = p.nsStatus.nodExposureTime.toMilliseconds.toInt
             val cycleMillis = nodMillis * nodCount
-            val remainingCycles = p.nsStatus.cycles - nsState.sub.cycle - 1
-            val remainingNods = nodCount - nsState.sub.stageIndex - 1
-            val remainingNodMillis = proxy().foldMap(_.remaining.toMilliseconds.toInt)
+            val remainingCycles = p.nsStatus.cycles - nsProgress.foldMap(_.sub.cycle - 1)
+            val remainingNods = nodCount - nsProgress.foldMap(_.sub.stageIndex - 1)
+            val remainingNodMillis = nsProgress.foldMap(_.remaining.toMilliseconds.toInt)
             val remainingMillis = remainingCycles * cycleMillis + remainingNods * nodMillis + remainingNodMillis
-            val stage = proxy().map(_.stage).getOrElse(ObserveStage.Idle)
+            val stage = nsProgress.map(_.stage).getOrElse(ObserveStage.Idle)
             <.span(label(p.fileId, remainingMillis.some, p.stopping, p.paused, stage))
           }
         } getOrElse <.span(p.fileId)
-        )
+      )
     }
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/NodAndShuffleProgress.scala
@@ -64,7 +64,7 @@ object NodAndShuffleProgressMessage extends ProgressLabel {
             val remainingNodMillis = proxy().foldMap(_.remaining.toMilliseconds.toInt)
             val remainingMillis = remainingCycles * cycleMillis + remainingNods * nodMillis + remainingNodMillis
             val stage = proxy().map(_.stage).getOrElse(ObserveStage.Idle)
-            <.span(label(p.fileId, remainingMillis, p.stopping, p.paused, stage))
+            <.span(label(p.fileId, remainingMillis.some, p.stopping, p.paused, stage))
           }
         } getOrElse <.span(p.fileId)
         )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -122,7 +122,13 @@ object StepProgressCell {
     <.div(
       SeqexecStyles.configuringRow,
       if(props.stateSummary.isBias) {
-        BiasStatus(fileId)
+        BiasStatus(
+          props.obsId,
+          props.step.id,
+          fileId,
+          stopping = !paused && props.isStopping,
+          paused
+        )
       } else {
         props.stateSummary.nsStatus.fold[VdomElement] {
           ObservationProgressBar(


### PR DESCRIPTION
Two of the fixes are related to issues reported in SEQNG-1163:

1. Display "Reading Out" on BIAS observations.
2. Disable observation control buttons during readout (this is implemented now for all kinds of observations).

Also, beyond the reported issues, this PR attempts to fix a problem with a "dancing" (going back and forth) countdown in N&S observations. This has to be tested on the telescope since our N&S simulation is not yet reflecting the same behavior.