### PR TITLE
SEQNG-1181 Removed redundant observe timeout, adjusted timeouts.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -167,28 +167,23 @@ trait ObserveActions {
       case ObserveCommandResult.Aborted =>
         abortTail(env.systems, env.obsId, fileId)
       case ObserveCommandResult.Paused =>
-        val timeout = env.inst.observeTimeout
         env.inst.calcObserveTime(env.config)
           .flatMap(totalTime => env.inst.observeControl(env.config) match {
             case c: CompleteControl[F] =>
             val resumePaused: Time => Stream[F, Result[F]] =
                 (elapsed: Time) => Stream.eval{
-                  val resumeTimeout: FiniteDuration = new FiniteDuration((elapsed + timeout).millis, MILLISECONDS)
                   c.continue
                     .self(elapsed)
-                    .timeoutTo(resumeTimeout, cio.raiseError(SeqexecFailure.ObsTimeout(fileId)))
                 }.flatMap(observeTail(fileId, dataId, env))
             val stopPaused: Stream[F, Result[F]] =
                 Stream.eval{
                   c.stopPaused
                     .self
-                    .timeoutTo(timeout, cio.raiseError(SeqexecFailure.ObsTimeout(fileId)))
                 }.flatMap(observeTail(fileId, dataId, env))
             val abortPaused: Stream[F, Result[F]] =
                 Stream.eval{
                   c.abortPaused
                     .self
-                    .timeoutTo(timeout, cio.raiseError(SeqexecFailure.ObsTimeout(fileId)))
                 }.flatMap(observeTail(fileId, dataId, env))
 
              Result.Paused(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -127,8 +127,7 @@ trait ObserveActions {
       _ <- notifyObserveStart(env).timeoutTo(env.inst.observeTimeout, Concurrent[F].raiseError(SeqexecFailure.ObsSystemTimeout(fileId)))
       _ <- env.headers(env.ctx).traverse(_.sendBefore(env.obsId, fileId))
       _ <- info(s"Start ${env.inst.resource.show} observation ${env.obsId.format} with label $fileId")
-      t <- env.inst.calcObserveTime(env.config).map(t => t + env.inst.observeTimeout)
-      r <- env.inst.observe(env.config)(fileId).timeoutTo(new FiniteDuration(t.millis, MILLISECONDS), Concurrent[F].raiseError(SeqexecFailure.ObsTimeout(fileId)))
+      r <- env.inst.observe(env.config)(fileId)
       _ <- info(s"Completed ${env.inst.resource.show} observation ${env.obsId.format} with label $fileId")
     } yield (d, r)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -7,7 +7,6 @@ import cats._
 import cats.data.{EitherT, NonEmptyList, NonEmptySet}
 import cats.effect.{Concurrent, Sync, Timer}
 import cats.effect.concurrent.Ref
-import cats.effect.implicits._
 import cats.implicits._
 import edu.gemini.seqexec.odb.{ExecutedDataset, SeqexecSequence}
 import edu.gemini.spModel.gemini.altair.AltairParams.GuideStarType
@@ -202,11 +201,11 @@ object SeqTranslate {
           .exists(isObserving)
       } yield Stream.eval(
         toInstrumentSys(obsSeq.seqGen.instrument)
-          .flatMap{i =>
+          .flatMap{ i =>
             f(i.observeControl(cfg))
               .attempt
               .flatMap(handleError)
-              .timeoutTo(ObserveOperationsTimeout, cio.raiseError(SeqexecFailure.ObsCommandTimeout(seqId)))}
+          }
       )
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
@@ -93,7 +93,7 @@ trait Flamingos2Encoders {
 
 object Flamingos2ControllerEpics extends Flamingos2Encoders {
 
-  val ReadoutTimeout: Time = Seconds(300)
+  val ReadoutTimeout: Time = Seconds(30)
   val DefaultTimeout: Time = Seconds(60)
   val ConfigTimeout: Time = Seconds(400)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -531,7 +531,7 @@ object GmosControllerEpics extends GmosEncoders {
   }
 
   val DefaultTimeout: Time = Seconds(60)
-  val ReadoutTimeout: Time = Seconds(300)
+  val ReadoutTimeout: Time = Seconds(90)
   val ConfigTimeout: Time = Seconds(600)
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -316,6 +316,6 @@ object GnirsControllerEpics extends GnirsEncoders {
     }
 
   private val DefaultTimeout: Time = Seconds(60)
-  private val ReadoutTimeout: Time = Seconds(300)
+  private val ReadoutTimeout: Time = Seconds(30)
   private val ConfigTimeout: Time = Seconds(240)
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -66,7 +66,7 @@ final case class Nifs[F[_]: Logger: Concurrent: Timer](
   override def calcObserveTime(config: CleanConfig): F[Time] =
     getDCConfig(config)
       .map(controller.calcTotalExposureTime)
-      .getOrElse(Sync[F].delay(60.seconds))
+      .getOrElse(60.seconds).pure[F]
 
   override def keywordsClient: KeywordsClient[F] = this
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsController.scala
@@ -30,7 +30,7 @@ trait NifsController[F[_]] {
 
   def observeProgress(total: Time): fs2.Stream[F, Progress]
 
-  def calcTotalExposureTime(cfg: DCConfig): F[Time]
+  def calcTotalExposureTime(cfg: DCConfig): Time
 }
 
 trait CentralWavelengthD
@@ -115,7 +115,7 @@ object NifsController {
 
   implicit val cfgShow: Show[NifsConfig] = Show.fromToString
 
-  def calcTotalExposureTime[F[_]: Applicative](cfg: DCConfig): F[Time] = {
+  def calcTotalExposureTime[F[_]: Applicative](cfg: DCConfig): Time = {
     val readOutTime = cfg.readMode match {
       case Right(LegacyReadMode.BRIGHT_OBJECT_SPEC) => 11.4
       case Right(LegacyReadMode.MEDIUM_OBJECT_SPEC) => 27.4
@@ -123,7 +123,7 @@ object NifsController {
       case Left(_)                                  => 1 // TBD What should this be?
     }
 
-    (cfg.coadds * (cfg.exposureTime + readOutTime.seconds)).pure[F]
+    (cfg.coadds * (cfg.exposureTime + readOutTime.seconds))
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
@@ -391,13 +391,12 @@ object NifsControllerEpics extends NifsEncoders {
       )
 
     def calcObserveTimeout(cfg: DCConfig): Time = {
-      val CoaddOverhead = 2.2
-      val TotalOverhead = 300.seconds
+      val SafetyPadding = 30.seconds
 
-      cfg.exposureTime * cfg.coadds.toDouble * CoaddOverhead + TotalOverhead
+      calcTotalExposureTime(cfg) + SafetyPadding
     }
 
-    override def calcTotalExposureTime(cfg: DCConfig): F[Time] =
+    override def calcTotalExposureTime(cfg: DCConfig): Time =
       NifsController.calcTotalExposureTime[F](cfg)
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerSim.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerSim.scala
@@ -24,10 +24,7 @@ object NifsControllerSim {
 
         override def observe(fileId: ImageFileId,
                              cfg:    DCConfig): F[ObserveCommandResult] =
-          calcTotalExposureTime(cfg).flatMap {ot =>
-            sim
-              .observe(fileId, ot)
-          }
+          sim.observe(fileId, calcTotalExposureTime(cfg))
 
         override def applyConfig(config: NifsConfig): F[Unit] =
           sim.applyConfig(config)
@@ -41,7 +38,7 @@ object NifsControllerSim {
         override def observeProgress(total: Time): fs2.Stream[F, Progress] =
           sim.observeCountdown(total, ElapsedTime(0.seconds))
 
-        override def calcTotalExposureTime(cfg: DCConfig): F[Time] =
+        override def calcTotalExposureTime(cfg: DCConfig): Time =
           NifsController.calcTotalExposureTime[F](cfg)
 
       }


### PR DESCRIPTION
The `timeoutTo` became redundant after the observe timeout in the acm code was fixed, and was causing problems because it was triggered before the ACM one in some cases.