### PR TITLE
SEQNG-1162 Monitor WebSocket pings and kill unresponsive clients, plu…

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/WebSocketHandler.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/handlers/WebSocketHandler.scala
@@ -80,7 +80,7 @@ class WebSocketHandler[M](modelRW: ModelRW[M, WebSocketConnection])
     def onClose(): Unit =
       // Increase the delay to get exponential backoff with a minimum of 200ms and a max of 1m
       if (value.autoReconnect) {
-        SeqexecCircuit.dispatch(ConnectionRetry(math.min(60000, math.max(200, value.nextAttempt * 2))))
+        SeqexecCircuit.dispatch(ConnectionRetry(math.min(60000, math.max(1000, value.nextAttempt * 2))))
       }
 
     ws.binaryType = "arraybuffer"

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/ClientsSetDb.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/ClientsSetDb.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.web.server.http4s
+
+import cats.effect.concurrent.Ref
+import cats.effect.Sync
+import cats.implicits._
+import org.http4s.headers.`User-Agent`
+import io.chrisdavenport.log4cats.Logger
+import java.time.Instant
+import seqexec.model.ClientId
+
+trait ClientsSetDb[F[_]] {
+  def newClient(id: ClientId, addr: ClientsSetDb.ClientAddr, ua: Option[ClientsSetDb.UserAgent]): F[Unit]
+  def removeClient(id: ClientId): F[Unit]
+  def report: F[Unit]
+}
+
+object ClientsSetDb {
+  type ClientAddr = String
+  type UserAgent = `User-Agent`
+  type ClientsSet = Map[ClientId, (Instant, ClientAddr, Option[UserAgent])]
+
+  def apply[F[_]: Sync: Logger](ref: Ref[F, ClientsSet]): ClientsSetDb[F] = new ClientsSetDb[F] {
+    def newClient(id: ClientId, addr: ClientsSetDb.ClientAddr, ua: Option[UserAgent]): F[Unit] =
+      Sync[F].delay(Instant.now).flatMap(i => ref.update(_ + (id -> ((i, addr, ua)))))
+    def removeClient(id: ClientId): F[Unit] =
+      ref.update(_ - id)
+    def report: F[Unit] =
+      ref.get.flatMap { m =>
+        Logger[F].debug("Clients Summary:") *>
+        Logger[F].debug("----------------") *>
+        m.map {
+          case (id, (i, addr, ua)) => s"  Client: $id, arrived on $i from addr: $addr ${ua.foldMap(u => s"UserAgent: $u")}"
+        }.toList.traverse(Logger[F].debug(_)) *>
+        Logger[F].debug("----------------")
+      }
+
+  }
+}

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -141,7 +141,7 @@ class SeqexecUIApiRoutes[F[_]: Concurrent: Timer](site: Site,
 
         def engineEvents(clientId: ClientId): Stream[F, WebSocketFrame]  =
           engineOutput
-            .subscribe(1)
+            .subscribe(100)
             .map(anonymizeF)
             .filter(filterOutNull)
             .filter(filterOutOnClientId(clientId))

--- a/modules/seqexec/web/server/src/test/scala/seqexec/web/server/http4s/TestRoutes.scala
+++ b/modules/seqexec/web/server/src/test/scala/seqexec/web/server/http4s/TestRoutes.scala
@@ -6,6 +6,7 @@ package seqexec.web.server.http4s
 import cats.effect.ContextShift
 import cats.effect.IO
 import cats.effect.Timer
+import cats.effect.concurrent.Ref
 import cats.tests.CatsSuite
 import fs2.concurrent.Queue
 import fs2.concurrent.Topic
@@ -48,13 +49,15 @@ trait TestRoutes extends ClientBooEncoders with CatsSuite {
 
   val uiRoutes =
     for {
-      o <- Topic[IO, SeqexecEvent](NullEvent)
+      o  <- Topic[IO, SeqexecEvent](NullEvent)
+      cs <- Ref.of[IO, ClientsSetDb.ClientsSet](Map.empty).map(ClientsSetDb.apply[IO](_))
     } yield
       new SeqexecUIApiRoutes(Site.GS,
                              Mode.Development,
                              authService,
                              GuideConfigDb.constant[IO],
                              statusDb,
+                             cs,
                              o).service
 
   def newLoginToken: IO[String] =


### PR DESCRIPTION
We have been observing a strange behaviour when the seqexec would hang for several minutes with the web side active but the engine blocked

There is evidence that sometimes clients go "zombie", possibly due to the re connection logic on the client or some odd behavior at the port mapping iptables. But we have seen multiples clients pointing to a given ip while we can see on the UI just one.
The hypothesis is that the server keeps trying to push WS messages to those clients but they are not getting them blocking the server upstream.

Unfortunately this is hard to reproduce but a possible remediation is offered in this PR:

WebSocket supports the concept of Ping/Pong where the server pushes ping control frames and the client should answer. http4s doesn't do this by default but the seqexec sends pings as a way to ensure the connection remains alive
However, the pongs are discarded and nobody is checking if they arrive timely

This PR adds a check that if Pongs don't arrive after n intervals the client connection is terminated. It is hard to prove this will solve the problem, the suggestion is to install it and field test it

Finally a bit more debugging is including, including printing every certain amount of time a summary of the clients currently connected