### PR TITLE
SEQNG-1199 Fixes missing styles on the guide config bar

### DIFF
--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/GuideConfigStatus.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/GuideConfigStatus.scala
@@ -69,22 +69,22 @@ object GuideConfigStatus {
             React.Fragment(
               Header(as    = "span",
                      size  = Small,
-                     clazz = SeqexecStyles.activeGuide.when_(s.nonEmpty))(
+                     clazz = SeqexecStyles.item |+| SeqexecStyles.activeGuide.when_(s.nonEmpty))(
                 s"Tip/Tilt: ${s.map(_.tag).mkString("+")}".when(s.nonEmpty),
                 s"Tip/Tilt: Off".when(s.isEmpty)
               ),
               Header(as    = "span",
                      size  = Small,
-                     clazz = SeqexecStyles.activeGuide.when_(c === ComaOption.ComaOn))(
+                     clazz = SeqexecStyles.item |+| SeqexecStyles.activeGuide.when_(c === ComaOption.ComaOn))(
                 s"Coma: ${c.show}"
               )
             )
           case M2GuideConfig.M2GuideOff =>
             React.Fragment(
-              Header(as = "span", size = Small)(
+              Header(as = "span", size = Small, clazz = SeqexecStyles.item)(
                 "Tip/Tilt: Off"
               ),
-              Header(as = "span", size = Small)(
+              Header(as = "span", size = Small, clazz = SeqexecStyles.item)(
                 "Coma: Off"
               )
             )


### PR DESCRIPTION
Some styles were missed on the last port to semantic-ui-react affecting the guide status bar

![image](https://user-images.githubusercontent.com/3615303/84788816-8e577f00-afbd-11ea-8d67-0989ba2d8b22.png)
