### PR TITLE
SEQNG-1198 Removed call to NIRI endObserve command.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
@@ -321,9 +321,7 @@ object NiriControllerEpics extends NiriEncoders {
           calcObserveTimeout(cfg).flatMap(epicsSys.observeCmd.post(_).flatTap{ _ => L.debug("Completed NIRI observe") })
 
       override def endObserve: F[Unit] =
-        L.debug("Send endObserve to NIRI") *>
-          epicsSys.endObserveCmd.mark *>
-          epicsSys.endObserveCmd.post(DefaultTimeout).void
+        L.debug("Skipped sending endObserve to NIRI")
 
       override def stopObserve: F[Unit] =
         L.debug("Stop NIRI exposure") *>


### PR DESCRIPTION
We had an instance of the "pendIO timeout" problem when Seqexec called the endObserve CAD record on NIRI. The old Seqexec does not use that record, so I removed the call.