### PR TITLE
SEQNG-512 Add the concept of unknown conditions

### DIFF
--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/Conditions.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/Conditions.scala
@@ -18,6 +18,14 @@ final case class Conditions(
 
 object Conditions {
 
+  val Unknown: Conditions =
+    Conditions(
+      CloudCover.Unknown,
+      ImageQuality.Unknown,
+      SkyBackground.Unknown,
+      WaterVapor.Unknown
+    )
+
   val Worst: Conditions =
     Conditions(
       CloudCover.Any,
@@ -45,12 +53,10 @@ object Conditions {
     )
 
   val Default: Conditions =
-    Worst // Taken from ODB
+    Unknown // Taken from ODB
 
   implicit val equalConditions: Eq[Conditions] =
     Eq.by(x => (x.cc, x.iq, x.sb, x.wv))
 
-  implicit val showConditions: Show[Conditions] =
-    Show.show(x => List(x.cc, x.iq, x.sb, x.wv).mkString(", "))
 
 }

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/SequencesQueue.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/SequencesQueue.scala
@@ -27,7 +27,6 @@ final case class SequencesQueue[T](
 )
 
 object SequencesQueue {
-
   implicit def equal[T: Eq]: Eq[SequencesQueue[T]] =
     Eq.by(x => (x.loaded, x.conditions, x.operator, x.queues, x.sessionQueue))
 

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/boopickle/ModelBooPicklers.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/boopickle/ModelBooPicklers.scala
@@ -35,7 +35,7 @@ import squants.time.TimeConversions._
 
 /**
   * Contains boopickle implicit picklers of model objects
-  * Boopickle can auto derived encoders but it is preferred to make
+  * Boopickle can auto derive encoders but it is preferred to make
   * them explicitly
   */
 trait ModelBooPicklers extends GemModelBooPicklers {

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/enum/CloudCover.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/enum/CloudCover.scala
@@ -3,19 +3,21 @@
 
 package seqexec.model.enum
 
+import cats.implicits._
 import gem.util.Enumerated
 
-sealed abstract class CloudCover(val toInt: Int, val label: String)
+sealed abstract class CloudCover(val toInt: Option[Int], val label: String)
   extends Product with Serializable
 
 object CloudCover {
 
-  case object Percent50 extends CloudCover(50,  "50%/Clear")
-  case object Percent70 extends CloudCover(70,  "70%/Cirrus")
-  case object Percent80 extends CloudCover(80,  "80%/Cloudy")
-  case object Any       extends CloudCover(100, "Any")
+  case object Unknown   extends CloudCover(none,     "Unknown")
+  case object Percent50 extends CloudCover(50.some,  "50%/Clear")
+  case object Percent70 extends CloudCover(70.some,  "70%/Cirrus")
+  case object Percent80 extends CloudCover(80.some,  "80%/Cloudy")
+  case object Any       extends CloudCover(100.some, "Any")
 
   /** @group Typeclass Instances */
   implicit val CloudCoverEnumerated: Enumerated[CloudCover] =
-    Enumerated.of(Percent50, Percent70, Percent80, Any)
+    Enumerated.of(Unknown, Percent50, Percent70, Percent80, Any)
 }

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/enum/ImageQuality.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/enum/ImageQuality.scala
@@ -3,19 +3,21 @@
 
 package seqexec.model.enum
 
+import cats.implicits._
 import gem.util.Enumerated
 
-sealed abstract class ImageQuality(val toInt: Int, val label: String)
+sealed abstract class ImageQuality(val toInt: Option[Int], val label: String)
   extends Product with Serializable
 
 object ImageQuality {
 
-  case object Percent20 extends ImageQuality(20,  "20%/Best")
-  case object Percent70 extends ImageQuality(70,  "70%/Good")
-  case object Percent85 extends ImageQuality(85,  "85%/Poor")
-  case object Any       extends ImageQuality(100, "Any")
+  case object Unknown   extends ImageQuality(none,     "Unknown")
+  case object Percent20 extends ImageQuality(20.some,  "20%/Best")
+  case object Percent70 extends ImageQuality(70.some,  "70%/Good")
+  case object Percent85 extends ImageQuality(85.some,  "85%/Poor")
+  case object Any       extends ImageQuality(100.some, "Any")
 
   /** @group Typeclass Instances */
   implicit val ImageQualityEnumerated: Enumerated[ImageQuality] =
-    Enumerated.of(Percent20, Percent70, Percent85, Any)
+    Enumerated.of(Unknown, Percent20, Percent70, Percent85, Any)
 }

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/enum/SkyBackground.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/enum/SkyBackground.scala
@@ -3,19 +3,21 @@
 
 package seqexec.model.enum
 
+import cats.implicits._
 import gem.util.Enumerated
 
-sealed abstract class SkyBackground(val toInt: Int, val label: String)
+sealed abstract class SkyBackground(val toInt: Option[Int], val label: String)
   extends Product with Serializable
 
 object SkyBackground {
 
-  case object Percent20 extends SkyBackground(20 , "20%/Darkest")
-  case object Percent50 extends SkyBackground(50 , "50%/Dark")
-  case object Percent80 extends SkyBackground(80 , "80%/Grey")
-  case object Any       extends SkyBackground(100, "Any/Bright")
+  case object Unknown   extends SkyBackground(none,     "Unknown")
+  case object Percent20 extends SkyBackground(20.some , "20%/Darkest")
+  case object Percent50 extends SkyBackground(50.some , "50%/Dark")
+  case object Percent80 extends SkyBackground(80.some , "80%/Grey")
+  case object Any       extends SkyBackground(100.some, "Any/Bright")
 
   /** @group Typeclass Instances */
   implicit val SkyBackgroundEnumerated: Enumerated[SkyBackground] =
-    Enumerated.of(Percent20, Percent50, Percent80, Any)
+    Enumerated.of(Unknown, Percent20, Percent50, Percent80, Any)
 }

--- a/modules/seqexec/model/shared/src/main/scala/seqexec/model/enum/WaterVapor.scala
+++ b/modules/seqexec/model/shared/src/main/scala/seqexec/model/enum/WaterVapor.scala
@@ -3,20 +3,22 @@
 
 package seqexec.model.enum
 
+import cats.implicits._
 import gem.util.Enumerated
 
-sealed abstract class WaterVapor(val toInt: Int, val label: String)
+sealed abstract class WaterVapor(val toInt: Option[Int], val label: String)
   extends Product with Serializable
 
 object WaterVapor {
 
-  case object Percent20 extends WaterVapor(20,  "20%/Low")
-  case object Percent50 extends WaterVapor(50,  "50%/Median")
-  case object Percent80 extends WaterVapor(80,  "85%/High")
-  case object Any       extends WaterVapor(100, "Any")
+  case object Unknown   extends WaterVapor(none,     "Unknown")
+  case object Percent20 extends WaterVapor(20.some,  "20%/Low")
+  case object Percent50 extends WaterVapor(50.some,  "50%/Median")
+  case object Percent80 extends WaterVapor(80.some,  "85%/High")
+  case object Any       extends WaterVapor(100.some, "Any")
 
   /** @group Typeclass Instances */
   implicit val WaterVaporEnumerated: Enumerated[WaterVapor] =
-    Enumerated.of(Percent20, Percent50, Percent80, Any)
+    Enumerated.of(Unknown, Percent20, Percent50, Percent80, Any)
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/StandardHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/StandardHeader.scala
@@ -20,7 +20,8 @@ final case class StateKeywordsReader[F[_]: Applicative](
   conditions: Conditions,
   operator: Option[Operator],
   observer: Option[Observer]) {
-  private def encodeCondition(c: Int): F[String] = (if(c === 100) "Any" else s"$c-percentile").pure[F]
+    private def encodeCondition(c: Option[Int]): F[String] =
+      c.map(c => (if(c === 100) "Any" else s"$c-percentile")).getOrElse("UNKNOWN").pure[F]
 
   def observerName: F[String] = observer.map(_.value).filter(_.nonEmpty).getOrElse("observer").pure[F]
   def operatorName: F[String] = operator.map(_.value).filter(_.nonEmpty).getOrElse("ssa").pure[F]


### PR DESCRIPTION
The old seqexec included the concept of unknown for conditions but it wasn't included in the new seqexec. This PR adds that value and sets it as the default
A special case for unknown is added to write keywords with that value