### PR TITLE
SEQNG-1210 Set DHS timeout to 20 seconds.

### DIFF
--- a/app/seqexec-server-gn/src/main/resources/app.conf
+++ b/app/seqexec-server-gn/src/main/resources/app.conf
@@ -61,4 +61,5 @@ seqexec-engine {
   tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gws=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:"
   epicsCaAddrList = "10.2.2.255 10.2.10.21 10.2.126.101"
   ioTimeout = 5 seconds
+  dhsTimeout = 20 seconds
 }

--- a/app/seqexec-server-gs/src/main/resources/app.conf
+++ b/app/seqexec-server-gs/src/main/resources/app.conf
@@ -58,6 +58,7 @@ seqexec-engine {
   tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gws=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:, gsaoi=gsaoi:, aom=aom:, myst=myst:, rtc=rtc:"
   epicsCaAddrList = "172.17.2.255 172.17.3.255 172.17.102.130 172.17.105.20 172.16.102.130 172.17.106.111 172.17.105.37 172.17.107.50 172.17.55.101 172.17.101.101 172.17.65.255 172.17.102.139 172.17.102.138"
   ioTimeout = 5 seconds
+  dhsTimeout = 20 seconds
   gpiUrl = "failover:(tcp://172.17.107.50:61616)?timeout=4000"
   gpiGDS = "http://172.17.107.50:8888/xmlrpc"
   ghostUrl = "failover:(tcp://172.16.111.22:61616)?timeout=4000"

--- a/modules/seqexec/model/jvm/src/main/scala/seqexec/model/config/SeqexecEngineConfiguration.scala
+++ b/modules/seqexec/model/jvm/src/main/scala/seqexec/model/config/SeqexecEngineConfiguration.scala
@@ -28,6 +28,7 @@ trait GhostSettings
  * @param tops Used to select the top component for epics subsystems
  * @param epicsCaAddrList List of IPs for the epics subsystem
  * @param ioTimeout Timeout to listen for EPICS events
+ * @param dhsTimeout Timeout for DHS operations
  */
 final case class SeqexecEngineConfiguration(
   odb:                     Uri,
@@ -43,7 +44,8 @@ final case class SeqexecEngineConfiguration(
   ghostGDS:                Uri @@ GhostSettings,
   tops:                    String,
   epicsCaAddrList:         Option[String],
-  ioTimeout:               FiniteDuration
+  ioTimeout:               FiniteDuration,
+  dhsTimeout:              FiniteDuration
 )
 
 object SeqexecEngineConfiguration {
@@ -65,7 +67,8 @@ object SeqexecEngineConfiguration {
          x.ghostGDS,
          x.tops,
          x.epicsCaAddrList,
-         x.ioTimeout)
+         x.ioTimeout,
+         x.dhsTimeout)
     )
 
 }

--- a/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
@@ -87,7 +87,8 @@ object TestCommon {
     tag[GhostSettings][Uri](uri("http://localhost:8888/xmlrpc")),
     "",
     Some("127.0.0.1"),
-    3.seconds
+    3.seconds,
+    10.seconds
   )
 
   def configure[F[_]: Applicative](resource: Resource): F[Result[F]] =

--- a/modules/seqexec/web/server/src/main/resources/app.conf
+++ b/modules/seqexec/web/server/src/main/resources/app.conf
@@ -73,6 +73,7 @@ seqexec-engine {
     tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gw=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:, gsaoi=gsaoi:, aom=aom:, myst=myst:, rtc=rtc:"
     epicsCaAddrList = "127.0.0.1"
     ioTimeout = 5 seconds
+    dhsTimeout = 20 seconds
     gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
     gpiGDS = "http://localhost:8888/xmlrpc"
     ghostUrl = "vm://ghost?marshal=false&broker.persistent=false"

--- a/modules/seqexec/web/server/src/test/scala/seqexec/web/server/config/ConfigurationLoaderSpec.scala
+++ b/modules/seqexec/web/server/src/test/scala/seqexec/web/server/config/ConfigurationLoaderSpec.scala
@@ -51,7 +51,8 @@ class ConfigurationLoaderSpec extends CatsSuite {
     tag[GhostSettings][Uri](uri("http://localhost:8888/xmlrpc")),
     "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gw=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:, gsaoi=gsaoi:, aom=aom:, myst=myst:, rtc=rtc:",
     Some("127.0.0.1"),
-    5.seconds)
+    5.seconds,
+    10.seconds)
   val ref = SeqexecConfiguration(Site.GS, Mode.Development, server, ws, gcal, auth)
 
   implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
@@ -143,6 +144,7 @@ seqexec-engine {
     tops = "tcs=tcs:, ao=ao:, gm=gm:, gc=gc:, gw=ws:, m2=m2:, oiwfs=oiwfs:, ag=ag:, f2=f2:, gsaoi=gsaoi:, aom=aom:, myst=myst:, rtc=rtc:"
     epicsCaAddrList = 127.0.0.1
     ioTimeout = 5 seconds
+    dhsTimeout = 10 seconds
     gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
     gpiGDS = "http://localhost:8888/xmlrpc"
     ghostUrl = "vm://ghost?marshal=false&broker.persistent=false"


### PR DESCRIPTION
Some DHS operations were taking up to 11 seconds, causing a timeout in Seqexec. I increased the timeout from 5 to 20 seconds, and made it a configuration parameter.