### PR TITLE
SEQNG-1206 Send event sequenceStart to ODB

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Event.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Event.scala
@@ -23,8 +23,8 @@ object Event {
   final case class EventUser[F[_], S, U](ue: UserEvent[F, S, U]) extends Event[F, S, U]
   final case class EventSystem[F[_]](se: SystemEvent[F]) extends Event[F, Nothing, Nothing]
 
-  def start[F[_], S, U](id: Observation.Id, user: UserDetails, clientId: ClientId, userCheck: S => Boolean): Event[F, S, U] =
-    EventUser[F, S, U](Start[S, U](id, user.some, clientId, userCheck))
+  def start[F[_], S, U](id: Observation.Id, user: UserDetails, clientId: ClientId): Event[F, S, U] =
+    EventUser[F, S, U](Start[S, U](id, user.some, clientId))
   def pause[F[_], S, U](id: Observation.Id, user: UserDetails): Event[F, S, U] = EventUser[F, S, U](Pause(id, user.some))
   def cancelPause[F[_], S, U](id: Observation.Id, user: UserDetails): Event[F, S, U] = EventUser[F, S, U](CancelPause(id, user.some))
   def breakpoint[F[_], S, U](id: Observation.Id, user: UserDetails, step: StepId, v: Boolean): Event[F, S, U] = EventUser[F, S, U](Breakpoint(id, user.some, step, v))

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Handle.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Handle.scala
@@ -72,12 +72,13 @@ object Handle {
   // are concatenated in the reverse order.
   implicit class HandleReverseMap[F[_]: Monad, D, V, A](self: Handle[F, D, V, A]) {
     private def reverseConcatOpP(op1: Option[Stream[F, V]],
-                              op2: Option[Stream[F, V]]): Option[Stream[F, V]] = (op1, op2) match {
-          case (None, None) => None
-          case (Some(p1), None) => Some(p1)
-          case (None, Some(p2)) => Some(p2)
-          case (Some(p1), Some(p2)) => Some(p2 ++ p1)
-        }
+                                 op2: Option[Stream[F, V]]): Option[Stream[F, V]] = (op1, op2) match {
+      case (None, None) => None
+      case (Some(p1), None) => Some(p1)
+      case (None, Some(p2)) => Some(p2)
+      case (Some(p1), Some(p2)) => Some(p2 ++ p1)
+    }
+
     def reversedStreamFlatMap[B](f: A => Handle[F, D, V, B]):Handle[F, D, V, B] = Handle[F, D, V, B](
       self.run.flatMap {
         case (a, op1) => f(a).run.map {

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Handle.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Handle.scala
@@ -68,6 +68,25 @@ object Handle {
     }
   }
 
+  // This class adds a method to Hadle similar to flatMap, but the Streams resulting from both Handle instances
+  // are concatenated in the reverse order.
+  implicit class HandleReverseMap[F[_]: Monad, D, V, A](self: Handle[F, D, V, A]) {
+    private def reverseConcatOpP(op1: Option[Stream[F, V]],
+                              op2: Option[Stream[F, V]]): Option[Stream[F, V]] = (op1, op2) match {
+          case (None, None) => None
+          case (Some(p1), None) => Some(p1)
+          case (None, Some(p2)) => Some(p2)
+          case (Some(p1), Some(p2)) => Some(p2 ++ p1)
+        }
+    def reversedStreamFlatMap[B](f: A => Handle[F, D, V, B]):Handle[F, D, V, B] = Handle[F, D, V, B](
+      self.run.flatMap {
+        case (a, op1) => f(a).run.map {
+          case (b, op2) => (b, reverseConcatOpP(op1, op2))
+        }
+      }
+    )
+  }
+
   implicit class StateToHandle[F[_]: Functor, D, V, A](self: StateT[F, D, A]) {
     def toHandle: Handle[F, D, V, A] = Handle(self.map((_, None)))
   }

--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/UserEvent.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/UserEvent.scala
@@ -19,7 +19,7 @@ sealed trait UserEvent[+F[_], S, U] extends Product with Serializable {
 
 object UserEvent {
 
-  final case class Start[S, U](id: Observation.Id, user: Option[UserDetails], clientId: ClientId, userCheck: S => Boolean) extends UserEvent[Nothing, S, U]
+  final case class Start[S, U](id: Observation.Id, user: Option[UserDetails], clientId: ClientId) extends UserEvent[Nothing, S, U]
   final case class Pause[S, U](id: Observation.Id, user: Option[UserDetails]) extends UserEvent[Nothing, S, U]
   final case class CancelPause[S, U](id: Observation.Id, user: Option[UserDetails]) extends UserEvent[Nothing, S, U]
   final case class Breakpoint[S, U](id: Observation.Id, user: Option[UserDetails], step: StepId, v: Boolean) extends UserEvent[Nothing, S, U]

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/SequenceSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/SequenceSpec.scala
@@ -61,8 +61,6 @@ class SequenceSpec extends AnyFlatSpec {
   private val user = UserDetails("telops", "Telops")
   private val executionEngine = new Engine[IO, TestState, Unit](TestState)
 
-  private def always[D]: D => Boolean = _ => true
-
   def simpleStep(id: Int, breakpoint: Boolean): Step[IO] =
     Step.init(
       id = id,
@@ -83,7 +81,7 @@ class SequenceSpec extends AnyFlatSpec {
     executionEngine.process(PartialFunction.empty)(
       Stream.eval(
         IO.pure(
-          Event.start[IO, TestUtil.TestState, Unit](seqId, user, ClientId(UUID.randomUUID), always)
+          Event.start[IO, TestUtil.TestState, Unit](seqId, user, ClientId(UUID.randomUUID))
         )
       )
     )(s0).drop(1).takeThrough(

--- a/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
+++ b/modules/seqexec/engine/src/test/scala/seqexec/engine/packageSpec.scala
@@ -66,8 +66,6 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
     _ <- IO(Thread.sleep(100))
   } yield Result.Error("There was an error in this action"))
 
-  private def always[D]: D => Boolean = _ => true
-
   private val clientId: ClientId = ClientId(UUID.randomUUID)
 
   val executions: List[ParallelActions[IO]] =
@@ -115,7 +113,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
   def runToCompletion(s0: TestState): Option[TestState] = {
     executionEngine.process(PartialFunction.empty)(
       Stream.eval(
-        IO.pure(Event.start[IO, TestState, Unit](seqId, user, clientId, always))
+        IO.pure(Event.start[IO, TestState, Unit](seqId, user, clientId))
       )
     )(s0).drop(1).takeThrough(
       a => !isFinished(a._2.sequences(seqId).status)
@@ -123,7 +121,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
   }
 
   it should "be in Running status after starting" in {
-    val p = Stream.eval(IO.pure(Event.start[IO, TestState, Unit](seqId, user, clientId, always)))
+    val p = Stream.eval(IO.pure(Event.start[IO, TestState, Unit](seqId, user, clientId)))
     val qs = executionEngine.process(PartialFunction.empty)(p)(qs1).take(1).compile.last.unsafeRunSync().map(_._2)
     assert(qs.exists(s => Sequence.State.isRunning(s.sequences(seqId))))
   }
@@ -153,7 +151,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         )
       ) ) )
     )
-    val p = Stream.eval(IO.pure(Event.start[IO, TestState, Unit](seqId, user, clientId, always)))
+    val p = Stream.eval(IO.pure(Event.start[IO, TestState, Unit](seqId, user, clientId)))
 
     //take(3): Start, Executing, Paused
     executionEngine.process(PartialFunction.empty)(p)(s0).take(3).compile.last.unsafeRunSync().map(_._2)
@@ -203,7 +201,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         )
         Stream.eval(List(
           List[IO[Unit]](
-            q.enqueue1(Event.start[IO, TestState, Unit](seqId, user, clientId, always)),
+            q.enqueue1(Event.start[IO, TestState, Unit](seqId, user, clientId)),
             startedFlag.acquire,
             q.enqueue1(Event.nullEvent),
             q.enqueue1(Event.getState[IO, TestState, Unit] { _ => Stream.eval(finishFlag.release).as(Event.nullEvent[IO]).some })

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
@@ -4,6 +4,7 @@
 package seqexec.server
 
 import gem.Observation
+import seqexec.model.dhs.DataId
 import seqexec.server.keywords._
 import seqexec.server.tcs.Tcs
 
@@ -15,6 +16,7 @@ final case class ObserveEnvironment[F[_]](
   config:   CleanConfig,
   stepType: StepType,
   obsId:    Observation.Id,
+  dataId:   DataId,
   inst:     InstrumentSystem[F],
   otherSys: List[System[F]],
   headers:  HeaderExtraData => List[Header[F]],

--- a/modules/seqexec/server/src/main/scala/seqexec/server/OdbProxy.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/OdbProxy.scala
@@ -80,49 +80,49 @@ object OdbProxy {
     private val sessionName = "sessionQueue"
 
     override def datasetStart(obsId: Observation.Id, dataId: DataId, fileId: ImageFileId): F[Boolean] =
-      L.debug(s"Start dataset for obsId: ${obsId.format} and dataId: $dataId") *>
+      L.debug(s"Send ODB event datasetStart for obsId: ${obsId.format} and dataId: $dataId, with fileId: $fileId") *>
       F.delay(
         xmlrpcClient.datasetStart(sessionName, obsId.format, dataId, fileId.toString)
       )
 
     override def datasetComplete(obsId: Observation.Id, dataId: DataId, fileId: ImageFileId): F[Boolean] =
-      L.debug(s"Complete dataset for obsId: ${obsId.format} and dataId: $dataId") *>
+      L.debug(s"Send ODB event datasetComplete for obsId: ${obsId.format} and dataId: $dataId, with fileId: $fileId") *>
       F.delay(
         xmlrpcClient.datasetComplete(sessionName, obsId.format, dataId, fileId.toString)
       )
 
     override def obsAbort(obsId: Observation.Id, reason: String): F[Boolean] =
-      L.debug(s"Aborted: ${obsId.format} reason: $reason") *>
+      L.debug(s"Send ODB event observationAbort for obsId: ${obsId.format} reason: $reason") *>
       F.delay(
         xmlrpcClient.observationAbort(sessionName, obsId.format, reason)
       )
 
     override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
-      L.debug(s"${obsId.format} sequence ended") *>
+      L.debug(s"Send ODB event sequenceEnd for obsId: ${obsId.format}") *>
       F.delay(
         xmlrpcClient.sequenceEnd(sessionName, obsId.format)
       )
 
     override def sequenceStart(obsId: Observation.Id, dataId: DataId): F[Boolean] =
-      L.debug(s"${obsId.format} sequence started") *>
+      L.debug(s"Send ODB event sequenceStart for obsId: ${obsId.format} and dataId: $dataId") *>
       F.delay(
         xmlrpcClient.sequenceStart(sessionName, obsId.format, dataId.toString)
       )
 
     override def obsContinue(obsId: Observation.Id): F[Boolean] =
-      L.debug(s"${obsId.format} sequence continues") *>
+      L.debug(s"Send ODB event observationContinue for obsId: ${obsId.format}") *>
       F.delay(
         xmlrpcClient.observationContinue(sessionName, obsId.format)
       )
 
     override def obsPause(obsId: Observation.Id, reason: String): F[Boolean] =
-      L.debug(s"${obsId.format} sequence paused: $reason") *>
+      L.debug(s"Send ODB event observationPause for obsId: ${obsId.format} $reason") *>
       F.delay(
         xmlrpcClient.observationPause(sessionName, obsId.format, reason)
       )
 
     override def obsStop(obsId: Observation.Id, reason: String): F[Boolean] =
-      L.debug(s"${obsId.format} sequence stopped: $reason") *>
+      L.debug(s"Send ODB event observationStop fro obsID: ${obsId.format} $reason") *>
       F.delay(
         xmlrpcClient.observationStop(sessionName, obsId.format, reason)
       )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqEvent.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqEvent.scala
@@ -22,22 +22,26 @@ object SeqEvent {
   final case class SetConditions(conditions: Conditions, user: Option[UserDetails]) extends SeqEvent
   final case class LoadSequence(sid: Observation.Id) extends SeqEvent
   final case class UnloadSequence(id: Observation.Id) extends SeqEvent
-  final case class AddLoadedSequence(instrument: Instrument, sid: Observation.Id, user: UserDetails, clientId: ClientId) extends SeqEvent
+  final case class AddLoadedSequence(instrument: Instrument, sid: Observation.Id, user: UserDetails, clientId: ClientId)
+    extends SeqEvent
   final case class ClearLoadedSequences(user: Option[UserDetails]) extends SeqEvent
   final case class SetImageQuality(iq: ImageQuality, user: Option[UserDetails]) extends SeqEvent
   final case class SetWaterVapor(wv: WaterVapor, user: Option[UserDetails]) extends SeqEvent
   final case class SetSkyBackground(wv: SkyBackground, user: Option[UserDetails]) extends SeqEvent
   final case class SetCloudCover(cc: CloudCover, user: Option[UserDetails]) extends SeqEvent
   final case class NotifyUser(memo: Notification, clientID: ClientId) extends SeqEvent
-  final case class StartQueue(qid: QueueId, clientID: ClientId) extends SeqEvent
+  final case class StartQueue(qid: QueueId, clientID: ClientId, startedSeqs: List[(Observation.Id, StepId)])
+    extends SeqEvent
   final case class StopQueue(qid: QueueId, clientID: ClientId) extends SeqEvent
   final case class UpdateQueueAdd(qid: QueueId, seqs: List[Observation.Id]) extends SeqEvent
-  final case class UpdateQueueRemove(qid: QueueId, seqs: List[Observation.Id], pos: List[Int]) extends SeqEvent
+  final case class UpdateQueueRemove(qid: QueueId, seqs: List[Observation.Id], pos: List[Int],
+                                     startedSeqs: List[(Observation.Id, StepId)]) extends SeqEvent
   final case class UpdateQueueMoved(qid: QueueId, cid: ClientId, oid: Observation.Id, pos: Int) extends SeqEvent
   final case class UpdateQueueClear(qid: QueueId) extends SeqEvent
   final case class StartSysConfig(sid: Observation.Id, stepId: StepId, res: Resource) extends SeqEvent
   final case class Busy(sid: Observation.Id, cid: ClientId) extends SeqEvent
   final case class SequenceStart(sid: Observation.Id, stepId: StepId) extends SeqEvent
+  final case class SequencesStart(startedSeqs: List[(Observation.Id, StepId)]) extends SeqEvent
   final case class ResourceBusy(sid: Observation.Id, stepId: StepId, res: Resource, clientID: ClientId) extends SeqEvent
   case object NullSeqEvent extends SeqEvent
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -85,6 +85,7 @@ object SeqTranslate {
                                 tio: Timer[F]
                      ): F[SequenceGen.StepGen[F]] = {
       def buildStep(
+        dataId: DataId,
         inst: InstrumentSystem[F],
         sys: List[System[F]],
         headers: HeaderExtraData => List[Header[F]],
@@ -100,7 +101,7 @@ object SeqTranslate {
         }.toMap
 
         def rest(ctx: HeaderExtraData): List[ParallelActions[F]] = {
-          val env = ObserveEnvironment(systems, config, stepType, obsId, inst, sys.filterNot(inst.equals), headers, ctx)
+          val env = ObserveEnvironment(systems, config, stepType, obsId, dataId, inst, sys.filterNot(inst.equals), headers, ctx)
           // Request the instrument to build the observe actions and merge them with the progress
           // Also catches any errors in the process of runnig an observation
           ia.observeActions(env)
@@ -109,17 +110,20 @@ object SeqTranslate {
         extractStatus(config) match {
           case StepState.Pending if i >= nextToRun => SequenceGen.PendingStepGen(
             i,
+            dataId,
             config,
             calcResources(sys),
             StepActionsGen(List.empty, configs, rest)
           )
           case StepState.Pending                   => SequenceGen.SkippedStepGen(
             i,
+            dataId,
             config
           )
           // TODO: This case should be for completed Steps only. Fail when step status is unknown.
           case _                                   => SequenceGen.CompletedStepGen(
             i,
+            dataId,
             config,
             datasets.get(i + 1).map(_.filename).map(toImageFileId)
           )
@@ -130,9 +134,10 @@ object SeqTranslate {
         inst      <- MonadError[F, Throwable].fromEither(extractInstrument(config))
         is        <- toInstrumentSys(inst)
         stepType  <- is.calcStepType(config, isNightSeq).fold(_.raiseError[F, StepType], _.pure[F])
+        dataId    <- dataIdFromConfig[F](config)
         systems   <- calcSystems(config, stepType, is)
         headers   <- calcHeaders(config, stepType, is)
-      } yield buildStep(is, systems, headers, stepType)
+      } yield buildStep(dataId, is, systems, headers, stepType)
     }
 
     override def sequence(obsId: Observation.Id, sequence: SeqexecSequence)(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -31,7 +31,6 @@ import seqexec.model.events.{SequenceStart => ClientSequenceStart, _}
 import seqexec.model.{StepId, UserDetails}
 import seqexec.model.config._
 import seqexec.server.SeqEvent._
-import seqexec.server.SeqTranslate.dataIdFromConfig
 
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
@@ -173,7 +172,7 @@ object SeqexecEngine {
             seq.seqGen.steps.find(_.id === step.id)
               .map { x =>
                 Handle.fromStream[F, EngineState[F], EventType[F]](Stream.eval(
-                  dataIdFromConfig[F](x.config).flatMap(systems.odb.sequenceStart(id, _)).as(Event.nullEvent[F])
+                  systems.odb.sequenceStart(id, x.dataId).as(Event.nullEvent[F])
                 )).as((id, step.id).some)
               }
           }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -9,14 +9,14 @@ import cats.effect.{Concurrent, ConcurrentEffect, Sync, Timer}
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import edu.gemini.seqexec.odb.SeqFailure
-import fs2.{Pure, Stream, Pipe}
+import fs2.{Pipe, Pure, Stream}
 import gem.Observation
 import gem.enum.Site
 import io.chrisdavenport.log4cats.Logger
 import java.util.concurrent.TimeUnit
 import java.time.Instant
 import mouse.all._
-import monocle.Monocle._
+import monocle.Monocle.index
 import monocle.Optional
 import seqexec.engine.Result.Partial
 import seqexec.engine.EventResult._
@@ -31,6 +31,8 @@ import seqexec.model.events.{SequenceStart => ClientSequenceStart, _}
 import seqexec.model.{StepId, UserDetails}
 import seqexec.model.config._
 import seqexec.server.SeqEvent._
+import seqexec.server.SeqTranslate.dataIdFromConfig
+
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
 
@@ -162,15 +164,43 @@ object SeqexecEngine {
       ((EngineState.atSequence[F](id) ^|-> SequenceData.pendingObsCmd).set(cmd.some)(s), SeqEvent.NullSeqEvent:SeqEvent)
     }.toHandle
 
-    override def start(q: EventQueue[F], id: Observation.Id, user: UserDetails, clientId: ClientId): F[Unit] =
-      q.enqueue1(Event.modifyState[F, EngineState[F], SeqEvent](clearObsCmd(id))) *>
-        q.enqueue1(Event.start[F, EngineState[F], SeqEvent](id, user, clientId, checkResources(id)))
+    // Produce a Handle that will send a SequenceStart notification to the ODB, and produces the (sequenceId, stepId)
+    // if there is a valid sequence with a valid current step.
+    private def sequenceStart(id: Observation.Id): HandleType[F, Option[(Observation.Id, StepId)]] =
+      executeEngine.get.flatMap { s =>
+        EngineState.atSequence(id).getOption(s).flatMap { seq =>
+          seq.seq.currentStep.flatMap { step =>
+            seq.seqGen.steps.find(_.id === step.id)
+              .map { x =>
+                Handle.fromStream[F, EngineState[F], EventType[F]](Stream.eval(
+                  dataIdFromConfig[F](x.config).flatMap(systems.odb.sequenceStart(id, _)).as(Event.nullEvent[F])
+                )).as((id, step.id).some)
+              }
+          }
+        }.getOrElse(executeEngine.pure(none[(Observation.Id, StepId)]))
+      }
 
+    // Stars a sequence from the first non executed step. The method checks for resources conflict.
+    override def start(q: EventQueue[F], id: Observation.Id, user: UserDetails, clientId: ClientId): F[Unit] =
+      q.enqueue1(Event.modifyState[F, EngineState[F], SeqEvent](
+        clearObsCmd(id) *>
+        executeEngine.get.flatMap(st => checkResources(id)(st).fold(
+          executeEngine.start(id).reversedStreamFlatMap(_ => sequenceStart(id).map(
+            _.map{case (sid, stepId) => SequenceStart(sid, stepId)}.getOrElse(NullSeqEvent)
+          )),
+          executeEngine.unit.as(Busy(id, clientId))
+        ) )
+      ) )
+
+    // Stars a sequence from an arbitrary step. All previous non executed steps are skipped.
+    // The method checks for resources conflict.
     override def startFrom(q: EventQueue[F], id: Observation.Id, stp: StepId, clientId: ClientId): F[Unit] =
       q.enqueue1(Event.modifyState[F, EngineState[F], SeqEvent](
         clearObsCmd(id) *>
         executeEngine.get.flatMap(st => checkResources(id)(st).fold(
-          executeEngine.startFrom(id, stp).as(SequenceStart(id, stp)),
+          executeEngine.startFrom(id, stp).reversedStreamFlatMap(_ => sequenceStart(id).map(
+            _.map{case (sid, stepId) => SequenceStart(sid, stepId)}.getOrElse(NullSeqEvent)
+          )),
           executeEngine.unit.as(Busy(id, clientId))
         ) )
       ) )
@@ -230,7 +260,7 @@ object SeqexecEngine {
       q.enqueue1(selectSequenceEvent(i, sid, observer, user, clientId))
 
     private def logDebugEvent(q: EventQueue[F], msg: String): F[Unit] =
-      Event.logDebugMsgF[F, EngineState[F], SeqEvent](msg).flatMap(q.enqueue1(_))
+      Event.logDebugMsgF[F, EngineState[F], SeqEvent](msg).flatMap(q.enqueue1)
 
     override def clearLoadedSequences(q: EventQueue[F], user: UserDetails): F[Unit] =
       logDebugEvent(q, "SeqexecEngine: Updating loaded sequences") *>
@@ -303,8 +333,7 @@ object SeqexecEngine {
         Stream.eval(notifyODB(x).attempt)).flatMap {
           case Right((ev, qState)) =>
             val sequences = qState.sequences.values.map(viewSequence).toList
-            val event = toSeqexecEvent[F](ev, qState)
-            Stream.eval(updateMetrics(ev, sequences).as(event))
+            toSeqexecEvent[F](ev, qState) <* Stream.eval(updateMetrics(ev, sequences))
           case Left(x) =>
             Stream.eval(Logger[F].error(x)("Error notifying the ODB").as(NullEvent))
       }
@@ -335,7 +364,7 @@ object SeqexecEngine {
     private def cmdStateO(qid: QueueId): Optional[EngineState[F], BatchCommandState] =
       queueO(qid) ^|-> ExecutionQueue.cmdState
 
-    private def addSeqs(qid: QueueId, seqIds: List[Observation.Id]): HandleType[F, Unit] =
+    private def addSeqs(qid: QueueId, seqIds: List[Observation.Id]): HandleType[F, List[(Observation.Id, StepId)]] =
       executeEngine.get.flatMap{ st => (
         for {
           q <- st.queues.get(qid)
@@ -347,12 +376,12 @@ object SeqexecEngine {
         } yield executeEngine.modify(queueO(qid).modify(_.addSeqs(seqs))) *>
           ((q.cmdState, q.status(st)) match {
             case (_, BatchExecState.Completed)       => ((EngineState.queues[F] ^|-? index(qid) ^|-> ExecutionQueue.cmdState)
-              .set(BatchCommandState.Idle) >>> {(_, ())}).toHandle
+              .set(BatchCommandState.Idle) >>> {(_, List.empty[(Observation.Id, StepId)])}).toHandle
             case (BatchCommandState.Run(o, u, c), _) => executeEngine.get.flatMap(st2 => runSequences(shouldSchedule(qid,
               seqs.toSet)(st2), o, u, c))
-            case _                                   => executeEngine.unit
+            case _                                   => executeEngine.pure(List.empty[(Observation.Id, StepId)])
           })
-      ).getOrElse(executeEngine.unit)}
+      ).getOrElse(executeEngine.pure(List.empty[(Observation.Id, StepId)]))}
 
     override def addSequencesToQueue(q: EventQueue[F], qid: QueueId, seqIds: List[Observation.Id])
     : F[Unit] = q.enqueue1(
@@ -363,7 +392,7 @@ object SeqexecEngine {
     override def addSequenceToQueue(q: EventQueue[F], qid: QueueId, seqId: Observation.Id): F[Unit] =
       addSequencesToQueue(q, qid, List(seqId))
 
-    private def removeSeq(qid: QueueId, seqId: Observation.Id): HandleType[F, Unit] =
+    private def removeSeq(qid: QueueId, seqId: Observation.Id): HandleType[F, List[(Observation.Id, StepId)]] =
       executeEngine.get.flatMap{ st => (
         for {
           q <- st.queues.get(qid)
@@ -373,23 +402,24 @@ object SeqexecEngine {
             sstOp.forall(sst => !sst.isRunning && !sst.isCompleted)
         } yield executeEngine.modify(queueO(qid).modify(_.removeSeq(seqId))) *>
           ((q.cmdState, q.status(st)) match {
-            case (_, BatchExecState.Completed)       => executeEngine.unit
+            case (_, BatchExecState.Completed)       => executeEngine.pure(List.empty[(Observation.Id, StepId)])
             // If removed sequence was halting the queue, then removing it frees resources to run the next sequences
             case (BatchCommandState.Run(o, u, c), _) => shouldSchedule(qid, Set(seqId))(st).isEmpty.fold(
-              executeEngine.unit,
+              executeEngine.pure(List.empty[(Observation.Id, StepId)]),
               st.sequences.get(seqId).map(x => runNextsInQueue(qid, o, u, c, x.seqGen.resources))
-                .getOrElse(executeEngine.unit)
+                .getOrElse(executeEngine.pure(List.empty[(Observation.Id, StepId)]))
             )
-            case _                                   => executeEngine.unit
+            case _                                   => executeEngine.pure(List.empty[(Observation.Id, StepId)])
           })
-      ).getOrElse(executeEngine.unit)}
+      ).getOrElse(executeEngine.pure(List.empty[(Observation.Id, StepId)]))}
 
     override def removeSequenceFromQueue(q: EventQueue[F], qid: QueueId, seqId: Observation.Id)
     : F[Unit] = q.enqueue1(
       Event.modifyState[F, EngineState[F], SeqEvent](
         executeEngine.get.flatMap(st => removeSeq(qid, seqId)
-          .as(UpdateQueueRemove(qid, List(seqId), st.queues.get(qid)
-            .map(_.queue.indexOf(seqId)).toList))))
+          .map(UpdateQueueRemove(qid, List(seqId), st.queues.get(qid).map(_.queue.indexOf(seqId)).toList, _))
+        )
+      )
     )
 
     private def moveSeq(qid: QueueId, seqId: Observation.Id, delta: Int): Endo[EngineState[F]] = st =>
@@ -436,22 +466,22 @@ object SeqexecEngine {
     )
 
     private def runSequences(ss: Set[Observation.Id], observer: Observer, user: UserDetails, clientId: ClientId)
-    :HandleType[F, Unit] =
-      ss.map(sid => setObserverAndSelect(sid, observer, user, clientId) *> executeEngine.start(sid, clientId,
-        { _ =>true }
-      )).fold(Handle.unit[F, EngineState[F], EventType[F]]){_ *> _}
+    :HandleType[F, List[(Observation.Id, StepId)]] =
+      ss.map(sid =>
+        setObserverAndSelect(sid, observer, user, clientId) *>
+          executeEngine.start(sid).reversedStreamFlatMap(_ => sequenceStart(sid))
+      ).toList.sequence.map(_.collect{case Some((sid, stepId)) => (sid, stepId)})
 
     /**
      * runQueue starts the queue. It founds the top eligible sequences in the queue, and runs them.
      */
     private def runQueue(qid: QueueId, observer: Observer, user: UserDetails, clientId: ClientId)
-    : HandleType[F, Unit] = {
-
+    : HandleType[F, List[(Observation.Id, StepId)]] = {
       executeEngine.get.map(findRunnableObservations(qid)).flatMap(runSequences(_, observer, user, clientId))
     }
 
     /**
-     * runNextsInQueue continues running the queue after a sequence completes. It founds the next eligible sequences in
+     * runNextsInQueue continues running the queue after a sequence completes. It finds the next eligible sequences in
      * the queue, and runs them.
      * At any given time a queue can be running, but one of the top eligible sequences are not. That is the case if the
      * sequence ended with an error or is stopped by the user. In both cases, the sequence should not be restarted
@@ -460,7 +490,7 @@ object SeqexecEngine {
      * sequence has freed.
      */
     private def runNextsInQueue(qid: QueueId, observer: Observer, user: UserDetails, clientId: ClientId,
-                                freed: Set[Resource]): HandleType[F, Unit] = {
+                                freed: Set[Resource]): HandleType[F, List[(Observation.Id, StepId)]] = {
       executeEngine.get.map(nextRunnableObservations(qid, freed)).flatMap(runSequences(_, observer, user, clientId))
     }
 
@@ -473,10 +503,10 @@ object SeqexecEngine {
                  BatchExecState.Stopping => ((EngineState.queues[F] ^|-? index(qid) ^|-> ExecutionQueue.cmdState)
               .set(BatchCommandState.Run(observer, user, clientId)) >>> {(_, ())}).toHandle *>
               runQueue(qid, observer, user, clientId)
-            case _                       => executeEngine.unit
+            case _                       => executeEngine.pure(List.empty)
           }
-        }.getOrElse(executeEngine.unit)
-      }}.as(StartQueue(qid, clientId)))
+        }.getOrElse(executeEngine.pure(List.empty))
+      }.map(StartQueue(qid, clientId, _))})
     )
 
     private def stopSequencesInQueue(qid: QueueId): HandleType[F, Unit] =
@@ -499,16 +529,20 @@ object SeqexecEngine {
       }.as(StopQueue(qid, clientId)))
     )
 
-    private val iterateQueues: PartialFunction[SystemEvent[F], HandleType[F, Unit]] = {
-      // Events that could trigger the scheduling of the next sequence in the queue:
-      // - The completion of a sequence (and subsequent release of resources)
-      case SystemEvent.Finished(sid)               => executeEngine.get.flatMap(st =>
+    private def iterateQueues: PartialFunction[SystemEvent[F], HandleType[F, Unit]] = {
+      // Responds to events that could trigger the scheduling of the next sequence in the queue:
+      case SystemEvent.Finished(sid) =>
+        executeEngine.get.flatMap(st =>
         st.sequences.get(sid).flatMap { seq =>
           val freed = seq.seqGen.resources
           st.queues.collectFirst {
             case (qid, q@ExecutionQueue(_, BatchCommandState.Run(observer, user, clid), _))
               if q.status(st) =!= BatchExecState.Completed =>
-              runNextsInQueue(qid, observer, user, clid, freed)
+              runNextsInQueue(qid, observer, user, clid, freed).flatMap{ l =>
+                Handle.fromStream(Stream.emit[F, EventType[F]](
+                  Event.modifyState[F, EngineState[F], SeqEvent](executeEngine.pure(SequencesStart(l)))
+                ))
+              }
           }
         }.getOrElse(executeEngine.unit)
       )
@@ -577,7 +611,7 @@ object SeqexecEngine {
       (e match {
         // TODO Add metrics for more events
         case UserCommandResponse(ue, _, _)   => ue match {
-          case UserEvent.Start(id, _, _, _) => instrument(id).map(sm.startRunning[F]).getOrElse(Sync[F].unit)
+          case UserEvent.Start(id, _, _)    => instrument(id).map(sm.startRunning[F]).getOrElse(Sync[F].unit)
           case _                            => Sync[F].unit
         }
         case SystemUpdate(se, _) => se match {
@@ -696,7 +730,7 @@ object SeqexecEngine {
   }
 
   /**
-    * Find next runable observations given that a set of resources has just being released
+    * Find next runnable observations given that a set of resources has just being released
     * @param qid The execution queue id
     * @param st The current engine state
     * @param freed Resources that were freed
@@ -743,31 +777,37 @@ object SeqexecEngine {
     createTranslator(site, systems)
       .map{ new SeqexecEngineImpl[F](systems, conf, metrics, _) }
 
-  private def modifyStateEvent(v: SeqEvent, svs: => SequencesQueue[SequenceView]): SeqexecEvent = v match {
-    case NullSeqEvent                       => NullEvent
-    case SetOperator(_, _)                  => OperatorUpdated(svs)
-    case SetObserver(_, _, _)               => ObserverUpdated(svs)
-    case AddLoadedSequence(i, s, _, c)      => LoadSequenceUpdated(i, s, svs, c)
-    case ClearLoadedSequences(_)            => ClearLoadedSequencesUpdated(svs)
-    case SetConditions(_, _)                => ConditionsUpdated(svs)
-    case SetImageQuality(_, _)              => ConditionsUpdated(svs)
-    case SetWaterVapor(_, _)                => ConditionsUpdated(svs)
-    case SetSkyBackground(_, _)             => ConditionsUpdated(svs)
-    case SetCloudCover(_, _)                => ConditionsUpdated(svs)
-    case LoadSequence(id)                   => SequenceLoaded(id, svs)
-    case UnloadSequence(id)                 => SequenceUnloaded(id, svs)
-    case NotifyUser(m, cid)                 => UserNotification(m, cid)
-    case UpdateQueueAdd(qid, seqs)          => QueueUpdated(QueueManipulationOp.AddedSeqs(qid, seqs), svs)
-    case UpdateQueueRemove(qid, s, p)       => QueueUpdated(QueueManipulationOp.RemovedSeqs(qid, s, p), svs)
-    case UpdateQueueMoved(qid, cid, oid, p) => QueueUpdated(QueueManipulationOp.Moved(qid, cid, oid, p), svs)
-    case UpdateQueueClear(qid)              => QueueUpdated(QueueManipulationOp.Clear(qid), svs)
-    case StartQueue(qid, _)                 => QueueUpdated(QueueManipulationOp.Started(qid), svs)
-    case StopQueue(qid, _)                  => QueueUpdated(QueueManipulationOp.Stopped(qid), svs)
-    case StartSysConfig(sid, stepId, res)   => SingleActionEvent(SingleActionOp.Started(sid, stepId, res))
-    case SequenceStart(sid, stepId)         => ClientSequenceStart(sid, stepId, svs)
-    case Busy(id, cid)                      => UserNotification(ResourceConflict(id), cid)
-    case ResourceBusy(id, sid, res, cid)    => UserNotification(SubsystemBusy(id, sid, res), cid)
-  }
+  private def modifyStateEvent[F[_]](v: SeqEvent, svs: => SequencesQueue[SequenceView]): Stream[F, SeqexecEvent] =
+    v match {
+      case NullSeqEvent                       => Stream.empty
+      case SetOperator(_, _)                  => Stream.emit(OperatorUpdated(svs))
+      case SetObserver(_, _, _)               => Stream.emit(ObserverUpdated(svs))
+      case AddLoadedSequence(i, s, _, c)      => Stream.emit(LoadSequenceUpdated(i, s, svs, c))
+      case ClearLoadedSequences(_)            => Stream.emit(ClearLoadedSequencesUpdated(svs))
+      case SetConditions(_, _)                => Stream.emit(ConditionsUpdated(svs))
+      case SetImageQuality(_, _)              => Stream.emit(ConditionsUpdated(svs))
+      case SetWaterVapor(_, _)                => Stream.emit(ConditionsUpdated(svs))
+      case SetSkyBackground(_, _)             => Stream.emit(ConditionsUpdated(svs))
+      case SetCloudCover(_, _)                => Stream.emit(ConditionsUpdated(svs))
+      case LoadSequence(id)                   => Stream.emit(SequenceLoaded(id, svs))
+      case UnloadSequence(id)                 => Stream.emit(SequenceUnloaded(id, svs))
+      case NotifyUser(m, cid)                 => Stream.emit(UserNotification(m, cid))
+      case UpdateQueueAdd(qid, seqs)          => Stream.emit(QueueUpdated(QueueManipulationOp.AddedSeqs(qid, seqs), svs))
+      case UpdateQueueRemove(qid, s, p, l)    => Stream.emits(QueueUpdated(QueueManipulationOp.RemovedSeqs(qid, s, p), svs)
+        +: l.map{case (sid, step) => ClientSequenceStart(sid, step, svs)}
+      )
+      case UpdateQueueMoved(qid, cid, oid, p) => Stream.emit(QueueUpdated(QueueManipulationOp.Moved(qid, cid, oid, p), svs))
+      case UpdateQueueClear(qid)              => Stream.emit(QueueUpdated(QueueManipulationOp.Clear(qid), svs))
+      case StartQueue(qid, _, l)              => Stream.emits(QueueUpdated(QueueManipulationOp.Started(qid), svs)
+        +: l.map{case (sid, step) => ClientSequenceStart(sid, step, svs)}
+      )
+      case StopQueue(qid, _)                  => Stream.emit(QueueUpdated(QueueManipulationOp.Stopped(qid), svs))
+      case StartSysConfig(sid, stepId, res)   => Stream.emit(SingleActionEvent(SingleActionOp.Started(sid, stepId, res)))
+      case SequenceStart(sid, stepId)         => Stream.emit(ClientSequenceStart(sid, stepId, svs))
+      case SequencesStart(l)                  => Stream.emits(l.map{case (sid, step) => ClientSequenceStart(sid, step, svs)})
+      case Busy(id, cid)                      => Stream.emit(UserNotification(ResourceConflict(id), cid))
+      case ResourceBusy(id, sid, res, cid)    => Stream.emit(UserNotification(SubsystemBusy(id, sid, res), cid))
+    }
 
   private def executionQueueViews[F[_]](st: EngineState[F]): SortedMap[QueueId, ExecutionQueueView] = {
     SortedMap(st.queues.map {
@@ -810,7 +850,7 @@ object SeqexecEngine {
     SequenceView(seq.id, SequenceMetadata(instrument, obsSeq.observer, obsSeq.seqGen.title), st.status, engineSteps(seq), None)
   }
 
-  private def toSeqexecEvent[F[_]](ev: EventResult[SeqEvent], qState: EngineState[F]): SeqexecEvent = {
+  private def toSeqexecEvent[F[_]](ev: EventResult[SeqEvent], qState: EngineState[F]): Stream[F, SeqexecEvent] = {
     val sequences = qState.sequences.values.map(viewSequence).toList
     // Building the view is a relatively expensive operation
     // By putting it into a def we only incur that cost if the message requires it
@@ -824,52 +864,52 @@ object SeqexecEngine {
 
     ev match {
       case UserCommandResponse(ue, _, uev) => ue match {
-        case UserEvent.Start(id, _, _, _)     =>
+        case UserEvent.Start(id, _, _)        =>
           val rs = sequences.find(_.id === id).flatMap(_.runningStep)
-          ClientSequenceStart(id, rs.foldMap(_.last), svs)
-        case UserEvent.Pause(_, _)            => SequencePauseRequested(svs)
-        case UserEvent.CancelPause(id, _)     => SequencePauseCanceled(id, svs)
-        case UserEvent.Breakpoint(_, _, _, _) => StepBreakpointChanged(svs)
-        case UserEvent.SkipMark(_, _, _, _)   => StepSkipMarkChanged(svs)
-        case UserEvent.Poll(cid)              => SequenceRefreshed(svs, cid)
-        case UserEvent.GetState(_)            => NullEvent
+          Stream.emit(ClientSequenceStart(id, rs.foldMap(_.last), svs))
+        case UserEvent.Pause(_, _)            => Stream.emit(SequencePauseRequested(svs))
+        case UserEvent.CancelPause(id, _)     => Stream.emit(SequencePauseCanceled(id, svs))
+        case UserEvent.Breakpoint(_, _, _, _) => Stream.emit(StepBreakpointChanged(svs))
+        case UserEvent.SkipMark(_, _, _, _)   => Stream.emit(StepSkipMarkChanged(svs))
+        case UserEvent.Poll(cid)              => Stream.emit(SequenceRefreshed(svs, cid))
+        case UserEvent.GetState(_)            => Stream.empty
         case UserEvent.ModifyState(_)         => modifyStateEvent(uev.getOrElse(NullSeqEvent), svs)
-        case UserEvent.ActionStop(_, _)       => ActionStopRequested(svs)
-        case UserEvent.LogDebug(_, _)         => NullEvent
-        case UserEvent.LogInfo(m, ts)         => ServerLogMessage(ServerLogLevel.INFO, ts, m)
-        case UserEvent.LogWarning(m, ts)      => ServerLogMessage(ServerLogLevel.WARN, ts, m)
-        case UserEvent.LogError(m, ts)        => ServerLogMessage(ServerLogLevel.ERROR, ts, m)
-        case UserEvent.ActionResume(_, _, _)  => SequenceUpdated(svs)
+        case UserEvent.ActionStop(_, _)       => Stream.emit(ActionStopRequested(svs))
+        case UserEvent.LogDebug(_, _)         => Stream.empty
+        case UserEvent.LogInfo(m, ts)         => Stream.emit(ServerLogMessage(ServerLogLevel.INFO, ts, m))
+        case UserEvent.LogWarning(m, ts)      => Stream.emit(ServerLogMessage(ServerLogLevel.WARN, ts, m))
+        case UserEvent.LogError(m, ts)        => Stream.emit(ServerLogMessage(ServerLogLevel.ERROR, ts, m))
+        case UserEvent.ActionResume(_, _, _)  => Stream.emit(SequenceUpdated(svs))
       }
       case SystemUpdate(se, _)             => se match {
         // TODO: Sequence completed event not emitted by engine.
-        case SystemEvent.Completed(_, _, _, _)                                    => SequenceUpdated(svs)
-        case SystemEvent.StopCompleted(id, _, _, _)                               => SequenceStopped(id, svs)
-        case SystemEvent.Aborted(id, _, _, _)                                     => SequenceAborted(id, svs)
-        case SystemEvent.PartialResult(_, _, _, Partial(_: InternalPartialVal))   => NullEvent
+        case SystemEvent.Completed(_, _, _, _)                                    => Stream.emit(SequenceUpdated(svs))
+        case SystemEvent.StopCompleted(id, _, _, _)                               => Stream.emit(SequenceStopped(id, svs))
+        case SystemEvent.Aborted(id, _, _, _)                                     => Stream.emit(SequenceAborted(id, svs))
+        case SystemEvent.PartialResult(_, _, _, Partial(_: InternalPartialVal))   => Stream.empty
         case SystemEvent.PartialResult(i, s, _, Partial(ObsProgress(t, r, v)))    =>
-          ObservationProgressEvent(ObservationProgress(i, s, t, r.self, v))
+          Stream.emit(ObservationProgressEvent(ObservationProgress(i, s, t, r.self, v)))
         case SystemEvent.PartialResult(i, s, _, Partial(NSProgress(t, r, v, u)))  =>
-          ObservationProgressEvent(NSObservationProgress(i, s, t, r.self, v, u))
+          Stream.emit(ObservationProgressEvent(NSObservationProgress(i, s, t, r.self, v, u)))
         case SystemEvent.PartialResult(_, _, _, Partial(FileIdAllocated(fileId))) =>
-          FileIdStepExecuted(fileId, svs)
+          Stream.emit(FileIdStepExecuted(fileId, svs))
         case SystemEvent.PartialResult(_, _, _, _)                                =>
-          SequenceUpdated(svs)
-        case SystemEvent.Failed(id, _, _)                                         => SequenceError(id, svs)
+          Stream.emit(SequenceUpdated(svs))
+        case SystemEvent.Failed(id, _, _)                                         => Stream.emit(SequenceError(id, svs))
         case SystemEvent.Busy(id, clientId)                                       =>
-          UserNotification(ResourceConflict(id), clientId)
-        case SystemEvent.Executed(s)                                              => StepExecuted(s, svs)
-        case SystemEvent.Executing(_)                                             => SequenceUpdated(svs)
-        case SystemEvent.Finished(_)                                              => SequenceCompleted(svs)
-        case SystemEvent.Null                                                     => NullEvent
-        case SystemEvent.Paused(id, _, _)                                         => ExposurePaused(id,
-          svs)
-        case SystemEvent.BreakpointReached(id)                                    => SequencePaused(id,
-          svs)
+          Stream.emit(UserNotification(ResourceConflict(id), clientId))
+        case SystemEvent.Executed(s)                                              => Stream.emit(StepExecuted(s, svs))
+        case SystemEvent.Executing(_)                                             => Stream.emit(SequenceUpdated(svs))
+        case SystemEvent.Finished(_)                                              => Stream.emit(SequenceCompleted(svs))
+        case SystemEvent.Null                                                     => Stream.empty
+        case SystemEvent.Paused(id, _, _)                                         => Stream.emit(ExposurePaused(id,
+          svs))
+        case SystemEvent.BreakpointReached(id)                                    => Stream.emit(SequencePaused(id,
+          svs))
         case SystemEvent.SingleRunCompleted(c, _) =>
-          singleActionEvent[F, SingleActionOp.Completed](c, qState, SingleActionOp.Completed)
+          Stream.emit(singleActionEvent[F, SingleActionOp.Completed](c, qState, SingleActionOp.Completed))
         case SystemEvent.SingleRunFailed(c, r)   =>
-          singleActionEvent[F, SingleActionOp.Error](c, qState, SingleActionOp.Error.apply(_, _, _, r.msg))
+          Stream.emit(singleActionEvent[F, SingleActionOp.Error](c, qState, SingleActionOp.Error.apply(_, _, _, r.msg)))
       }
     }
   }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepsView.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepsView.scala
@@ -139,7 +139,7 @@ object StepsView {
         configStatus = configStatus,
         observeStatus = observeStatus(step.executions),
         fileId = fileId(step.executions).orElse(stepg.some.collect{
-          case SequenceGen.CompletedStepGen(_, _, fileId) => fileId
+          case SequenceGen.CompletedStepGen(_, _, _, fileId) => fileId
         }.flatten))
     }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosStepView.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosStepView.scala
@@ -60,7 +60,7 @@ final class GmosStepsView[F[_]] extends StepsView[F] {
           fileId = StepsView
             .fileId(step.executions)
             .orElse(stepg.some.collect {
-              case SequenceGen.CompletedStepGen(_, _, fileId) => fileId
+              case SequenceGen.CompletedStepGen(_, _, _, fileId) => fileId
             }.flatten),
           pendingObserveCmd = (observeStatus(step.executions) === ActionStatus.Running).option(pendingObsCmd).flatten
         )

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -3,6 +3,7 @@
 
 package seqexec.server
 
+import cats.Monoid
 import cats.implicits._
 import cats.effect._
 import cats.data.NonEmptyList
@@ -10,6 +11,7 @@ import fs2.Stream
 import gem.Observation
 import gem.enum.Site
 import io.chrisdavenport.log4cats.noop.NoOpLogger
+
 import scala.concurrent.ExecutionContext
 import seqexec.engine.{Action, Result, Sequence}
 import seqexec.model.enum.Instrument.GmosS
@@ -41,6 +43,7 @@ class SeqTranslateSpec extends AnyFlatSpec {
     GmosS,
     List(SequenceGen.PendingStepGen(
       1,
+      Monoid.empty[DataId],
       config,
       Set(GmosS),
       SequenceGen.StepActionsGen(List(), Map(), _ => List(observeActions(Action.ActionState.Idle)))

--- a/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
@@ -3,7 +3,7 @@
 
 package seqexec.server
 
-import cats.Applicative
+import cats.{Applicative, Monoid}
 import cats.effect.{ContextShift, IO, Timer}
 import cats.implicits._
 import cats.data.NonEmptyList
@@ -219,6 +219,7 @@ object TestCommon {
     instrument = Instrument.F2,
     steps = List(SequenceGen.PendingStepGen(
       id = 1,
+      Monoid.empty[DataId],
       config = CleanConfig.empty,
       resources = Set.empty,
       generator = SequenceGen.StepActionsGen(
@@ -237,6 +238,7 @@ object TestCommon {
         .range(1, n)
         .map(SequenceGen.PendingStepGen(
           _,
+          Monoid.empty[DataId],
           config = CleanConfig.empty,
           resources = Set.empty,
           generator = SequenceGen.StepActionsGen(
@@ -253,6 +255,7 @@ object TestCommon {
     steps = List(
       SequenceGen.PendingStepGen(
         id = 1,
+        Monoid.empty[DataId],
         config = CleanConfig.empty,
         resources = resources,
         generator = SequenceGen.StepActionsGen(
@@ -263,6 +266,7 @@ object TestCommon {
       ),
       SequenceGen.PendingStepGen(
         id = 2,
+        Monoid.empty[DataId],
         config = CleanConfig.empty,
         resources = resources,
         generator = SequenceGen.StepActionsGen(


### PR DESCRIPTION
The event was sent only when executing the first step, which meant there was not event when starting a partially executed sequence.
I also found several cases where the server was not notifying the web clients when a sequence started, particularly when run from the calibration queue. That was also fixed. 