### PR TITLE
SEQNG-1205 Fixed RELEASE keyword.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/ObsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/ObsKeywordReader.scala
@@ -52,7 +52,7 @@ sealed trait ObsKeywordsReader[F[_]] {
   def odgw3Guide: F[StandardGuideOptions.Value]
   def odgw4Guide: F[StandardGuideOptions.Value]
   def headerPrivacy: F[Boolean]
-  def proprietaryMonths: F[String]
+  def releaseDate: F[String]
   def obsObject: F[String]
   def geminiQA: F[String]
   def pIReq: F[String]
@@ -295,10 +295,7 @@ object ObsKeywordReader extends ObsKeywordsReaderConstants {
 
     override def headerPrivacy: F[Boolean] = headerPrivacyF
 
-    private val noProprietaryMonths: F[String] =
-      LocalDate.now(ZoneId.of("GMT")).format(DateTimeFormatter.ISO_LOCAL_DATE).pure[F]
-
-    private val calcProprietaryMonths: F[String] =
+    private val calcReleaseDate: F[String] =
       EitherT(
         config.extractAs[Integer](PROPRIETARY_MONTHS_KEY)
           .recoverWith {
@@ -314,9 +311,7 @@ object ObsKeywordReader extends ObsKeywordsReaderConstants {
           .pure[F]
       ).widenRethrowT
 
-    override def proprietaryMonths: F[String] =
-      headerPrivacyF
-        .ifM(calcProprietaryMonths, noProprietaryMonths)
+    override def releaseDate: F[String] = calcReleaseDate
 
     private val manualDarkValue    = "Manual Dark"
     private val manualDarkOverride = "Dark"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/StandardHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/StandardHeader.scala
@@ -228,6 +228,6 @@ class StandardHeader[F[_]: Sync](
       buildDouble(tcsReader.startAirMass, KeywordName.AMSTART),
       buildDouble(tcsReader.endAirMass, KeywordName.AMEND),
       buildBoolean(obsReader.headerPrivacy, KeywordName.PROP_MD, DefaultHeaderValue.FalseDefaultValue),
-      buildString(obsReader.proprietaryMonths, KeywordName.RELEASE)
+      buildString(obsReader.releaseDate, KeywordName.RELEASE)
     ))
 }


### PR DESCRIPTION
Use proprietaryMonths to calculate release date regardless of the value of headerVisibility, as the old Seqexec does.