### PR TITLE
SEQNG-1197 FIx for TCS in-position timeout problem.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -319,7 +319,7 @@ lazy val seqexec_server = project
   .dependsOn(seqexec_engine % "compile->compile;test->test",
              giapi,
              seqexec_model.jvm % "compile->compile;test->test",
-             acm)
+             acm % "compile->compile;test->test")
 
 // Unfortunately crossProject doesn't seem to work properly at the module/build.sbt level
 // We have to define the project properties at this level

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/ApplySenderWithResource.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/ApplySenderWithResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/AttributeNotifier.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/AttributeNotifier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package edu.gemini.epics.acm;
 
 import java.util.LinkedList;

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/AttributeNotifier.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/AttributeNotifier.java
@@ -24,7 +24,15 @@ public class AttributeNotifier<T> {
     }
 
     public void notifyValueChangeSingle(CaAttributeListener<T> listener, List<T> vals) {
-        executor.execute(() -> listener.onValueChange(vals));
+        executor.execute(() -> {
+            synchronized (AttributeNotifier.this) {
+                // Check that the listener has not been removed between the call to notifyValueChangeSingle and
+                // the deferred execution of the callback.
+                if(AttributeNotifier.this.listeners.contains(listener)) {
+                    listener.onValueChange(vals);
+                }
+            }
+        });
     }
 
     synchronized public void notifyValueChange(List<T> newVals) {
@@ -34,7 +42,15 @@ public class AttributeNotifier<T> {
     }
 
     public void notifyValidityChangeSingle(CaAttributeListener<T> listener, boolean validity) {
-        executor.execute(() -> listener.onValidityChange(validity));
+        executor.execute(() -> {
+            synchronized (AttributeNotifier.this) {
+                // Check that the listener has not been removed between the call to notifyValidityChangeSingle and
+                // the deferred execution of the callback.
+                if(AttributeNotifier.this.listeners.contains(listener)) {
+                    listener.onValidityChange(validity);
+                }
+            }
+        });
     }
 
     synchronized public void notifyValidityChange(boolean newValidity) {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/AttributeNotifier.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/AttributeNotifier.java
@@ -1,0 +1,45 @@
+package edu.gemini.epics.acm;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class AttributeNotifier<T> {
+
+    private final ScheduledExecutorService executor;
+    private final List<CaAttributeListener<T>> listeners = new LinkedList<>();
+
+    public AttributeNotifier(ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
+    synchronized public void addListener(CaAttributeListener<T> listener) {
+        if (!listeners.contains(listener)) {
+            listeners.add(listener);
+        }
+    }
+
+    synchronized public void removeListener(CaAttributeListener<T> listener) {
+        listeners.remove(listener);
+    }
+
+    public void notifyValueChangeSingle(CaAttributeListener<T> listener, List<T> vals) {
+        executor.execute(() -> listener.onValueChange(vals));
+    }
+
+    synchronized public void notifyValueChange(List<T> newVals) {
+        for (CaAttributeListener<T> listener : listeners) {
+            notifyValueChangeSingle(listener, newVals);
+        }
+    }
+
+    public void notifyValidityChangeSingle(CaAttributeListener<T> listener, boolean validity) {
+        executor.execute(() -> listener.onValidityChange(validity));
+    }
+
+    synchronized public void notifyValidityChange(boolean newValidity) {
+        for (CaAttributeListener<T> listener : listeners) {
+            notifyValidityChangeSingle(listener, newValidity);
+        }
+    }
+}

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplyRecord.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplyRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySender.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaApplySenderImpl.java
@@ -8,7 +8,6 @@ package edu.gemini.epics.acm;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,11 +33,11 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
 
     private long timeout;
     private TimeUnit timeoutUnit;
-    private ScheduledExecutorService executor;
+    private final ScheduledExecutorService executor;
     private ScheduledFuture<?> timeoutFuture;
     private final ChannelListener<Integer> valListener;
-    private ChannelListener<Integer> carClidListener;
-    private ChannelListener<C> carValListener;
+    private final ChannelListener<Integer> carClidListener;
+    private final ChannelListener<C> carValListener;
     private State currentState;
     private static final State IdleState = new State() {
         @Override
@@ -72,11 +71,14 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
         final String description,
         final Class<C> carClass,
         final EpicsReader epicsReader,
-        final EpicsWriter epicsWriter) throws CAException {
+        final EpicsWriter epicsWriter,
+        final ScheduledExecutorService executor
+    ) throws CAException {
         super();
         this.name = name;
         this.description = description;
         this.currentState = IdleState;
+        this.executor = executor;
 
         apply = new CaApplyRecord(applyRecord, epicsReader, epicsWriter);
         apply.registerValListener(valListener = new ChannelListener<Integer>() {
@@ -106,7 +108,6 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
             }
         });
 
-        executor = SafeExecutor.safeExecutor(2, LOG);
     }
 
     @Override
@@ -161,12 +162,7 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
 
                 apply.setDir(CadDirective.START);
                 if (timeout > 0) {
-                    timeoutFuture = executor.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            CaApplySenderImpl.this.onTimeout();
-                        }
-                    }, timeout, timeoutUnit);
+                    timeoutFuture = executor.schedule(CaApplySenderImpl.this::onTimeout, timeout, timeoutUnit);
                 }
             } catch (CAException | TimeoutException e) {
                 failCommand(cm, e);
@@ -446,47 +442,29 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
     }
 
     private void succedCommand(final CaCommandMonitorImpl cm) {
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                cm.completeSuccess();
-            }
-        });
+        executor.execute(cm::completeSuccess);
     }
 
     private void pauseCommand(final CaCommandMonitorImpl cm) {
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                cm.completePause();
-            }
-        });
+        executor.execute(cm::completePause);
     }
 
     private void failCommand(final CaCommandMonitorImpl cm, final Exception ex) {
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                cm.completeFailure(ex);
-            }
-        });
+        executor.execute(() -> cm.completeFailure(ex));
     }
 
     private void failCommandWithApplyError(final CaCommandMonitorImpl cm) {
         // I found that if I try to read OMSS or MESS from the same thread that
         // is processing a channel notifications, the reads fails with a
         // timeout. But it works if the read is done later from another thread.
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                String msg = null;
-                try {
-                    msg = apply.getMessValue();
-                } catch (CAException | TimeoutException e) {
-                    LOG.warn(e.getMessage());
-                }
-                cm.completeFailure(new CaCommandError(msg));
+        executor.execute(() -> {
+            String msg = null;
+            try {
+                msg = apply.getMessValue();
+            } catch (CAException | TimeoutException e) {
+                LOG.warn(e.getMessage());
             }
+            cm.completeFailure(new CaCommandError(msg));
         });
     }
 
@@ -494,17 +472,14 @@ final class CaApplySenderImpl<C extends Enum<C> & CarStateGeneric> implements Ap
         // I found that if I try to read OMSS or MESS from the same thread that
         // is processing a channel notifications, the reads fails with a
         // timeout. But it works if the read is done later from another thread.
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                String msg = null;
-                try {
-                    msg = car.getOmssValue();
-                } catch (CAException | TimeoutException e) {
-                    LOG.warn(e.getMessage());
-                }
-                cm.completeFailure(new CaCommandError(msg));
+        executor.execute(() -> {
+            String msg = null;
+            try {
+                msg = car.getOmssValue();
+            } catch (CAException | TimeoutException e) {
+                LOG.warn(e.getMessage());
             }
+            cm.completeFailure(new CaCommandError(msg));
         });
     }
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttribute.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttributeImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttributeImpl.java
@@ -121,8 +121,12 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
     }
 
     @Override
-    public void addListener(CaAttributeListener<T> listener) {
+    synchronized public void addListener(CaAttributeListener<T> listener) {
         notifier.addListener(listener);
+        //Call listener with first value, if there is one.
+        if(values() != null) {
+            notifier.notifyValueChangeSingle(listener, values());
+        }
     }
 
     @Override

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttributeImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttributeImpl.java
@@ -6,8 +6,9 @@
 package edu.gemini.epics.acm;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +31,10 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
     private final String channel;
     private final Class<T> type;
     private final String description;
+    private final AttributeNotifier<T> notifier;
 
     private CaAttributeImpl(String name, String channel, Class<T> type,
-            String description, EpicsReader epicsReader) {
+            String description, EpicsReader epicsReader, ScheduledExecutorService executor) {
 
         super();
         this.name = name;
@@ -40,6 +42,7 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
         this.type = type;
         this.description = description;
         this.epicsReader = epicsReader;
+        this.notifier = new AttributeNotifier<T>(executor);
     }
 
     void bind(ReadOnlyClientEpicsChannel<T> epicsChannel)
@@ -117,34 +120,6 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
         }
     }
 
-    private final class Notifier {
-        private final List<CaAttributeListener<T>> listeners = new LinkedList<>();
-
-        synchronized public void addListener(CaAttributeListener<T> listener) {
-            if (!listeners.contains(listener)) {
-                listeners.add(listener);
-            }
-        }
-
-        synchronized public void removeListener(CaAttributeListener<T> listener) {
-            listeners.remove(listener);
-        }
-
-        synchronized public void notifyValueChange(List<T> newVals) {
-            for (CaAttributeListener<T> listener : listeners) {
-                listener.onValueChange(newVals);
-            }
-        }
-
-        synchronized public void notifyValidityChange(boolean newValidity) {
-            for (CaAttributeListener<T> listener : listeners) {
-                listener.onValidityChange(newValidity);
-            }
-        }
-    }
-
-    private final Notifier notifier = new Notifier();
-
     @Override
     public void addListener(CaAttributeListener<T> listener) {
         notifier.addListener(listener);
@@ -168,10 +143,10 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
     }
 
     static CaAttributeImpl<Double> createDoubleAttribute(
-            String name, String channel, String description, EpicsReader epicsReader)
-            throws CAException {
+            String name, String channel, String description,
+            EpicsReader epicsReader, ScheduledExecutorService executor) {
         CaAttributeImpl<Double> attr = new CaAttributeImpl<>(name,
-                channel, Double.class, description, epicsReader);
+                channel, Double.class, description, epicsReader, executor);
         try {
             attr.bind(epicsReader.getDoubleChannel(channel));
         } catch(Throwable e) {
@@ -182,10 +157,10 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
     }
 
     static public CaAttributeImpl<Float> createFloatAttribute(
-            String name, String channel, String description, EpicsReader epicsReader)
-            throws CAException {
+            String name, String channel, String description,
+            EpicsReader epicsReader, ScheduledExecutorService executor) {
         CaAttributeImpl<Float> attr = new CaAttributeImpl<>(name, channel,
-                Float.class, description, epicsReader);
+                Float.class, description, epicsReader, executor);
         try {
             attr.bind(epicsReader.getFloatChannel(channel));
         } catch(Throwable e) {
@@ -196,10 +171,10 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
     }
 
     static public CaAttributeImpl<Integer> createIntegerAttribute(
-            String name, String channel, String description, EpicsReader epicsReader)
-            throws CAException {
+            String name, String channel, String description,
+            EpicsReader epicsReader, ScheduledExecutorService executor) {
         CaAttributeImpl<Integer> attr = new CaAttributeImpl<>(name,
-                channel, Integer.class, description, epicsReader);
+                channel, Integer.class, description, epicsReader, executor);
         try {
             attr.bind(epicsReader.getIntegerChannel(channel));
         } catch(Throwable e) {
@@ -210,10 +185,10 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
     }
 
     static public CaAttributeImpl<Short> createShortAttribute(
-            String name, String channel, String description, EpicsReader epicsReader)
-            throws CAException {
+            String name, String channel, String description,
+            EpicsReader epicsReader, ScheduledExecutorService executor) {
         CaAttributeImpl<Short> attr = new CaAttributeImpl<>(name,
-                channel, Short.class, description, epicsReader);
+                channel, Short.class, description, epicsReader, executor);
         try {
             attr.bind(epicsReader.getShortChannel(channel));
         } catch(Throwable e) {
@@ -224,10 +199,10 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
     }
 
     static public CaAttributeImpl<String> createStringAttribute(
-            String name, String channel, String description, EpicsReader epicsReader)
-            throws CAException {
+            String name, String channel, String description,
+            EpicsReader epicsReader, ScheduledExecutorService executor) {
         CaAttributeImpl<String> attr = new CaAttributeImpl<>(name,
-                channel, String.class, description, epicsReader);
+                channel, String.class, description, epicsReader, executor);
         try {
             attr.bind(epicsReader.getStringChannel(channel));
         } catch(Throwable e) {
@@ -239,9 +214,9 @@ final class CaAttributeImpl<T> implements CaAttribute<T> {
 
     static public <T extends Enum<T>> CaAttributeImpl<T> createEnumAttribute(
             String name, String channel, String description, Class<T> enumType,
-            EpicsReader epicsReader) throws CAException {
+            EpicsReader epicsReader, ScheduledExecutorService executor) {
         CaAttributeImpl<T> attr = new CaAttributeImpl<>(name, channel,
-                enumType, description, epicsReader);
+                enumType, description, epicsReader, executor);
         try {
             attr.bind(epicsReader.getEnumChannel(channel, enumType));
         } catch(Throwable e) {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttributeImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttributeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttributeListener.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaAttributeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCarRecord.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCarRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandError.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandInProgress.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandInProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandListener.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandMonitor.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandMonitorImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandMonitorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandPostError.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandPostError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandSender.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandSenderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandSenderTest.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandTrigger.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaCommandTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaConfigFileConverter.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaConfigFileConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaContinuousApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaContinuousApplySenderImpl.java
@@ -33,11 +33,11 @@ public class CaContinuousApplySenderImpl<C extends Enum<C> & CarStateGeneric> im
 
     private long timeout;
     private TimeUnit timeoutUnit;
-    private ScheduledExecutorService executor;
+    private final ScheduledExecutorService executor;
     private ScheduledFuture<?> timeoutFuture;
     private final ChannelListener<Integer> valListener;
-    private ChannelListener<Integer> carClidListener;
-    private ChannelListener<C> carValListener;
+    private final ChannelListener<Integer> carClidListener;
+    private final ChannelListener<C> carValListener;
     private State currentState;
     private static final State IdleState = new State() {
         @Override
@@ -71,11 +71,14 @@ public class CaContinuousApplySenderImpl<C extends Enum<C> & CarStateGeneric> im
             final String description,
             final Class<C> carClass,
             final EpicsReader epicsReader,
-            final EpicsWriter epicsWriter) throws CAException {
+            final EpicsWriter epicsWriter,
+            final ScheduledExecutorService executor
+            ) throws CAException {
         super();
         this.name = name;
         this.description = description;
         this.currentState = IdleState;
+        this.executor = executor;
 
         apply = new CaApplyRecord(applyRecord, epicsReader, epicsWriter);
         apply.registerValListener(valListener = (String arg0, List<Integer> newVals) -> {
@@ -96,7 +99,6 @@ public class CaContinuousApplySenderImpl<C extends Enum<C> & CarStateGeneric> im
             }
         });
 
-        executor = SafeExecutor.safeExecutor(2, LOG);
     }
 
     @Override
@@ -151,7 +153,7 @@ public class CaContinuousApplySenderImpl<C extends Enum<C> & CarStateGeneric> im
 
                 apply.setDir(CadDirective.START);
                 if (timeout > 0) {
-                    timeoutFuture = executor.schedule(() -> CaContinuousApplySenderImpl.this.onTimeout(), timeout,
+                    timeoutFuture = executor.schedule(CaContinuousApplySenderImpl.this::onTimeout, timeout,
                             timeoutUnit);
                 }
             } catch (CAException | TimeoutException e) {
@@ -369,7 +371,7 @@ public class CaContinuousApplySenderImpl<C extends Enum<C> & CarStateGeneric> im
     }
 
     private void succedCommand(final CaCommandMonitorImpl cm) {
-        executor.execute(() -> cm.completeSuccess());
+        executor.execute(cm::completeSuccess);
     }
 
     private void failCommand(final CaCommandMonitorImpl cm, final Exception ex) {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaContinuousApplySenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaContinuousApplySenderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaException.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveAborted.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveAborted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveSenderImpl.java
@@ -32,7 +32,6 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
     private final String name;
     private final String description;
 
-    private final EpicsReader epicsReader;
     private final CaApplyRecord apply;
     private final CaCarRecord<C> car;
     private final CaCarRecord<C> observeCar;
@@ -46,12 +45,12 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
 
     private long timeout;
     private TimeUnit timeoutUnit;
-    private ScheduledExecutorService executor;
+    private final ScheduledExecutorService executor;
     private ScheduledFuture<?> timeoutFuture;
     private final ChannelListener<Integer> valListener;
-    private ChannelListener<Integer> carClidListener;
-    private ChannelListener<C> carValListener;
-    private ChannelListener<C> observeCarValListener;
+    private final ChannelListener<Integer> carClidListener;
+    private final ChannelListener<C> carValListener;
+    private final ChannelListener<C> observeCarValListener;
     private ChannelListener<Short> abortMarkListener;
     private ChannelListener<Short> stopMarkListener;
     private CaObserveSenderImpl.ApplyState currentState;
@@ -66,13 +65,14 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
         final String description,
         final Class<C> carClass,
         final EpicsReader epicsReader,
-        final EpicsWriter epicsWriter) throws CAException {
+        final EpicsWriter epicsWriter,
+        final ScheduledExecutorService executor
+    ) throws CAException {
         super();
         this.name = name;
         this.description = description;
         this.currentState = idleState;
-
-        this.epicsReader = epicsReader;
+        this.executor = executor;
 
         apply = new CaApplyRecord(applyRecord, epicsReader, epicsWriter);
         // apply.VAL int > 0
@@ -142,7 +142,6 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
         }
         this.abortMark = abortMark;
 
-        executor = SafeExecutor.safeExecutor(2, LOG);
     }
 
     @Override
@@ -324,7 +323,7 @@ public class CaObserveSenderImpl<C extends Enum<C> & CarStateGeneric> implements
 
     }
 
-    private static ObserveState idleObserveState = new ObserveIdleState();
+    private static final ObserveState idleObserveState = new ObserveIdleState();
 
     // At this state we are waiting for busy on the observeC
     private final class ObserveWaitBusy implements ObserveState {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveStopped.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaObserveStopped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaParameter.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaParameterImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaParameterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaParameterStorage.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaParameterStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaResource.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -69,7 +69,7 @@ public final class CaService {
         commandSenders = new HashMap<>();
         taskControlSenders = new HashMap<>();
         epicsService = new EpicsService(addrList, (double) timeout.getSeconds());
-        executorService = SafeExecutor.safeExecutor(THREAD_COUNT, LOG);
+        executorService = SafeExecutor.safeExecutor(THREAD_COUNT, LOG, this.getClass().getName());
 
         epicsService.startService();
     }

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaService.java
@@ -8,6 +8,7 @@ package edu.gemini.epics.acm;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -19,6 +20,8 @@ import edu.gemini.epics.impl.EpicsReaderImpl;
 import edu.gemini.epics.EpicsWriter;
 import edu.gemini.epics.impl.EpicsWriterImpl;
 import gov.aps.jca.CAException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Works as the main access point for the EPICS Action Command Model API. It
@@ -43,6 +46,7 @@ import gov.aps.jca.CAException;
 public final class CaService {
 
     private static final String EPICS_CA_ADDR_LIST = "EPICS_CA_ADDR_LIST";
+    private static final Logger LOG = LoggerFactory.getLogger(CaService.class.getName());
     private EpicsService epicsService;
     private final Map<String, StatusAcceptorWithResource> statusAcceptors;
     private final Map<String, ApplySenderWithResource> applySenders;
@@ -50,10 +54,12 @@ public final class CaService {
     private final Map<String, ApplySenderWithResource> continuousCmdSenders;
     private final Map<String, CommandSenderWithResource> commandSenders;
     private final Map<String, TaskControlWithResource> taskControlSenders;
+    private final ScheduledExecutorService executorService;
     static private String addrList = "";
     static private Duration ioTimeout = Duration.ofSeconds(1);
     static private CaService theInstance;
-    static private Lock instanceLock = new ReentrantLock();
+    static private final Lock instanceLock = new ReentrantLock();
+    static private final int THREAD_COUNT = 8;
 
     private CaService(String addrList, Duration timeout) {
         statusAcceptors = new HashMap<>();
@@ -62,7 +68,8 @@ public final class CaService {
         continuousCmdSenders = new HashMap<>();
         commandSenders = new HashMap<>();
         taskControlSenders = new HashMap<>();
-        epicsService = new EpicsService(addrList, Double.valueOf(timeout.getSeconds()));
+        epicsService = new EpicsService(addrList, (double) timeout.getSeconds());
+        executorService = SafeExecutor.safeExecutor(THREAD_COUNT, LOG);
 
         epicsService.startService();
     }
@@ -150,7 +157,7 @@ public final class CaService {
     public CaStatusAcceptor createStatusAcceptor(String name, String description) {
         CaStatusAcceptor a = statusAcceptors.get(name);
         if (a == null) {
-            StatusAcceptorWithResource b = new CaStatusAcceptorImpl(name, description, epicsService);
+            StatusAcceptorWithResource b = new CaStatusAcceptorImpl(name, description, epicsService, executorService);
             statusAcceptors.put(name, b);
             return b;
         } else {
@@ -198,11 +205,11 @@ public final class CaService {
             EpicsWriter epicsWriter = new EpicsWriterImpl(epicsService);
             if(gem5) {
                 b = new CaApplySenderImpl<>(name, applyRecord, carRecord,
-                        description, CarStateGEM5.class, epicsReader, epicsWriter);
+                        description, CarStateGEM5.class, epicsReader, epicsWriter, executorService);
             }
             else {
                 b = new CaApplySenderImpl<>(name, applyRecord, carRecord,
-                        description, CarState.class, epicsReader, epicsWriter);
+                        description, CarState.class, epicsReader, epicsWriter, executorService);
             }
             applySenders.put(name, b);
             return b;
@@ -249,11 +256,11 @@ public final class CaService {
             EpicsWriter epicsWriter = new EpicsWriterImpl(epicsService);
             if(gem5) {
                 b = new CaObserveSenderImpl<CarStateGEM5>(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
-                        description, CarStateGEM5.class, epicsReader, epicsWriter);
+                        description, CarStateGEM5.class, epicsReader, epicsWriter, executorService);
             }
             else  {
                 b = new CaObserveSenderImpl<CarState>(name, applyRecord, carRecord, observeCarRecord, stopCmdRecord, abortCmdRecord,
-                        description, CarState.class, epicsReader, epicsWriter);
+                        description, CarState.class, epicsReader, epicsWriter, executorService);
             }
             observeSenders.put(name, b);
             return b;
@@ -298,11 +305,11 @@ public final class CaService {
             EpicsWriter epicsWriter = new EpicsWriterImpl(epicsService);
             if(gem5) {
                 b = new CaSimpleObserveSenderImpl<CarStateGEM5>(name, applyRecord, carRecord, stopCmdRecord, abortCmdRecord,
-                        description, CarStateGEM5.class, epicsReader, epicsWriter);
+                        description, CarStateGEM5.class, epicsReader, epicsWriter, executorService);
             }
             else  {
                 b = new CaSimpleObserveSenderImpl<CarState>(name, applyRecord, carRecord, stopCmdRecord, abortCmdRecord,
-                        description, CarState.class, epicsReader, epicsWriter);
+                        description, CarState.class, epicsReader, epicsWriter, executorService);
             }
             observeSenders.put(name, b);
             return b;
@@ -349,11 +356,11 @@ public final class CaService {
             EpicsWriter epicsWriter = new EpicsWriterImpl(epicsService);
             if(gem5) {
                 b = new CaContinuousApplySenderImpl<CarStateGEM5>(name, applyRecord, carRecord, description,
-                        CarStateGEM5.class, epicsReader, epicsWriter);
+                        CarStateGEM5.class, epicsReader, epicsWriter, executorService);
             }
             else  {
                 b = new CaContinuousApplySenderImpl<CarState>(name, applyRecord, carRecord, description,
-                        CarState.class, epicsReader, epicsWriter);
+                        CarState.class, epicsReader, epicsWriter, executorService);
             }
             continuousCmdSenders.put(name, b);
             return b;
@@ -496,7 +503,8 @@ public final class CaService {
             throws CAException {
         CaTaskControl a = taskControlSenders.get(name);
         if(a == null) {
-            TaskControlWithResource b = new CaTaskControlImpl(name, recordName, description, epicsService);
+            TaskControlWithResource b = new CaTaskControlImpl(name, recordName, description, epicsService,
+                    executorService);
             taskControlSenders.put(name, b);
             return b;
         } else {
@@ -522,6 +530,10 @@ public final class CaService {
         if(t != null) {
             t.unbind();
         }
+    }
+
+    public <T> CaWindowStabilizer<T> timeWindowFilter(CaAttribute<T> attr, Duration stabilizationTime) {
+        return new CaWindowStabilizer<T>(attr, stabilizationTime, executorService);
     }
 
 }

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaSimpleObserveSenderImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaSimpleObserveSenderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptor.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorImpl.java
@@ -9,6 +9,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,13 +33,15 @@ final class CaStatusAcceptorImpl implements StatusAcceptorWithResource {
     private final Map<String, CaAttributeImpl<Integer>> integerAttributes;
     private final Map<String, CaAttributeImpl<Short>> shortAttributes;
     private final Map<String, Object> enumAttributes;
+    private final ScheduledExecutorService executor;
     private EpicsReader epicsReader;
 
     public CaStatusAcceptorImpl(String name, String description,
-            EpicsService epicsService) {
+            EpicsService epicsService, ScheduledExecutorService executor) {
         super();
         this.name = name;
         this.description = description;
+        this.executor = executor;
         stringAttributes = new HashMap<>();
         doubleAttributes = new HashMap<>();
         floatAttributes = new HashMap<>();
@@ -63,7 +67,7 @@ final class CaStatusAcceptorImpl implements StatusAcceptorWithResource {
                         "Attribute already exists with a different type.");
             } else {
                 attr = CaAttributeImpl.createDoubleAttribute(name, channel, description,
-                        epicsReader);
+                        epicsReader, executor);
                 doubleAttributes.put(name, attr);
             }
         } else {
@@ -91,7 +95,7 @@ final class CaStatusAcceptorImpl implements StatusAcceptorWithResource {
                         "Attribute already exists with a different type.");
             } else {
                 attr = CaAttributeImpl.createFloatAttribute(name, channel, description,
-                        epicsReader);
+                        epicsReader, executor);
                 floatAttributes.put(name, attr);
             }
         } else {
@@ -119,7 +123,7 @@ final class CaStatusAcceptorImpl implements StatusAcceptorWithResource {
                         "Attribute already exists with a different type.");
             } else {
                 attr = CaAttributeImpl.createIntegerAttribute(name, channel, description,
-                        epicsReader);
+                        epicsReader, executor);
                 integerAttributes.put(name, attr);
             }
         } else {
@@ -147,7 +151,7 @@ final class CaStatusAcceptorImpl implements StatusAcceptorWithResource {
                         "Attribute already exists with a different type.");
             } else {
                 attr = CaAttributeImpl.createShortAttribute(name, channel, description,
-                        epicsReader);
+                        epicsReader, executor);
                 shortAttributes.put(name, attr);
             }
         } else {
@@ -188,7 +192,7 @@ final class CaStatusAcceptorImpl implements StatusAcceptorWithResource {
                         "Attribute already exists with a different type.");
             } else {
                 attr = CaAttributeImpl.createEnumAttribute(name, channel, description, enumType,
-                        epicsReader);
+                        epicsReader, executor);
                 enumAttributes.put(name, attr);
             }
         } else {
@@ -215,7 +219,7 @@ final class CaStatusAcceptorImpl implements StatusAcceptorWithResource {
                         "Attribute already exists with a different type.");
             } else {
                 attr = CaAttributeImpl.createStringAttribute(name, channel, description,
-                        epicsReader);
+                        epicsReader, executor);
                 stringAttributes.put(name, attr);
             }
         } else {

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorTest.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaStatusAcceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlImpl.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlImpl.java
@@ -33,9 +33,8 @@ public class CaTaskControlImpl implements TaskControlWithResource {
 
     private long timeout;
     private TimeUnit timeoutUnit;
-    private ScheduledExecutorService executor;
+    private final ScheduledExecutorService executor;
     private ScheduledFuture<?> timeoutFuture;
-    private final EpicsWriter epicsWriter;
     private final ChannelListener<Integer> valListener;
     private final ChannelListener<TaskControlState> stateListener;
     private final CaParameterStorage storage;
@@ -64,12 +63,14 @@ public class CaTaskControlImpl implements TaskControlWithResource {
         }
     };
 
-    public CaTaskControlImpl(String name, String channel, String description, EpicsService epicsService)
+    public CaTaskControlImpl(String name, String channel, String description, EpicsService epicsService,
+                             ScheduledExecutorService executor)
             throws CAException {
         this.name = name;
         this.description = description;
+        this.executor = executor;
 
-        epicsWriter = new EpicsWriterImpl(epicsService);
+        EpicsWriter epicsWriter = new EpicsWriterImpl(epicsService);
         storage = new CaParameterStorage(epicsWriter);
         record = new CaTaskControlRecord(channel, epicsService);
 
@@ -90,8 +91,6 @@ public class CaTaskControlImpl implements TaskControlWithResource {
                 }
             }
         });
-
-        executor = new ScheduledThreadPoolExecutor(2);
 
     }
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlRecord.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaTaskControlRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaWindowStabilizer.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaWindowStabilizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CaWindowStabilizer.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CaWindowStabilizer.java
@@ -114,8 +114,12 @@ public class CaWindowStabilizer<T> implements CaAttribute<T> {
     }
 
     @Override
-    public void addListener(CaAttributeListener<T> listener) {
+    synchronized public void addListener(CaAttributeListener<T> listener) {
         notifier.addListener(listener);
+        //Call listener with first value, if there is one.
+        if(values() != null) {
+            notifier.notifyValueChangeSingle(listener, values());
+        }
     }
 
     @Override

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CadDirective.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CadDirective.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CarState.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CarState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CarStateGEM5.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CarStateGEM5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/CarStateGeneric.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/CarStateGeneric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/SafeExecutor.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/SafeExecutor.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ThreadFactory;
 import org.slf4j.Logger;
 
 public interface SafeExecutor {
-    public static ScheduledExecutorService safeExecutor(Integer threadCount, Logger logger) {
+    public static ScheduledExecutorService safeEsaxecutor(Integer threadCount, Logger logger, String className) {
         ThreadFactory threadFactory = new ThreadFactory() {
 
             @Override
@@ -27,7 +27,7 @@ public interface SafeExecutor {
 
                     @Override
                     public void uncaughtException(Thread t, Throwable e) {
-                        logger.error("Uncaught exception on CaSimpleObserverSender at thread: " + t.getId(), e);
+                        logger.error("Uncaught exception on " + className + " at thread: " + t.getId(), e);
                     }
                 });
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/SafeExecutor.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/SafeExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -16,7 +16,7 @@ import java.util.concurrent.ThreadFactory;
 import org.slf4j.Logger;
 
 public interface SafeExecutor {
-    public static ScheduledExecutorService safeEsaxecutor(Integer threadCount, Logger logger, String className) {
+    public static ScheduledExecutorService safeExecutor(Integer threadCount, Logger logger, String className) {
         ThreadFactory threadFactory = new ThreadFactory() {
 
             @Override

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/TaskControlState.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/TaskControlState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/main/java/edu/gemini/epics/acm/XMLBuilder.java
+++ b/modules/acm/src/main/java/edu/gemini/epics/acm/XMLBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaCommandSenderTest.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaCommandSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaConfigFileConverterTest.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaConfigFileConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaStatusAcceptorTest.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaStatusAcceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaWindowStabilizerTest.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaWindowStabilizerTest.java
@@ -1,0 +1,50 @@
+package edu.gemini.epics.acm.test;
+
+import edu.gemini.epics.acm.CaWindowStabilizer;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+public class CaWindowStabilizerTest {
+
+    private final ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(2);
+
+    @Test
+    public void testFilteredConstantValue() {
+        Duration settleTime = Duration.ofMillis(100);
+
+        DummyAttribute<Integer> attr = new DummyAttribute<Integer>("foo", "dummy:foo");
+
+        CaWindowStabilizer<Integer> filteredVal = new CaWindowStabilizer<Integer>(attr, settleTime, executor);
+
+        attr.setValue(1);
+
+        filteredVal.restart();
+        try {
+            Thread.sleep(settleTime.toMillis() * 2);
+        } catch(Exception ignored) {}
+
+        assert(filteredVal.valid() && filteredVal.value() == 1);
+    }
+
+    @Test
+    public void testZeroSettleTime() {
+        Duration settleTime = Duration.ofMillis(0);
+
+        DummyAttribute<Integer> attr = new DummyAttribute<Integer>("foo", "dummy:foo");
+
+        CaWindowStabilizer<Integer> filteredVal = new CaWindowStabilizer<Integer>(attr, settleTime, executor);
+
+        attr.setValue(1);
+
+        filteredVal.restart();
+        try {
+            Thread.sleep(100);
+        } catch(Exception ignored) {}
+
+        assert(filteredVal.valid() && filteredVal.value() == 1);
+    }
+
+}

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaWindowStabilizerTest.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/CaWindowStabilizerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package edu.gemini.epics.acm.test;
 
 import edu.gemini.epics.acm.CaWindowStabilizer;

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/DummyAttribute.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/DummyAttribute.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package edu.gemini.epics.acm.test;
 
 import edu.gemini.epics.acm.CaAttribute;

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/DummyAttribute.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/DummyAttribute.java
@@ -93,8 +93,11 @@ public class DummyAttribute<T> implements CaAttribute<T> {
     private final Notifier notifier = new Notifier();
 
     @Override
-    public void addListener(CaAttributeListener<T> listener) {
+    synchronized public void addListener(CaAttributeListener<T> listener) {
         notifier.addListener(listener);
+        if(values()!=null) {
+            listener.onValueChange(values());
+        }
     }
 
     @Override

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/DummyAttribute.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/DummyAttribute.java
@@ -1,0 +1,105 @@
+package edu.gemini.epics.acm.test;
+
+import edu.gemini.epics.acm.CaAttribute;
+import edu.gemini.epics.acm.CaAttributeListener;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+public class DummyAttribute<T> implements CaAttribute<T> {
+    private final String name;
+    private final String channel;
+    private List<T> vals;
+    private boolean validity;
+
+    public DummyAttribute(String name, String channel) {
+        this.name = name;
+        this.channel = channel;
+        this.validity = false;
+    }
+
+    synchronized public void setValue(T v) {
+        this.validity = true;
+        this.vals = Collections.singletonList(v);
+        notifier.notifyValueChange(this.vals);
+    }
+
+    synchronized public void setValidity(boolean v) {
+        this.validity = v;
+        notifier.notifyValidityChange(this.validity);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String channel() {
+        return channel;
+    }
+
+    @Override
+    public String description() {
+        return null;
+    }
+
+    @Override
+    synchronized public T value() {
+        if(validity && vals != null && vals.size() > 0) {
+            return vals.get(0);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    synchronized public List<T> values() {
+        return vals;
+    }
+
+    @Override
+    synchronized public boolean valid() {
+        return validity;
+    }
+
+    private final class Notifier {
+        private final List<CaAttributeListener<T>> listeners = new LinkedList<>();
+
+        synchronized public void addListener(CaAttributeListener<T> listener) {
+            if (!listeners.contains(listener)) {
+                listeners.add(listener);
+            }
+        }
+
+        synchronized public void removeListener(CaAttributeListener<T> listener) {
+            listeners.remove(listener);
+        }
+
+        synchronized public void notifyValueChange(List<T> newVals) {
+            for (CaAttributeListener<T> listener : listeners) {
+                listener.onValueChange(newVals);
+            }
+        }
+
+        synchronized public void notifyValidityChange(boolean newValidity) {
+            for (CaAttributeListener<T> listener : listeners) {
+                listener.onValidityChange(newValidity);
+            }
+        }
+    }
+
+    private final Notifier notifier = new Notifier();
+
+    @Override
+    public void addListener(CaAttributeListener<T> listener) {
+        notifier.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(CaAttributeListener<T> listener) {
+        notifier.removeListener(listener);
+    }
+
+}

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/TestSimulator.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/TestSimulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/test/java/edu/gemini/epics/acm/test/XMLBuilderTest.java
+++ b/modules/acm/src/test/java/edu/gemini/epics/acm/test/XMLBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
  * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
@@ -7,10 +7,11 @@ import edu.gemini.epics.EpicsReader
 import edu.gemini.epics.EpicsWriter
 import edu.gemini.epics.api.ChannelListener
 import edu.gemini.epics.ReadWriteClientEpicsChannel
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 import java.lang.{Integer => JInteger}
 import java.lang.{Short => JShort}
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -25,6 +26,8 @@ import org.scalatest.funsuite.AnyFunSuite
   */
 final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks with GmosMocks with NiriMocks with GnirsMocks {
 
+  val executor:ScheduledExecutorService = new ScheduledThreadPoolExecutor(2)
+
   test("NIFS normal observation") {
     val (epicsReader, epicsWriter) = nifsMocks
 
@@ -38,7 +41,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "NIFS Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -110,7 +114,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GMOS Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -205,7 +210,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GMOS Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
     val observeErrorCount = new AtomicInteger()
@@ -373,7 +379,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GMOS Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -448,7 +455,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GMOS Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -513,7 +521,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "NIRI Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
 
     // Start idle
     assert(observe.applyState().isIdle)
@@ -583,7 +592,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GSAOI Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -647,7 +657,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GSAOI Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -716,7 +727,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GSAOI Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -787,7 +799,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GNIRS Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -859,7 +872,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GNIRS Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 
@@ -931,7 +945,8 @@ final class ObserveStateSpec extends AnyFunSuite with GsaoiMocks with NifsMocks 
       "GNIRS Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     // Start idle
     assert(observe.applyState().isIdle)
 

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveStateSpec.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package edu.gemini.epics.acm

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveTimeoutSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveTimeoutSpec.scala
@@ -3,14 +3,17 @@
 
 package edu.gemini.epics.acm
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
+
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
   * Tests of the observe state machine timeouts
   */
 final class ObserveTimeoutSpec extends AnyFunSuite with NiriMocks with GsaoiMocks {
+
+  val executor: ScheduledExecutorService = new ScheduledThreadPoolExecutor(2)
 
   test("NIRI no response should timeout") {
     val (epicsReader, epicsWriter) = niriMocks
@@ -25,7 +28,8 @@ final class ObserveTimeoutSpec extends AnyFunSuite with NiriMocks with GsaoiMock
       "NIRI Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
 
     observe.setTimeout(5, TimeUnit.SECONDS)
     // Start idle
@@ -95,7 +99,8 @@ final class ObserveTimeoutSpec extends AnyFunSuite with NiriMocks with GsaoiMock
       "GSAOI Observe",
       classOf[CarState],
       epicsReader,
-      epicsWriter)
+      epicsWriter,
+      executor)
     observe.setTimeout(5, TimeUnit.SECONDS)
     // Start idle
     assert(observe.applyState().isIdle)

--- a/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveTimeoutSpec.scala
+++ b/modules/acm/src/test/scala/edu/gemini/epics/acm/ObserveTimeoutSpec.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package edu.gemini.epics.acm

--- a/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/EpicsUtil.scala
@@ -192,6 +192,9 @@ object EpicsUtil {
       val lock = new ReentrantLock()
 
       // First we verify that the attribute doesn't already have the required value.
+      // NOTE: It was possible to lose a change to the right value if it happened between here and the line that
+      // subscribes to the attribute, and the wait would end in timeout. That is not the case anymore, because the
+      // CaAttribute will call the callback once on subscription.
       if (!attr.values().isEmpty && vv.contains(attr.value)) {
         f(attr.value.asRight)
       } else {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiEpics.scala
@@ -195,7 +195,7 @@ class GsaoiEpics[F[_]: Async](epicsService: CaService, tops: Map[String, String]
 
   private val guideStabilizeTime = FiniteDuration(1, SECONDS)
   private val filteredNotGuidingAttr: CaWindowStabilizer[Integer] =
-    new CaWindowStabilizer[Integer](notGuidingAttr, java.time.Duration.ofMillis(guideStabilizeTime.toMillis))
+    epicsService.timeWindowFilter(notGuidingAttr, java.time.Duration.ofMillis(guideStabilizeTime.toMillis))
 
   private val guideTimeout = FiniteDuration(5, SECONDS)
   def waitForGuideOn: F[Unit] =

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
@@ -777,7 +777,7 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
   private val defaultTcsStabilizeTime = Duration.ofSeconds(1)
 
   private val filteredInPositionAttr: CaWindowStabilizer[String] =
-    new CaWindowStabilizer[String](inPositionAttr, defaultTcsStabilizeTime)
+    epicsService.timeWindowFilter(inPositionAttr, defaultTcsStabilizeTime)
 
   // Tcs fudge1 (time to wait for in-position to change to false)
   private val tcsSettleTime = FiniteDuration(2800, MILLISECONDS)
@@ -793,7 +793,7 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
   private val agStabilizeTime = Duration.ofSeconds(1)
 
   private val filteredAGInPositionAttr: CaWindowStabilizer[java.lang.Double] =
-    new CaWindowStabilizer[java.lang.Double](agInPositionAttr, agStabilizeTime)
+    epicsService.timeWindowFilter(agInPositionAttr, agStabilizeTime)
 
   def filteredAGInPosition: F[Double] = safeAttributeSDoubleF(filteredAGInPositionAttr)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
@@ -459,6 +459,7 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("m2GuideMode"))
 
     private val coma = cs.map(_.getString("coma"))
+
     override def setComa(v: String): F[Unit] = setParameter(coma, v)
   }
 
@@ -466,12 +467,15 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("m2GuideConfig"))
 
     private val source = cs.map(_.getString("source"))
+
     override def setSource(v: String): F[Unit] = setParameter(source, v)
 
     private val beam = cs.map(_.getString("beam"))
+
     override def setBeam(v: String): F[Unit] = setParameter(beam, v)
 
     private val reset = cs.map(_.getString("reset"))
+
     override def setReset(v: String): F[Unit] = setParameter(reset, v)
   }
 
@@ -611,12 +615,15 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("aoCorrect"))
 
     private val correct = cs.map(_.getString("correct"))
+
     override def setCorrections(v: String): F[Unit] = setParameter(correct, v)
 
     private val gains = cs.map(_.getInteger("gains"))
+
     override def setGains(v: Int): F[Unit] = setParameter[F, java.lang.Integer](gains, v)
 
     private val matrix = cs.map(_.getInteger("matrix"))
+
     override def setMatrix(v: Int): F[Unit] = setParameter[F, java.lang.Integer](matrix, v)
   }
 
@@ -625,18 +632,23 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
       override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("aoPrepareCm"))
 
       private val x = cs.map(_.getDouble("x"))
+
       override def setX(v: Double): F[Unit] = setParameter[F, java.lang.Double](x, v)
 
       private val y = cs.map(_.getDouble("y"))
+
       override def setY(v: Double): F[Unit] = setParameter[F, java.lang.Double](y, v)
 
       private val seeing = cs.map(_.getDouble("seeing"))
+
       override def setSeeing(v: Double): F[Unit] = setParameter[F, java.lang.Double](seeing, v)
 
       private val starMagnitude = cs.map(_.getDouble("gsmag"))
+
       override def setStarMagnitude(v: Double): F[Unit] = setParameter[F, java.lang.Double](starMagnitude, v)
 
       private val windSpeed = cs.map(_.getDouble("windspeed"))
+
       override def setWindSpeed(v: Double): F[Unit] = setParameter[F, java.lang.Double](windSpeed, v)
     }
 
@@ -648,15 +660,19 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("aoStats"))
 
     private val fileName = cs.map(_.getString("filename"))
+
     override def setFileName(v: String): F[Unit] = setParameter(fileName, v)
 
     private val samples = cs.map(_.getInteger("samples"))
+
     override def setSamples(v: Int): F[Unit] = setParameter[F, java.lang.Integer](samples, v)
 
     private val interval = cs.map(_.getDouble("interval"))
+
     override def setInterval(v: Double): F[Unit] = setParameter[F, java.lang.Double](interval, v)
 
     private val triggerTime = cs.map(_.getDouble("trigtime"))
+
     override def setTriggerTimeInterval(v: Double): F[Unit] = setParameter[F, java.lang.Double](triggerTime, v)
   }
 
@@ -664,15 +680,19 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
     override protected val cs: Option[CaCommandSender] = Option(epicsService.getCommandSender("filter1"))
 
     private val bandwidth = cs.map(_.getDouble("bandwidth"))
+
     override def setBandwidth(v: Double): F[Unit] = setParameter[F, java.lang.Double](bandwidth, v)
 
     private val maxVelocity = cs.map(_.getDouble("maxv"))
+
     override def setMaxVelocity(v: Double): F[Unit] = setParameter[F, java.lang.Double](maxVelocity, v)
 
     private val grabRadius = cs.map(_.getDouble("grab"))
+
     override def setGrabRadius(v: Double): F[Unit] = setParameter[F, java.lang.Double](grabRadius, v)
 
     private val shortCircuit = cs.map(_.getString("shortCircuit"))
+
     override def setShortCircuit(v: String): F[Unit] = setParameter(shortCircuit, v)
   }
 
@@ -684,6 +704,7 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
 
   private val m1GuideAttr: CaAttribute[BinaryOnOff] = tcsState.addEnum("m1Guide",
     s"${TcsTop}im:m1GuideOn", classOf[BinaryOnOff], "M1 guide")
+
   override def m1Guide: F[BinaryOnOff] = safeAttributeF(m1GuideAttr)
 
   override def m2p1Guide: F[String] = safeAttributeF(tcsState.getStringAttribute("m2p1Guide"))
@@ -698,6 +719,7 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
 
   private val m2GuideStateAttr: CaAttribute[BinaryOnOff] = tcsState.addEnum("m2GuideState",
     s"${TcsTop}om:m2GuideState", classOf[BinaryOnOff], "M2 guiding state")
+
   override def m2GuideState: F[BinaryOnOff] = safeAttributeF(m2GuideStateAttr)
 
   override def xoffsetPoA1: F[Double] = safeAttributeSDoubleF(tcsState.getDoubleAttribute("xoffsetPoA1"))
@@ -739,12 +761,13 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
 
   private val pwfs1OnAttr: CaAttribute[BinaryYesNo] = tcsState.addEnum("pwfs1On",
     s"${TcsTop}drives:p1Integrating", classOf[BinaryYesNo], "P1 integrating")
+
   override def pwfs1On: F[BinaryYesNo] = safeAttributeF(pwfs1OnAttr)
 
   private val pwfs2OnAttr: CaAttribute[BinaryYesNo] = tcsState.addEnum("pwfs2On",
     s"${TcsTop}drives:p2Integrating", classOf[BinaryYesNo], "P2 integrating")
 
-  override def pwfs2On:F[BinaryYesNo] = safeAttributeF(pwfs2OnAttr)
+  override def pwfs2On: F[BinaryYesNo] = safeAttributeF(pwfs2OnAttr)
 
   private val oiwfsOnAttr: CaAttribute[BinaryYesNo] = tcsState.addEnum("oiwfsOn",
     s"${TcsTop}drives:oiIntegrating", classOf[BinaryYesNo], "P2 integrating")
@@ -763,10 +786,11 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
 
   private val inPositionAttr: CaAttribute[String] = tcsState.getStringAttribute("inPosition")
 
-  override def inPosition:F[String] = safeAttributeF(inPositionAttr)
+  override def inPosition: F[String] = safeAttributeF(inPositionAttr)
 
   private val agInPositionAttr: CaAttribute[java.lang.Double] = tcsState.getDoubleAttribute("agInPosition")
-  override def agInPosition:F[Double] = safeAttributeSDoubleF(agInPositionAttr)
+
+  override def agInPosition: F[Double] = safeAttributeSDoubleF(agInPositionAttr)
 
   override val pwfs1ProbeGuideConfig: ProbeGuideConfig[F] = new ProbeGuideConfigImpl("p1", tcsState)
 
@@ -786,9 +810,14 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
   // for the in-position to change to true and stay true for stabilizationTime. It will wait up to `timeout`
   // seconds for that to happen.
   override def waitInPosition(stabilizationTime: Duration, timeout: FiniteDuration)(implicit T: Timer[F]): F[Unit] =
-    T.sleep(FiniteDuration(tcsSettleTime.toMillis, TimeUnit.MILLISECONDS)) *>
-      Sync[F].delay(filteredInPositionAttr.restart(stabilizationTime))
-        .flatMap(waitForValueF(_, "TRUE", timeout,"TCS inposition flag"))
+    T.sleep(FiniteDuration(tcsSettleTime.toMillis, TimeUnit.MILLISECONDS)) *> (
+      if (stabilizationTime.isZero) {
+        waitForValueF(inPositionAttr, "TRUE", timeout, "TCS inposition flag")
+      } else {
+        Sync[F].delay(filteredInPositionAttr.restart(stabilizationTime))
+          .flatMap(waitForValueF(_, "TRUE", timeout, "TCS inposition flag"))
+      }
+    )
 
   private val agStabilizeTime = Duration.ofSeconds(1)
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -333,6 +333,8 @@ object TcsSouthControllerEpicsAo {
 
       def sysConfig(current: EpicsTcsAoConfig): F[EpicsTcsAoConfig] = {
         val params = configParams(current)
+        val mountMoves: Boolean = subsystems.contains(Subsystem.Mount) &&
+          tcs.tc.offsetA.exists(_ =!= current.base.instrumentOffset)
         val stabilizationTime = tcs.tc.offsetA
           .map(TcsSettleTimeCalculator.calc(current.base.instrumentOffset, _, subsystems, tcs.inst.instrument))
           .getOrElse(0.seconds)
@@ -342,7 +344,7 @@ object TcsSouthControllerEpicsAo {
             s <- params.foldLeft(current.pure[F]){ case (c, p) => c.flatMap(p) }
             _ <- epicsSys.post(TcsControllerEpicsCommon.ConfigTimeout)
             _ <- L.debug("TCS configuration command post")
-            _ <- if(subsystems.contains(Subsystem.Mount))
+            _ <- if(mountMoves)
               epicsSys.waitInPosition(Duration.ofMillis(stabilizationTime.toMillis), tcsTimeout) *> L.debug("TCS inposition")
             else if(Set(Subsystem.PWFS1, Subsystem.PWFS2, Subsystem.AGUnit).exists(subsystems.contains))
               epicsSys.waitAGInPosition(agTimeout) *> L.debug("AG inposition")

--- a/modules/seqexec/server/src/test/scala/seqexec/server/EpicsUtilSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/EpicsUtilSpec.scala
@@ -1,0 +1,27 @@
+package seqexec.server
+
+import java.time.Duration
+import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor}
+
+import cats.effect.IO
+import edu.gemini.epics.acm.CaWindowStabilizer
+import edu.gemini.epics.acm.test.DummyAttribute
+import org.scalatest.flatspec.AnyFlatSpec
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+import scala.concurrent.duration.FiniteDuration
+
+class EpicsUtilSpec extends AnyFlatSpec {
+
+  val executor: ScheduledExecutorService = new ScheduledThreadPoolExecutor(2)
+
+  "EpicsUtil waitForValue" should "work with CaWindowStabilizer" in {
+    val attr: DummyAttribute[Integer] = new DummyAttribute[Integer]("dummy", "foo")
+    val filtered: CaWindowStabilizer[Integer] = new CaWindowStabilizer(attr, Duration.ofMillis(50), executor)
+    attr.setValue(1)
+    (IO.delay(filtered.restart) *>
+      EpicsUtil.waitForValueF[Integer, IO](filtered, 1, FiniteDuration(100, MILLISECONDS), "")
+    ).unsafeRunSync
+  }
+
+}

--- a/modules/seqexec/server/src/test/scala/seqexec/server/EpicsUtilSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/EpicsUtilSpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server
 
 import java.time.Duration


### PR DESCRIPTION
The main purpose of this PR is to fix the TCS in-position timeout problem. The fix was to avoid waiting for the in-position to stabilize when there was no offset applied. I found other minor problems that I fixed.
Other changes:

- Consolidated the construction of thread pools in the ACM module.
- Callback calls are now done in their own thread.